### PR TITLE
v0.16.6 fix: wp_unslash chat fallback message content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.6] — 2026-07-04 — Fix: Quotes and Apostrophes in Chat Messages No Longer Get Mangled
+
+**If the chat's live-streaming connection dropped and it silently fell back to its backup delivery method, every apostrophe, quote mark, and backslash you'd typed started coming out wrong — and it got worse with every message after that.** WordPress adds a layer of escaping to form submissions that the theme forgot to remove on that one fallback path, so `"It's live!"` would arrive at the AI as `\"It\'s live!\"`, and the mangling compounded each time the fallback was used again in the same conversation.
+
+### Fixed
+- The chat's non-streaming fallback and the action/apply preview and execute requests now correctly preserve quotes, apostrophes, and backslashes in your messages and inputs instead of corrupting them.
+
 ## [v0.16.5] — 2026-07-04 — Fix: Pages with Accented or Non-English Filenames No Longer Fail Validation
 
 **If an AI-applied change touched an image with an accented or non-English filename — common on Spanish, French, or other non-English sites — the chat reported "Changes applied but rendered page validation failed... missing media" for a page that was actually completely fine.** The validator that checks a page after an edit was misreading the filename's special characters, so it looked for a file that didn't exist under that garbled name instead of the real one already sitting in the Media Library.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.5-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.6-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.5');
+define('PP_VERSION', '0.16.6');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/ai-chat.php
+++ b/lib/ai-chat.php
@@ -784,6 +784,18 @@ function _pp_user_meets_required_caps(array $required): bool {
     return true;
 }
 
+/**
+ * Returns $_POST['params'] unslashed once, as an array.
+ *
+ * WordPress magic-quotes every $_POST value (wp_magic_quotes()). Unslashing
+ * the whole params array here — rather than per-param-type inside
+ * pp_ai_coerce_params() — protects every plain string param, not just
+ * array-type params destined for json_decode there.
+ */
+function _pp_ai_get_unslashed_post_params(): array {
+    return isset($_POST['params']) ? wp_unslash((array) $_POST['params']) : [];
+}
+
 // ── AJAX: Preview Action/Apply ─────────────────────────────────────────────
 
 add_action('wp_ajax_pp_ai_preview', function () {
@@ -795,10 +807,7 @@ add_action('wp_ajax_pp_ai_preview', function () {
 
     $type   = sanitize_text_field($_POST['type'] ?? '');
     $name   = sanitize_text_field($_POST['name'] ?? '');
-    // Unslash once here rather than per-param-type in pp_ai_coerce_params(),
-    // so every plain string param (not just array-type params destined for
-    // json_decode) is protected from WordPress's magic-quotes on $_POST.
-    $params = isset($_POST['params']) ? wp_unslash((array) $_POST['params']) : [];
+    $params = _pp_ai_get_unslashed_post_params();
 
     if (!in_array($type, ['action', 'apply'], true)) {
         wp_send_json_error('Invalid type. Must be "action" or "apply".');
@@ -858,10 +867,7 @@ add_action('wp_ajax_pp_ai_execute', function () {
 
     $type   = sanitize_text_field($_POST['type'] ?? '');
     $name   = sanitize_text_field($_POST['name'] ?? '');
-    // Unslash once here rather than per-param-type in pp_ai_coerce_params(),
-    // so every plain string param (not just array-type params destined for
-    // json_decode) is protected from WordPress's magic-quotes on $_POST.
-    $params = isset($_POST['params']) ? wp_unslash((array) $_POST['params']) : [];
+    $params = _pp_ai_get_unslashed_post_params();
 
     if (!in_array($type, ['action', 'apply'], true)) {
         wp_send_json_error('Invalid type. Must be "action" or "apply".');

--- a/lib/ai-chat.php
+++ b/lib/ai-chat.php
@@ -239,6 +239,10 @@ add_action('wp_ajax_pp_ai_switch_provider', function () {
 // FormData sends all values as strings. The action/apply layer does strict
 // type checking via gettype(). Coerce params to match declared types before
 // passing them through.
+//
+// $params must already be wp_unslash()'d by the caller (both AJAX handlers
+// that call this do so once, on the whole array) — do not unslash again
+// here, or a value containing real backslashes/quotes gets double-stripped.
 
 function pp_ai_coerce_params(string $type, string $name, array $params): array {
     if ($type === 'action') {
@@ -264,7 +268,9 @@ function pp_ai_coerce_params(string $type, string $name, array $params): array {
         } elseif ($expected === 'bool' && is_string($val)) {
             $params[$param_name] = filter_var($val, FILTER_VALIDATE_BOOLEAN);
         } elseif ($expected === 'array' && is_string($val)) {
-            $decoded = json_decode(wp_unslash($val), true);
+            // $val is already unslashed (see the note above) — do not
+            // wp_unslash() it again here.
+            $decoded = json_decode($val, true);
             if (is_array($decoded)) {
                 $params[$param_name] = $decoded;
             }
@@ -789,7 +795,10 @@ add_action('wp_ajax_pp_ai_preview', function () {
 
     $type   = sanitize_text_field($_POST['type'] ?? '');
     $name   = sanitize_text_field($_POST['name'] ?? '');
-    $params = isset($_POST['params']) ? (array) $_POST['params'] : [];
+    // Unslash once here rather than per-param-type in pp_ai_coerce_params(),
+    // so every plain string param (not just array-type params destined for
+    // json_decode) is protected from WordPress's magic-quotes on $_POST.
+    $params = isset($_POST['params']) ? wp_unslash((array) $_POST['params']) : [];
 
     if (!in_array($type, ['action', 'apply'], true)) {
         wp_send_json_error('Invalid type. Must be "action" or "apply".');
@@ -849,7 +858,10 @@ add_action('wp_ajax_pp_ai_execute', function () {
 
     $type   = sanitize_text_field($_POST['type'] ?? '');
     $name   = sanitize_text_field($_POST['name'] ?? '');
-    $params = isset($_POST['params']) ? (array) $_POST['params'] : [];
+    // Unslash once here rather than per-param-type in pp_ai_coerce_params(),
+    // so every plain string param (not just array-type params destined for
+    // json_decode) is protected from WordPress's magic-quotes on $_POST.
+    $params = isset($_POST['params']) ? wp_unslash((array) $_POST['params']) : [];
 
     if (!in_array($type, ['action', 'apply'], true)) {
         wp_send_json_error('Invalid type. Must be "action" or "apply".');
@@ -924,7 +936,12 @@ add_action('wp_ajax_pp_ai_chat', function () {
 
     set_time_limit(0);
 
-    $conversation = isset($_POST['messages']) ? (array) $_POST['messages'] : [];
+    // WordPress magic-quotes every $_POST value during bootstrap
+    // (wp_magic_quotes()); the SSE path is immune (reads raw JSON from
+    // php://input) but this fallback reads $_POST directly, so every
+    // quote/backslash in the conversation must be unslashed before it
+    // reaches the provider.
+    $conversation = isset($_POST['messages']) ? wp_unslash((array) $_POST['messages']) : [];
     $page_id      = isset($_POST['page_id']) ? (int) $_POST['page_id'] : null;
 
     if (empty($conversation)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.5
+Stable tag: 0.16.6
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.5
+Version:          0.16.6
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/AiChatHandlersTest.php
+++ b/tests/AiChatHandlersTest.php
@@ -487,6 +487,22 @@ class AiChatHandlersTest extends TestCase
         $this->assertSame($composition, $params['composition']);
     }
 
+    public function testGetUnslashedPostParamsRestoresPlainStringValues(): void
+    {
+        // Regression (#125): before this fix, plain string params (e.g.
+        // update_page_title's 'title', type='string') were never unslashed
+        // anywhere — pp_ai_coerce_params() only ever touched array-type
+        // params. _pp_ai_get_unslashed_post_params() now unslashes the
+        // whole $_POST['params'] array once, covering plain strings too.
+        $original = 'It\'s "live" now';
+        $_POST['params'] = ['title' => addslashes($original)];
+
+        $params = _pp_ai_get_unslashed_post_params();
+
+        $this->assertSame($original, $params['title']);
+        unset($_POST['params']);
+    }
+
     // ── Proposal Parsing Integration ──────────────────────────────────────
 
     public function testProposalParsingIntegrationWithActionTypes(): void

--- a/tests/AiChatHandlersTest.php
+++ b/tests/AiChatHandlersTest.php
@@ -444,6 +444,49 @@ class AiChatHandlersTest extends TestCase
         $this->assertNotContains('query', $valid);
     }
 
+    // ── Magic-quotes unslashing (#125) ──────────────────────────────────────
+
+    public function testWpUnslashRestoresQuotesAndBackslashesInMessages(): void
+    {
+        // Regression (#125): WordPress magic-quotes every $_POST value
+        // during bootstrap (wp_magic_quotes()). The non-streaming chat
+        // fallback (wp_ajax_pp_ai_chat) reads $_POST['messages'] directly
+        // and previously passed it straight to the provider unslashed.
+        // Simulate what $_POST would actually contain for a message like
+        // `change the hero title to "It's live!"` and confirm wp_unslash()
+        // restores the original text byte-for-byte.
+        $original = 'change the hero title to "It\'s live!" and note the \\ character';
+        $slashed = addslashes($original);
+        $this->assertNotSame($original, $slashed, 'Fixture must actually be slashed to test anything.');
+
+        $postMessages = [
+            ['role' => 'user', 'content' => $slashed],
+        ];
+
+        $unslashed = wp_unslash($postMessages);
+
+        $this->assertSame($original, $unslashed[0]['content']);
+    }
+
+    public function testCoerceParamsDoesNotDoubleUnslashArrayTypeParams(): void
+    {
+        // Regression (#125): pp_ai_coerce_params() used to call
+        // wp_unslash() again on array-type params after both AJAX
+        // handlers already unslash the whole $params array once. Confirm
+        // a JSON string containing an escaped backslash decodes correctly
+        // without being stripped twice (which would corrupt it).
+        $composition = [['component' => 'section', 'props' => ['body' => 'A path: C:\\Users\\x']]];
+        $json = wp_json_encode($composition);
+
+        // Simulate the caller's single top-level unslash of the whole
+        // params array (the JSON string itself carries no magic-quote
+        // slashes here — it's the raw encoded value the caller already
+        // unslashed once, matching what both handlers now do).
+        $params = pp_ai_coerce_params('action', 'update_composition', ['composition' => $json]);
+
+        $this->assertSame($composition, $params['composition']);
+    }
+
     // ── Proposal Parsing Integration ──────────────────────────────────────
 
     public function testProposalParsingIntegrationWithActionTypes(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -343,6 +343,12 @@ if (!function_exists('maybe_unserialize')) {
 
 if (!function_exists('wp_unslash')) {
     function wp_unslash($value) {
+        // Real WordPress recurses (stripslashes_deep()) — this stub must
+        // too, since callers pass arrays of messages/params, not just
+        // single strings.
+        if (is_array($value)) {
+            return array_map('wp_unslash', $value);
+        }
         return is_string($value) ? stripslashes($value) : $value;
     }
 }


### PR DESCRIPTION
## Summary

**Bug fix**
- WordPress magic-quotes every `$_POST` value during bootstrap (`wp_magic_quotes()`). The SSE streaming chat path is immune (reads raw JSON from `php://input`), but the non-streaming AJAX fallback (`wp_ajax_pp_ai_chat`, `lib/ai-chat.php`) read `$_POST['messages']` directly and passed it straight to the LLM provider — every quote and backslash in the conversation arrived corrupted, and the corruption compounded on each fallback round-trip. Added `wp_unslash()` to the messages array.
- **Audit from the issue's own fix plan step 2:** `pp_ai_coerce_params()` already unslashed array-type params (JSON strings destined for `json_decode`) via an internal `wp_unslash()` call, but left plain string params slashed. Consolidated both `wp_ajax_pp_ai_preview` and `wp_ajax_pp_ai_execute` to unslash the whole `$_POST['params']` array once at the top (extracted as a shared `_pp_ai_get_unslashed_post_params()` helper per the maintainability specialist's review), and removed the now-redundant internal `wp_unslash()` call inside `pp_ai_coerce_params()` — keeping both would double-unslash a value like a Windows path or a JSON-escaped backslash and corrupt it.
- **Test infra fix:** `tests/bootstrap.php`'s `wp_unslash()` stub only handled plain strings; real WordPress recurses into arrays via `stripslashes_deep()`, and callers here pass arrays of messages/params, not single strings. The stub silently no-op'd on array input, which would have made any regression test for this issue meaningless. Fixed it to recurse.

## Test Coverage

Verified the double-unslash corruption mechanism manually before writing tests: confirmed a JSON-encoded Windows-path value decodes correctly with a single unslash and fails `json_decode` (returns `NULL`) with an extra one — proving the regression test actually guards the fix, not just passes vacuously.

Tests: 830 → 833 PHP (+3, after the specialist-flagged coverage gap for plain string params was closed), 262 JS (unchanged). All green (`vendor/bin/phpunit` + `npm test`).

## Pre-Landing Review

- Specialist dispatch (Testing, Maintainability, Security — diff was backend, >50 lines):
  - **Testing (4 informational, 1 fixed):** all four findings were variations of "the actual AJAX closures aren't exercised end-to-end" — this project's `add_action` is a no-op stub, a deliberate pre-existing test-layer boundary (documented in `AiChatHandlersTest.php`'s own docstring), not something this PR should rearchitect. Unlike #131 (permission logic, verifiable via a live wp-env HTTP request with no external dependency), this fix's actual effect is only observable inside a real LLM provider call, which would require a live API key I don't have and shouldn't fabricate — so the established "test the extracted function directly" pattern is the right approach here, not a gap to work around. One finding *was* directly actionable — a plain-string-param coverage gap matching the issue's own stated concern — fixed and tested directly against the new shared helper.
  - **Security (0 findings):** confirmed unslashing doesn't weaken any validation (the array-type coercion branch is `is_string($val)`-gated, so a pre-decoded array was never affected; `pp_execute_action`/`pp_execute_apply` callers outside the chat AJAX layer bypass `pp_ai_coerce_params()` entirely and are untouched).
- Adversarial review (Claude subagent + Codex, both run): traced every caller of the touched functions, verified actual client-side payload shapes (`assets/js/pp-ai-chat.js`) match what the fix assumes, confirmed the SSE path really is immune, and confirmed chat content renders via `textContent` (not `innerHTML`) so preserving quotes/backslashes introduces no new XSS surface. One INVESTIGATE-only, non-blocking note: the test stub's array recursion doesn't also recurse into objects like real WP's `stripslashes_deep()` does — unreachable today since PHP superglobals never contain objects. Both recommended merge.

PR Quality Score: 9.5/10

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-template files changed — evals skipped. (This PR fixes how user message *content* reaches the provider, not the system prompt or tool schemas.)

## Scope Drift

Scope Check: CLEAN — delivered all three steps of #125's fix plan (unslash messages, audit + consolidate params unslashing, add a byte-for-byte regression test) plus the plain-string-param coverage gap and DRY duplication its own specialist review surfaced as direct consequences.

## Plan Completion

No plan file (size:S issue — fix plan + issue body served as the spec per this repo's backlog-loop convention).

## TODOS

No TODO items completed in this PR.

## Documentation

No AI-facing capability changed — this is an internal request-handling correctness fix with no new component, action, apply, or operating-loop behavior.

## Test plan
- [x] All PHP unit tests pass (833 tests, 3169 assertions, 0 failures)
- [x] All JS/Vitest tests pass (262 tests)
- [x] Manually verified the double-unslash corruption mechanism byte-for-byte before writing the regression test

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
