### PR TITLE
v0.16.4 fix: cta/grid field editability map drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.4] — 2026-07-04 — Fix: Editing a CTA Button or Card Link Through Chat Actually Works Now
+
+**Asking the AI to change a CTA button's text or URL, or a grid card's link, previously either silently did nothing or told you the field couldn't be edited — for opposite reasons.** The internal map of "which fields can be edited by name" had drifted from the real component props: it listed fields the CTA and grid components don't have (so editing them wrote data nothing ever reads, and reported success) and left out the fields they actually use (so editing the *real* button text or link failed with "not editable"). Both are now correct — CTA's title/text/button text/button URL and grid cards' title/text/link text/link URL are all editable, and the AI's picture of what's currently in those fields is now accurate too.
+
+### Fixed
+- The AI chat's and `wp pp operate`'s field-editing map now matches the CTA and grid components' real props, so editing a CTA button or a grid card's link through chat (or the `patch` CLI command) actually changes what's rendered instead of silently no-opping or failing.
+
+### For contributors
+- Added a test that checks every component's field-editing map against its `schema.json` automatically, so this class of drift can't ship again.
+
 ## [v0.16.3] — 2026-07-04 — Security: Chat Can No Longer Publish, Trash, or Rewrite Your Site as a Contributor
 
 **A Contributor-level user could previously use the AI chat to publish or trash any page, rename the site, wipe Custom CSS, or reset every design token — all through the same "Permission denied" gate that should have stopped them.** The chat's execute/preview endpoints checked only one coarse capability (the ability to edit posts at all) before running *any* registered action or design change, regardless of how privileged that specific change was. Now each action and design change checks the real WordPress capability it actually requires — the same rules the rest of the admin already enforces. A Contributor can still chat and propose changes, but every privileged step now correctly returns "Permission denied" and changes nothing. Editors keep full page-building power through chat; only site-wide settings and design changes stay Administrator-only.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.3-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.4-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.3');
+define('PP_VERSION', '0.16.4');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -1149,6 +1149,16 @@ function pp_get_component_fields(string $component_type): array {
     return $_pp_component_fields[$component_type] ?? [];
 }
 
+/**
+ * Returns the full component-fields registry: component_type => field definitions.
+ *
+ * @return array<string, array>
+ */
+function pp_get_registered_component_fields(): array {
+    global $_pp_component_fields;
+    return $_pp_component_fields ?? [];
+}
+
 // ── Register default component fields ────────────────────────────────────
 
 pp_register_component_fields('hero', [
@@ -1165,9 +1175,10 @@ pp_register_component_fields('section', [
 ]);
 
 pp_register_component_fields('grid', [
-    ['name' => 'items[].title', 'type' => 'string'],
-    ['name' => 'items[].text',  'type' => 'string'],
-    ['name' => 'items[].link',  'type' => 'url'],
+    ['name' => 'items[].title',     'type' => 'string'],
+    ['name' => 'items[].text',      'type' => 'string'],
+    ['name' => 'items[].link_url',  'type' => 'url'],
+    ['name' => 'items[].link_text', 'type' => 'string'],
 ]);
 
 pp_register_component_fields('faq', [
@@ -1176,10 +1187,10 @@ pp_register_component_fields('faq', [
 ]);
 
 pp_register_component_fields('cta', [
-    ['name' => 'title',    'type' => 'string'],
-    ['name' => 'subtitle', 'type' => 'string'],
-    ['name' => 'cta_text', 'type' => 'string'],
-    ['name' => 'cta_url',  'type' => 'url'],
+    ['name' => 'title',       'type' => 'string'],
+    ['name' => 'text',        'type' => 'string'],
+    ['name' => 'button_text', 'type' => 'string'],
+    ['name' => 'button_url',  'type' => 'url'],
 ]);
 
 // ── Inspect Composition ──────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.3
+Stable tag: 0.16.4
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.3
+Version:          0.16.4
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -1028,6 +1028,92 @@ class OperateTest extends TestCase
         $this->assertSame('Learn more', $gridByValue['grid.items[title="Feature A"].link_text']);
     }
 
+    public function testPatchCtaRealFieldsApply(): void
+    {
+        // Regression (#120 write path): cta.button_text/button_url were
+        // previously unpatchable (field_not_editable) because the map
+        // declared cta_text/cta_url instead. Confirm the real fields apply.
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'CTA Patch', 'post_status' => 'publish']);
+        update_post_meta($post_id, '_pp_composition', json_encode([
+            ['component' => 'cta', 'props' => ['id' => 'pp-cta9999', 'title' => 'Join', 'button_text' => 'Old', 'button_url' => '/old']],
+        ]));
+
+        $result = pp_patch_composition($post_id, 'cta.button_text', 'New');
+        $this->assertTrue($result['ok']);
+        $comp = pp_get_composition($post_id);
+        $this->assertSame('New', $comp[0]['props']['button_text']);
+
+        $result = pp_patch_composition($post_id, 'cta.button_url', '/new');
+        $this->assertTrue($result['ok']);
+        $comp = pp_get_composition($post_id);
+        $this->assertSame('/new', $comp[0]['props']['button_url']);
+    }
+
+    public function testPatchCtaDeadFieldsNowFailNotEditable(): void
+    {
+        // Regression (#120 write path): before the fix, patching these dead
+        // selectors reported success (ok: true) while writing an unused
+        // prop the render never reads. Confirm they now correctly fail.
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'CTA Dead Fields', 'post_status' => 'publish']);
+        update_post_meta($post_id, '_pp_composition', json_encode([
+            ['component' => 'cta', 'props' => ['id' => 'pp-cta8888', 'title' => 'Join', 'button_text' => 'Go', 'button_url' => '/go']],
+        ]));
+
+        foreach (['cta.subtitle', 'cta.cta_text', 'cta.cta_url'] as $selector) {
+            $result = pp_patch_composition($post_id, $selector, 'value');
+            $this->assertInstanceOf(WP_Error::class, $result, "{$selector} should be field_not_editable, not applied.");
+            $this->assertSame('field_not_editable', $result->get_error_code());
+        }
+    }
+
+    public function testPatchGridLinkFieldsApply(): void
+    {
+        // Regression (#120 write path): grid items[].link_url/link_text
+        // were previously unpatchable (the map declared a bare 'link' field
+        // that doesn't exist). Confirm the real fields apply.
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'Grid Patch', 'post_status' => 'publish']);
+        update_post_meta($post_id, '_pp_composition', json_encode([
+            ['component' => 'grid', 'props' => ['id' => 'pp-grid9999', 'items' => [
+                ['title' => 'Feature A', 'link_url' => '/old', 'link_text' => 'Old label'],
+            ]]],
+        ]));
+
+        $result = pp_patch_composition($post_id, 'grid.items[title="Feature A"].link_url', '/new');
+        $this->assertTrue($result['ok']);
+        $comp = pp_get_composition($post_id);
+        $this->assertSame('/new', $comp[0]['props']['items'][0]['link_url']);
+
+        $result = pp_patch_composition($post_id, 'grid.items[title="Feature A"].link_text', 'New label');
+        $this->assertTrue($result['ok']);
+        $comp = pp_get_composition($post_id);
+        $this->assertSame('New label', $comp[0]['props']['items'][0]['link_text']);
+    }
+
+    public function testPatchGridDeadLinkFieldNowFailsNotEditable(): void
+    {
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'Grid Dead Field', 'post_status' => 'publish']);
+        update_post_meta($post_id, '_pp_composition', json_encode([
+            ['component' => 'grid', 'props' => ['id' => 'pp-grid8888', 'items' => [
+                ['title' => 'Feature A', 'link_url' => '/a', 'link_text' => 'A'],
+            ]]],
+        ]));
+
+        $result = pp_patch_composition($post_id, 'grid.items[title="Feature A"].link', 'value');
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('field_not_editable', $result->get_error_code());
+    }
+
+    public function testGetRegisteredComponentFieldsMatchesPerTypeAccessor(): void
+    {
+        $registry = pp_get_registered_component_fields();
+        $this->assertIsArray($registry);
+        $this->assertArrayHasKey('cta', $registry);
+        $this->assertArrayHasKey('grid', $registry);
+        foreach (array_keys($registry) as $type) {
+            $this->assertSame($registry[$type], pp_get_component_fields($type));
+        }
+    }
+
     // ── Inspect Composition Tests ────────────────────────────────────────────
 
     public function testInspectCompositionReturnsTargets(): void

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -959,8 +959,10 @@ class OperateTest extends TestCase
         $this->assertSame('html', $section[1]['type']);
 
         $grid = pp_get_component_fields('grid');
-        $this->assertCount(3, $grid);
+        $this->assertCount(4, $grid);
         $this->assertSame('items[].title', $grid[0]['name']);
+        $this->assertSame('items[].link_url', $grid[2]['name']);
+        $this->assertSame('items[].link_text', $grid[3]['name']);
 
         $faq = pp_get_component_fields('faq');
         $this->assertCount(2, $faq);
@@ -969,10 +971,61 @@ class OperateTest extends TestCase
 
         $cta = pp_get_component_fields('cta');
         $this->assertCount(4, $cta);
+        $this->assertSame('title', $cta[0]['name']);
+        $this->assertSame('text', $cta[1]['name']);
+        $this->assertSame('button_text', $cta[2]['name']);
+        $this->assertSame('button_url', $cta[3]['name']);
 
         // Unmapped type returns empty array.
         $unknown = pp_get_component_fields('nonexistent');
         $this->assertSame([], $unknown);
+    }
+
+    public function testInspectCompositionResolvesRealCtaAndGridValues(): void
+    {
+        // Regression (#120): the editability map previously declared dead
+        // selectors (cta.subtitle/cta_text/cta_url, grid items[].link) that
+        // don't exist on either component, so pp_inspect_composition()
+        // always reported current_value: null for them — poisoning the AI
+        // context with editable-looking fields that silently no-op on
+        // patch. Assert the map now resolves to the real, populated props.
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'CTA Grid Inspect', 'post_status' => 'publish']);
+        update_post_meta($post_id, '_pp_composition', json_encode([
+            [
+                'component' => 'cta',
+                'props' => [
+                    'id' => 'pp-cta0001', 'title' => 'Join now', 'text' => 'Limited spots',
+                    'button_text' => 'Sign up', 'button_url' => '/signup',
+                ],
+            ],
+            [
+                'component' => 'grid',
+                'props' => [
+                    'id' => 'pp-grid001',
+                    'items' => [
+                        ['title' => 'Feature A', 'text' => 'Does a thing', 'link_url' => '/a', 'link_text' => 'Learn more'],
+                    ],
+                ],
+            ],
+        ]));
+
+        $result = pp_inspect_composition($post_id);
+
+        $cta = $result[0]['fields'];
+        $ctaByField = array_column($cta, 'current_value', 'field');
+        $this->assertSame('Join now', $ctaByField['title']);
+        $this->assertSame('Limited spots', $ctaByField['text']);
+        $this->assertSame('Sign up', $ctaByField['button_text']);
+        $this->assertSame('/signup', $ctaByField['button_url']);
+        $this->assertArrayNotHasKey('subtitle', $ctaByField);
+        $this->assertArrayNotHasKey('cta_text', $ctaByField);
+        $this->assertArrayNotHasKey('cta_url', $ctaByField);
+
+        $grid = $result[1]['fields'];
+        $gridByValue = array_column($grid, 'current_value', 'selector');
+        // Grid items are matched by 'title' (see _pp_pick_nested_match_field).
+        $this->assertSame('/a', $gridByValue['grid.items[title="Feature A"].link_url']);
+        $this->assertSame('Learn more', $gridByValue['grid.items[title="Feature A"].link_text']);
     }
 
     // ── Inspect Composition Tests ────────────────────────────────────────────

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -513,6 +513,80 @@ class SchemaValidationTest extends TestCase
         }
     }
 
+    // ── Field editability map drift (#120) ──────────────────────────────────
+
+    /**
+     * pp_register_component_fields() (lib/operate.php) is a hand-maintained
+     * map of which props each component exposes for semantic-selector
+     * patching (wp pp operate patch) and AI-chat inspection. It silently
+     * drifted from the real component props: cta declared subtitle/cta_text/
+     * cta_url (none exist — cta has text/button_text/button_url) and grid
+     * declared items[].link (grid items use link_url/link_text). A patch to
+     * a dead field wrote an unused prop and reported success while the
+     * rendered page didn't change (lib/operate.php update_component does a
+     * shallow merge that accepts unknown props).
+     *
+     * This walks every registered component type and asserts each field
+     * name resolves to a real prop in that component's schema.json — top-
+     * level props directly, `items[].X` fields against the schema's
+     * `items` sub-definition — so this class of drift fails the suite
+     * instead of shipping.
+     */
+    public function testFieldEditabilityMapMatchesSchemaProps(): void
+    {
+        // Known, pre-existing drift tracked as its own issue (not
+        // introduced or fixed here): hero's registered 'eyebrow' field has
+        // no corresponding prop anywhere in hero.php or hero/schema.json.
+        // Fixing it requires a product decision (render eyebrow, or remove
+        // it) that #120's fix plan explicitly scopes out — see GitHub #85
+        // ("Hero eyebrow render-or-remove"). Exception is intentionally
+        // narrow: exactly one field, on one component.
+        $knownExceptions = [
+            'hero' => ['eyebrow'],
+        ];
+
+        $registry = pp_get_registered_component_fields();
+        $this->assertNotEmpty($registry, 'Expected at least one registered component field map.');
+
+        foreach ($registry as $componentType => $fields) {
+            $schemaFile = $this->themeRoot . "/components/{$componentType}/schema.json";
+            $this->assertFileExists($schemaFile, "Missing schema.json for registered component '{$componentType}'.");
+
+            $schema = json_decode(file_get_contents($schemaFile), true);
+            $this->assertIsArray($schema, "schema.json for '{$componentType}' must be valid JSON.");
+            $props = $schema['props'] ?? [];
+            $itemProps = $props['items']['items'] ?? null;
+
+            foreach ($fields as $field) {
+                $name = $field['name'];
+
+                if (in_array($name, $knownExceptions[$componentType] ?? [], true)) {
+                    continue;
+                }
+
+                if (str_starts_with($name, 'items[].')) {
+                    $itemField = substr($name, strlen('items[].'));
+                    $this->assertIsArray(
+                        $itemProps,
+                        "'{$componentType}' registers '{$name}' but its schema has no props.items.items definition."
+                    );
+                    $this->assertArrayHasKey(
+                        $itemField,
+                        $itemProps,
+                        "'{$componentType}' registers editable field '{$name}', but '{$itemField}' is not a key in schema.json props.items.items."
+                    );
+                    continue;
+                }
+
+                $this->assertArrayHasKey(
+                    $name,
+                    $props,
+                    "'{$componentType}' registers editable field '{$name}', but it is not a key in schema.json props."
+                );
+            }
+        }
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
 
     private function removeDir(string $dir): void


### PR DESCRIPTION
## Summary

**Bug fix**
- `pp_register_component_fields()` (`lib/operate.php`) declared `cta` fields (`subtitle`, `cta_text`, `cta_url`) and a `grid` field (`items[].link`) that don't exist on either component's real props (`components/cta/schema.json` has `title`/`text`/`button_text`/`button_url`; `components/grid/schema.json` items have `title`/`text`/`link_url`/`link_text`). This meant: patching a real field like `cta.button_text` failed with `field_not_editable`; patching a dead field like `cta.subtitle` reported success while writing a prop nothing renders; and `pp_inspect_composition()` (surfaced to the AI chat) advertised the dead selectors with `current_value: null`, steering the model toward mutations that don't render. Corrected both registrations to match schema.json exactly.
- Added `pp_get_registered_component_fields()` (matches the existing `pp_get_registered_actions()`/`pp_get_registered_applies()` accessor pattern) so tests can walk every registered component type without hardcoding a list.
- Added a drift-prevention test (`tests/SchemaValidationTest.php::testFieldEditabilityMapMatchesSchemaProps`) that walks every registered component's field map and asserts each field resolves to a real `schema.json` prop — this class of bug now fails the suite instead of shipping. It carries one narrow, documented exception for `hero`'s pre-existing `eyebrow` field (zero references anywhere in `hero.php`/`hero/schema.json`), tracked separately as **#85** ("Hero eyebrow render-or-remove") since fixing it requires a product decision (render vs. remove) explicitly out of scope here.
- Added write-path regression tests (`pp_patch_composition()`) proving both directions: the real fields now apply, and the old dead selectors now correctly fail with `field_not_editable`.

## Test Coverage

```
COVERAGE: all changed/added branches tested — read path (pp_inspect_composition),
write path (pp_patch_composition apply + reject), and the new registry accessor.
```

Tests: 823 → 828 PHP (+5 after the specialist-flagged gap was closed; net diff also updated 2 pre-existing test-count assertions that had baked in the old, wrong field names/counts), 262 JS (unchanged). All green (`vendor/bin/phpunit` + `npm test`).

## Pre-Landing Review

- Specialist dispatch (Testing, Maintainability, Security, Performance — diff was backend, >100 lines):
  - **Testing (1 critical, fixed):** flagged that only the read path (`pp_inspect_composition`) was regression-tested, not the write path (`pp_patch_composition`) — added tests proving both the corrected-fields-now-apply and dead-fields-now-fail directions, directly covering the issue's own two central failure scenarios.
  - **Testing (1 informational, fixed):** added a direct test for the new `pp_get_registered_component_fields()` accessor.
  - **Maintainability, Security, Performance:** 0 findings.
- Adversarial review (Claude subagent + Codex, both run): confirmed the fix is correct against the real render code (`esc_html()`/`esc_url()` on the corrected prop names, no legacy fallback needed) and the full suite. One INVESTIGATE finding accepted and filed as a follow-up rather than absorbed into this PR's scope: the field-editability map only gates the semantic-selector patch path — `update_component` accepts arbitrary prop keys directly, with no schema-based allowlist at the action layer itself. Filed as **#147**.

PR Quality Score: 9/10

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN — delivered #120's fix plan (correct cta/grid registrations + drift-prevention test) plus the write-path test coverage its own review surfaced as a direct gap in proving the issue's failure scenarios.

## Plan Completion

No plan file (size:S issue — fix plan + issue body served as the spec per this repo's backlog-loop convention).

## TODOS

No TODO items completed in this PR.

## Documentation

No AI-facing capability changed — `pp_register_component_fields()` is an internal implementation detail of the semantic-selector patch feature, not a documented capability surface. Verified all `AI_CONTEXT.md`/`ai-instructions/*.md` examples using the `cta` component already used the correct prop names (`text`/`button_text`/`button_url`) — the drift was isolated to this one internal registry. `docs/AI_IMPLEMENTATION_RECIPES.md` already documents the exact invariant this PR enforces, referencing `#120`/`#85` by number.

## Test plan
- [x] All PHP unit tests pass (828 tests, 3161 assertions, 0 failures)
- [x] All JS/Vitest tests pass (262 tests)
- [x] Regression tests prove both directions: `cta.button_text`/`button_url` and `grid...link_url`/`link_text` now apply via patch; `cta.subtitle`/`cta_text`/`cta_url` and a bare grid `link` field now correctly fail with `field_not_editable`

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
