### PR TITLE
Fix: AI media inventory no longer advertises non-image attachments as images

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -420,6 +420,8 @@ All mutations go through typed actions. AJAX handlers, WP-CLI, and future AI cal
 
 **Execute always validates first.** Callers never need to pre-validate.
 
+**`pp_validate_action()` also rejects bad media URLs.** Any `image_url`/`background_image` value (flat or inside `items[]`) that points into the site's uploads directory must resolve to an actual Media Library attachment AND be an image — a URL to a PDF/video/audio attachment, or to no attachment at all, fails validation with `invalid_media_url` before anything is written. External URLs (outside uploads) are passed through unchecked. This applies uniformly to every caller — AJAX, WP-CLI, `pp_patch_composition()` — not just the AI chat surface.
+
 **Registry functions:**
 - `pp_get_registered_actions()` — all 14 actions
 - `pp_get_action($name)` — single action definition or null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.8] — 2026-07-04 — Fix: The AI Chat Can No Longer Turn a PDF Into a "Photo"
+
+**The AI chat's media picker used to tell the model every file in your Media Library — PDFs, videos, audio — was an "available image" and to copy its URL exactly.** Ask for a hero photo, and it could hand back a brochure PDF as `image_url`, which the page would happily try to render as a broken `<img>`. The media list now only ever shows real, displayable images (SVGs included — WordPress doesn't treat those as renderable images either). And the same check that used to live only in the chat's "run this" button now runs everywhere an action can be executed — the WP-CLI automation path and the composition-patch tool included — so a non-image URL gets rejected no matter which door it comes through.
+
+### Fixed
+- The AI chat's media inventory only lists genuine, renderable images — no more PDFs, videos, or audio files mislabeled as "available images."
+- Any action that would write a non-image URL into an `image_url` or `background_image` field is now rejected before anything is saved, whether it's triggered from the chat, WP-CLI, or the composition-patch tool — not just the chat's own execute button.
+
+### For contributors
+- 12 new PHP tests covering the inventory filter, the execute-time image check (including the SVG mismatch case and a direct `pp_execute_action()` call that bypasses the AJAX layer entirely), and a hardened `$wpdb` test stub that actually verifies the queried URL instead of always returning a fixed match.
+- Filed follow-ups for three narrower gaps found during review: relative/CDN media URLs bypassing the check entirely (#153), the image-prop allowlist being hand-maintained instead of schema-driven (#154), and the nav/footer logo picker lacking the same explicit image-type check the site-logo option already has (#155).
+
 ## [v0.16.7] — 2026-07-04 — Fix: Nonsensical Spacing/Size Values Are Now Actually Rejected
 
 **A design-token or style-slot value like `calc(px)` or `calc((rem) + 1px)` — missing the number that should go with the unit — used to be accepted as "changed successfully," but the browser just silently threw the value away, so nothing on the page actually moved.** The check meant to catch exactly this kind of malformed value existed in the code but was never wired up — it evaluated a condition and then did nothing with the answer. Now it's enforced: a `calc()` or `clamp()` value has to have a real number attached to every size unit, or the change is rejected up front instead of quietly doing nothing.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.7-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.8-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.7');
+define('PP_VERSION', '0.16.8');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -95,8 +95,149 @@ function pp_validate_action(string $name, array $params) {
         }
     }
 
+    // Media-library URL/image-type validation (#124). Runs here — not in a
+    // per-caller AJAX handler — so every caller of pp_validate_action()
+    // (AJAX, WP-CLI, pp_patch_composition()) is covered by the same guard.
+    $url_error = _pp_validate_media_urls_in_params($params);
+    if (is_wp_error($url_error)) {
+        return $url_error;
+    }
+
     // Semantic validation: action's own checks
     return call_user_func($action['validate'], $params);
+}
+
+/**
+ * Validates that any URL in action params matching the site's uploads directory
+ * corresponds to an actual media library attachment, AND that the attachment
+ * is an image (#124 — the AI media inventory only lists images, but nothing
+ * stops a proposed action from pointing at a non-image attachment it saw
+ * elsewhere, or from hallucinating one that happens to resolve). URLs not
+ * matching the uploads pattern are passed through (external URLs are allowed).
+ *
+ * Checks: props (flat string values), props.items[].image_url/image_alt style,
+ * and composition arrays.
+ *
+ * @return true|WP_Error
+ */
+function _pp_validate_media_urls_in_params(array $params) {
+    $upload_dir = wp_get_upload_dir();
+    $upload_base = $upload_dir['baseurl'] ?? '';
+    if (empty($upload_base)) {
+        return true;
+    }
+
+    $urls = _pp_extract_urls_from_params($params);
+    if (empty($urls)) {
+        return true;
+    }
+
+    foreach ($urls as $url) {
+        // Only validate URLs that look like they reference the site's uploads
+        if (strpos($url, $upload_base) !== 0) {
+            continue;
+        }
+
+        // Check if this URL matches any attachment in the media library
+        $attachment_id = _pp_resolve_attachment_id_by_url($url);
+        if ($attachment_id <= 0) {
+            $filename = basename($url);
+            return new WP_Error(
+                'invalid_media_url',
+                sprintf('Image URL does not match any file in the media library: %s', $filename)
+            );
+        }
+
+        // Defense in depth: pp_ai_media_inventory() only lists image
+        // attachments, but nothing stops the model from fabricating a URL to
+        // a non-image attachment it saw elsewhere (or hallucinating one that
+        // happens to resolve). Reject at execute time too (#124).
+        if (!wp_attachment_is_image($attachment_id)) {
+            $filename = basename($url);
+            return new WP_Error(
+                'invalid_media_url',
+                sprintf('URL does not point to an image file: %s', $filename)
+            );
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Extracts all URL-like string values from action params.
+ * Walks props, composition arrays, and items arrays.
+ */
+function _pp_extract_urls_from_params(array $params): array {
+    $urls = [];
+    // logo_id is an attachment ID, not a URL — excluded from URL extraction.
+    $url_props = ['image_url', 'background_image'];
+
+    // Direct props (flat)
+    if (isset($params['props']) && is_array($params['props'])) {
+        _pp_collect_urls_from_props($params['props'], $url_props, $urls);
+    }
+
+    // Composition array (update_composition / create_page)
+    if (isset($params['composition']) && is_array($params['composition'])) {
+        foreach ($params['composition'] as $component) {
+            if (isset($component['props']) && is_array($component['props'])) {
+                _pp_collect_urls_from_props($component['props'], $url_props, $urls);
+            }
+        }
+    }
+
+    return $urls;
+}
+
+/**
+ * Collects URLs from a props array, including nested items arrays.
+ */
+function _pp_collect_urls_from_props(array $props, array $url_props, array &$urls): void {
+    foreach ($url_props as $prop) {
+        if (isset($props[$prop]) && is_string($props[$prop]) && $props[$prop] !== '') {
+            $urls[] = $props[$prop];
+        }
+    }
+    // Items arrays (grid, logos)
+    if (isset($props['items']) && is_array($props['items'])) {
+        foreach ($props['items'] as $item) {
+            if (is_array($item)) {
+                foreach ($url_props as $prop) {
+                    if (isset($item[$prop]) && is_string($item[$prop]) && $item[$prop] !== '') {
+                        $urls[] = $item[$prop];
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Resolves a URL to its media library attachment ID, or 0 if none matches.
+ */
+function _pp_resolve_attachment_id_by_url(string $url): int {
+    // Try attachment_url_to_postid (handles scaled/resized URLs too)
+    $attachment_id = attachment_url_to_postid($url);
+    if ($attachment_id > 0) {
+        return (int) $attachment_id;
+    }
+
+    // Fallback: check by guid (handles edge cases where the above misses).
+    // No $wpdb (unit test context, mirroring _pp_with_token_lock's check) —
+    // treat as no match rather than fatal on a missing global.
+    global $wpdb;
+    if (!isset($wpdb) || !is_object($wpdb) || !method_exists($wpdb, 'get_var')) {
+        return 0;
+    }
+    // ORDER BY + LIMIT 1: the old COUNT(*)-only query didn't care which row
+    // matched, but this one returns a specific ID that feeds
+    // wp_attachment_is_image() — a duplicate guid must resolve deterministically.
+    $id = $wpdb->get_var($wpdb->prepare(
+        "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'attachment' AND guid = %s ORDER BY ID ASC LIMIT 1",
+        $url
+    ));
+    return (int) $id;
 }
 
 /**

--- a/lib/ai-chat.php
+++ b/lib/ai-chat.php
@@ -280,133 +280,6 @@ function pp_ai_coerce_params(string $type, string $name, array $params): array {
     return $params;
 }
 
-/**
- * Validates that any URL in action params matching the site's uploads directory
- * corresponds to an actual media library attachment. URLs not matching the
- * uploads pattern are passed through (external URLs are allowed).
- *
- * Checks: props (flat string values), props.items[].image_url/image_alt style,
- * and composition arrays.
- *
- * @return true|WP_Error
- */
-function _pp_validate_media_urls_in_params(array $params) {
-    $upload_dir = wp_get_upload_dir();
-    $upload_base = $upload_dir['baseurl'] ?? '';
-    if (empty($upload_base)) {
-        return true;
-    }
-
-    $urls = _pp_extract_urls_from_params($params);
-    if (empty($urls)) {
-        return true;
-    }
-
-    foreach ($urls as $url) {
-        // Only validate URLs that look like they reference the site's uploads
-        if (strpos($url, $upload_base) !== 0) {
-            continue;
-        }
-
-        // Check if this URL matches any attachment in the media library
-        $attachment_id = _pp_resolve_attachment_id_by_url($url);
-        if ($attachment_id <= 0) {
-            $filename = basename($url);
-            return new WP_Error(
-                'invalid_media_url',
-                sprintf('Image URL does not match any file in the media library: %s', $filename)
-            );
-        }
-
-        // Defense in depth: pp_ai_media_inventory() only lists image
-        // attachments, but nothing stops the model from fabricating a URL to
-        // a non-image attachment it saw elsewhere (or hallucinating one that
-        // happens to resolve). Reject at execute time too (#124).
-        if (!wp_attachment_is_image($attachment_id)) {
-            $filename = basename($url);
-            return new WP_Error(
-                'invalid_media_url',
-                sprintf('URL does not point to an image file: %s', $filename)
-            );
-        }
-    }
-
-    return true;
-}
-
-/**
- * Extracts all URL-like string values from action params.
- * Walks props, composition arrays, and items arrays.
- */
-function _pp_extract_urls_from_params(array $params): array {
-    $urls = [];
-    // logo_id is an attachment ID, not a URL — excluded from URL extraction.
-    $url_props = ['image_url', 'background_image'];
-
-    // Direct props (flat)
-    if (isset($params['props']) && is_array($params['props'])) {
-        _pp_collect_urls_from_props($params['props'], $url_props, $urls);
-    }
-
-    // Composition array (update_composition / create_page)
-    if (isset($params['composition']) && is_array($params['composition'])) {
-        foreach ($params['composition'] as $component) {
-            if (isset($component['props']) && is_array($component['props'])) {
-                _pp_collect_urls_from_props($component['props'], $url_props, $urls);
-            }
-        }
-    }
-
-    return $urls;
-}
-
-/**
- * Collects URLs from a props array, including nested items arrays.
- */
-function _pp_collect_urls_from_props(array $props, array $url_props, array &$urls): void {
-    foreach ($url_props as $prop) {
-        if (isset($props[$prop]) && is_string($props[$prop]) && $props[$prop] !== '') {
-            $urls[] = $props[$prop];
-        }
-    }
-    // Items arrays (grid, logos)
-    if (isset($props['items']) && is_array($props['items'])) {
-        foreach ($props['items'] as $item) {
-            if (is_array($item)) {
-                foreach ($url_props as $prop) {
-                    if (isset($item[$prop]) && is_string($item[$prop]) && $item[$prop] !== '') {
-                        $urls[] = $item[$prop];
-                    }
-                }
-            }
-        }
-    }
-}
-
-/**
- * Resolves a URL to its media library attachment ID, or 0 if none matches.
- */
-function _pp_resolve_attachment_id_by_url(string $url): int {
-    // Try attachment_url_to_postid (handles scaled/resized URLs too)
-    $attachment_id = attachment_url_to_postid($url);
-    if ($attachment_id > 0) {
-        return (int) $attachment_id;
-    }
-
-    // Fallback: check by guid (handles edge cases where the above misses).
-    // No $wpdb (unit test context, mirroring _pp_with_token_lock's check) —
-    // treat as no match rather than fatal on a missing global.
-    global $wpdb;
-    if (!isset($wpdb) || !is_object($wpdb) || !method_exists($wpdb, 'get_var')) {
-        return 0;
-    }
-    $id = $wpdb->get_var($wpdb->prepare(
-        "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'attachment' AND guid = %s",
-        $url
-    ));
-    return (int) $id;
-}
-
 // ── Style Repair Helper ───────────────────────────────────────────────────
 // When the LLM proposes an invalid style slot name, attempt to find the
 // closest match via Levenshtein distance. Returns repaired params or null.
@@ -901,13 +774,10 @@ add_action('wp_ajax_pp_ai_execute', function () {
         wp_send_json_error('Permission denied.');
     }
 
-    // Validate media-library URLs in props before execution
-    if ($type === 'action') {
-        $url_error = _pp_validate_media_urls_in_params($params);
-        if (is_wp_error($url_error)) {
-            wp_send_json_error($url_error->get_error_message());
-        }
-    }
+    // Media-library URL/image-type validation (#124) now runs inside
+    // pp_validate_action() itself (lib/actions.php), so every caller —
+    // this AJAX handler, WP-CLI, and pp_patch_composition() — is covered
+    // by the same guard instead of one ad-hoc check per entry point.
 
     if ($type === 'action') {
         $result = pp_execute_action($name, $params);

--- a/lib/ai-chat.php
+++ b/lib/ai-chat.php
@@ -309,11 +309,24 @@ function _pp_validate_media_urls_in_params(array $params) {
         }
 
         // Check if this URL matches any attachment in the media library
-        if (!_pp_attachment_exists_by_url($url)) {
+        $attachment_id = _pp_resolve_attachment_id_by_url($url);
+        if ($attachment_id <= 0) {
             $filename = basename($url);
             return new WP_Error(
                 'invalid_media_url',
                 sprintf('Image URL does not match any file in the media library: %s', $filename)
+            );
+        }
+
+        // Defense in depth: pp_ai_media_inventory() only lists image
+        // attachments, but nothing stops the model from fabricating a URL to
+        // a non-image attachment it saw elsewhere (or hallucinating one that
+        // happens to resolve). Reject at execute time too (#124).
+        if (!wp_attachment_is_image($attachment_id)) {
+            $filename = basename($url);
+            return new WP_Error(
+                'invalid_media_url',
+                sprintf('URL does not point to an image file: %s', $filename)
             );
         }
     }
@@ -371,22 +384,27 @@ function _pp_collect_urls_from_props(array $props, array $url_props, array &$url
 }
 
 /**
- * Checks if a URL corresponds to an existing media library attachment.
+ * Resolves a URL to its media library attachment ID, or 0 if none matches.
  */
-function _pp_attachment_exists_by_url(string $url): bool {
+function _pp_resolve_attachment_id_by_url(string $url): int {
     // Try attachment_url_to_postid (handles scaled/resized URLs too)
     $attachment_id = attachment_url_to_postid($url);
     if ($attachment_id > 0) {
-        return true;
+        return (int) $attachment_id;
     }
 
-    // Fallback: check by guid (handles edge cases where the above misses)
+    // Fallback: check by guid (handles edge cases where the above misses).
+    // No $wpdb (unit test context, mirroring _pp_with_token_lock's check) —
+    // treat as no match rather than fatal on a missing global.
     global $wpdb;
-    $count = $wpdb->get_var($wpdb->prepare(
-        "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'attachment' AND guid = %s",
+    if (!isset($wpdb) || !is_object($wpdb) || !method_exists($wpdb, 'get_var')) {
+        return 0;
+    }
+    $id = $wpdb->get_var($wpdb->prepare(
+        "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'attachment' AND guid = %s",
         $url
     ));
-    return (int) $count > 0;
+    return (int) $id;
 }
 
 // ── Style Repair Helper ───────────────────────────────────────────────────

--- a/lib/ai-context.php
+++ b/lib/ai-context.php
@@ -278,6 +278,7 @@ function pp_ai_media_inventory(int $limit = 50): array {
     $attachments = get_posts([
         'post_type'      => 'attachment',
         'post_status'    => 'inherit',
+        'post_mime_type' => 'image',
         'posts_per_page' => $limit,
         'orderby'        => 'date',
         'order'          => 'DESC',

--- a/lib/ai-context.php
+++ b/lib/ai-context.php
@@ -286,6 +286,14 @@ function pp_ai_media_inventory(int $limit = 50): array {
 
     $items = [];
     foreach ($attachments as $att) {
+        // 'post_mime_type' => 'image' matches any image/* mime, but SVGs
+        // (image/svg+xml) fail wp_attachment_is_image() in WordPress core —
+        // it isn't a "displayable" raster image. Recheck here so the
+        // inventory never advertises a URL that _pp_validate_media_urls_in_params()
+        // would then reject at execute time (#124).
+        if (!wp_attachment_is_image($att->ID)) {
+            continue;
+        }
         $meta = wp_get_attachment_metadata($att->ID);
         $items[] = [
             'id'        => $att->ID,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.7
+Stable tag: 0.16.8
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.7
+Version:          0.16.8
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -464,6 +464,33 @@ class ActionsTest extends TestCase
         $this->assertStringContainsString('out of bounds', $result['error']);
     }
 
+    public function testUpdateComponentRejectsNonImageUrlViaDirectExecuteCall(): void
+    {
+        // Regression for #124: the media-URL/image-type check must protect
+        // EVERY caller of pp_execute_action() — WP-CLI (wp pp action execute),
+        // pp_patch_composition(), not just the AI chat AJAX handler. This test
+        // calls pp_execute_action() directly, the same way lib/cli.php and
+        // lib/operate.php do, with no AJAX handler involved at all.
+        $id = pp_create_page('Direct Execute Test', 'draft');
+        pp_update_composition($id, [
+            ['component' => 'hero', 'props' => ['title' => 'Original', 'variant' => 'split']],
+        ]);
+        $GLOBALS['_pp_test_store']['attachment_urls'][90] = 'https://example.com/wp-content/uploads/brochure.pdf';
+        $GLOBALS['_pp_test_store']['attachment_is_image'][90] = false;
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 0,
+            'props'           => ['image_url' => 'https://example.com/wp-content/uploads/brochure.pdf'],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('does not point to an image', $result['error']);
+        // Confirm nothing was written.
+        $comp = pp_get_composition($id);
+        $this->assertArrayNotHasKey('image_url', $comp[0]['props']);
+    }
+
     // ── Preview tests ──────────────────────────────────────────────────────
 
     public function testPreviewNeverWrites(): void

--- a/tests/AiChatHandlersTest.php
+++ b/tests/AiChatHandlersTest.php
@@ -28,7 +28,7 @@ class AiChatHandlersTest extends TestCase
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['_pp_test_user_caps']);
+        unset($GLOBALS['_pp_test_user_caps'], $GLOBALS['wpdb']);
         parent::tearDown();
     }
 
@@ -643,5 +643,93 @@ class AiChatHandlersTest extends TestCase
         $actions = pp_get_registered_actions();
         $this->assertArrayHasKey('update_component', $actions);
         $this->assertArrayNotHasKey('impact_warning', $actions['update_component']);
+    }
+
+    // ── Media URL Validation (#124 defense in depth) ────────────────────────
+
+    private function seedAttachment(int $id, string $url, bool $isImage): void
+    {
+        $GLOBALS['_pp_test_store']['attachment_urls'][$id] = $url;
+        $GLOBALS['_pp_test_store']['attachment_is_image'][$id] = $isImage;
+    }
+
+    public function testValidateMediaUrlsAcceptsRealImageUrl(): void
+    {
+        $this->seedAttachment(70, 'https://example.com/wp-content/uploads/photo.jpg', true);
+
+        $result = _pp_validate_media_urls_in_params([
+            'props' => ['image_url' => 'https://example.com/wp-content/uploads/photo.jpg'],
+        ]);
+
+        $this->assertTrue($result);
+    }
+
+    public function testValidateMediaUrlsRejectsUrlForNonImageAttachment(): void
+    {
+        // The attachment exists in the media library, but it's a PDF —
+        // pp_ai_media_inventory() would never have listed it as an image,
+        // but nothing stops the model from proposing the URL anyway (#124).
+        $this->seedAttachment(71, 'https://example.com/wp-content/uploads/brochure.pdf', false);
+
+        $result = _pp_validate_media_urls_in_params([
+            'props' => ['image_url' => 'https://example.com/wp-content/uploads/brochure.pdf'],
+        ]);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('invalid_media_url', $result->get_error_code());
+        $this->assertStringContainsString('does not point to an image', $result->get_error_message());
+    }
+
+    public function testValidateMediaUrlsRejectsUnknownUploadsUrl(): void
+    {
+        $result = _pp_validate_media_urls_in_params([
+            'props' => ['background_image' => 'https://example.com/wp-content/uploads/ghost.jpg'],
+        ]);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('invalid_media_url', $result->get_error_code());
+        $this->assertStringContainsString('does not match any file', $result->get_error_message());
+    }
+
+    public function testValidateMediaUrlsRejectsUnknownUrlWithoutWpdbGlobal(): void
+    {
+        // No $wpdb global at all (the default unit-test state) — the guid
+        // fallback must degrade to "no match" rather than fatal.
+        $this->assertArrayNotHasKey('wpdb', $GLOBALS);
+
+        $result = _pp_validate_media_urls_in_params([
+            'props' => ['image_url' => 'https://example.com/wp-content/uploads/ghost.jpg'],
+        ]);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('invalid_media_url', $result->get_error_code());
+    }
+
+    public function testValidateMediaUrlsPassesThroughExternalUrls(): void
+    {
+        // URLs outside the uploads directory (external images) are not
+        // checked against the media library at all.
+        $result = _pp_validate_media_urls_in_params([
+            'props' => ['image_url' => 'https://cdn.example.net/some-photo.jpg'],
+        ]);
+
+        $this->assertTrue($result);
+    }
+
+    public function testValidateMediaUrlsFallsBackToGuidLookup(): void
+    {
+        // attachment_url_to_postid() misses (e.g. a scaled/rewritten URL),
+        // but the guid fallback query resolves it. $wpdb only needs to be a
+        // real object for this one test — see bootstrap.php's note on why
+        // it isn't installed globally by default.
+        $GLOBALS['wpdb'] = new wpdb();
+        $GLOBALS['_pp_test_store']['wpdb_guid_match_id'] = 72;
+        $GLOBALS['_pp_test_store']['attachment_is_image'][72] = true;
+
+        $result = _pp_validate_media_urls_in_params([
+            'props' => ['image_url' => 'https://example.com/wp-content/uploads/legacy.jpg'],
+        ]);
+
+        $this->assertTrue($result);
     }
 }

--- a/tests/AiChatHandlersTest.php
+++ b/tests/AiChatHandlersTest.php
@@ -646,6 +646,10 @@ class AiChatHandlersTest extends TestCase
     }
 
     // ── Media URL Validation (#124 defense in depth) ────────────────────────
+    // _pp_validate_media_urls_in_params() itself now lives in lib/actions.php
+    // (wired into pp_validate_action(), the shared choke point for AJAX/CLI/
+    // operate.php) — kept tested here since these tests predate the move and
+    // the AI chat AJAX execute handler is still the primary caller in spirit.
 
     private function seedAttachment(int $id, string $url, bool $isImage): void
     {
@@ -719,11 +723,14 @@ class AiChatHandlersTest extends TestCase
     public function testValidateMediaUrlsFallsBackToGuidLookup(): void
     {
         // attachment_url_to_postid() misses (e.g. a scaled/rewritten URL),
-        // but the guid fallback query resolves it. $wpdb only needs to be a
-        // real object for this one test — see bootstrap.php's note on why
-        // it isn't installed globally by default.
+        // but the guid fallback query resolves it by the exact URL queried —
+        // not just any seeded value (the stub's prepare()/get_var() actually
+        // parse the guid out of the query, so this proves the right URL was
+        // asked for, not merely that the fallback path ran at all).
+        // $wpdb only needs to be a real object for this one test — see
+        // bootstrap.php's note on why it isn't installed globally by default.
         $GLOBALS['wpdb'] = new wpdb();
-        $GLOBALS['_pp_test_store']['wpdb_guid_match_id'] = 72;
+        $GLOBALS['_pp_test_store']['wpdb_guid_map']['https://example.com/wp-content/uploads/legacy.jpg'] = 72;
         $GLOBALS['_pp_test_store']['attachment_is_image'][72] = true;
 
         $result = _pp_validate_media_urls_in_params([
@@ -731,5 +738,22 @@ class AiChatHandlersTest extends TestCase
         ]);
 
         $this->assertTrue($result);
+    }
+
+    public function testValidateMediaUrlsGuidLookupRejectsMismatchedUrl(): void
+    {
+        // The guid map has an entry, but for a DIFFERENT URL than the one
+        // being validated — proves the fallback actually queries by the
+        // requested guid rather than returning any configured match.
+        $GLOBALS['wpdb'] = new wpdb();
+        $GLOBALS['_pp_test_store']['wpdb_guid_map']['https://example.com/wp-content/uploads/other-file.jpg'] = 72;
+
+        $result = _pp_validate_media_urls_in_params([
+            'props' => ['image_url' => 'https://example.com/wp-content/uploads/legacy.jpg'],
+        ]);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('invalid_media_url', $result->get_error_code());
+        $this->assertStringContainsString('does not match any file', $result->get_error_message());
     }
 }

--- a/tests/AiContextTest.php
+++ b/tests/AiContextTest.php
@@ -285,6 +285,52 @@ class AiContextTest extends TestCase
         $this->assertStringNotContainsString('alt="', $prompt);
     }
 
+    public function testMediaInventoryExcludesNonImageAttachments(): void
+    {
+        $GLOBALS['_pp_test_store']['posts'][60] = [
+            'post_type'      => 'attachment',
+            'post_status'    => 'inherit',
+            'post_mime_type' => 'image/jpeg',
+        ];
+        $GLOBALS['_pp_test_store']['posts'][61] = [
+            'post_type'      => 'attachment',
+            'post_status'    => 'inherit',
+            'post_mime_type' => 'application/pdf',
+        ];
+
+        $media = pp_ai_media_inventory();
+
+        $ids = array_column($media, 'id');
+        $this->assertContains(60, $ids);
+        $this->assertNotContains(61, $ids);
+    }
+
+    public function testMediaInventoryExcludesVideoAndAudioAttachments(): void
+    {
+        $GLOBALS['_pp_test_store']['posts'][62] = [
+            'post_type'      => 'attachment',
+            'post_status'    => 'inherit',
+            'post_mime_type' => 'image/png',
+        ];
+        $GLOBALS['_pp_test_store']['posts'][63] = [
+            'post_type'      => 'attachment',
+            'post_status'    => 'inherit',
+            'post_mime_type' => 'video/mp4',
+        ];
+        $GLOBALS['_pp_test_store']['posts'][64] = [
+            'post_type'      => 'attachment',
+            'post_status'    => 'inherit',
+            'post_mime_type' => 'audio/mpeg',
+        ];
+
+        $media = pp_ai_media_inventory();
+
+        $ids = array_column($media, 'id');
+        $this->assertContains(62, $ids);
+        $this->assertNotContains(63, $ids);
+        $this->assertNotContains(64, $ids);
+    }
+
     // ── Component Summary ────────────────────────────────────────────────
 
     public function testSummarizeComponentIncludesVariant(): void

--- a/tests/AiContextTest.php
+++ b/tests/AiContextTest.php
@@ -210,6 +210,7 @@ class AiContextTest extends TestCase
             'post_status'    => 'inherit',
             'post_mime_type' => 'image/jpeg',
         ];
+        $GLOBALS['_pp_test_store']['attachment_is_image'][50] = true;
 
         $prompt = pp_ai_system_prompt();
         $this->assertStringContainsString('## Media Library', $prompt);
@@ -223,6 +224,7 @@ class AiContextTest extends TestCase
             'post_status'    => 'inherit',
             'post_mime_type' => 'image/jpeg',
         ];
+        $GLOBALS['_pp_test_store']['attachment_is_image'][51] = true;
 
         $prompt = pp_ai_system_prompt();
         // Stubs return: filename = "image-51.jpg", url = "https://example.com/wp-content/uploads/image-51.jpg", dims = 1200x800
@@ -255,6 +257,7 @@ class AiContextTest extends TestCase
             'post_status'    => 'inherit',
             'post_mime_type' => 'image/png',
         ];
+        $GLOBALS['_pp_test_store']['attachment_is_image'][52] = true;
         // Override wp_get_attachment_metadata to return null dims
         // The stub returns ['width' => 1200, 'height' => 800] by default.
         // We test via pp_ai_media_inventory directly with a crafted item.
@@ -278,6 +281,7 @@ class AiContextTest extends TestCase
             'post_status'    => 'inherit',
             'post_mime_type' => 'image/jpeg',
         ];
+        $GLOBALS['_pp_test_store']['attachment_is_image'][53] = true;
 
         $prompt = pp_ai_system_prompt();
         // The bootstrap stub for get_post_meta returns '' for _wp_attachment_image_alt
@@ -292,6 +296,7 @@ class AiContextTest extends TestCase
             'post_status'    => 'inherit',
             'post_mime_type' => 'image/jpeg',
         ];
+        $GLOBALS['_pp_test_store']['attachment_is_image'][60] = true;
         $GLOBALS['_pp_test_store']['posts'][61] = [
             'post_type'      => 'attachment',
             'post_status'    => 'inherit',
@@ -305,6 +310,26 @@ class AiContextTest extends TestCase
         $this->assertNotContains(61, $ids);
     }
 
+    public function testMediaInventoryExcludesSvgAttachments(): void
+    {
+        // image/svg+xml matches the 'image' mime-type prefix filter, but WordPress
+        // core's wp_attachment_is_image() rejects SVGs (not a "displayable" raster
+        // image). If the inventory listed it anyway, the model would be told it's
+        // an "available image" and then have the exact same URL rejected by
+        // _pp_validate_media_urls_in_params() at execute time (#124 follow-up
+        // found during adversarial review). Both paths must agree.
+        $GLOBALS['_pp_test_store']['posts'][65] = [
+            'post_type'      => 'attachment',
+            'post_status'    => 'inherit',
+            'post_mime_type' => 'image/svg+xml',
+        ];
+        $GLOBALS['_pp_test_store']['attachment_is_image'][65] = false;
+
+        $media = pp_ai_media_inventory();
+
+        $this->assertNotContains(65, array_column($media, 'id'));
+    }
+
     public function testMediaInventoryExcludesVideoAndAudioAttachments(): void
     {
         $GLOBALS['_pp_test_store']['posts'][62] = [
@@ -312,6 +337,7 @@ class AiContextTest extends TestCase
             'post_status'    => 'inherit',
             'post_mime_type' => 'image/png',
         ];
+        $GLOBALS['_pp_test_store']['attachment_is_image'][62] = true;
         $GLOBALS['_pp_test_store']['posts'][63] = [
             'post_type'      => 'attachment',
             'post_status'    => 'inherit',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -554,12 +554,21 @@ if (!class_exists('wpdb')) {
     class wpdb {
         public string $posts = 'wp_posts';
 
+        // Substitutes %s placeholders so get_var() below can inspect the
+        // actual guid being queried, rather than returning a fixed value
+        // regardless of what was asked for.
         public function prepare(string $query, ...$args): string {
+            foreach ($args as $arg) {
+                $query = preg_replace('/%s/', "'" . addslashes((string) $arg) . "'", $query, 1);
+            }
             return $query;
         }
 
         public function get_var(string $query) {
-            return $GLOBALS['_pp_test_store']['wpdb_guid_match_id'] ?? null;
+            if (preg_match("/guid = '([^']*)'/", $query, $m)) {
+                return $GLOBALS['_pp_test_store']['wpdb_guid_map'][$m[1]] ?? null;
+            }
+            return null;
         }
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -263,6 +263,20 @@ if (!function_exists('get_posts')) {
                     continue;
                 }
             }
+            if (isset($args['post_type']) && is_string($args['post_type'])) {
+                if (($data['post_type'] ?? '') !== $args['post_type']) {
+                    continue;
+                }
+            }
+            if (isset($args['post_mime_type']) && is_string($args['post_mime_type'])) {
+                $mime = $data['post_mime_type'] ?? '';
+                $wanted = $args['post_mime_type'];
+                // WordPress matches a general type ("image") against the full
+                // mime type ("image/jpeg") as well as an exact match.
+                if ($mime !== $wanted && strpos($mime, $wanted . '/') !== 0) {
+                    continue;
+                }
+            }
             $post = (object) array_merge(['ID' => $id], $data);
             $results[] = $post;
         }
@@ -518,6 +532,35 @@ if (!function_exists('wp_get_attachment_image_url')) {
 if (!function_exists('wp_attachment_is_image')) {
     function wp_attachment_is_image($attachment_id = null): bool {
         return !empty($GLOBALS['_pp_test_store']['attachment_is_image'][(int) $attachment_id]);
+    }
+}
+
+if (!function_exists('attachment_url_to_postid')) {
+    function attachment_url_to_postid(string $url): int {
+        $map = $GLOBALS['_pp_test_store']['attachment_urls'] ?? [];
+        $id = array_search($url, $map, true);
+        return $id !== false ? (int) $id : 0;
+    }
+}
+
+// Minimal $wpdb stub — only the guid-fallback lookup in
+// _pp_resolve_attachment_id_by_url() touches $wpdb. NOT installed as a global
+// by default: _pp_with_token_lock() (lib/wp.php) deliberately treats an
+// absent/non-object $wpdb as "unit test context" and degrades to running
+// its mutator unlocked, so a global $wpdb here would silently break every
+// token-override test. Tests that need the guid-fallback path must set
+// $GLOBALS['wpdb'] = new wpdb() themselves and unset it in tearDown.
+if (!class_exists('wpdb')) {
+    class wpdb {
+        public string $posts = 'wp_posts';
+
+        public function prepare(string $query, ...$args): string {
+            return $query;
+        }
+
+        public function get_var(string $query) {
+            return $GLOBALS['_pp_test_store']['wpdb_guid_match_id'] ?? null;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
`pp_ai_media_inventory()` (`lib/ai-context.php`) queried attachments with no MIME filter and the system prompt told the model every result was an "available image" to copy the URL from verbatim. A PDF, video, or audio upload could be handed back as `image_url`, producing a broken `<img>` on the page. The only existing guard (`_pp_validate_media_urls_in_params()`) checked that a URL resolved to *some* media library attachment, not that it was an image.

This PR, per the issue's fix plan plus findings from adversarial review:
1. Adds `post_mime_type => 'image'` to the inventory query, and separately rechecks `wp_attachment_is_image()` per item — WordPress core's mime filter matches `image/svg+xml`, but `wp_attachment_is_image()` rejects SVGs (not a "displayable" raster image), so without the second check the inventory and the execute-time guard would disagree on SVGs (found during Codex adversarial review).
2. Adds the same `wp_attachment_is_image()` check at execute time, rejecting a non-image attachment URL even if the model fabricates or hallucinates one.
3. **Escalated finding, user-approved fix:** a Claude adversarial subagent found the execute-time guard was wired into exactly one caller — the AI chat's AJAX handler — while `pp_execute_action()` is also reachable unguarded from WP-CLI (`wp pp action execute`, the project's actual agent-automation surface) and `pp_patch_composition()`. Per user decision, moved the check into `pp_validate_action()` in `lib/actions.php` — the single choke point already used by every caller (AJAX, CLI, admin, operate.php) — so all of them are covered by the same guard instead of one ad-hoc check per entry point. This also required relocating the four validation functions out of `lib/ai-chat.php` (which only loads `if (is_admin())`, so it's absent under WP-CLI) into `lib/actions.php` (always loaded).
4. Adds `ORDER BY ID ASC LIMIT 1` to the guid-fallback SQL query — it now returns a specific ID (fed into `wp_attachment_is_image()`) rather than just a count, so a duplicate guid needs a deterministic result (Codex finding).

## Test Coverage
- `tests/AiContextTest.php` — inventory excludes non-image, video/audio, and SVG attachments (12 new/updated tests across the two touched test files, full count below)
- `tests/AiChatHandlersTest.php` — accepts real images, rejects non-image attachments, rejects unknown URLs, passes through external URLs, guid-fallback resolves by the exact URL queried (not just any seeded value) and rejects a mismatched guid, and an explicit "no `$wpdb` global" regression test
- `tests/ActionsTest.php` — **`testUpdateComponentRejectsNonImageUrlViaDirectExecuteCall`**: calls `pp_execute_action()` directly (no AJAX handler involved), proving the CLI/`pp_patch_composition()` gap is closed
- `tests/bootstrap.php` — `get_posts()` stub now honors `post_type`/`post_mime_type` filters; new `attachment_url_to_postid()` stub; minimal `wpdb` class (deliberately **not** installed as a global by default — `_pp_with_token_lock()` in `lib/wp.php` treats an absent/non-object `$wpdb` as unit-test context to degrade gracefully, so a global stub would've silently broken every token-override test, which it did on the first pass — caught by running the full suite before considering this done)

Full suite: 854 PHP tests / 3203 assertions pass (up from 843 baseline). 262 JS tests pass.

## Pre-Landing Review
`/review` dispatched Testing, Maintainability, and Security specialists, plus a Claude adversarial subagent and Codex adversarial review (`codex exec`). Findings and disposition:
- **Fixed in this PR:** SVG mime/`wp_attachment_is_image()` mismatch (Codex), the CLI/`pp_patch_composition()` bypass (Claude adversarial, escalated to the user — see Scope Drift), non-deterministic duplicate-guid fallback query (Codex), stale/incomplete docblock and an overly-permissive test stub that didn't actually verify the queried URL (maintainability + Codex).
- **Filed as follow-ups** (none introduced or worsened by this diff, each needs its own scope decision): #153 (relative/CDN/offloaded media URLs bypass the uploads-prefix match; fails open if `wp_get_upload_dir()` lacks `baseurl`), #154 (image-prop allowlist is hand-maintained, not schema-driven), #155 (`pp_resolve_logo()`'s component-level `logo_id` path lacks the explicit `wp_attachment_is_image()` check the site-option `pp_logo_id` path already has).

## Design Review
Not applicable — backend validation only, no UI surface changed.

## Eval Results
Not applicable — no LLM prompt/eval surface touched (the system prompt's media-list wording is unchanged; only the underlying query and validation changed).

## Scope Drift
The move from an AJAX-handler-only check to `pp_validate_action()` (covering every caller) expands the diff beyond the issue's literal fix plan. This was a user-approved decision after the Claude adversarial subagent flagged (INVESTIGATE, high confidence) that the narrower fix left the CLI automation surface — the project's documented agent-execution path — with the exact same bug class unpatched. See commit `031c2a2`.

## Plan Completion
Followed the issue's own Fix plan and Suggested tests as the plan of record (per standing instruction), then extended per the escalated finding above. All acceptance criteria met, plus the closed CLI gap.

## TODOS
Checked `TODOS.md` — no related open items.

## Documentation
`AI_CONTEXT.md` updated: documented that `pp_validate_action()` now rejects bad media URLs uniformly across every caller (added under the existing "Execute always validates first" note). `CHANGELOG.md` updated with a user-facing v0.16.8 entry. `AI_RULES.md` / `docs/AI_IMPLEMENTATION_RECIPES.md` checked — no references to touch.

## Security
CSO audit run (scoped to this diff): 0 findings at the 8/10 confidence gate. Report at `.gstack/security-reports/2026-07-04-issue-124.json`. Labeled `security-sensitive` since this is a trust-boundary hardening change (LLM-proposed URLs) touching the shared action-validation choke point — flagging for review before merge per project policy.

## Test plan
- [x] `vendor/bin/phpunit --configuration phpunit.xml` — 854 tests, 3203 assertions, pass
- [x] `npm test` (vitest) — 262 tests, pass
- [x] Direct `pp_execute_action()` call (no AJAX) confirms the CLI-equivalent path is guarded
- [x] Redaction-scanned diff before push — clean

Closes #124