### PR TITLE
v0.16.1 docs: logo safe-surface doc sync + set-logo how-to (#106 queue)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -37,6 +37,8 @@ auto-loader picks up any component at `/components/{name}/{name}.php` — no reg
 
 **To style a specific component instance:** Read `ai-instructions/style-component.md`. Use the `style_component` action to set per-instance CSS custom properties (style slots) without editing CSS files.
 
+**To set the site logo:** Read `ai-instructions/set-logo.md`. Use the `update_site_option` action with key `pp_logo_id` (a Media Library image attachment ID, not a URL) to set the nav/footer logo.
+
 **To validate a site (CSS conflicts, navigation readiness, rendered review):** Read `ai-instructions/validate-site.md`. Run `wp pp validate site`; navigation readiness (empty/unassigned menus) surfaces automatically in preflight and post-apply output.
 
 **To provision a new WordPress site:** Read `ai-instructions/bootstrap.md` for the full state contract and WP-CLI verification commands.

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -212,7 +212,7 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | `pp_set_token_override($token, $value)` | Writes a single token override to the database. |
 | `pp_clear_token_override($token)` | Removes a single token override (reverts to default). |
 | `pp_clear_all_token_overrides()` | Removes all overrides (reverts site to shipped defaults). |
-| `pp_site_option($key)`         | Whitelisted option value (blogname, blogdescription) or WP_Error |
+| `pp_site_option($key)`         | Whitelisted option value (blogname, blogdescription, pp_logo_id, pp_logo_alt) or WP_Error |
 | `pp_update_composition($post_id, $composition)` | Writes composition array to post meta (handles JSON serialization). Returns true\|WP_Error |
 | `pp_update_page_title($post_id, $title)` | Updates page title. Returns true\|WP_Error |
 | `pp_create_page($title, $status)` | Creates page with Composition template. Returns post ID\|WP_Error |
@@ -430,7 +430,7 @@ All mutations go through typed actions. AJAX handlers, WP-CLI, and future AI cal
 | Action | Scope | Params | Semantics |
 |---|---|---|---|
 | `create_page` | site | title (req), composition, status | Create. Defaults to draft with empty composition |
-| `update_site_option` | site | key (req), value (req) | Replace. Whitelisted: blogname, blogdescription |
+| `update_site_option` | site | key (req), value (req) | Replace. Whitelisted: blogname, blogdescription, pp_logo_id (attachment ID), pp_logo_alt |
 | `update_page_title` | page | post_id (req), title (req) | Replace |
 | `update_composition` | page | post_id (req), composition (req) | Replace entire array |
 | `publish_page` | page | post_id (req) | Sets status to publish. Idempotent |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.1] — 2026-07-04 — Docs: The AI Now Has an Accurate Map to the Logo Safe Surface
+
+**Patch release so the theme's AI-facing docs correctly describe the v0.16.0 logo surface, plus a step-by-step guide for setting it.** No code change.
+
+When v0.16.0 added `pp_logo_id` / `pp_logo_alt` to the `update_site_option` whitelist, two `AI_CONTEXT.md` reference tables still listed the whitelist as only `blogname, blogdescription`. An agent reading those tables would think it couldn't set the logo through a site option. Both tables now list the logo keys, and the site-options map in `ai-instructions/website-building.md` gains a "Site logo" row.
+
+New `ai-instructions/set-logo.md` is a task-oriented how-to: find the image's Media Library attachment ID, preview, run a site-scoped preflight, execute `update_site_option` with `pp_logo_id`, and verify — plus the resolution fallback (`logo_id` prop → `pp_logo_id` option → WP `custom_logo` → text wordmark), the footer `show_logo` opt-in, and troubleshooting. It's linked from the `AI_CONTEXT.md` orientation list, so an agent finds it the same way it finds every other task guide.
+
 ## [v0.16.0] — 2026-06-30 — Brand Book Fidelity: The Site Logo Is Now a Safe Surface
 
 **The site logo can finally be set the safe way: an attachment ID, validated server-side, rendered in the nav and (opt-in) the footer.** Until now the nav only accepted a raw `logo_url`, and there was no safe path for an AI agent to set the site-wide logo at all. You can now point the logo at a Media Library image by ID through the `update_site_option` action (`pp_logo_id`) or a component prop (`logo_id`), and it resolves the same way everywhere.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.0-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.1-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/set-logo.md
+++ b/ai-instructions/set-logo.md
@@ -1,0 +1,99 @@
+# Set the Site Logo
+
+Use the `update_site_option` action to set the site-wide logo through a safe surface. The logo is a **Media Library attachment ID** (`pp_logo_id`), never a raw URL. It renders in the nav automatically, and in the footer when opted in.
+
+---
+
+## Step 1 -- Find the logo image's attachment ID
+
+The logo must already be an **image** in the Media Library. Its attachment ID is what you set — not a URL.
+
+- From the operating picture: `wp pp operate inspect` surfaces the Media Library inventory (filenames + attachment IDs). Pick the image you want.
+- Or list images directly:
+
+```bash
+wp post list --post_type=attachment --post_mime_type=image --fields=ID,post_title
+```
+
+If the image isn't in the Media Library yet, upload it there first — this action does not import files.
+
+---
+
+## Step 2 -- Preview the change (no write, no run token)
+
+Preview validates the value and shows the diff without mutating anything:
+
+```bash
+wp pp action preview update_site_option --params='{"key":"pp_logo_id","value":"109"}'
+```
+
+The value must resolve to an image attachment. A non-image attachment, a bogus ID, or a URL is rejected here with a clear message — fix it before executing.
+
+---
+
+## Step 3 -- Preflight (site-scoped)
+
+Setting a site option is a site-scoped mutation, so it needs a completed INSPECT plus a covering PREFLIGHT for the run. Use the run token from `wp pp operate inspect`:
+
+```bash
+wp pp apply preflight --run-id=<uuid>
+```
+
+A site-scoped preflight (no `--post_id`) covers site actions like `update_site_option`.
+
+---
+
+## Step 4 -- Execute
+
+```bash
+wp pp action execute update_site_option --run-id=<uuid> --params='{"key":"pp_logo_id","value":"109"}'
+```
+
+Optionally set explicit alt text (defaults to the attachment's own alt metadata, then the site title):
+
+```bash
+wp pp action execute update_site_option --run-id=<uuid> --params='{"key":"pp_logo_alt","value":"Acme brand mark"}'
+```
+
+---
+
+## Step 5 -- Verify
+
+Load the homepage and confirm the nav renders an `<img class="nav__logo-image">` pointing at the attachment. `wp pp validate site` and post-apply output also confirm the change landed.
+
+---
+
+## How the logo resolves
+
+The nav and footer share one resolver. It picks the first source that yields an image, then falls back to text:
+
+1. an explicit `logo_id` prop on the component (if the nav/footer is invoked with one),
+2. the `pp_logo_id` site option (what you set above),
+3. WordPress' native `custom_logo` theme-mod (Appearance → Customize → Logo),
+4. the text wordmark (`logo_text`, defaulting to the site title).
+
+So if you never set `pp_logo_id`, a logo set through the WordPress Customizer still shows. If nothing resolves to an image, the nav shows the site name as text.
+
+---
+
+## Footer logo (opt-in)
+
+The footer does **not** show the logo by default, so existing footers are unchanged. To turn it on, the footer component must be invoked with `show_logo: true`; it then uses the same resolution as the nav. Nav is always on; footer is opt-in.
+
+---
+
+## Whitelisted logo options
+
+| Key | Value | Notes |
+|-----|-------|-------|
+| `pp_logo_id` | Media Library attachment ID (integer) | Must be an image. Never a URL. |
+| `pp_logo_alt` | string | Optional. Defaults to the attachment's alt metadata, then the site title. |
+
+---
+
+## Troubleshooting
+
+- **"requires a Media Library image attachment ID"** — the value isn't an image attachment. Confirm the ID with Step 1; a PDF/video attachment or a plain number that isn't an attachment is rejected. Never pass a URL.
+- **Logo shows as text, not an image** — no source resolved to an image. Check that `pp_logo_id` is set (or a `custom_logo` theme-mod exists) and that the attachment still exists.
+- **Action refused with a preflight error** — you skipped the run token flow. Run `wp pp operate inspect` for a `run_id`, then `wp pp apply preflight --run-id=<uuid>` before executing.
+- **Footer logo not appearing** — that's expected; the footer logo is opt-in via `show_logo`.

--- a/ai-instructions/website-building.md
+++ b/ai-instructions/website-building.md
@@ -12,6 +12,7 @@ Every visual change maps to exactly one mutation surface. Writing to the wrong s
 | Component variants (dark, inverted, steps) | `_pp_composition` post meta | `update_component` action (set `variant` or `theme` prop) |
 | Component-specific CSS (spacing, layout) | `assets/css/components.css` | Direct file edit (BEM classes, token values only) |
 | Site name, tagline | WordPress options | `update_site_option` action |
+| Site logo (nav, and footer via `show_logo`) | WordPress option (Media Library attachment) | `update_site_option` action (key `pp_logo_id`, an attachment ID) |
 
 ## What NOT to use
 

--- a/docs/IMPLEMENTATION_ORDER.md
+++ b/docs/IMPLEMENTATION_ORDER.md
@@ -51,7 +51,7 @@
 ## Tier 1 — media (ordered by dependency)
 - [ ] 28. #105 — import/sideload media action (SSRF-hardened) `enhancement security-sensitive area:media size:L` · precedes #107
 - [ ] 29. #107 — responsive srcset/sizes output `enhancement area:media size:M` · needs #105 attachment ids
-- [ ] 30. #106 — site logo via safe surface `enhancement area:media size:S`
+- [x] ~~30. #106 — site logo via safe surface~~ `enhancement area:media size:S` · ✅ shipped v0.16.0
 - [ ] 31. #108 — image focal-point / aspect control `enhancement area:media size:M`
 
 ## Tier 1 — SEO (one subsystem)

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.0');
+define('PP_VERSION', '0.16.1');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.0
+Stable tag: 0.16.1
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.0
+Version:          0.16.1
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Docs-only follow-ups to the **v0.16.0** logo release. No code, no version change (5-file version stays consistent at 0.16.0).

### Release coherence
- Mark **#106** (site logo safe surface) shipped in `docs/IMPLEMENTATION_ORDER.md` — it closed with v0.16.0 but was still listed as an open to-do.

### Doc sync (`/document-release`)
- `AI_CONTEXT.md`: the `update_site_option` whitelist was still listed as only `blogname, blogdescription` in the function and action tables — now includes `pp_logo_id` / `pp_logo_alt`.
- `ai-instructions/website-building.md`: added a "Site logo" row to the site-options map.

### Documentation generated (`/document-generate`)

| File | Quadrant | Description |
|------|----------|-------------|
| `ai-instructions/set-logo.md` | How-to | Set the site logo via `update_site_option` (`pp_logo_id`, attachment-ID only): find the attachment → preview → site-scoped preflight → execute → verify, plus resolution fallback, footer `show_logo` opt-in, and troubleshooting. |

Linked from the `AI_CONTEXT.md` orientation list. Reference coverage already existed (AI_CONTEXT + composition.md); this fills the how-to gap.
