### PR TITLE
v0.15.1 docs: show --run-id on mutating AI_CONTEXT examples (#96)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -373,7 +373,9 @@ It returns `[]` when meta is absent or invalid JSON.
 
 **To write a composition as AI (preferred):**
 ```bash
-wp pp action execute update_composition --params='{"post_id":4,"composition":[{"component":"hero","props":{"title":"Hello"}}]}'
+# Mutating actions require --run-id and a PREFLIGHT covering the target post first:
+#   wp pp operate inspect  →  wp pp apply preflight --run-id=<uuid> --post_id=4  →  the action below
+wp pp action execute update_composition --run-id=<uuid> --params='{"post_id":4,"composition":[{"component":"hero","props":{"title":"Hello"}}]}'
 ```
 
 **Direct meta write (legacy, bypasses validation):**
@@ -439,8 +441,8 @@ All mutations go through typed actions. AJAX handlers, WP-CLI, and future AI cal
 
 ```bash
 wp pp action list                                    # all actions with scope and params
-wp pp action preview <name> --params='{"key":"val"}'  # validate + diff, never writes
-wp pp action execute <name> --params='{"key":"val"}'  # validate + execute
+wp pp action preview <name> --params='{"key":"val"}'  # validate + diff, never writes (no run-id)
+wp pp action execute <name> --run-id=<uuid> --params='{"key":"val"}'  # mutates: needs INSPECT + a covering PREFLIGHT
 wp pp check conflicts                                 # Custom CSS conflict detection
 wp pp check page --post_id=42                         # composition styling validation
 wp pp check surface lib/wp.php                        # surface classification (safe/extension/core)
@@ -448,11 +450,11 @@ wp pp validate site                                   # full site validation bat
 
 # Semantic composition operator
 wp pp operate inspect-composition <page>              # editable targets with selectors and current values
-wp pp operate patch <page> --target=hero.subtitle --value="New" --preview  # field-level diff, no write
-wp pp operate patch <page> --target=hero.subtitle --value="New"           # apply through action path
+wp pp operate patch <page> --target=hero.subtitle --value="New" --preview  # field-level diff, no write (no run-id)
+wp pp operate patch <page> --target=hero.subtitle --value="New" --run-id=<uuid>  # mutates: needs INSPECT + a covering PREFLIGHT
 
 # Component ID targeting (alternative to index)
-wp pp action execute update_component --params='{"post_id":19,"component_id":"pp-a1b2c3d4","props":{"subtitle":"Via ID"}}'
+wp pp action execute update_component --run-id=<uuid> --params='{"post_id":19,"component_id":"pp-a1b2c3d4","props":{"subtitle":"Via ID"}}'
 
 # Theme integrity
 wp pp integrity check                                 # compare live files against shipped manifest (exit 0/1/2/3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.15.1] — 2026-06-29 — Docs: AI Command Reference Now Shows the Run Token Mutations Require
+
+**Patch release so the theme's AI-facing command reference matches the v0.15.0 gate.** No code change.
+
+`AI_CONTEXT.md` ships inside the theme as the reference an AI agent reads to operate the site. Four mutating examples (`action execute` and the `operate patch` apply path) still showed commands without `--run-id` — so an agent copying them after v0.15.0 would hit the preflight gate and fail. The examples now carry `--run-id=<uuid>` and a one-line note that mutations require a completed INSPECT plus a PREFLIGHT covering the target. Preview commands stay shown without a run token, because they are read-only.
+
+### Itemized changes
+
+#### Changed
+- `AI_CONTEXT.md`: `action execute` and the mutating `operate patch` examples now include `--run-id=<uuid>` and note the INSPECT + covering-PREFLIGHT requirement; preview examples remain run-token-free. Matches the v0.15.0 preflight-before-mutation gate. (#96)
+
 ## [v0.15.0] — 2026-06-29 — Preflight Before Mutation: No DB-Backed Write Lands Before the Safety Gate
 
 **Mutating `wp pp action execute` and `wp pp operate patch` now refuse to run until a preflight covering their target has passed.** Before this release a typed action could write `_pp_composition` to the database before `wp pp apply preflight` ever ran its target, drift, capability, and surface checks. The operating loop even documented it that way, listing EDIT before PREFLIGHT. A production page could be mutated before the gate that was supposed to protect it.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.15.0-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.15.1-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.15.0');
+define('PP_VERSION', '0.15.1');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.15.0
+Stable tag: 0.15.1
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.15.0
+Version:          0.15.1
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
## What this does

Doc-only follow-up to #96 (v0.15.0). `AI_CONTEXT.md` ships inside the theme as the command reference an AI agent reads to operate the site. Four mutating examples still showed commands **without `--run-id`**, so an agent copying them after v0.15.0 hits the new preflight gate and fails.

## Changes

- `action execute` examples (compose write, generic, component-ID, the WP-CLI cheat-sheet line) now include `--run-id=<uuid>` and a one-line note: mutations need a completed INSPECT + a PREFLIGHT covering the target.
- The mutating `operate patch` example gains `--run-id=<uuid>`. The `--preview` example stays run-token-free (read-only).
- Patch bump 0.15.0 → 0.15.1 across the five synced files + CHANGELOG entry, so the corrected reference reaches the distributed theme (same pattern as v0.13.1).

No code change. Surfaced by `/document-release`'s doc-drift sweep after #96 landed.

## Note

`CHANGELOG.md` line 803 lists the old `EDIT, PREFLIGHT` loop order — that's a historical entry describing the loop as it shipped then, left intact per the no-rewrite-history rule. All current docs (README, operating-loop, playbooks, bootstrap) were updated in #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
