### PR TITLE
Fix: register inspect-composition as the canonical WP-CLI subcommand name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.13] — 2026-07-04 — Fix: The CLI Command in the Docs Now Actually Works
+
+**Every doc and example told you to run `wp pp operate inspect-composition`, but that command didn't exist — WordPress registered it with an underscore (`inspect_composition`) instead of the hyphen the docs used everywhere.** A person hits that, reads the "did you mean" suggestion, and moves on in two seconds. An AI agent following the documented operating loop exactly as written can stop cold on it, or worse, quietly decide the tool doesn't support the step at all.
+
+### Fixed
+- `wp pp operate inspect-composition` now works exactly as documented. (The old underscore form now correctly points you back to the hyphenated one if you type it out of habit.)
+
 ## [v0.16.12] — 2026-07-04 — Fix: Grid Sections Now Show Their Title When Collapsed
 
 **Collapse a hero section in the composition editor and it shows you a preview of what's inside — but collapse a grid section, and it just says "grid," even with a title set.** On a page with three or four grids, that meant opening each one just to figure out which was which. The label was actually being computed correctly for hero; grid (and several other components — FAQ, section headers, stats blocks, tables, logo strips, embeds) just never got the same treatment because the code only looked at a component's *required* fields, and their title is optional by design.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.12-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.13-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.12');
+define('PP_VERSION', '0.16.13');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -924,6 +924,7 @@ class PP_Operate_Command extends WP_CLI_Command {
      *     wp pp operate inspect-composition 19
      *     wp pp operate inspect-composition about-us
      *
+     * @subcommand inspect-composition
      */
     public function inspect_composition($args, $assoc_args) {
         $page = $args[0] ?? null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.12",
+  "version": "0.16.13",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.12
+Stable tag: 0.16.13
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.12
+Version:          0.16.13
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
## Summary
`wp pp operate inspect_composition` (`lib/cli.php`, `PP_Operate_Command::inspect_composition`) was registered under its literal underscore PHP method name, but every documentation reference — `AI_CONTEXT.md`'s operating-loop examples, the method's own docblock `## EXAMPLES` section — consistently showed the hyphenated form `wp pp operate inspect-composition`, which didn't actually work. WP-CLI uses the raw PHP method name as the subcommand unless a `@subcommand` docblock annotation overrides it; this codebase already uses that exact pattern elsewhere in the same file (`@subcommand list`, `@subcommand check`, `@subcommand status`) but it was missing here. A production-site pass following the docs exactly hit `'inspect-composition' is not a registered subcommand... Did you mean 'inspect_composition'?` — for an AI agent following the documented operating loop literally, this can mean stopping early or reporting a false blocker.

Fix: one line — `@subcommand inspect-composition` added to the method's docblock, making the hyphenated form (the one every doc already uses) the canonical registered name.

## Test Coverage
This is a WP-CLI command-registration change; `lib/cli.php` returns immediately (`if (!class_exists('WP_CLI') || !class_exists('WP_CLI_Command')) { return; }`) when the real WP-CLI framework isn't present, which is always true in this codebase's PHPUnit environment — so none of `lib/cli.php`'s command classes are unit-testable via the existing test harness (a pre-existing, codebase-wide limitation, not introduced here). Verified directly against a real, ephemeral wp-env instance instead:
- `wp pp operate` (usage listing) now shows `wp pp operate inspect-composition <page>` as the registered subcommand.
- `wp pp operate inspect-composition 2` (read-only, no data created/mutated) ran successfully.
- `wp pp operate inspect_composition 2` now correctly fails: `'inspect_composition' is not a registered subcommand of 'pp operate'... Did you mean 'inspect-composition'?` — WP-CLI's own fuzzy-match now points toward the documented form instead of away from it.
- wp-env was torn down after verification; no test data was created (the command is read-only).

Full suite: 872 PHP tests / 3239 assertions pass (unchanged — no PHP logic touched, docblock-only). 281 JS tests pass (unchanged — this issue doesn't touch JS).

## Pre-Landing Review
Diff is 1 line, well under the specialist-dispatch threshold, and not security-sensitive, so `/review` specialists were skipped per the size gate. Both always-on adversarial passes ran regardless: Codex and a Claude adversarial subagent independently confirmed no findings — grepped the full repo for any script/doc/CI reference to the underscore CLI-invocation form (none found; all existing `inspect_composition`-underscore hits are the unrelated PHP function `pp_inspect_composition()`, never a CLI invocation string), confirmed no `@subcommand` naming collision within the class or across other `pp *` command registrations, and confirmed `@subcommand` has no caching/version-compatibility gotchas (WP-CLI re-parses docblocks via reflection on every invocation; the annotation is a long-standing, stable feature already used 4 times elsewhere in this exact file).

## Design Review
Not applicable — CLI-only, no UI surface.

## Eval Results
Not applicable — no LLM prompt/eval surface touched. This does make the documented operating-loop CLI command actually runnable, which is the entire point of the issue (per its own framing: "exact-instruction agents may stop early... or drift away from the prescribed operating loop" when docs and CLI disagree).

## Scope Drift
None — single docblock line, matching the issue's own suggested fix option 1 exactly ("add a CLI alias for inspect-composition").

## Plan Completion
Both acceptance criteria met: the documented command (`wp pp operate inspect-composition <page>`) now runs successfully, and since `@subcommand` fully replaces rather than dual-registers the name, there's only one canonical form — no ambiguity to clarify in help output (the conditional acceptance criterion, "if both forms remain supported," doesn't apply).

## TODOS
Checked `TODOS.md` — one item references `inspect-composition` output (a different, unrelated concern: adding a content hash for concurrent-edit detection) — no changes needed there.

## Documentation
`AI_CONTEXT.md` already consistently used the hyphenated form everywhere; no doc changes needed since the docs were correct all along — only the CLI registration needed to match them.

## Test plan
- [x] `vendor/bin/phpunit --configuration phpunit.xml` — 872 tests, 3239 assertions, pass (regression check; no PHP logic changed)
- [x] `npm test` (vitest) — 281 tests, pass (regression check; issue doesn't touch JS)
- [x] Live verification against a real, ephemeral wp-env instance (positive + negative case), torn down after, no test data left behind
- [x] Redaction-scanned diff before push — clean

Closes #95