### PR TITLE
v0.16.2 fix: INSPECT now surfaces composition smells for real pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.2] — 2026-07-04 — Fix: INSPECT Now Actually Sees Composition Smells
+
+**`wp pp operate inspect --post_id=<id>` finally surfaces the composition warnings it always claimed to.** The INSPECT step reads a page's composition to flag layout smells (like a left-aligned hero with no image), but on every real page it silently returned `smells: []` — the code checked `is_array()` on meta that WordPress always stores as a JSON string, so the check never matched. `wp pp check page` caught the same smells correctly (it used the right accessor); INSPECT just never got the memo. Now it does: an agent running the operating loop's INSPECT step sees the same smells a manual `check page` would.
+
+### Fixed
+- `pp_inspect_site()` reads composition through the canonical `pp_get_composition()` accessor instead of raw post meta, so page-specific composition smells reach the INSPECT surface.
+- `pp_validate_composition_styling()` and `pp_validate_composition_smells()` now skip malformed (non-array) composition entries instead of indexing into them — hardening added because INSPECT now exercises these validators against real page data for the first time.
+
+### For contributors
+- Filed #144 to track a related, pre-existing gap: `pp_get_composition()` can't currently distinguish "no composition" from "composition JSON failed to decode," both return `[]`.
+
 ## [v0.16.1] — 2026-07-04 — Docs: The AI Now Has an Accurate Map to the Logo Safe Surface
 
 **Patch release so the theme's AI-facing docs correctly describe the v0.16.0 logo surface, plus a step-by-step guide for setting it.** No code change.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.1-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.2-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/docs/AI_IMPLEMENTATION_RECIPES.md
+++ b/docs/AI_IMPLEMENTATION_RECIPES.md
@@ -58,8 +58,8 @@ Used by: #132 (menus), #134 (slug), #105 (import media), #122, #133.
 
 Used by: #51, #87.
 
-1. In `lib/guardrails.php` `pp_validate_composition_smells(array $composition): array`, append a check returning `['type'=>..., 'index'=>$i, 'message'=>...]` (warning-grade; **never auto-remove content**).
-2. It must reach the INSPECT surface: this depends on **#119** being fixed (`pp_inspect_site` must read via `pp_get_composition`, not raw meta) — otherwise the smell never shows. Do #119 first.
+1. In `lib/guardrails.php` `pp_validate_composition_smells(array $composition): array`, append a check returning `['type'=>..., 'index'=>$i, 'message'=>...]` (warning-grade; **never auto-remove content**). Guard non-array `$item`/`props` entries (`if (!is_array($item)) { continue; }`) — composition data can be malformed.
+2. It reaches the INSPECT surface automatically (`pp_inspect_site` reads composition via `pp_get_composition`, not raw meta — fixed in #119).
 3. `wp pp check page` (`lib/cli.php`) already calls the smell checker; confirm your new smell appears there.
 4. **Test:** `tests/GuardrailsTest.php` — smelly composition → warning with the right `type`/`index`; clean composition → none.
 5. **Verify:** `composer test`.

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.1');
+define('PP_VERSION', '0.16.2');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/guardrails.php
+++ b/lib/guardrails.php
@@ -233,8 +233,14 @@ function pp_validate_composition_styling(array $composition): array {
     $type_map = [];
 
     foreach ($composition as $i => $item) {
+        // Defensive: a malformed composition that bypassed validation may
+        // carry non-array items or props, so guard both before indexing.
+        if (!is_array($item)) {
+            continue;
+        }
         $component = $item['component'] ?? '';
-        $has_id    = !empty($item['props']['id']);
+        $props     = is_array($item['props'] ?? null) ? $item['props'] : [];
+        $has_id    = !empty($props['id']);
 
         if (!$has_id) {
             $type_map[$component][] = $i;
@@ -269,7 +275,12 @@ function pp_validate_composition_smells(array $composition): array {
     $consecutive_text_only = 0;
 
     foreach ($composition as $i => $item) {
-        $props = $item['props'] ?? [];
+        // Defensive: a malformed composition that bypassed validation may
+        // carry non-array items or props, so guard both before indexing.
+        if (!is_array($item)) {
+            continue;
+        }
+        $props = is_array($item['props'] ?? null) ? $item['props'] : [];
         $component = $item['component'] ?? '';
         $variant = $props['variant'] ?? 'centered';
         $image_url = $props['image_url'] ?? '';

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -156,8 +156,12 @@ function pp_inspect_site(?int $post_id = null): array {
 
     $smells = [];
     if ($post_id !== null) {
-        $composition = get_post_meta($post_id, '_pp_composition', true);
-        if (is_array($composition) && !empty($composition)) {
+        // Read through the canonical accessor: normal storage is a JSON string
+        // (pp_update_composition), so a raw get_post_meta + is_array() check
+        // always reports empty for real pages. See lib/operate.php preflight
+        // check 6 for the same pattern.
+        $composition = pp_get_composition($post_id);
+        if (!empty($composition)) {
             $smells = pp_validate_composition_smells($composition);
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.1
+Stable tag: 0.16.2
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.1
+Version:          0.16.2
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/GuardrailsTest.php
+++ b/tests/GuardrailsTest.php
@@ -151,6 +151,19 @@ class GuardrailsTest extends TestCase
         $this->assertSame([], pp_validate_composition_styling($composition));
     }
 
+    public function testStylingSkipsNonArrayProps(): void
+    {
+        // The item itself is a valid array, but its 'props' value is a
+        // scalar. Without the props-level guard (not just the item-level
+        // guard above), indexing ['id'] into a string triggers an "Illegal
+        // string offset" warning and can coerce garbage into a truthy id.
+        $composition = [
+            ['component' => 'section', 'props' => 'not-an-array'],
+            ['component' => 'section', 'props' => ['id' => 'pp-bbb', 'body' => 'B']],
+        ];
+        $this->assertSame([], pp_validate_composition_styling($composition));
+    }
+
     public function testSingleComponentWithoutIdNotFlagged(): void
     {
         $composition = [
@@ -303,6 +316,19 @@ class GuardrailsTest extends TestCase
         // would otherwise coerce garbage into $props/$variant/$image_url).
         $composition = [
             'not-an-array',
+            ['component' => 'hero', 'props' => ['variant' => 'left', 'image_url' => '/img/x.jpg']],
+        ];
+        $this->assertSame([], pp_validate_composition_smells($composition));
+    }
+
+    public function testSmellsSkipsNonArrayProps(): void
+    {
+        // The item itself is a valid array, but its 'props' value is a
+        // scalar. Without the props-level guard (not just the item-level
+        // guard above), this must still not coerce garbage into
+        // $props/$variant/$image_url via string-offset access.
+        $composition = [
+            ['component' => 'hero', 'props' => 'not-an-array'],
             ['component' => 'hero', 'props' => ['variant' => 'left', 'image_url' => '/img/x.jpg']],
         ];
         $this->assertSame([], pp_validate_composition_smells($composition));

--- a/tests/GuardrailsTest.php
+++ b/tests/GuardrailsTest.php
@@ -138,6 +138,19 @@ class GuardrailsTest extends TestCase
         $this->assertSame([], pp_validate_composition_styling([]));
     }
 
+    public function testStylingSkipsNonArrayItems(): void
+    {
+        // Regression (#119 follow-up): a malformed/corrupted composition
+        // decoded from JSON can contain non-array elements (e.g. a scalar
+        // from truncated storage). Non-array items must be skipped rather
+        // than indexed into, mirroring pp_check_nav_readiness's guard.
+        $composition = [
+            'not-an-array',
+            ['component' => 'section', 'props' => ['body' => 'A']],
+        ];
+        $this->assertSame([], pp_validate_composition_styling($composition));
+    }
+
     public function testSingleComponentWithoutIdNotFlagged(): void
     {
         $composition = [
@@ -280,6 +293,19 @@ class GuardrailsTest extends TestCase
     public function testSmellsEmptyCompositionReturnsNoWarnings(): void
     {
         $this->assertSame([], pp_validate_composition_smells([]));
+    }
+
+    public function testSmellsSkipsNonArrayItems(): void
+    {
+        // Regression (#119 follow-up): a malformed/corrupted composition
+        // decoded from JSON can contain non-array elements. Non-array items
+        // must be skipped rather than indexed into (string-offset access
+        // would otherwise coerce garbage into $props/$variant/$image_url).
+        $composition = [
+            'not-an-array',
+            ['component' => 'hero', 'props' => ['variant' => 'left', 'image_url' => '/img/x.jpg']],
+        ];
+        $this->assertSame([], pp_validate_composition_smells($composition));
     }
 
     public function testSmellsHeroLeftNoImageTriggersWarning(): void

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -241,6 +241,28 @@ class OperateTest extends TestCase
         $this->assertIsArray($preflight['checks']);
     }
 
+    public function testInspectSiteReturnsSmellsForRealPage(): void
+    {
+        // Regression (#119): production stores _pp_composition as a JSON
+        // STRING (pp_update_composition), not a PHP array. pp_inspect_site()
+        // must read it through pp_get_composition() so smells are detected.
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'Smelly Page', 'post_status' => 'publish']);
+        update_post_meta($post_id, '_pp_composition', json_encode([
+            ['component' => 'hero', 'props' => ['id' => 'pp-hero1111', 'variant' => 'left']],
+        ]));
+
+        $result = pp_inspect_site($post_id);
+
+        $this->assertNotEmpty($result['smells']);
+        $this->assertSame('hero_left_no_image', $result['smells'][0]['type']);
+    }
+
+    public function testInspectSiteReturnsNoSmellsWithoutPostId(): void
+    {
+        $result = pp_inspect_site();
+        $this->assertSame([], $result['smells']);
+    }
+
     // ── Preflight ──────────────────────────────────────────────────────────
 
     public function testPreflightIncludesDriftCheck(): void

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -257,6 +257,15 @@ class OperateTest extends TestCase
         $this->assertSame('hero_left_no_image', $result['smells'][0]['type']);
     }
 
+    public function testInspectSiteReturnsNoSmellsForPageWithoutComposition(): void
+    {
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'Blank Page', 'post_status' => 'publish']);
+
+        $result = pp_inspect_site($post_id);
+
+        $this->assertSame([], $result['smells']);
+    }
+
     public function testInspectSiteReturnsNoSmellsWithoutPostId(): void
     {
         $result = pp_inspect_site();


### PR DESCRIPTION
## Summary

**Bug fix**
- `pp_inspect_site()` (`lib/operate.php`) read `_pp_composition` post meta raw and gated the smells check on `is_array()`, but production always stores this meta as a JSON string (`pp_update_composition`), so the check never matched and `wp pp operate inspect --post_id=N` never surfaced composition smells for real pages — even though `wp pp check page` correctly flagged the same smell. Now reads through the canonical `pp_get_composition()` accessor, matching the pattern already used by preflight check 6.

**Hardening**
- `pp_validate_composition_styling()` and `pp_validate_composition_smells()` (`lib/guardrails.php`) now guard against non-array composition items/props (`is_array($item)` / `is_array($item['props'] ?? null)`), mirroring the existing guard in `pp_check_nav_readiness()`. Added because INSPECT now exercises these validators against real page data for the first time — an adversarial review flagged that malformed composition JSON could otherwise trigger PHP string-offset coercion instead of being skipped.

**Docs**
- `docs/AI_IMPLEMENTATION_RECIPES.md`: removed the now-resolved "depends on #119" blocker note from Recipe C (add a composition smell/guardrail), and documented the new guard-clause requirement for future smell recipes.

## Test Coverage

```
CODE PATHS
[+] lib/operate.php — pp_inspect_site()
  ├── [★★ TESTED] post_id null branch
  ├── [★★★ TESTED] post_id set, composition non-empty (smelly)
  └── [★★ TESTED] post_id set, composition empty
[+] lib/guardrails.php — pp_validate_composition_styling()
  ├── [★★★ TESTED] item is array, props is array (normal)
  ├── [★★ TESTED] item is non-array (malformed)
  └── [★★ TESTED] item is array, props is non-array (malformed)
[+] lib/guardrails.php — pp_validate_composition_smells()
  ├── [★★★ TESTED] item is array, props is array (normal)
  ├── [★★ TESTED] item is non-array (malformed)
  └── [★★ TESTED] item is array, props is non-array (malformed)

COVERAGE: 9/9 paths tested (100%)
```

Tests: 790 → 795 PHP (+5), 262 JS (unchanged). All green (`vendor/bin/phpunit` + `npm test`).

Also verified end-to-end in an ephemeral local wp-env: created a page with a `hero`/`variant: left` composition stored as a JSON string (matching production), confirmed `wp pp operate inspect --post_id=N` now returns the `hero_left_no_image` smell (previously always `[]`). Environment torn down after, no data left behind.

## Pre-Landing Review

- Structured + adversarial review (Claude subagent + Codex, both run) found no issues introduced by the core fix itself.
- Specialist dispatch (Testing, Maintainability, Performance — diff was backend-only, no auth/migration/API scope):
  - **Testing (2 informational, fixed):** the new item-level malformed-composition tests didn't separately exercise the props-level guard. Added `testStylingSkipsNonArrayProps` / `testSmellsSkipsNonArrayProps`.
  - **Maintainability (1 informational, deferred):** the malformed-item guard clause is now duplicated across three functions (`pp_check_nav_readiness` in `lib/wp.php`, and the two validators here). A shared `pp_normalize_composition_item()` helper would DRY this up, but extracting it touches a function outside this issue's scope — noting here rather than expanding this PR's blast radius.
  - **Performance:** no findings.
- One INVESTIGATE-grade finding surfaced during adversarial review: `pp_get_composition()` (pre-existing, `lib/wp.php`, untouched by this diff) can't distinguish "no composition" from "corrupted/undecodable JSON" — both silently return `[]`. Harmless before this fix (INSPECT never read real data); now that INSPECT depends on this return value, a corrupted page will silently look clean. Filed as **#144** rather than expanding this PR's scope.

PR Quality Score: 9/10

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN — delivered exactly the fix plan in #119 (route `pp_inspect_site()` through `pp_get_composition()`), plus the guard-clause hardening and follow-up issue that its own adversarial review surfaced as immediate consequences of activating that code path for real.

## Plan Completion

No plan file (size:S issue — fix plan + issue body served as the spec per this repo's backlog-loop convention).

## TODOS

No TODO items completed in this PR.

## Documentation

`docs/AI_IMPLEMENTATION_RECIPES.md`: Recipe C ("Add a composition smell / guardrail") no longer tells implementers to block on #119 — it's fixed, so INSPECT reaches composition smells automatically. Added a note that new smell/guardrail checks should guard non-array composition items, matching the pattern this PR introduced.

## Test plan
- [x] All PHP unit tests pass (795 tests, 3045 assertions, 0 failures)
- [x] All JS/Vitest tests pass (262 tests)
- [x] Manually verified in ephemeral local wp-env: `wp pp operate inspect --post_id=N` now surfaces `hero_left_no_image` for a JSON-string-stored composition (previously always `smells: []`)

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
