### PR TITLE
Fix: internal apply-confirmation messages no longer leak into the AI chat transcript on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.9] — 2026-07-04 — Fix: Reloading the AI Chat No Longer Shows It Talking to Itself
+
+**After the AI chat applied a change, it quietly noted "changes applied" for its own reference on the next turn — but reload the page, and that note could reappear as if the assistant had actually said it out loud, mixed into your real conversation.** Only the plainest version of that note was ever hidden; anything with a warning, a validation failure, or a "some settings didn't carry over" note leaked straight into the visible transcript. Now every version of that internal note stays exactly what it was meant to be — invisible bookkeeping the assistant still remembers, but never something you see it "say."
+
+### Fixed
+- Reloading the AI chat no longer shows internal apply-confirmation notes (including the warning and validation-failure variants) as if the assistant said them conversationally.
+- Chat histories saved before this fix are covered too — this isn't just a fix for new conversations going forward.
+
+### For contributors
+- 7 new JS tests across two files: one exercising every current confirmation shape plus a genuine reply that happens to start with the same words (never suppressed), one specifically covering pre-existing localStorage data that predates today's structural fix (a real regression cross-model review caught before it shipped — the first version of this fix would have un-hidden the one case that already worked).
+- `restoreConversation()` also now tolerates a malformed/hand-edited localStorage entry without breaking the rest of the chat widget's setup.
+- Filed a follow-up (#157) for a related but separate finding: the chat's local history isn't isolated per browser tab or per WordPress user, which is a pre-existing gap this fix doesn't touch.
+
 ## [v0.16.8] — 2026-07-04 — Fix: The AI Chat Can No Longer Turn a PDF Into a "Photo"
 
 **The AI chat's media picker used to tell the model every file in your Media Library — PDFs, videos, audio — was an "available image" and to copy its URL exactly.** Ask for a hero photo, and it could hand back a brochure PDF as `image_url`, which the page would happily try to render as a broken `<img>`. The media list now only ever shows real, displayable images (SVGs included — WordPress doesn't treat those as renderable images either). And the same check that used to live only in the chat's "run this" button now runs everywhere an action can be executed — the WP-CLI automation path and the composition-patch tool included — so a non-image URL gets rejected no matter which door it comes through.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.8-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.9-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/js/pp-ai-chat.js
+++ b/assets/js/pp-ai-chat.js
@@ -1039,14 +1039,19 @@ function ppChatAppendValidationItems(container, items, className) {
                     '. These were kept as-is — update them if the visual result looks inconsistent.';
             }
 
+            // internal: true marks these as apply-confirmation context for the
+            // model's next turn, not a real conversational reply — restoreConversation()
+            // skips them structurally on reload instead of matching on English text
+            // (pp_ai_format_messages() already strips unknown keys before the request
+            // reaches the provider, so this flag never leaves the browser/our backend).
             if (!lastVal || (lastVal.ok && (!lastVal.warnings || lastVal.warnings.length === 0))) {
-                conversation.push({ role: 'assistant', content: 'Changes applied successfully.' + staleSuffix });
+                conversation.push({ role: 'assistant', content: 'Changes applied successfully.' + staleSuffix, internal: true });
             } else if (lastVal.ok && lastVal.warnings && lastVal.warnings.length > 0) {
                 var warnSummary = lastVal.warnings.map(function (w) { return w.message; }).join('; ');
-                conversation.push({ role: 'assistant', content: 'Changes applied with warnings: ' + warnSummary });
+                conversation.push({ role: 'assistant', content: 'Changes applied with warnings: ' + warnSummary, internal: true });
             } else {
                 var errSummary = lastVal.errors.map(function (e) { return e.message; }).join('; ');
-                conversation.push({ role: 'assistant', content: 'Changes applied but rendered page validation failed: ' + errSummary + '. The page may still have broken images or missing content.' });
+                conversation.push({ role: 'assistant', content: 'Changes applied but rendered page validation failed: ' + errSummary + '. The page may still have broken images or missing content.', internal: true });
             }
             saveState();
             inputEl.focus();
@@ -1392,8 +1397,10 @@ function ppChatAppendValidationItems(container, items, className) {
                 if (msg.content.charAt(0) === '[') return;
                 addMessage('user', msg.content);
             } else if (msg.role === 'assistant') {
-                // Skip internal apply-confirmation messages in display
-                if (msg.content === 'Changes applied successfully.') return;
+                // Skip internal apply-confirmation messages in display (structural
+                // flag, not content matching — a genuine model reply that happens
+                // to start with "Changes applied..." is never suppressed).
+                if (msg.internal === true) return;
                 var displayText = stripProposalJson(msg.content);
                 if (displayText) {
                     addMessage('assistant', displayText);

--- a/assets/js/pp-ai-chat.js
+++ b/assets/js/pp-ai-chat.js
@@ -1383,30 +1383,48 @@ function ppChatAppendValidationItems(container, items, className) {
 
     // ── Restore Previous Conversation ─────────────────────────────────
 
+    // localStorage conversations saved before #140 shipped have no `internal`
+    // key at all on any of the four confirmation shapes. `internal === true`
+    // alone would un-hide all of them for existing users on upgrade — the same
+    // leak the fix closes for new conversations, reappearing for old ones
+    // (cross-model review finding: Codex + Testing specialist + Claude
+    // adversarial subagent all independently flagged this). These prefixes
+    // are a temporary, content-based fallback ONLY for pre-flag data; every
+    // message written going forward carries `internal: true` and never
+    // touches this path.
+    var LEGACY_INTERNAL_PREFIXES = [
+        'Changes applied successfully.',
+        'Changes applied with warnings: ',
+        'Changes applied but rendered page validation failed: '
+    ];
+
+    function isLegacyInternalMessage(content) {
+        return LEGACY_INTERNAL_PREFIXES.some(function (prefix) {
+            return content.indexOf(prefix) === 0;
+        });
+    }
+
     function restoreConversation() {
         var state = loadState();
-        if (!state || !state.conversation || !state.conversation.length) return;
+        if (!state || !Array.isArray(state.conversation) || !state.conversation.length) return;
 
         conversation = state.conversation;
         activePageId = state.activePageId || null;
 
         // Re-render messages from conversation history
         conversation.forEach(function (msg) {
+            if (!msg || typeof msg.content !== 'string') return;
             if (msg.role === 'user') {
                 // Skip internal apply-confirmation messages in display
                 if (msg.content.charAt(0) === '[') return;
                 addMessage('user', msg.content);
             } else if (msg.role === 'assistant') {
-                // Skip internal apply-confirmation messages in display (structural
-                // flag, not content matching — a genuine model reply that happens
-                // to start with "Changes applied..." is never suppressed). The
-                // legacy exact-match also stays as a fallback: localStorage
-                // conversations saved before this fix have no `internal` key at
-                // all, and without this OR, the one shape the OLD code correctly
-                // hid (bare "Changes applied successfully.") would start leaking
-                // for existing users on upgrade instead of staying hidden (#140
-                // cross-model review finding).
-                if (msg.internal === true || msg.content === 'Changes applied successfully.') return;
+                // Skip internal apply-confirmation messages in display —
+                // structural flag first (never content-based for new data, so
+                // a genuine reply that happens to start with "Changes
+                // applied..." is never suppressed), legacy prefix match as a
+                // fallback only for messages that predate the flag.
+                if (msg.internal === true || isLegacyInternalMessage(msg.content)) return;
                 var displayText = stripProposalJson(msg.content);
                 if (displayText) {
                     addMessage('assistant', displayText);
@@ -1448,7 +1466,14 @@ function ppChatAppendValidationItems(container, items, className) {
 
     // ── Init ──────────────────────────────────────────────────────────
 
-    restoreConversation();
+    try {
+        restoreConversation();
+    } catch (e) {
+        // A corrupted/hand-edited localStorage entry must not abort the rest
+        // of init (send/new-chat button wiring) — worst case is losing the
+        // restored transcript, not a broken widget (#140 adversarial review).
+        conversation = [];
+    }
     inputEl.focus();
 
 })();

--- a/assets/js/pp-ai-chat.js
+++ b/assets/js/pp-ai-chat.js
@@ -1399,8 +1399,14 @@ function ppChatAppendValidationItems(container, items, className) {
             } else if (msg.role === 'assistant') {
                 // Skip internal apply-confirmation messages in display (structural
                 // flag, not content matching — a genuine model reply that happens
-                // to start with "Changes applied..." is never suppressed).
-                if (msg.internal === true) return;
+                // to start with "Changes applied..." is never suppressed). The
+                // legacy exact-match also stays as a fallback: localStorage
+                // conversations saved before this fix have no `internal` key at
+                // all, and without this OR, the one shape the OLD code correctly
+                // hid (bare "Changes applied successfully.") would start leaking
+                // for existing users on upgrade instead of staying hidden (#140
+                // cross-model review finding).
+                if (msg.internal === true || msg.content === 'Changes applied successfully.') return;
                 var displayText = stripProposalJson(msg.content);
                 if (displayText) {
                     addMessage('assistant', displayText);

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.8');
+define('PP_VERSION', '0.16.9');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.8
+Stable tag: 0.16.9
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.8
+Version:          0.16.9
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/pp-ai-chat-restore-legacy.test.js
+++ b/tests/js/pp-ai-chat-restore-legacy.test.js
@@ -1,0 +1,74 @@
+/**
+ * Regression test for #140: localStorage conversations saved BEFORE this fix
+ * have no `internal` key at all on their apply-confirmation assistant messages.
+ * Cross-model adversarial review (Codex + Testing specialist, independently)
+ * found that a naive `msg.internal === true` check alone would un-hide the one
+ * shape ("Changes applied successfully." with no stale suffix) that the OLD
+ * exact-string-match code correctly suppressed — a regression on upgrade for
+ * existing users. restoreConversation() must fall back to the legacy exact
+ * match for messages that predate the `internal` flag.
+ *
+ * Kept in its own file (separate module instance) because restoreConversation()
+ * runs once, automatically, inside the top-level IIFE at require() time.
+ */
+
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!DOCTYPE html><html><body>' +
+    '<div id="pp-ai-messages"></div>' +
+    '<textarea id="pp-ai-input"></textarea>' +
+    '<button id="pp-ai-send"></button>' +
+    '</body></html>', { url: 'http://localhost' });
+
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.localStorage = dom.window.localStorage;
+global.FormData = dom.window.FormData;
+global.fetch = function () { return Promise.resolve({ json: function () { return Promise.resolve({}); } }); };
+
+dom.window.ppAiChat = {
+    configured: true,
+    ajaxUrl: '/wp-admin/admin-ajax.php',
+    executeNonce: 'test-nonce',
+    siteUrl: 'http://example.com',
+    streamUrl: '/wp-admin/admin-ajax.php?action=pp_ai_stream',
+    streamNonce: 'stream-nonce'
+};
+global.window.ppAiChat = dom.window.ppAiChat;
+
+const STORAGE_KEY = 'pp_ai_chat_' + dom.window.ppAiChat.siteUrl;
+
+// Pre-fix shape: no `internal` key anywhere — this is what's actually sitting
+// in real users' browsers the moment this fix ships.
+const legacyConversation = [
+    { role: 'user', content: 'Add a hero section' },
+    { role: 'assistant', content: 'Changes applied successfully.' },
+    { role: 'assistant', content: 'Changes applied with warnings: missing alt text' },
+];
+
+localStorage.setItem(STORAGE_KEY, JSON.stringify({ conversation: legacyConversation, activePageId: null }));
+
+require('../../assets/js/pp-ai-chat.js');
+
+describe('restoreConversation legacy fallback (#140)', function () {
+    test('still hides the bare success message with no internal flag (pre-fix behavior preserved)', function () {
+        var bodies = Array.prototype.slice.call(
+            document.querySelectorAll('#pp-ai-messages .pp-ai-msg-assistant .pp-ai-msg-body')
+        ).map(function (el) { return el.textContent; });
+
+        expect(bodies).not.toContain('Changes applied successfully.');
+    });
+
+    test('the warnings shape without internal flag still leaks (pre-existing gap, not a new regression)', function () {
+        // This is the SAME gap the original bug report described for legacy
+        // data — it only closes going forward for newly-created messages
+        // (which always carry internal: true). Documenting it here so a
+        // future change to this fallback logic doesn't silently reintroduce
+        // the opposite regression without anyone noticing the tradeoff.
+        var bodies = Array.prototype.slice.call(
+            document.querySelectorAll('#pp-ai-messages .pp-ai-msg-assistant .pp-ai-msg-body')
+        ).map(function (el) { return el.textContent; });
+
+        expect(bodies.some(function (t) { return t.indexOf('Changes applied with warnings') !== -1; })).toBe(true);
+    });
+});

--- a/tests/js/pp-ai-chat-restore-legacy.test.js
+++ b/tests/js/pp-ai-chat-restore-legacy.test.js
@@ -1,12 +1,13 @@
 /**
  * Regression test for #140: localStorage conversations saved BEFORE this fix
  * have no `internal` key at all on their apply-confirmation assistant messages.
- * Cross-model adversarial review (Codex + Testing specialist, independently)
- * found that a naive `msg.internal === true` check alone would un-hide the one
- * shape ("Changes applied successfully." with no stale suffix) that the OLD
- * exact-string-match code correctly suppressed — a regression on upgrade for
- * existing users. restoreConversation() must fall back to the legacy exact
- * match for messages that predate the `internal` flag.
+ * Cross-model adversarial review (Codex, the Testing specialist, and a Claude
+ * adversarial subagent, all independently) found that a naive
+ * `msg.internal === true` check alone would un-hide EVERY pre-fix confirmation
+ * shape for existing users on upgrade — reproducing issue #140 for exactly the
+ * conversations already sitting in their browsers. restoreConversation() falls
+ * back to matching the three known legacy content prefixes for messages that
+ * predate the `internal` flag (see LEGACY_INTERNAL_PREFIXES in pp-ai-chat.js).
  *
  * Kept in its own file (separate module instance) because restoreConversation()
  * runs once, automatically, inside the top-level IIFE at require() time.
@@ -30,7 +31,7 @@ dom.window.ppAiChat = {
     configured: true,
     ajaxUrl: '/wp-admin/admin-ajax.php',
     executeNonce: 'test-nonce',
-    siteUrl: 'http://example.com',
+    siteUrl: 'http://legacy.example.com',
     streamUrl: '/wp-admin/admin-ajax.php?action=pp_ai_stream',
     streamNonce: 'stream-nonce'
 };
@@ -39,11 +40,17 @@ global.window.ppAiChat = dom.window.ppAiChat;
 const STORAGE_KEY = 'pp_ai_chat_' + dom.window.ppAiChat.siteUrl;
 
 // Pre-fix shape: no `internal` key anywhere — this is what's actually sitting
-// in real users' browsers the moment this fix ships.
+// in real users' browsers the moment this fix ships. Also includes a
+// malformed entry (null content) to exercise the defensive guard added
+// alongside the fallback.
 const legacyConversation = [
     { role: 'user', content: 'Add a hero section' },
     { role: 'assistant', content: 'Changes applied successfully.' },
+    { role: 'assistant', content: 'Changes applied successfully. Note: some existing token overrides may not match the new palette: --accent.' },
     { role: 'assistant', content: 'Changes applied with warnings: missing alt text' },
+    { role: 'assistant', content: 'Changes applied but rendered page validation failed: broken image.' },
+    { role: 'assistant', content: null },
+    { role: 'assistant', content: 'Great, all set!' },
 ];
 
 localStorage.setItem(STORAGE_KEY, JSON.stringify({ conversation: legacyConversation, activePageId: null }));
@@ -51,24 +58,25 @@ localStorage.setItem(STORAGE_KEY, JSON.stringify({ conversation: legacyConversat
 require('../../assets/js/pp-ai-chat.js');
 
 describe('restoreConversation legacy fallback (#140)', function () {
-    test('still hides the bare success message with no internal flag (pre-fix behavior preserved)', function () {
-        var bodies = Array.prototype.slice.call(
+    function getAssistantBodies() {
+        return Array.prototype.slice.call(
             document.querySelectorAll('#pp-ai-messages .pp-ai-msg-assistant .pp-ai-msg-body')
         ).map(function (el) { return el.textContent; });
+    }
+
+    test('hides all three legacy confirmation shapes with no internal flag', function () {
+        var bodies = getAssistantBodies();
 
         expect(bodies).not.toContain('Changes applied successfully.');
+        expect(bodies.some(function (t) { return t.indexOf('Note: some existing token overrides') !== -1; })).toBe(false);
+        expect(bodies.some(function (t) { return t.indexOf('Changes applied with warnings') !== -1; })).toBe(false);
+        expect(bodies.some(function (t) { return t.indexOf('rendered page validation failed') !== -1; })).toBe(false);
     });
 
-    test('the warnings shape without internal flag still leaks (pre-existing gap, not a new regression)', function () {
-        // This is the SAME gap the original bug report described for legacy
-        // data — it only closes going forward for newly-created messages
-        // (which always carry internal: true). Documenting it here so a
-        // future change to this fallback logic doesn't silently reintroduce
-        // the opposite regression without anyone noticing the tradeoff.
-        var bodies = Array.prototype.slice.call(
-            document.querySelectorAll('#pp-ai-messages .pp-ai-msg-assistant .pp-ai-msg-body')
-        ).map(function (el) { return el.textContent; });
-
-        expect(bodies.some(function (t) { return t.indexOf('Changes applied with warnings') !== -1; })).toBe(true);
+    test('does not crash on a malformed entry and still renders a genuine message', function () {
+        // The null-content entry must not throw inside the top-level IIFE —
+        // if it did, the whole widget (including this genuine message) would
+        // never render at all.
+        expect(getAssistantBodies()).toContain('Great, all set!');
     });
 });

--- a/tests/js/pp-ai-chat-restore.test.js
+++ b/tests/js/pp-ai-chat-restore.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tests for restoreConversation() in assets/js/pp-ai-chat.js (#140)
+ *
+ * Internal apply-confirmation assistant messages (marked with `internal: true`)
+ * must never render as visible chat bubbles on reload, regardless of which of
+ * the four confirmation shapes they are (success, success+stale-note, warnings,
+ * validation failure). A genuine assistant message must still render even if
+ * its text happens to start with "Changes applied".
+ *
+ * restoreConversation() runs automatically inside the module's top-level IIFE
+ * at require() time, so localStorage must be seeded BEFORE requiring the
+ * module — there is no exported hook to call it again per-test.
+ */
+
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!DOCTYPE html><html><body>' +
+    '<div id="pp-ai-messages"></div>' +
+    '<textarea id="pp-ai-input"></textarea>' +
+    '<button id="pp-ai-send"></button>' +
+    '</body></html>', { url: 'http://localhost' });
+
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.localStorage = dom.window.localStorage;
+global.FormData = dom.window.FormData;
+global.fetch = function () { return Promise.resolve({ json: function () { return Promise.resolve({}); } }); };
+
+dom.window.ppAiChat = {
+    configured: true,
+    ajaxUrl: '/wp-admin/admin-ajax.php',
+    executeNonce: 'test-nonce',
+    siteUrl: 'http://example.com',
+    streamUrl: '/wp-admin/admin-ajax.php?action=pp_ai_stream',
+    streamNonce: 'stream-nonce'
+};
+global.window.ppAiChat = dom.window.ppAiChat;
+
+const STORAGE_KEY = 'pp_ai_chat_' + dom.window.ppAiChat.siteUrl;
+
+const conversation = [
+    { role: 'user', content: 'Add a hero section' },
+    { role: 'assistant', content: 'Changes applied successfully.', internal: true },
+    { role: 'assistant', content: 'Changes applied successfully. Note: some existing token overrides may not match the new palette: --accent. These were kept as-is — update them if the visual result looks inconsistent.', internal: true },
+    { role: 'assistant', content: 'Changes applied with warnings: missing alt text', internal: true },
+    { role: 'assistant', content: 'Changes applied but rendered page validation failed: broken image. The page may still have broken images or missing content.', internal: true },
+    { role: 'assistant', content: 'Changes applied to your resume, nice work on the new job!' },
+    { role: 'user', content: '[Applied changes: hero updated]' },
+];
+
+localStorage.setItem(STORAGE_KEY, JSON.stringify({ conversation: conversation, activePageId: null }));
+
+require('../../assets/js/pp-ai-chat.js');
+
+describe('restoreConversation (#140)', function () {
+    test('suppresses all four internal apply-confirmation shapes', function () {
+        var bodies = Array.prototype.slice.call(
+            document.querySelectorAll('#pp-ai-messages .pp-ai-msg-assistant .pp-ai-msg-body')
+        ).map(function (el) { return el.textContent; });
+
+        expect(bodies).not.toContain('Changes applied successfully.');
+        expect(bodies.some(function (t) { return t.indexOf('Note: some existing token overrides') !== -1; })).toBe(false);
+        expect(bodies.some(function (t) { return t.indexOf('Changes applied with warnings') !== -1; })).toBe(false);
+        expect(bodies.some(function (t) { return t.indexOf('rendered page validation failed') !== -1; })).toBe(false);
+    });
+
+    test('does not suppress a genuine assistant message starting with "Changes applied"', function () {
+        var bodies = Array.prototype.slice.call(
+            document.querySelectorAll('#pp-ai-messages .pp-ai-msg-assistant .pp-ai-msg-body')
+        ).map(function (el) { return el.textContent; });
+
+        expect(bodies.some(function (t) { return t.indexOf('nice work on the new job') !== -1; })).toBe(true);
+    });
+
+    test('renders exactly one assistant bubble (the non-internal one)', function () {
+        var assistantMsgs = document.querySelectorAll('#pp-ai-messages .pp-ai-msg-assistant');
+        expect(assistantMsgs.length).toBe(1);
+    });
+
+    test('still skips bracket-prefixed internal user messages (pre-existing behavior)', function () {
+        var userMsgs = document.querySelectorAll('#pp-ai-messages .pp-ai-msg-user .pp-ai-msg-body');
+        var texts = Array.prototype.slice.call(userMsgs).map(function (el) { return el.textContent; });
+        expect(texts).toEqual(['Add a hero section']);
+    });
+
+    test('internal messages remain in conversation context for the next model turn', function () {
+        // sendMessage() synchronously pushes the new user message and calls
+        // saveState() before the (mocked, unresolved-in-this-test) fetch even
+        // starts — so the persisted conversation reflects the full history
+        // the next request will send, without needing to mock the SSE reader.
+        document.getElementById('pp-ai-input').value = 'Now add a footer too';
+        document.getElementById('pp-ai-send').click();
+
+        var persisted = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        var internalCount = persisted.conversation.filter(function (m) { return m.internal === true; }).length;
+
+        expect(internalCount).toBe(4);
+        expect(persisted.conversation[persisted.conversation.length - 1]).toEqual(
+            { role: 'user', content: 'Now add a footer too' }
+        );
+    });
+});

--- a/tests/js/pp-ai-chat-restore.test.js
+++ b/tests/js/pp-ai-chat-restore.test.js
@@ -53,10 +53,14 @@ localStorage.setItem(STORAGE_KEY, JSON.stringify({ conversation: conversation, a
 require('../../assets/js/pp-ai-chat.js');
 
 describe('restoreConversation (#140)', function () {
-    test('suppresses all four internal apply-confirmation shapes', function () {
-        var bodies = Array.prototype.slice.call(
+    function getAssistantBodies() {
+        return Array.prototype.slice.call(
             document.querySelectorAll('#pp-ai-messages .pp-ai-msg-assistant .pp-ai-msg-body')
         ).map(function (el) { return el.textContent; });
+    }
+
+    test('suppresses all four internal apply-confirmation shapes', function () {
+        var bodies = getAssistantBodies();
 
         expect(bodies).not.toContain('Changes applied successfully.');
         expect(bodies.some(function (t) { return t.indexOf('Note: some existing token overrides') !== -1; })).toBe(false);
@@ -65,11 +69,7 @@ describe('restoreConversation (#140)', function () {
     });
 
     test('does not suppress a genuine assistant message starting with "Changes applied"', function () {
-        var bodies = Array.prototype.slice.call(
-            document.querySelectorAll('#pp-ai-messages .pp-ai-msg-assistant .pp-ai-msg-body')
-        ).map(function (el) { return el.textContent; });
-
-        expect(bodies.some(function (t) { return t.indexOf('nice work on the new job') !== -1; })).toBe(true);
+        expect(getAssistantBodies().some(function (t) { return t.indexOf('nice work on the new job') !== -1; })).toBe(true);
     });
 
     test('renders exactly one assistant bubble (the non-internal one)', function () {

--- a/tests/js/pp-ai-chat-restore.test.js
+++ b/tests/js/pp-ai-chat-restore.test.js
@@ -30,12 +30,17 @@ dom.window.ppAiChat = {
     configured: true,
     ajaxUrl: '/wp-admin/admin-ajax.php',
     executeNonce: 'test-nonce',
-    siteUrl: 'http://example.com',
+    siteUrl: 'http://restore.example.com',
     streamUrl: '/wp-admin/admin-ajax.php?action=pp_ai_stream',
     streamNonce: 'stream-nonce'
 };
 global.window.ppAiChat = dom.window.ppAiChat;
 
+// Distinct siteUrl (and therefore STORAGE_KEY) from the other test files that
+// touch localStorage — this file is the first to seed nontrivial pre-existing
+// conversation content, so a shared key risks cross-file bleed if vitest's
+// per-file isolation is ever disabled for a CI speed optimization (#140
+// adversarial review finding).
 const STORAGE_KEY = 'pp_ai_chat_' + dom.window.ppAiChat.siteUrl;
 
 const conversation = [


### PR DESCRIPTION
## Summary
`restoreConversation()` (`assets/js/pp-ai-chat.js`) used exact string equality (`msg.content === 'Changes applied successfully.'`) to hide internal apply-confirmation assistant messages when restoring the chat transcript from localStorage. There are four shapes of that message (bare success, success+stale-token-note, warnings, validation-failure) — the exact-match check only caught one, so the other three rendered as if the assistant said them conversationally on every page reload.

Fix, in three commits reflecting how the review process shaped it:
1. Tag each of the four `conversation.push({role: 'assistant', ...})` calls with `internal: true`; `restoreConversation()` checks that flag structurally instead of matching English text, so a genuine assistant reply that happens to start with "Changes applied" is never wrongly suppressed. Verified `pp_ai_format_messages()` (`lib/ai-context.php`, unchanged) already strips unknown object keys down to `role`/`content` before any request reaches the LLM provider — the flag never leaves the browser/our backend.
2. **Cross-model-confirmed finding (Codex + Testing specialist + Claude adversarial subagent, independently):** the structural-flag-only fix regresses existing users — localStorage conversations saved *before* this deploy have no `internal` key at all, so `msg.internal === true` alone would un-hide every legacy confirmation message, reproducing #140 for anyone with an in-progress chat across the upgrade. Added a legacy content-prefix fallback (`LEGACY_INTERNAL_PREFIXES`) covering all three known shapes, so pre-existing conversations get the same protection without needing a flag they were never written with.
3. Hardened `restoreConversation()` against malformed data (per the same adversarial pass): it now guards `Array.isArray(state.conversation)` and skips any entry with non-string `content`, and the init call site wraps it in try/catch so a corrupted/hand-edited localStorage entry can't abort the rest of widget setup (send/new-chat button wiring).

## Test Coverage
- `tests/js/pp-ai-chat-restore.test.js` (new) — seeds a mixed conversation (all four `internal: true` shapes, a genuine reply starting with "Changes applied", a bracket-prefixed internal user message) into localStorage *before* requiring the module (since `restoreConversation()` runs inside the module's top-level IIFE at require-time and isn't exported), then asserts on the resulting DOM. Also verifies internal messages remain in the persisted conversation for the next model turn.
- `tests/js/pp-ai-chat-restore-legacy.test.js` (new) — separate module instance, seeds all three legacy (no `internal` key) shapes plus a malformed `content: null` entry, asserts they're all still hidden and the malformed entry doesn't crash the widget.
- Both new files use distinct `siteUrl` values (hence distinct `localStorage` keys) from each other and from the two pre-existing chat test files, closing a test-fragility gap the adversarial review flagged (shared keys are harmless today under vitest's per-file isolation, but would silently bleed state if that isolation were ever disabled for a CI speed optimization).

Full suite: 854 PHP tests / 3203 assertions pass (unchanged — this issue is JS-only). 269 JS tests pass (up from 262).

## Pre-Landing Review
`/review` dispatched Testing + Maintainability specialists, a Claude adversarial subagent, and Codex adversarial review. The specialists' and Codex's findings (upgrade-regression gap, missing legacy-fixture test, minor test-code duplication) and the Claude adversarial subagent's follow-up pass (same regression, plus the malformed-data crash risk and the test-key-collision fragility) are all fixed in this PR — see commits `6e6f27a` and `98e4651`.

Two additional findings from the Claude adversarial subagent are pre-existing architecture, not introduced or worsened by this diff, and need their own scope decision: a multi-tab `saveState()` overwrite race that can silently drop `internal`-tagged context, and a shared-browser-profile cross-user leak (the localStorage key has no per-user component). Filed as **#157**.

## Design Review
Not applicable programmatically — this is chat-transcript rendering behavior, not a new UI surface. Verified manually via the jsdom-based tests (which exercise the real DOM structure `addMessage()` produces) rather than a live wp-env screenshot: this bug and fix are pure client-side localStorage/DOM logic with no PHP or WordPress involvement, and reproducing all four (now seven, with the legacy fallback) message shapes live would require either a real AI provider call or an equal amount of manual mocking — the jsdom tests exercise the identical code path a live browser would run.

## Eval Results
Not applicable — no LLM prompt/eval surface touched.

## Scope Drift
The legacy-fallback and defensive-hardening commits expand the diff beyond the issue's literal fix plan (which only described the `internal: true` flag approach). Both are direct, cross-model-confirmed consequences of implementing that exact fix plan correctly — the flag approach silently regresses existing users without the fallback, and the diff touched `restoreConversation()`'s forEach loop closely enough that hardening it against the adjacent crash risk was in scope, not a tangent.

## Plan Completion
Followed the issue's own Fix plan (option 2: `internal: true` flag) and Suggested tests as the plan of record, extended per the adversarial findings above. All acceptance criteria met, including the explicit "genuine assistant message is not suppressed" requirement.

## TODOS
Checked `TODOS.md` — no related open items.

## Documentation
Checked `AI_CONTEXT.md` / `AI_RULES.md` / `docs/AI_IMPLEMENTATION_RECIPES.md` — no references to `restoreConversation` or these message shapes; this doesn't change any AI-facing capability or contract (the model never sees the `internal` flag), so no doc updates needed. `CHANGELOG.md` updated with a user-facing v0.16.9 entry.

## Test plan
- [x] `npm test` (vitest) — 269 tests, pass
- [x] `vendor/bin/phpunit --configuration phpunit.xml` — 854 tests, 3203 assertions, pass (regression check; issue is JS-only)
- [x] Redaction-scanned diff before push — 3 MEDIUM false positives (`msg.internal`/`m.internal` property access mis-flagged as `internal.hostname`-shaped strings), verified by inspection, no real secrets/hostnames/PII present

Closes #140