### PR TITLE
docs: explain the operating-loop mutation safety model (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ install, require it to work through `wp pp`, and gate production on a human read
 the HANDOFF report.
 
 → How to prompt your agent to use it safely: [docs/running-an-ai-agent.md](docs/running-an-ai-agent.md)
+→ Why a DB write can't land before the safety gate (the design): [docs/operating-loop-safety.md](docs/operating-loop-safety.md)
 
 ---
 

--- a/docs/operating-loop-safety.md
+++ b/docs/operating-loop-safety.md
@@ -1,0 +1,139 @@
+# 🔒 Operating-loop safety — why a DB write can't land before the safety gate
+
+When an AI agent operates a PromptingPress site, every change it makes to a page
+goes through a small set of typed commands. The danger is obvious once you say it
+out loud: an agent that writes to the database *before* anyone checks whether the
+write is safe can corrupt a live page, and you only find out after the fact.
+
+PromptingPress closes that trap with two cooperating mechanisms: a **run token**
+that enforces the order of operations, and a **preflight gate** that must pass,
+for the specific thing you're about to change, before any mutation is allowed.
+This is the design-rationale companion to the operator-facing
+[`ai-instructions/operating-loop.md`](../ai-instructions/operating-loop.md)
+contract. It explains the *why*; the contract is the *what*.
+
+> 💡 **The one rule:** a mutating command (`wp pp action execute`,
+> `wp pp operate patch`, `wp pp apply execute`) refuses to run until the run has a
+> completed **PREFLIGHT covering the exact target** it is about to change. Preview
+> commands stay read-only and need no run token at all.
+
+## 📖 The problem
+
+The operating loop has steps that read state and steps that change it. The
+mutating steps write DB-backed data: a page's composition (`_pp_composition`), its
+title, its publish status, and site-level design tokens.
+
+Before this gate existed, the loop let a typed action change a page's composition
+*before* `wp pp apply preflight` ran its safety checks (target resolution, drift
+detection, capability, surface classification, and the page-specific "does this
+post exist and have a composition" check). The documented loop even encoded the
+wrong order: it listed EDIT (the typed mutation) before PREFLIGHT (the gate). So a
+production page could be mutated, and only then would the gate that was supposed to
+protect it get a chance to object. By then the write had already landed.
+
+A naive fix makes it worse. "Require *any* completed preflight" sounds safe but
+isn't: if a preflight for post 4 (or a site-wide token preflight that names no
+post at all) could unlock a composition write to post 7, the gate would hand out a
+false pass for the exact case it exists to stop. Page edits need page-specific
+proof, not a blanket "some preflight happened."
+
+## 🛠️ The approach
+
+### The run token enforces order
+
+`wp pp operate inspect` mints a **run token** (a UUID v4) and writes a small JSON
+state file in the system temp dir. Every mutating command takes that token via
+`--run-id` and checks the recorded state before doing anything. INSPECT must come
+first; mutations come later. Out-of-order CLI calls are refused. The token is
+bound to a site identity (site URL + database + blog id) and expires after two
+hours, so a token from one install or an old session can't drive a mutation
+somewhere else.
+
+### Preflight records the target it covered
+
+When `wp pp apply preflight` passes, it doesn't just record "a preflight
+happened." It records **what the preflight covered**:
+
+- a specific `post_id` when you preflight a page (`--post_id=N`), or
+- the **site grain** when you preflight with no post (site-level work like
+  creating a page or changing a site option).
+
+A mutating action then asks a precise question through
+`pp_operate_preflight_covers()`: *is there a completed preflight covering my exact
+target?* The match is strict and refuses to weaken:
+
+- A page/section mutation on post N requires a preflight recorded for **post N**. A
+  site-grain preflight does **not** cover it.
+- A site mutation requires a **site-grain** preflight. A page preflight does not
+  cover it.
+
+That strictness is the whole point. A preflight for post 4 never unlocks a write
+to post 7, and a site preflight never quietly unlocks a page edit.
+
+### The loop runs PREFLIGHT before EDIT
+
+```
+INSPECT  →  PLAN  →  PREFLIGHT  →  EDIT  →  APPLY  →  SCREENSHOT  →  REVIEW  →  HANDOFF
+                     ^^^^^^^^^      ^^^^
+                     gate first     mutation second
+```
+
+The safety gate now sits in front of the mutating steps, not behind them. The
+typed action that changes the database only runs once a covering preflight is on
+record.
+
+### The unlock is recorded fail-closed, in one atomic write
+
+There's a subtle trap in recording the unlock. A mutating action unlocks on the
+recorded coverage alone, unlike `apply execute`, which also checks for a rollback
+snapshot. If the coverage were written first and a later required write (the
+rollback snapshot) failed, a run could end up *unlocked but unprotected*: the gate
+would pass even though the preflight command errored.
+
+So `pp_operate_record_preflight()` commits everything the successful preflight
+produces — the PREFLIGHT step, the target coverage, and the pre-apply rollback
+snapshot — inside a **single locked write**. The run gains the complete
+post-preflight state or none of it. Any failure leaves both the action gate and
+the apply gate fail-closed: no coverage recorded means no mutation unlocked.
+
+### Validate first, so errors point at the real problem
+
+A mutating action validates its parameters *before* it checks the gate. If you
+target a page that doesn't exist, you get "post N does not exist," not a confusing
+"go preflight a page that isn't there." The gate only demands a preflight for an
+action that would actually run.
+
+## ⚖️ Trade-offs (made on purpose)
+
+- **Operators run an extra step per page.** You must preflight each page
+  (`--post_id=N`) before editing it. That is friction, and it is the cost of the
+  page-specific guarantee. A blanket "any preflight" would remove the friction and
+  the protection together.
+- **Creating a page is a two-phase flow.** A brand-new page has no `post_id` to
+  preflight against, so page creation is site-scoped (covered by a site preflight).
+  If you then set its composition as a separate page-scoped step, you preflight
+  that new `post_id` first. Creating the page with its composition inline keeps it
+  to one site-scoped mutation.
+- **`operate patch` mutations now require a run token.** The mutating
+  `wp pp operate patch` path was previously callable standalone. It now needs
+  `--run-id` plus a covering preflight, the same as `action execute`. The
+  `--preview` path stays standalone and read-only. This is a deliberate breaking
+  change: the previously-ungated mutation was the hole.
+
+## 🔭 Out of scope (on purpose)
+
+- **Content freshness between preflight and mutation** ([#113](https://github.com/FJCF76/PromptingPress/issues/113)).
+  The gate proves *ordering* (a covering preflight ran first), not that the
+  composition still matches what preflight validated. Two actions after one
+  preflight, or a concurrent edit, can move the state. Single-operator run tokens
+  make this low-risk today; a content-hash freshness check is tracked separately.
+- **Finer-grained site-target coverage** ([#114](https://github.com/FJCF76/PromptingPress/issues/114)).
+  A no-post preflight covers all site-scoped actions for the run's lifetime. That
+  matches what `pp_preflight()` actually checks today; per-option coverage is a
+  future refinement.
+
+## 📚 Related
+
+- 🔁 The operating contract and command reference: [`ai-instructions/operating-loop.md`](../ai-instructions/operating-loop.md)
+- 🤖 How to prompt an agent to run your site safely: [running-an-ai-agent.md](running-an-ai-agent.md)
+- 🛡️ Why direct theme-file edits are blocked (the sibling file-safety system): [upgrade-safety.md](upgrade-safety.md)

--- a/docs/running-an-ai-agent.md
+++ b/docs/running-an-ai-agent.md
@@ -177,3 +177,4 @@ files and an agent that operates a site.
 - 🔁 The full loop and command reference: [`ai-instructions/operating-loop.md`](../ai-instructions/operating-loop.md)
 - 🧭 The site map and component/action list: [`AI_CONTEXT.md`](../AI_CONTEXT.md)
 - 🛡️ Why direct theme-file edits are blocked: [upgrade-safety.md](upgrade-safety.md)
+- 🔒 Why a DB write can't land before the safety gate: [operating-loop-safety.md](operating-loop-safety.md)


### PR DESCRIPTION
## What this does

Fills the one real Diataxis gap left after #96: there was no **Explanation** doc for the operating-loop mutation safety model. The how-tos (`running-an-ai-agent.md`, the playbooks) and the AI contract (`ai-instructions/operating-loop.md`) cover *what* to do; `upgrade-safety.md` explains the *file* safety system. This adds the missing "why" for the *mutation* safety system.

## Documentation Generated

| File | Quadrant | Description |
|------|----------|-------------|
| `docs/operating-loop-safety.md` | Explanation | Why a DB write can't land before the safety gate: the problem, run-token ordering, covering-preflight matching, fail-closed atomic recording, post-vs-site strictness, trade-offs, and the deferred #113/#114 |

Cross-linked both ways from `README.md` and `docs/running-an-ai-agent.md` (sibling of `upgrade-safety.md`).

## Notes

- **No code, no behavior change.** Generated by `/document-generate` after #96 shipped.
- **No version bump.** All five version files stay synced at 0.15.1; this additive contributor doc rides the next release rather than spawning a 0.15.2 just for a doc. `docs/` does ship in the theme zip, so it reaches the distributed theme with the next release.
- Accuracy gate: every claim traces to shipped code (`pp_operate_record_preflight`, `pp_operate_preflight_covers`, the loop reorder, `operate patch --run-id`). Links verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
