### PR TITLE
v0.16.5 fix: DOMDocument charset in post-apply validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.5] — 2026-07-04 — Fix: Pages with Accented or Non-English Filenames No Longer Fail Validation
+
+**If an AI-applied change touched an image with an accented or non-English filename — common on Spanish, French, or other non-English sites — the chat reported "Changes applied but rendered page validation failed... missing media" for a page that was actually completely fine.** The validator that checks a page after an edit was misreading the filename's special characters, so it looked for a file that didn't exist under that garbled name instead of the real one already sitting in the Media Library.
+
+### Fixed
+- Post-apply page validation now reads image and link filenames correctly regardless of accented characters or other non-ASCII text, eliminating false "missing media" failures after otherwise-successful AI edits.
+
+### For contributors
+- Added regression tests covering a multibyte filename and a component whose rendered output could otherwise re-trigger the mis-read.
+
 ## [v0.16.4] — 2026-07-04 — Fix: Editing a CTA Button or Card Link Through Chat Actually Works Now
 
 **Asking the AI to change a CTA button's text or URL, or a grid card's link, previously either silently did nothing or told you the field couldn't be edited — for opposite reasons.** The internal map of "which fields can be edited by name" had drifted from the real component props: it listed fields the CTA and grid components don't have (so editing them wrote data nothing ever reads, and reported success) and left out the fields they actually use (so editing the *real* button text or link failed with "not editable"). Both are now correct — CTA's title/text/button text/button URL and grid cards' title/text/link text/link URL are all editable, and the AI's picture of what's currently in those fields is now accurate too.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.4-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.5-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.4');
+define('PP_VERSION', '0.16.5');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/post-apply-validate.php
+++ b/lib/post-apply-validate.php
@@ -101,9 +101,16 @@ function pp_post_apply_validate(int $post_id, ?array $target = null): array {
         // ISO-8859-1 and mis-decodes UTF-8 bytes — e.g. "café.jpg" reads
         // back as "cafÃ©.jpg", which then fails the media lookup below
         // for any real, correctly-uploaded file with a multibyte name.
+        // Strip any <meta> tags from the rendered fragment first: an
+        // in-content <meta charset="..."> takes priority over the
+        // document-level XML encoding hint in libxml's HTML sniffing, so
+        // a component whose output happens to carry one (e.g. embed's
+        // shortcode-rendered content) could silently defeat the fix and
+        // reintroduce the mis-decode. This validator has no legitimate
+        // use for a <meta> tag inside a component fragment anyway.
         $doc = new DOMDocument();
         $doc->loadHTML(
-            '<?xml encoding="utf-8"?><!DOCTYPE html><html><body>' . $html . '</body></html>',
+            '<?xml encoding="utf-8"?><!DOCTYPE html><html><body>' . preg_replace('/<meta\b[^>]*>/i', '', $html) . '</body></html>',
             LIBXML_NOERROR | LIBXML_NOWARNING
         );
 

--- a/lib/post-apply-validate.php
+++ b/lib/post-apply-validate.php
@@ -97,9 +97,13 @@ function pp_post_apply_validate(int $post_id, ?array $target = null): array {
         $rendered_count++;
 
         // 3. DOM inspection.
+        // Without an encoding hint, DOMDocument::loadHTML() assumes
+        // ISO-8859-1 and mis-decodes UTF-8 bytes — e.g. "café.jpg" reads
+        // back as "cafÃ©.jpg", which then fails the media lookup below
+        // for any real, correctly-uploaded file with a multibyte name.
         $doc = new DOMDocument();
         $doc->loadHTML(
-            '<!DOCTYPE html><html><body>' . $html . '</body></html>',
+            '<?xml encoding="utf-8"?><!DOCTYPE html><html><body>' . $html . '</body></html>',
             LIBXML_NOERROR | LIBXML_NOWARNING
         );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.4
+Stable tag: 0.16.5
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.4
+Version:          0.16.5
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/PostApplyValidateTest.php
+++ b/tests/PostApplyValidateTest.php
@@ -211,6 +211,34 @@ class PostApplyValidateTest extends TestCase
         $this->assertEmpty($result['errors']);
     }
 
+    public function testValidLocalImgWithMultibyteFilenamePasses(): void
+    {
+        // Regression (#128): DOMDocument::loadHTML() without an encoding
+        // hint assumes ISO-8859-1 and mis-decodes UTF-8, so
+        // "logotipo-diseño.png" would read back mangled and never match
+        // the real (correctly UTF-8) _wp_attached_file value.
+        $filename = 'logotipo-diseño.png';
+        $imgUrl = 'https://example.com/wp-content/uploads/2026/06/' . $filename;
+        $this->createTestComponent('card', '<div><img src="' . $imgUrl . '" alt="logo"></div>');
+        $this->setComposition([
+            ['component' => 'card', 'props' => [], 'style' => []],
+        ]);
+
+        $attachmentId = 201;
+        $GLOBALS['_pp_test_store']['posts'][$attachmentId] = [
+            'post_type' => 'attachment',
+            'post_status' => 'inherit',
+        ];
+        $GLOBALS['_pp_test_store']['post_meta'][$attachmentId] = [
+            '_wp_attached_file' => '2026/06/' . $filename,
+        ];
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertEmpty($result['errors']);
+    }
+
     public function testLocalImgNotInMediaLibraryIsError(): void
     {
         $imgUrl = 'https://example.com/wp-content/uploads/2026/06/missing.jpg';

--- a/tests/PostApplyValidateTest.php
+++ b/tests/PostApplyValidateTest.php
@@ -239,6 +239,39 @@ class PostApplyValidateTest extends TestCase
         $this->assertEmpty($result['errors']);
     }
 
+    public function testMultibyteFilenamePassesEvenWithEmbeddedMetaCharsetOverride(): void
+    {
+        // Regression (#128 adversarial review): libxml's HTML encoding
+        // sniffing prioritizes an in-content <meta charset="..."> over the
+        // document-level XML encoding hint. If a component's rendered
+        // output happens to carry one (e.g. embed's shortcode-rendered
+        // content), it could silently defeat the fix above and
+        // reintroduce the mis-decode. Confirm the validator strips it.
+        $filename = 'logotipo-diseño.png';
+        $imgUrl = 'https://example.com/wp-content/uploads/2026/06/' . $filename;
+        $this->createTestComponent(
+            'embed',
+            '<meta charset="ISO-8859-1"><div><img src="' . $imgUrl . '" alt="logo"></div>'
+        );
+        $this->setComposition([
+            ['component' => 'embed', 'props' => [], 'style' => []],
+        ]);
+
+        $attachmentId = 202;
+        $GLOBALS['_pp_test_store']['posts'][$attachmentId] = [
+            'post_type' => 'attachment',
+            'post_status' => 'inherit',
+        ];
+        $GLOBALS['_pp_test_store']['post_meta'][$attachmentId] = [
+            '_wp_attached_file' => '2026/06/' . $filename,
+        ];
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertEmpty($result['errors']);
+    }
+
     public function testLocalImgNotInMediaLibraryIsError(): void
     {
         $imgUrl = 'https://example.com/wp-content/uploads/2026/06/missing.jpg';


### PR DESCRIPTION
## Summary

**Bug fix**
- `pp_post_apply_validate()` (`lib/post-apply-validate.php`) parsed rendered component HTML with `DOMDocument::loadHTML()` without an encoding hint, so libxml assumed ISO-8859-1 and mis-decoded UTF-8 bytes — e.g. `café.jpg` read back as `cafÃ©.jpg`. Any image with a multibyte filename (accented, CJK — common on non-English sites) then failed the media-library lookup against the correctly-UTF-8-stored `_wp_attached_file` value, and the chat reported "Changes applied but rendered page validation failed... missing media" for a perfectly healthy page. Fixed by prepending `<?xml encoding="utf-8"?>` to the string passed to `loadHTML()`.
- **Hardened during adversarial review:** a Claude subagent found (and I verified manually) that an in-content `<meta charset="...">` tag takes priority over that document-level encoding hint in libxml's HTML sniffing — so a component whose rendered output happens to carry one (the `embed` component's shortcode-rendered content is the one user-influenced path that could) would silently defeat the fix and reintroduce the exact bug. Now strips `<meta>` tags from the rendered fragment before parsing; this validator has no legitimate use for one anyway.

## Test Coverage

Verified the core bug and both fixes empirically before writing tests: confirmed `logotipo-diseño.png` mis-decodes to `logotipo-diseÃ±o.png` without the hint and round-trips correctly with it, and confirmed an embedded `<meta charset="ISO-8859-1">` defeats the hint unless stripped.

Tests: 828 → 830 PHP (+2), 262 JS (unchanged). All green (`vendor/bin/phpunit` + `npm test`).

```
COVERAGE: both new branches (multibyte filename read correctly; meta-charset
override neutralized) directly regression-tested with real fixture data.
```

## Pre-Landing Review

- Diff was 33-74 lines — below the specialist-dispatch threshold, so specialists were skipped per policy.
- Adversarial review (Claude subagent + Codex, both run): Claude found the meta-charset override gap described above (fixed and regression-tested in this PR) and two lower-severity informational notes (malformed-UTF-8 input produces different-but-still-garbage output post-fix — acceptable since `$html` is server-rendered, not raw user input; keep the regression test running in CI against the deployed PHP/libxml version — already true by default). Codex: no findings, recommended merge.

PR Quality Score: 9.5/10

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN — delivered #128's fix plan (encoding hint) plus the meta-charset hardening its own adversarial review surfaced as a direct way to defeat that same fix.

## Plan Completion

No plan file (size:S issue — fix plan + issue body served as the spec per this repo's backlog-loop convention).

## TODOS

No TODO items completed in this PR. Note: `TODOS.md`'s "Investigate broken-media missing_local_media validation on WP 7.0" item (tracking #83) explicitly names #128 as a prerequisite but is a distinct, still-open bug (a false *negative* — `style_component` succeeding when it should fail — the opposite direction from this PR's false *positive* fix) and is left open.

## Documentation

No AI-facing capability changed — `AI_CONTEXT.md`'s existing description of `pp_post_apply_validate()` ("DOM inspection for broken images, empty content, missing components") remains accurate; this fixes an internal correctness bug in that check, not its documented contract.

## Test plan
- [x] All PHP unit tests pass (830 tests, 3165 assertions, 0 failures)
- [x] All JS/Vitest tests pass (262 tests)
- [x] Manually verified the exact byte-level mis-decode and both fixes with standalone PHP reproduction scripts before writing tests

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
