### PR TITLE
v0.16.0 feat: site logo safe surface via attachment ID (#106)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -114,7 +114,7 @@ site-customization permission.
 | grid      | components/grid/grid.php       | Responsive card grid for real content objects    | items[] (req) {title, text, image_url, link_url, link_text}, title, variant, theme, id |
 | table     | components/table/table.php     | Data/comparison table, horizontal scroll mobile  | headers[] (req), rows[][] (req), title, caption    |
 | cta       | components/cta/cta.php         | Call-to-action block. Layout + color + bg-image  | title (req), button_text (req), button_url (req), text, variant, theme, background_image, id |
-| nav       | components/nav/nav.php         | Site header, logo, hamburger mobile nav          | location, logo_text, logo_url, logo_alt            |
+| nav       | components/nav/nav.php         | Site header, logo, hamburger mobile nav          | location, logo_text, logo_id, logo_alt             |
 | footer    | components/footer/footer.php   | Site footer with nav menu and copyright          | location                                           |
 | stats     | components/stats/stats.php     | Horizontal row of large-number metrics + labels  | items[] (req) {number, label}, title, variant, background_image, id |
 | logos     | components/logos/logos.php     | Flex-wrap image grid — logo strips or icon tiles | items[] (req) {image_url, image_alt, label?}, title, variant, id |
@@ -138,7 +138,7 @@ If adding background-image support to another component, follow this exact patte
 
 **Hero:** Variants `left`, `centered`, `split` (inline image), `cover` (fullscreen background-image with overlay). Supports dual CTA buttons (`cta_text` + `cta2_text`); secondary renders as outline/ghost style. Composition props: `spacing` (compact/default/spacious), `width` (narrow/default/full), `split_ratio` (50-50/60-40/40-60, split variant only), `vertical_align` (top/center/bottom, cover and split only), `proof` (HTML string for trust signals like logos/ratings, rendered after CTA group). Hero content uses `--measure-centered` (56rem) as default max-width.
 
-**Nav:** Supports image logos via `logo_url` + `logo_alt`. Falls back to `logo_text` (text) when `logo_url` is empty.
+**Nav/Footer:** Supports image logos via `logo_id` (Media Library attachment ID, not a URL) + `logo_alt`. Resolution: `logo_id` prop → `pp_logo_id` site option → WP `custom_logo` theme-mod → `logo_text` (text) wordmark. Footer logo is opt-in via `show_logo` (default off). Set the site-wide logo through the `update_site_option` action with key `pp_logo_id`.
 
 **Grid:** Variants `default` (card grid), `steps` (numbered process steps with arrow connectors at desktop). `theme` controls background color independently of layout variant.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.0] — 2026-06-30 — Brand Book Fidelity: The Site Logo Is Now a Safe Surface
+
+**The site logo can finally be set the safe way: an attachment ID, validated server-side, rendered in the nav and (opt-in) the footer.** Until now the nav only accepted a raw `logo_url`, and there was no safe path for an AI agent to set the site-wide logo at all. You can now point the logo at a Media Library image by ID through the `update_site_option` action (`pp_logo_id`) or a component prop (`logo_id`), and it resolves the same way everywhere.
+
+Setting the logo by attachment ID closes a real gap. A logo set this way gets WordPress' own validation for free: the value must be an actual image attachment, so a PDF, a video, a bogus ID, or a pasted URL is rejected at write time with a clear message instead of silently producing a broken or unsafe `<img>`. Resolution falls back gracefully: the explicit `logo_id`, then the `pp_logo_id` site option, then WordPress' native `custom_logo`, then the text wordmark. Alt text comes from the attachment's own metadata when you don't set it.
+
+The footer can now carry the logo too, opt-in via `show_logo` so existing footers are untouched. Both nav and footer share one resolver, so the fallback chain and alt handling never drift between them.
+
+### Itemized changes
+
+**Added**
+- `pp_logo_id` site option (Media Library attachment ID) settable through the `update_site_option` action — the safe surface for the site-wide logo.
+- `logo_id` prop on `nav` and `footer`; `show_logo` opt-in on `footer` (default off).
+- Server-side validation: a logo value must resolve to a real image attachment, rejected with a clear error otherwise.
+- Graceful resolution: explicit `logo_id` → `pp_logo_id` option → WordPress `custom_logo` → text wordmark, with alt text from attachment metadata.
+
+**Changed**
+- The logo input is now an attachment ID, never a raw URL. The old literal `logo_url` prop is gone; an arbitrary URL can no longer reach the logo `<img src>`.
+- The site-option allowlist is a single source of truth (`pp_allowed_site_options`) shared by every read and write path.
+
+**For contributors**
+- New `pp_allowed_site_options()`, `pp_validate_site_option_value()`, and `pp_resolve_logo()` in `lib/wp.php`; `tests/LogoTest.php` (21 cases) covers validation, the write path, the action, resolution, and footer gating.
+
 ## [v0.15.1] — 2026-06-29 — Docs: AI Command Reference Now Shows the Run Token Mutations Require
 
 **Patch release so the theme's AI-facing command reference matches the v0.15.0 gate.** No code change.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.15.1-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -44,7 +44,7 @@ See `AI_CONTEXT.md` → Component index for the current list. As of last update:
 | grid    | items[] {title, text, ...}              | title, variant, theme                                   |
 | table   | headers[], rows[][]                     | title, caption                                          |
 | cta     | title, button_text, button_url          | text, variant, theme, background_image                  |
-| nav     | (no required props)                     | logo_text, logo_url, logo_alt                           |
+| nav     | (no required props)                     | logo_text, logo_id, logo_alt                            |
 | footer  | (no required props)                     | location                                                |
 | stats   | items[] {number, label}                 | title, variant, background_image                        |
 | logos   | items[] {image_url, image_alt}          | title, variant                                          |

--- a/components/footer/footer.php
+++ b/components/footer/footer.php
@@ -8,12 +8,28 @@
  * @var array $props
  */
 
-$id       = $props['id']       ?? '';
-$location = $props['location'] ?? 'footer';
-$year     = wp_date('Y');
+$id        = $props['id']        ?? '';
+$location  = $props['location']  ?? 'footer';
+$show_logo = !empty($props['show_logo']); // default OFF — opt-in only
+$logo      = $show_logo ? pp_resolve_logo($props) : null; // {type, url, alt, text}
+$year      = wp_date('Y');
 ?>
 <footer<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="site-footer" data-pp-component="footer">
     <div class="container site-footer__inner">
+
+        <?php if ($logo) : ?>
+            <a class="site-footer__logo" href="<?php echo esc_url(pp_site_url()); ?>">
+                <?php if ($logo['type'] === 'image') : ?>
+                    <img
+                        src="<?php echo esc_url($logo['url']); ?>"
+                        alt="<?php echo esc_attr($logo['alt']); ?>"
+                        class="site-footer__logo-image"
+                    >
+                <?php else : ?>
+                    <?php echo esc_html($logo['text']); ?>
+                <?php endif; ?>
+            </a>
+        <?php endif; ?>
 
         <div class="site-footer__nav">
             <?php pp_nav_menu($location); ?>

--- a/components/footer/schema.json
+++ b/components/footer/schema.json
@@ -7,6 +7,30 @@
       "required": false,
       "default": "footer",
       "description": "WP theme location slug for the footer nav menu."
+    },
+    "show_logo": {
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "description": "Opt-in: render the site logo in the footer. Defaults OFF so existing footers are unchanged. When true, uses the same resolution as the nav logo."
+    },
+    "logo_text": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Footer logo text wordmark (only when show_logo is true). Falls back to pp_site_title() when empty."
+    },
+    "logo_id": {
+      "type": "number",
+      "required": false,
+      "default": 0,
+      "description": "Media Library attachment ID for the footer logo image (NOT a URL; only when show_logo is true). Same resolution as nav: this prop, then the pp_logo_id site option, then the WP custom_logo theme-mod."
+    },
+    "logo_alt": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Alt text for the footer logo image. Defaults to the attachment's own alt metadata, then logo_text/site title."
     }
   },
   "styling": {

--- a/components/nav/nav.php
+++ b/components/nav/nav.php
@@ -10,25 +10,23 @@
  * @var array $props
  */
 
-$id        = $props['id']        ?? '';
-$location  = $props['location']  ?? 'primary';
-$logo_text = $props['logo_text'] ?? pp_site_title();
-$logo_url  = $props['logo_url']  ?? '';
-$logo_alt  = $props['logo_alt']  ?? $logo_text;
+$id       = $props['id']       ?? '';
+$location = $props['location'] ?? 'primary';
+$logo     = pp_resolve_logo($props); // {type, url, alt, text} — attachment-ID only
 ?>
 <header<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="site-header" data-pp-component="nav">
     <nav class="nav" aria-label="Main navigation">
         <div class="container nav__container">
 
             <a class="nav__logo" href="<?php echo esc_url(pp_site_url()); ?>">
-                <?php if ($logo_url) : ?>
+                <?php if ($logo['type'] === 'image') : ?>
                     <img
-                        src="<?php echo esc_url($logo_url); ?>"
-                        alt="<?php echo esc_attr($logo_alt); ?>"
+                        src="<?php echo esc_url($logo['url']); ?>"
+                        alt="<?php echo esc_attr($logo['alt']); ?>"
                         class="nav__logo-image"
                     >
                 <?php else : ?>
-                    <?php echo esc_html($logo_text); ?>
+                    <?php echo esc_html($logo['text']); ?>
                 <?php endif; ?>
             </a>
 

--- a/components/nav/schema.json
+++ b/components/nav/schema.json
@@ -12,19 +12,19 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Logo text. Falls back to pp_site_title() when empty. Ignored when logo_url is set."
+      "description": "Logo text wordmark. Falls back to pp_site_title() when empty. Shown when no logo image resolves."
     },
-    "logo_url": {
-      "type": "string",
+    "logo_id": {
+      "type": "number",
       "required": false,
-      "default": "",
-      "description": "Logo image URL. When set, renders an img tag instead of text. Falls back to logo_text if empty."
+      "default": 0,
+      "description": "Media Library attachment ID for the logo image (NOT a URL). When it resolves to an image, renders an img tag instead of the text wordmark. Resolution order: this prop, then the pp_logo_id site option, then the WP custom_logo theme-mod."
     },
     "logo_alt": {
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Alt text for the logo image. Defaults to logo_text if empty."
+      "description": "Alt text for the logo image. Defaults to the attachment's own alt metadata, then logo_text/site title."
     }
   },
   "styling": {

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.15.1');
+define('PP_VERSION', '0.16.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -233,22 +233,22 @@ pp_register_action('create_page', [
 ]);
 
 // ── Action: update_site_option ──────────────────────────────────────────────
-// Scope: site | Semantics: replace. Only blogname, blogdescription
+// Scope: site | Semantics: replace. Whitelist: pp_allowed_site_options()
 
 pp_register_action('update_site_option', [
     'scope'       => 'site',
-    'description' => 'Updates a whitelisted WordPress site option (blogname or blogdescription).',
-    'semantics'   => 'Replace. Key must be whitelisted (blogname, blogdescription). Value replaces entirely.',
+    'description' => 'Updates a whitelisted WordPress site option (blogname, blogdescription, pp_logo_id, pp_logo_alt). pp_logo_id takes a Media Library attachment ID (not a URL) to set the site logo.',
+    'semantics'   => 'Replace. Key must be whitelisted. Value replaces entirely and is validated against the key type (pp_logo_id must be an attachment ID).',
     'params'      => [
         'key'   => ['type' => 'string', 'required' => true],
         'value' => ['type' => 'string', 'required' => true],
     ],
     'validate' => function (array $params) {
-        $allowed = ['blogname', 'blogdescription'];
-        if (!in_array($params['key'], $allowed, true)) {
-            return new WP_Error('invalid_option', sprintf('Option "%s" is not whitelisted. Allowed: %s.', $params['key'], implode(', ', $allowed)));
+        $allowed = pp_allowed_site_options();
+        if (!isset($allowed[$params['key']])) {
+            return new WP_Error('invalid_option', sprintf('Option "%s" is not whitelisted. Allowed: %s.', $params['key'], implode(', ', array_keys($allowed))));
         }
-        return true;
+        return pp_validate_site_option_value($params['key'], (string) $params['value']);
     },
     'preview' => function (array $params): array {
         $current = pp_site_option($params['key']);

--- a/lib/ai-chat.php
+++ b/lib/ai-chat.php
@@ -321,7 +321,8 @@ function _pp_validate_media_urls_in_params(array $params) {
  */
 function _pp_extract_urls_from_params(array $params): array {
     $urls = [];
-    $url_props = ['image_url', 'background_image', 'logo_url'];
+    // logo_id is an attachment ID, not a URL — excluded from URL extraction.
+    $url_props = ['image_url', 'background_image'];
 
     // Direct props (flat)
     if (isset($params['props']) && is_array($params['props'])) {

--- a/lib/ai-context.php
+++ b/lib/ai-context.php
@@ -181,7 +181,7 @@ function pp_ai_system_prompt(): string {
     $parts[] = '  - section (layout: "image-left" or "image-right"): `image_url` + `image_alt`';
     $parts[] = '  - grid items (default variant only): `items[].image_url` + `items[].image_alt`';
     $parts[] = '  - logos items: `items[].image_url` + `items[].image_alt`';
-    $parts[] = '  - nav: `logo_url` + `logo_alt`';
+    $parts[] = '  - nav/footer: `logo_id` (Media Library attachment ID, not a URL) + `logo_alt`';
     $parts[] = '- Background images (no `image_alt` needed):';
     $parts[] = '  - hero (variant: "cover"): `image_url` rendered as CSS background-image';
     $parts[] = '  - section: `background_image`';
@@ -356,8 +356,9 @@ function _pp_summarize_component(array $item, ?array $inspect_target = null): st
         $parts[] = "title: \"{$title}\"";
     }
 
-    // Image filename (key for image-bearing components)
-    foreach (['image_url', 'background_image', 'logo_url'] as $img_prop) {
+    // Image filename (key for image-bearing components). logo_id is an
+    // attachment ID, not a URL, so it is not a basename source here.
+    foreach (['image_url', 'background_image'] as $img_prop) {
         if (!empty($props[$img_prop])) {
             $parts[] = basename($props[$img_prop]);
             break;

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -877,18 +877,101 @@ function pp_set_font_urls(array $urls): bool {
 }
 
 /**
+ * Single source of truth for the site-option whitelist (a security boundary —
+ * the only WP options the AI/CLI surface may read or write). Maps each allowed
+ * key to its value type, used for server-side validation on write.
+ *
+ * Types: 'string' (free text) | 'attachment_id' (a positive int that resolves
+ * to a Media Library attachment — never a raw URL).
+ *
+ * @return array<string,string>  key => type
+ */
+function pp_allowed_site_options(): array {
+    return [
+        'blogname'        => 'string',
+        'blogdescription' => 'string',
+        'pp_logo_id'      => 'attachment_id',
+        'pp_logo_alt'     => 'string',
+    ];
+}
+
+/**
+ * Validates a site-option value against its declared type.
+ *
+ * @param string $key    Whitelisted option key (caller has already checked membership).
+ * @param string $value  Proposed value.
+ * @return true|WP_Error
+ */
+function pp_validate_site_option_value(string $key, string $value) {
+    $type = pp_allowed_site_options()[$key] ?? null;
+    if ($type === 'attachment_id') {
+        $id = (int) $value;
+        if ($id <= 0 || get_post_type($id) !== 'attachment' || !wp_attachment_is_image($id)) {
+            return new WP_Error('invalid_option_value', sprintf(
+                'Option "%s" requires a Media Library image attachment ID, got "%s".',
+                $key, $value
+            ));
+        }
+    }
+    return true;
+}
+
+/**
  * Returns a whitelisted WordPress option value.
- * Only allows: blogname, blogdescription.
+ * Whitelist is the single source pp_allowed_site_options().
  *
  * @param string $key  Option name (must be whitelisted).
  * @return string|WP_Error  Option value, or WP_Error if key not whitelisted.
  */
 function pp_site_option(string $key) {
-    $allowed = ['blogname', 'blogdescription'];
-    if (!in_array($key, $allowed, true)) {
+    if (!isset(pp_allowed_site_options()[$key])) {
         return new WP_Error('invalid_option', sprintf('Option "%s" is not whitelisted.', $key));
     }
     return (string) get_option($key, '');
+}
+
+/**
+ * Resolves the site logo for a nav/footer component into a render-ready shape.
+ * Attachment-ID only — never accepts a raw URL as input. The returned `url` is
+ * an OUTPUT, resolved from the attachment ID for the <img src>.
+ *
+ * Resolution order: explicit `logo_id` prop → `pp_logo_id` site option (the
+ * AI/CLI safe surface) → WP `custom_logo` theme-mod → text wordmark.
+ *
+ * Alt resolution: explicit `logo_alt` → the attachment's own alt metadata →
+ * the wordmark text. (In nav/footer the logo replaces the text wordmark, so a
+ * meaningful alt is correct; an empty decorative alt would only apply if a
+ * layout rendered both the image AND the visible site title together.)
+ *
+ * @param array $props  Component props (logo_id, logo_alt, logo_text).
+ * @return array{type:string,url:string,alt:string,text:string}
+ *         type is 'image' when an attachment resolved to a URL, else 'text'.
+ */
+function pp_resolve_logo(array $props): array {
+    $text = $props['logo_text'] ?? pp_site_title();
+
+    $id = 0;
+    if (!empty($props['logo_id'])) {
+        $id = (int) $props['logo_id'];
+    } elseif (($opt = get_option('pp_logo_id', '')) !== '') {
+        $id = (int) $opt;
+    } elseif (($mod = get_theme_mod('custom_logo')) !== false && $mod) {
+        $id = (int) $mod;
+    }
+
+    if ($id > 0) {
+        $url = wp_get_attachment_image_url($id, 'full');
+        if ($url) {
+            $alt = $props['logo_alt'] ?? '';
+            if ($alt === '') {
+                $meta_alt = (string) get_post_meta($id, '_wp_attachment_image_alt', true);
+                $alt = $meta_alt !== '' ? $meta_alt : $text;
+            }
+            return ['type' => 'image', 'url' => $url, 'alt' => $alt, 'text' => $text];
+        }
+    }
+
+    return ['type' => 'text', 'url' => '', 'alt' => $props['logo_alt'] ?? $text, 'text' => $text];
 }
 
 // ── Site-state write functions (persistence wrappers) ────────────────────────
@@ -971,16 +1054,24 @@ function pp_publish_page(int $post_id) {
 
 /**
  * Updates a whitelisted WordPress option.
- * Only allows: blogname, blogdescription.
+ * Whitelist is the single source pp_allowed_site_options(); value is validated
+ * against the key's declared type (e.g. pp_logo_id must be an attachment ID).
  *
  * @param string $key    Option name (must be whitelisted).
  * @param string $value  New option value.
  * @return true|WP_Error
  */
 function pp_update_site_option(string $key, string $value) {
-    $allowed = ['blogname', 'blogdescription'];
-    if (!in_array($key, $allowed, true)) {
+    if (!isset(pp_allowed_site_options()[$key])) {
         return new WP_Error('invalid_option', sprintf('Option "%s" is not whitelisted.', $key));
+    }
+    $valid = pp_validate_site_option_value($key, $value);
+    if (is_wp_error($valid)) {
+        return $valid;
+    }
+    // Normalize attachment IDs to a canonical integer string on store.
+    if ((pp_allowed_site_options()[$key] ?? null) === 'attachment_id') {
+        $value = (string) (int) $value;
     }
     update_option($key, $value);
     return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.15.1
+Stable tag: 0.16.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.15.1
+Version:          0.16.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/LogoTest.php
+++ b/tests/LogoTest.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * tests/LogoTest.php
+ *
+ * PR1 (#106) — logo safe surface: site-option whitelist + attachment-id
+ * validation (pp_allowed_site_options / pp_validate_site_option_value /
+ * pp_update_site_option / update_site_option action) and the shared logo
+ * resolver (pp_resolve_logo). Attachment-ID only — never a URL.
+ */
+
+declare(strict_types=1);
+
+namespace PromptingPress\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class LogoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['_pp_test_store'] = [
+            'post_meta'           => [],
+            'posts'               => [],
+            'options'             => [],
+            'theme_mods'          => [],
+            'attachment_urls'     => [],
+            'attachment_is_image' => [],
+            'next_id'             => 100,
+        ];
+    }
+
+    /** Seed a Media Library image attachment with a resolvable URL and optional alt. */
+    private function seedAttachment(int $id, string $url, string $alt = '', bool $isImage = true): void
+    {
+        $GLOBALS['_pp_test_store']['posts'][$id] = ['post_type' => 'attachment'];
+        $GLOBALS['_pp_test_store']['attachment_urls'][$id] = $url;
+        $GLOBALS['_pp_test_store']['attachment_is_image'][$id] = $isImage;
+        if ($alt !== '') {
+            $GLOBALS['_pp_test_store']['post_meta'][$id]['_wp_attachment_image_alt'] = $alt;
+        }
+    }
+
+    // ── Whitelist single source ─────────────────────────────────────────────
+
+    public function testAllowedSiteOptionsIncludesLogoKeys(): void
+    {
+        $allowed = pp_allowed_site_options();
+        $this->assertArrayHasKey('blogname', $allowed);
+        $this->assertArrayHasKey('blogdescription', $allowed);
+        $this->assertSame('attachment_id', $allowed['pp_logo_id']);
+        $this->assertSame('string', $allowed['pp_logo_alt']);
+    }
+
+    public function testSiteOptionAcceptsLogoIdKey(): void
+    {
+        update_option('pp_logo_id', '42');
+        $this->assertSame('42', pp_site_option('pp_logo_id'));
+    }
+
+    // ── Value validation (attachment-id only) ───────────────────────────────
+
+    public function testValidateAcceptsRealAttachmentId(): void
+    {
+        $this->seedAttachment(42, 'https://example.com/logo.png');
+        $this->assertTrue(pp_validate_site_option_value('pp_logo_id', '42'));
+    }
+
+    public function testValidateRejectsNonAttachmentId(): void
+    {
+        // ID 7 exists but is a page, not an attachment.
+        $GLOBALS['_pp_test_store']['posts'][7] = ['post_type' => 'page'];
+        $result = pp_validate_site_option_value('pp_logo_id', '7');
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertStringContainsString('attachment', $result->get_error_message());
+    }
+
+    public function testValidateRejectsZeroAndNonNumericLogoId(): void
+    {
+        $this->assertInstanceOf(\WP_Error::class, pp_validate_site_option_value('pp_logo_id', '0'));
+        $this->assertInstanceOf(\WP_Error::class, pp_validate_site_option_value('pp_logo_id', 'https://evil.test/x.png'));
+    }
+
+    public function testValidateRejectsNonImageAttachment(): void
+    {
+        // ID 8 is an attachment but not an image (e.g. a PDF/video).
+        $this->seedAttachment(8, 'https://example.com/doc.pdf', '', false);
+        $result = pp_validate_site_option_value('pp_logo_id', '8');
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertStringContainsString('image', $result->get_error_message());
+    }
+
+    public function testValidateStringTypePassesThrough(): void
+    {
+        $this->assertTrue(pp_validate_site_option_value('pp_logo_alt', 'Acme logo'));
+        $this->assertTrue(pp_validate_site_option_value('blogname', 'Anything'));
+    }
+
+    // ── pp_update_site_option ───────────────────────────────────────────────
+
+    public function testUpdateRejectsNonAttachmentLogoId(): void
+    {
+        $result = pp_update_site_option('pp_logo_id', '999'); // 999 not in store
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertArrayNotHasKey('pp_logo_id', $GLOBALS['_pp_test_store']['options']);
+    }
+
+    public function testUpdateAcceptsValidAttachmentLogoId(): void
+    {
+        $this->seedAttachment(55, 'https://example.com/brand.png');
+        $this->assertTrue(pp_update_site_option('pp_logo_id', '55'));
+        $this->assertSame('55', get_option('pp_logo_id'));
+    }
+
+    public function testUpdateNormalizesStoredAttachmentId(): void
+    {
+        $this->seedAttachment(7, 'https://example.com/seven.png');
+        $this->assertTrue(pp_update_site_option('pp_logo_id', '007'));
+        $this->assertSame('7', get_option('pp_logo_id')); // normalized to canonical int string
+    }
+
+    public function testUpdateRejectsUnwhitelistedKey(): void
+    {
+        $result = pp_update_site_option('admin_email', 'x@y.test');
+        $this->assertInstanceOf(\WP_Error::class, $result);
+    }
+
+    // ── update_site_option action (validate path) ───────────────────────────
+
+    public function testActionRejectsNonAttachmentLogoIdWithClearMessage(): void
+    {
+        $result = pp_execute_action('update_site_option', ['key' => 'pp_logo_id', 'value' => '404']);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('attachment', $result['error']);
+    }
+
+    public function testActionAcceptsValidAttachmentLogoId(): void
+    {
+        $this->seedAttachment(88, 'https://example.com/logo2.png');
+        $result = pp_execute_action('update_site_option', ['key' => 'pp_logo_id', 'value' => '88']);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('88', get_option('pp_logo_id'));
+    }
+
+    // ── pp_resolve_logo ─────────────────────────────────────────────────────
+
+    public function testResolveLogoFromPropId(): void
+    {
+        $this->seedAttachment(10, 'https://example.com/a.png', 'Brand A');
+        $logo = pp_resolve_logo(['logo_id' => 10, 'logo_text' => 'Site']);
+        $this->assertSame('image', $logo['type']);
+        $this->assertSame('https://example.com/a.png', $logo['url']);
+        $this->assertSame('Brand A', $logo['alt']); // attachment alt metadata
+    }
+
+    public function testResolveLogoExplicitAltWins(): void
+    {
+        $this->seedAttachment(10, 'https://example.com/a.png', 'Meta Alt');
+        $logo = pp_resolve_logo(['logo_id' => 10, 'logo_alt' => 'Explicit Alt']);
+        $this->assertSame('Explicit Alt', $logo['alt']);
+    }
+
+    public function testResolveLogoAltFallsBackToText(): void
+    {
+        $this->seedAttachment(10, 'https://example.com/a.png'); // no alt meta
+        $logo = pp_resolve_logo(['logo_id' => 10, 'logo_text' => 'Wordmark']);
+        $this->assertSame('Wordmark', $logo['alt']);
+    }
+
+    public function testResolveLogoFromSiteOption(): void
+    {
+        $this->seedAttachment(20, 'https://example.com/opt.png');
+        update_option('pp_logo_id', '20');
+        $logo = pp_resolve_logo(['logo_text' => 'Site']);
+        $this->assertSame('image', $logo['type']);
+        $this->assertSame('https://example.com/opt.png', $logo['url']);
+    }
+
+    public function testResolveLogoFromCustomLogoThemeMod(): void
+    {
+        $this->seedAttachment(30, 'https://example.com/mod.png');
+        $GLOBALS['_pp_test_store']['theme_mods']['custom_logo'] = 30;
+        $logo = pp_resolve_logo(['logo_text' => 'Site']);
+        $this->assertSame('image', $logo['type']);
+        $this->assertSame('https://example.com/mod.png', $logo['url']);
+    }
+
+    public function testResolvePrecedencePropBeatsOptionBeatsThemeMod(): void
+    {
+        $this->seedAttachment(1, 'https://example.com/prop.png');
+        $this->seedAttachment(2, 'https://example.com/opt.png');
+        $this->seedAttachment(3, 'https://example.com/mod.png');
+        update_option('pp_logo_id', '2');
+        $GLOBALS['_pp_test_store']['theme_mods']['custom_logo'] = 3;
+
+        $this->assertSame('https://example.com/prop.png', pp_resolve_logo(['logo_id' => 1])['url']);
+        $this->assertSame('https://example.com/opt.png', pp_resolve_logo([])['url']);
+    }
+
+    public function testResolveTextWhenNoLogoAnywhere(): void
+    {
+        $logo = pp_resolve_logo(['logo_text' => 'Just Text']);
+        $this->assertSame('text', $logo['type']);
+        $this->assertSame('', $logo['url']);
+        $this->assertSame('Just Text', $logo['text']);
+    }
+
+    public function testResolveTextWhenAttachmentHasNoUrl(): void
+    {
+        // ID is an attachment in the store but has no resolvable URL.
+        $GLOBALS['_pp_test_store']['posts'][9] = ['post_type' => 'attachment'];
+        $logo = pp_resolve_logo(['logo_id' => 9, 'logo_text' => 'Fallback']);
+        $this->assertSame('text', $logo['type']);
+        $this->assertSame('Fallback', $logo['text']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -476,7 +476,33 @@ if (!function_exists('get_post')) {
 }
 
 if (!function_exists('get_post_type')) {
-    function get_post_type($post = null): string { return 'page'; }
+    // Store-aware: an ID present in the posts store returns its post_type
+    // (e.g. 'attachment' for logo tests); unknown IDs default to 'page'.
+    function get_post_type($post = null): string {
+        if (is_int($post) || (is_string($post) && ctype_digit($post))) {
+            $id = (int) $post;
+            return $GLOBALS['_pp_test_store']['posts'][$id]['post_type'] ?? 'page';
+        }
+        return 'page';
+    }
+}
+
+if (!function_exists('get_theme_mod')) {
+    function get_theme_mod(string $name, $default = false) {
+        return $GLOBALS['_pp_test_store']['theme_mods'][$name] ?? $default;
+    }
+}
+
+if (!function_exists('wp_get_attachment_image_url')) {
+    function wp_get_attachment_image_url($attachment_id, $size = 'thumbnail', $icon = false) {
+        return $GLOBALS['_pp_test_store']['attachment_urls'][(int) $attachment_id] ?? false;
+    }
+}
+
+if (!function_exists('wp_attachment_is_image')) {
+    function wp_attachment_is_image($attachment_id = null): bool {
+        return !empty($GLOBALS['_pp_test_store']['attachment_is_image'][(int) $attachment_id]);
+    }
 }
 
 if (!function_exists('get_page_template_slug')) {


### PR DESCRIPTION
## What this ships (#106)

The site logo is now a safe surface. An AI agent or operator can set the site-wide logo by **Media Library attachment ID** — never a raw URL — and it renders in the nav and (opt-in) the footer.

### Capability
- **Set the logo** via the `update_site_option` action with key `pp_logo_id` (an attachment ID), or per-component with the `logo_id` prop on `nav`/`footer`.
- **Footer logo** is opt-in via `show_logo` (default off) — existing footers are unchanged.
- **Resolution fallback:** explicit `logo_id` → `pp_logo_id` site option → WordPress `custom_logo` theme-mod → text wordmark. Alt text derives from the attachment's metadata when not set.

### Security / contract
- Input is an attachment ID, validated server-side to be a real **image** attachment. A PDF, video, bogus ID, or pasted URL is rejected at write time with a clear message.
- The old literal `logo_url` prop is **removed** — an arbitrary URL can no longer reach the logo `<img src>`. Migrated the 4 internal `logo_url` references (`nav.php`, `nav/schema.json`, `lib/ai-context.php`, `lib/ai-chat.php`); `logo_id` is correctly kept out of the URL-resolution lists (it needs ID→URL resolution).
- The site-option allowlist is now a single source of truth (`pp_allowed_site_options`) shared by every read/write/action path.

### New API surface
- `pp_allowed_site_options()`, `pp_validate_site_option_value()`, `pp_resolve_logo()` in `lib/wp.php`.

## Tests
- `tests/LogoTest.php` — 21 cases: image/non-image/bogus/URL validation, normalized write path, the `update_site_option` action, the full resolution chain, footer gating, nav render.
- Full suite green: **PHP 788/788, JS 262/262.**

## Verification
- Reviewed clean via `/review` (0 critical; 2 informational found + fixed: require image attachment, normalize stored ID).
- Dev-smoke-tested on https://dev.promptingpress.com: logo renders in nav from the attachment URL, footer logo absent by default, non-image/bogus IDs rejected, no public `logo_url` path, all published pages + admin load 200 with zero new PHP fatals.

## Build order
First of four PRs in the Brand Book Fidelity sprint (PR1 → PR4 closed-set validation → PR2 section header → PR3 faq/stats slots).
