### PR TITLE
docs: agent implementation scaffold (issue template, ordered queue #141, recipes)

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-order.md
+++ b/.github/ISSUE_TEMPLATE/work-order.md
@@ -1,0 +1,52 @@
+---
+name: Work order (bug or enhancement)
+about: A self-contained issue an AI agent can implement without broad repo context
+title: ""
+labels: []
+---
+
+<!--
+Fill EVERY section. The goal is an issue that another agent can implement in isolation.
+After filing, a maintainer adds status/area/size labels and a place in #141 (the ordered queue).
+Reference exact files/functions/symbols, NOT line numbers (they drift).
+-->
+
+## Type
+<!-- bug (implementation defect) or enhancement (missing/incomplete functionality) -->
+
+## Current behavior
+<!-- What happens today. Cite the exact file + function/symbol. -->
+
+## Expected behavior
+<!-- What should happen. -->
+
+## Evidence in code
+<!-- File paths + function/component names + the specific lines of logic (quote them). -->
+
+## Root cause hypothesis
+<!-- Why it behaves this way. -->
+
+## User / product impact
+<!-- Who is affected and how. -->
+
+## Invariants this change must preserve
+<!-- e.g. only lib/wp.php calls WordPress functions; the {};<> style-slot injection guard;
+     components auto-load by convention; actions follow validate/preview/execute. -->
+
+## Fix plan
+<!-- Concrete steps. -->
+
+## depends-on
+<!-- List issue numbers that must land first, e.g. "depends-on: #119, #99". Used to derive #141. -->
+
+## Acceptance criteria
+<!-- Observable, testable conditions for "done". -->
+
+## Suggested tests
+<!-- Unit / integration / E2E, with the file they belong in (PHPUnit tests/, vitest tests/js/, playwright tests/e2e/). -->
+
+## Verify with
+<!-- The exact command that proves the fix, e.g. `composer test`, `npm test`, or a `wp pp ...` invocation. -->
+
+## Security surface
+<!-- None, or describe the threat (injection, SSRF, XSS, capability bypass) and the mitigation. -->

--- a/docs/AI_IMPLEMENTATION_RECIPES.md
+++ b/docs/AI_IMPLEMENTATION_RECIPES.md
@@ -1,0 +1,95 @@
+# AI Implementation Recipes
+
+Repeatable patterns for the most common change types in this backlog, plus the load-bearing invariants every change must preserve. If an issue says "add a style slot / add an action / add a smell," follow the matching recipe rather than reverse-engineering it.
+
+> Read this alongside `AI_CONTEXT.md`, `AI_RULES.md`, and the pinned queue **#141** / `docs/IMPLEMENTATION_ORDER.md`. Work issues in the queue order; run the full suite green between issues.
+
+---
+
+## Load-bearing invariants (do not break these)
+
+1. **Only `lib/wp.php` calls WordPress functions directly.** Templates and components call `pp_*` wrappers. If you need a new WP capability in a component/template, add a `pp_*` wrapper in `lib/wp.php` and call that.
+2. **Components auto-load by convention:** `components/{name}/{name}.php` + `components/{name}/schema.json`. No registration. Do not edit `lib/components.php` (the loader contract).
+3. **Actions/applies follow the contract:** `name`, `scope`/`domain`, `description`, `params`, and `validate` / `preview` (never writes) / `execute`|`apply` callables returning the canonical result shape. See `lib/actions.php` / `lib/apply.php`.
+4. **Style-slot & token values are injection-guarded:** every value that becomes CSS passes the `{};<>` guard (`_pp_validate_token_value` in `lib/apply.php`, mirrored in `pp_render_style_vars` in `lib/wp.php`). Never render a raw slot value.
+5. **Escaping at output:** `esc_html` for text, `esc_url` for URLs, `esc_attr` for attributes, `wp_kses_post` for rich HTML fields. Do not widen `esc_url` protocols globally.
+6. **Composition is stored as a JSON string** in `_pp_composition` post meta. Read via `pp_get_composition($post_id)` (it decodes and tolerates array fixtures) — never `get_post_meta(...)` + `is_array()` (that was bug #119).
+7. **Capabilities:** mutations must check the right capability for their scope. The AJAX execute path is `edit_posts`-only today and under-gated — see #131; do not copy that pattern.
+8. **Preserve the file-vs-composition authority model.** Presentation changes go through tokens / style slots / composition, not ad hoc CSS in core files.
+
+---
+
+## Recipe A — Add a per-instance style slot to a component
+
+Used by: #99, #100, #108, #111, #61 (and the #99 scaffold issue defines the reusable path).
+
+1. **Schema:** in `components/{name}/schema.json`, add under `styling.style_slots`:
+   ```json
+   "--{name}-{slot}": { "type": "color|length|number|duration|font-family|shadow|gradient", "default": "<css>", "description": "<what it controls>" }
+   ```
+2. **Validation is automatic** for known types via `_pp_validate_token_value()` (`lib/apply.php`) — but if you introduce a *new* type (e.g. `gradient`, #99), add its validator there and to the `switch` in `_pp_validate_token_value`, keeping the `{};<>` guard and a positive-pattern grammar (see `_pp_validate_length` clamp/calc handling as the model). Reject `var()`/`url()`/`env()` unless explicitly allowlisted.
+3. **Render:** the slot is emitted by `pp_render_style_vars($props['__pp_style'] ?? [], '{name}')` in `components/{name}/{name}.php` (already wired for hero/section/grid/cta; add the call for components that lack it). Reference the CSS var in `assets/css/components.css` with a fallback: `color: var(--{name}-{slot}, var(--color-text));`
+4. **Do not** hardcode a color that beats the slot (that is bug #61 for `.faq__heading`). If a hardcoded rule exists, relax it so the slot wins.
+5. **Test:** `tests/ComponentPropsTest.php` — assert the schema declares the slot with `type`+`default`; a render test asserts setting the slot emits the inline `--{name}-{slot}: <value>`; a negative test asserts an injection value (`}<script>`) is dropped.
+6. **Verify:** `composer test`.
+
+---
+
+## Recipe B — Add an action or apply
+
+Used by: #132 (menus), #134 (slug), #105 (import media), #122, #133.
+
+1. In `lib/actions.php` (DB/WP mutations) or `lib/apply.php` (file/option mutations), call `pp_register_action('name', [...])` / `pp_register_apply(...)` with:
+   - `scope` (`site`|`page`|`section`) or `domain`; `description`; `params` (`['type'=>'int|string|array|bool','required'=>bool]`);
+   - `validate(array $params): true|WP_Error` — semantic checks only (structural type checks are automatic);
+   - `preview(array $params): array` — compute before/after via `_pp_action_preview(...)`, **never write**;
+   - `execute`/`apply(array $params): array` — do the write, return `_pp_action_result(...)` / `_pp_action_error(...)`.
+2. **All WP calls go through a `pp_*` wrapper in `lib/wp.php`** (add one if missing) — do not call `wp_*` directly from the action closure except through those wrappers already used there.
+3. **Capability:** if this is reachable from the AJAX chat path, ensure the (post-#131) capability check covers it. Page/section → `edit_post` on the post; site → `manage_options`; publish → `publish_pages`.
+4. **Register editable fields** (only if the action edits component props addressable by selector) in `lib/operate.php` `pp_register_component_fields()` — and **every field name must exist in that component's `schema.json`** (drift is bug #120/#85). Add the assertion test.
+5. **Surface in the AI prompt:** actions/applies auto-appear in `pp_ai_system_prompt()` (`lib/ai-context.php`) via the registry — no extra step, but verify the `description` is accurate.
+6. **CLI:** if operators need it, add a subcommand in `lib/cli.php`. Method name = subcommand name; add `@subcommand hyphen-form` if the docs use hyphens (that mismatch is #95).
+7. **Test:** `tests/ActionsTest.php` / `tests/ApplyTest.php` — validate/preview/execute happy path + a rejection path. Preview must not mutate.
+8. **Verify:** `composer test`.
+
+---
+
+## Recipe C — Add a composition smell / guardrail
+
+Used by: #51, #87.
+
+1. In `lib/guardrails.php` `pp_validate_composition_smells(array $composition): array`, append a check returning `['type'=>..., 'index'=>$i, 'message'=>...]` (warning-grade; **never auto-remove content**).
+2. It must reach the INSPECT surface: this depends on **#119** being fixed (`pp_inspect_site` must read via `pp_get_composition`, not raw meta) — otherwise the smell never shows. Do #119 first.
+3. `wp pp check page` (`lib/cli.php`) already calls the smell checker; confirm your new smell appears there.
+4. **Test:** `tests/GuardrailsTest.php` — smelly composition → warning with the right `type`/`index`; clean composition → none.
+5. **Verify:** `composer test`.
+
+---
+
+## Recipe D — Add / change a component
+
+Used by: #1 (testimonial), #102, #103, #56.
+
+1. Create `components/{name}/{name}.php`, `schema.json`, `README.md`. It auto-loads.
+2. Renderer: read `$props`, validate enums against an allowlist (see hero/section for the pattern), escape all output, and call `pp_render_style_vars(..., '{name}')` if it has style slots.
+3. `schema.json`: `props` (with `required`), and `styling.style_slots` sized to the component's real visual jobs (Recipe A).
+4. If it should be editable by semantic selector, register fields (Recipe B step 4).
+5. **Test:** `tests/ComponentLoaderTest.php` picks it up; `tests/ComponentPropsTest.php` for required props; a render test for output shape and escaping.
+6. **Verify:** `composer test`.
+
+---
+
+## Recipe E — Chat UI / JS change
+
+Used by: #123, #125, #136, #137, #139, #140, #14.
+
+1. Pure logic goes in `assets/js/pp-editor-logic.js` (browser + Node/Vitest) or is extracted so it can be unit-tested; DOM wiring in `pp-admin-editor.js` / `pp-ai-chat.js`.
+2. Assistant text is rendered via `renderMarkdown()` (escapes first) — keep that; user text stays `textContent`.
+3. **Test:** `tests/js/*.test.js` (vitest). For flows, `tests/e2e/*.spec.ts` (playwright) with a deterministic mock SSE (#14).
+4. **Verify:** `npm test` (and `npm run test:e2e` where applicable).
+
+---
+
+## Between every issue
+- `composer test` (PHPUnit) and `npm test` (vitest) must be green before starting the next queue item. A regression at step N silently breaks later steps in a sequential chain.
+- Do not start a `status:blocked` / `needs-decision` / `investigation` / `discussion` issue, or a `needs-design` issue whose design-gate comment is unresolved. See the `[Backlog metadata]` header at the top of each issue and the queue in #141.

--- a/docs/IMPLEMENTATION_ORDER.md
+++ b/docs/IMPLEMENTATION_ORDER.md
@@ -1,0 +1,109 @@
+# Implementation Order (sequential)
+
+> Mirror of pinned tracking issue #141. Regenerate both from the `depends-on:` metadata in issue bodies.
+
+**Canonical, ordered implementation queue for sequential issue-by-issue work by AI agents.** Walk it top to bottom. This list is *derived* from `depends-on` metadata in each issue, tie-broken by (unblock-count desc, then size asc). Mirror in the repo at `docs/IMPLEMENTATION_ORDER.md`.
+
+## Rules for the implementing agent
+1. **Pick the lowest-numbered unchecked `status:ready` item.** Skip any item that is `status:blocked` / `needs-decision` / `investigation` / `discussion`, and any `status:needs-design` item whose design-gate comment is unresolved.
+2. **Read the issue's `> Order:` header first** — it names the blockers to do before it.
+3. **Between every item: run the full suite green** (`composer test` + `npm test`) before starting the next. In a single sequential chain, an uncaught regression at step N poisons every later step.
+4. `security-sensitive` items require a security-aware review; do not ship the happy-path only.
+5. When an issue closes, its box here strikes through automatically; re-derive if `depends-on` changes.
+
+---
+
+## Tier 0 — foundations & quick-win bugs (do first; several unblock the rest)
+- [ ] 1. #119 — inspect_site returns smells for real pages `bug area:guardrails size:S` · unblocks #51, #87
+- [ ] 2. #131 — AJAX capability model per action/apply `bug security-sensitive size:M` · unblocks #16
+- [ ] 3. #120 — field-map ⊆ schema drift test (cta/grid) `bug area:actions size:S` · pairs #85
+- [ ] 4. #128 — DOMDocument charset in post-apply validator `bug area:ai-chat size:S` · unblocks #77, clears #83
+- [ ] 5. #125 — wp_unslash chat fallback message content `bug area:ai-chat size:S`
+- [ ] 6. #129 — dead validation block in _pp_validate_length `bug area:actions size:S`
+- [ ] 7. #124 — media inventory image-mime filter `bug area:ai-chat size:S`
+- [ ] 8. #140 — internal confirmation msgs leak on reload `bug area:ai-chat size:S`
+- [ ] 9. #123 — style repair resolves wrong component (id targeting) `bug area:ai-chat size:S`
+- [ ] 10. #121 — auto-draft GC for Add-New-Page `bug area:actions size:S`
+- [ ] 11. #122 — apply reset records touched tokens / rollbackable `bug area:cli size:M`
+- [ ] 12. #76 — grid collapsed-row title label `bug area:editor size:S`
+- [ ] 13. #95 — inspect-composition CLI alias / doc `enhancement area:cli size:S`
+- [ ] 14. #36 — safe data:image/* source escaper `bug security-sensitive area:media size:S` · precedes media cluster
+- [ ] 15. #129→ (done above)
+
+## Tier 0b — shared primitives (build once; many issues consume these)
+- [ ] 16. #99 — gradient slot type **+ the reusable "add-a-style-slot" scaffold** `enhancement security-sensitive area:styling size:L` · precedes #100, #111
+- [ ] 17. #93 — extend shared button primitive to hero/grid/section `enhancement area:styling size:M` · precedes #111
+- [ ] 18. **DESIGN SPIKE:** composition freshness/version marker (see gate on #13) — one decision consumed by #13, #113, #133
+
+## Tier 1 — styling consumers
+- [ ] 19. #100 — faq/stats per-instance style slots `enhancement area:styling size:M` · needs #99
+- [ ] 20. #61 — dark-surface foreground authority (needs `--faq-heading-color` from #100) `bug area:styling size:M` · needs #100
+- [ ] 21. #111 — secondary/outline CTA style slots `enhancement area:styling size:M` · needs #93, #99
+
+## Tier 1 — component/content patterns
+- [ ] 22. #102 — section-header pattern (eyebrow+centered heading+subhead) `enhancement area:components size:L` · supersedes/absorbs #85
+- [ ] 23. #85 — hero eyebrow render-or-remove `bug area:components size:S` · do within #102
+- [ ] 24. #110 — two-tone/accent-word headings `enhancement security-sensitive area:components size:M`
+- [ ] 25. #103 — grid card richness: rich body + per-item icon/image (absorbed #109) `enhancement area:components size:L`
+- [ ] 26. #1 — testimonial/quote component `enhancement area:components size:M` · can emit Review schema via #3
+- [ ] 27. #56 — grid-steps default layout balance `enhancement area:components/visual-qa size:M`
+
+## Tier 1 — media (ordered by dependency)
+- [ ] 28. #105 — import/sideload media action (SSRF-hardened) `enhancement security-sensitive area:media size:L` · precedes #107
+- [ ] 29. #107 — responsive srcset/sizes output `enhancement area:media size:M` · needs #105 attachment ids
+- [ ] 30. #106 — site logo via safe surface `enhancement area:media size:S`
+- [ ] 31. #108 — image focal-point / aspect control `enhancement area:media size:M`
+
+## Tier 1 — SEO (one subsystem)
+- [ ] 32. #41 — per-page SEO metadata (head plumbing) `enhancement area:seo size:M` · precedes #3
+- [ ] 33. #3 — JSON-LD structured data (FAQPage first) `enhancement area:seo size:M` · needs #41
+
+## Tier 1 — routing
+- [ ] 34. #134 — update_page_slug / create_page slug param `enhancement area:cli/actions size:S` · supports #62
+- [ ] 35. #62 — canonical core routes / redirects (no 404) `bug area:routing size:M` · needs #134
+- [ ] 36. #126 — blog listing (home.php) + pagination `bug area:routing size:M`
+- [ ] 37. #138 — search results template `enhancement area:routing size:M`
+
+## Tier 1 — guardrails (need #119 first)
+- [ ] 38. #51 — over-narrow/over-compact rhythm smells `enhancement area:guardrails size:S` · needs #119
+- [ ] 39. #87 — empty-FAQ (empty structured section) smell `enhancement area:guardrails size:S` · needs #119
+
+## Tier 1 — AI-chat robustness
+- [ ] 40. #130 — preview-time media-URL validation (preview/execute parity) `enhancement area:ai-chat size:S`
+- [ ] 41. #135 — enqueue_font wires font-family token `enhancement area:ai-chat size:M`
+- [ ] 42. #136 — explicit page-target selector (not substring match) `enhancement area:ai-chat size:M`
+- [ ] 43. #139 — stop button + first-token SSE fallback `enhancement area:ai-chat size:M`
+- [ ] 44. #137 — atomic multi-step proposal apply/rollback `enhancement area:ai-chat size:M` · benefits from #133
+
+## Tier 1 — actions / cli / integrity
+- [ ] 45. #132 — create/populate/assign nav menus `enhancement area:actions size:L`
+- [ ] 46. #127 — Windows path separators in integrity/drift hashing `bug area:integrity size:M`
+- [ ] 47. #77 — `wp pp validate page` reuses post-apply validator `enhancement area:cli size:S` · needs #128
+- [ ] 48. #63 — sticky-header anchor scroll offset `bug area:visual-qa size:S`
+
+## Tier 1 — tests / CI
+- [ ] 49. #16 — PHP unit-coverage gaps (refresh refs; encode #131 caps) `enhancement area:tests size:M` · needs #131
+- [ ] 50. #14 — JS/E2E chat coverage (mock SSE) `enhancement area:tests size:M`
+- [ ] 51. #98 — real WP+MySQL token concurrency harness `enhancement area:tests/concurrency size:M`
+- [ ] 52. #54 — dev QA gallery for logos/stats/embed `enhancement area:tests size:M`
+- [ ] 53. #81 — move wp-env CLI out of E2E test bodies `enhancement area:tests size:M`
+
+## Tier 2 — needs-design (resolve the gate comment before coding; not for the smallest agents)
+- [ ] 54. #13 — optimistic locking on composition writes `enhancement needs-design area:concurrency size:L` · needs spike (18)
+- [ ] 55. #113 — preflight freshness marker `enhancement needs-design area:concurrency size:M` · needs spike (18)
+- [ ] 56. #133 — composition history / restore_composition `enhancement needs-design area:concurrency size:L` · needs spike (18)
+- [ ] 57. #69 — variant/theme/layout naming (branch: early-with-alias or last) `enhancement needs-design area:styling size:L`
+- [ ] 58. #104 — text + content-panel/columns layout `enhancement needs-design area:components size:L`
+
+---
+
+## Not in the chain (do NOT pick these as implementation work)
+- **Epics (umbrellas, tracked, not single work orders):** #27 (visual-QA gate), #45 (durable artifacts).
+- **status:blocked (depend on a feature that doesn't exist yet):** #94 (needs an import/bulk path), #114 (deferred site-target grain).
+- **status:needs-decision (maintainer call first):** #60 (rgba policy), #82 (branch protection).
+- **status:investigation (confirm root cause first):** #83 (missing_local_media on WP7 — do #128 first, then investigate the uploads-baseurl prefix).
+- **status:discussion (product/workflow, not code):** #38 (writable presentation path), #49 (target override), #59 (page-family drift), #72 (homepage CSS upgrade risk).
+
+## Derivation / maintenance
+- Source of truth = `depends-on:` lines in issue bodies (see each `> Order:` header). Order = tiered topological sort, tie-break (unblock-count desc, size asc).
+- To regenerate after closures/edits: `gh issue list --state open --json number,title,labels,body`, parse `depends-on:`, topo-sort, re-emit. Re-pin this issue.

--- a/docs/IMPLEMENTATION_ORDER.md
+++ b/docs/IMPLEMENTATION_ORDER.md
@@ -6,7 +6,7 @@
 
 ## Rules for the implementing agent
 1. **Pick the lowest-numbered unchecked `status:ready` item.** Skip any item that is `status:blocked` / `needs-decision` / `investigation` / `discussion`, and any `status:needs-design` item whose design-gate comment is unresolved.
-2. **Read the issue's `> Order:` header first** — it names the blockers to do before it.
+2. **Read the issue's `**[Backlog metadata]**` header first** — its `depends-on:` line names the blockers to do before it.
 3. **Between every item: run the full suite green** (`composer test` + `npm test`) before starting the next. In a single sequential chain, an uncaught regression at step N poisons every later step.
 4. `security-sensitive` items require a security-aware review; do not ship the happy-path only.
 5. When an issue closes, its box here strikes through automatically; re-derive if `depends-on` changes.
@@ -105,5 +105,21 @@
 - **status:discussion (product/workflow, not code):** #38 (writable presentation path), #49 (target override), #59 (page-family drift), #72 (homepage CSS upgrade risk).
 
 ## Derivation / maintenance
-- Source of truth = `depends-on:` lines in issue bodies (see each `> Order:` header). Order = tiered topological sort, tie-break (unblock-count desc, size asc).
-- To regenerate after closures/edits: `gh issue list --state open --json number,title,labels,body`, parse `depends-on:`, topo-sort, re-emit. Re-pin this issue.
+
+**Source of truth** = the `> depends-on:` line inside each issue's `**[Backlog metadata]**` block (every open issue has exactly one; value is a comma-separated list of `#N` refs, or `none`). Order = tiered topological sort of that graph, tie-broken by (unblock-count desc, then `size:` asc), with `status:ready` items only.
+
+**Extract every edge** (proven to parse cleanly for all open issues except the index #141):
+
+```bash
+gh issue list --repo FJCF76/PromptingPress --state open --limit 200 --json number,body \
+  --jq '.[] | select(.number != 141)
+        | "\(.number): \(.body | capture("(?m)^> depends-on: (?<d>.+)$").d)"'
+```
+
+**Regenerate after closures/edits:**
+1. Run the command above to get `issue: deps` for every open issue.
+2. Also pull labels: `gh issue list --state open --limit 200 --json number,labels` — keep only `status:ready`; note `size:S|M|L` for tie-breaking and `security-sensitive` for the review flag.
+3. Build the DAG from the `#N` refs; topological-sort; within a layer sort by unblock-count (how many issues name this one) desc, then size asc.
+4. Re-emit this list and the pinned tracking issue #141; both are outputs, not hand-maintained.
+
+The current edge set (for reference): `3→41, 16→131, 51→119, 61→100, 62→134, 77→128, 83→128, 85→102, 87→119, 94→105, 100→99, 107→105, 111→{93,99}, 113→13, 133→13`; all others `none`. The graph is acyclic — every edge points to a more-foundational issue.


### PR DESCRIPTION
Docs/templates only — **no source behavior changes**. Makes the issue backlog implementable one issue at a time by AI agents.

## What's here
- **`.github/ISSUE_TEMPLATE/work-order.md`** — a self-contained issue template (current/expected/evidence/invariants/`depends-on`/acceptance/verify/security) so future issues are born ready without a curation pass.
- **`docs/IMPLEMENTATION_ORDER.md`** — a mirror of the pinned tracking issue **#141**: the canonical, dependency-ordered queue. Derived from `depends-on` metadata, tie-broken by (unblock-count desc, size asc), with shared primitives (#99 slot scaffold/gradient type, #93 button primitive, the composition-marker spike) sequenced before their consumers, and the needs-design items gated at the end.
- **`docs/AI_IMPLEMENTATION_RECIPES.md`** — repeatable recipes (add a style slot / action / smell / component / chat change) plus the load-bearing invariants (only `lib/wp.php` calls WP; the `{};<>` style-slot guard; components auto-load by convention; the validate/preview/execute action contract; read composition via `pp_get_composition`).

## How this fits the backlog work
Companion to the metadata already applied to the issues:
- a status/area/size/`security-sensitive` label taxonomy on every open issue;
- a `> [Backlog metadata]` header on each issue giving its queue position, blockers, and verify command (or a "not implementable" status);
- design-gate comments on the high-blast-radius issues (#13, #69, #104, #133) defining the shared composition-marker spike.

## Reviewer note
Merging is optional — the pinned issue #141 already carries the order. This just gives the *checked-out* agent the same guidance as files in the tree, and standardizes future issue filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)