### PR TITLE
Fix: apply reset records touched tokens and gates on rollback safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.15] — 2026-07-04 — Fix: Resetting Design Tokens Is No Longer a One-Way Trip
+
+**Run `wp pp apply reset` to clear a design token override (or wipe them all back to defaults), and there was no way to undo it.** `wp pp apply restore` — the command that's supposed to undo any token change made during a run — had nothing to work with, because `reset` never told it what it had just cleared. Ask an AI agent to reset a token, watch it reset *every* token by mistake, and the only way back was re-entering every value by hand. Every other token mutation (`apply execute`) already recorded what it touched so `restore` could revert it; `reset` was the one gap.
+
+### Fixed
+- `wp pp apply reset` (single-token and reset-all) now records what it cleared, the same way `wp pp apply execute` already does — so `wp pp apply restore` can bring a reset back within the same run, instead of being a dead end.
+- `wp pp apply reset` now also requires a valid rollback snapshot before it's allowed to run at all, matching `apply execute`'s existing safety check — the same protection that stops an unrecoverable mistake before it happens, not just after.
+
+### For contributors
+- 4 new PHPUnit tests covering the full round trip (override → reset → restore) for both single-token and reset-all, plus a test pinning that `reset`'s touched-token recording unions with — rather than overwrites — anything `execute` already recorded earlier in the same run.
+
 ## [v0.16.14] — 2026-07-04 — Fix: Inline SVG Images No Longer Vanish From Your Page
 
 **Set an image field to an inline SVG — a `data:image/svg+xml,...` value, the kind an AI naturally produces when generating a quick icon or graphic on the fly — and it used to just disappear.** Hero backgrounds, grid images, logo strips, section images: any component with an image slot would silently render with no image at all, no error, nothing to click on. WordPress's own URL-safety function throws out `data:` URIs entirely, on the reasonable assumption that most of them aren't real image URLs — but that meant a legitimate, self-contained inline image was treated exactly like a broken link. Regular image URLs (`https://...`, uploaded media) were never affected.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.14-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.15-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.14');
+define('PP_VERSION', '0.16.15');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -434,6 +434,10 @@ class PP_Apply_Command extends WP_CLI_Command {
      * keys WERE recorded and cannot revert a change whose keys never landed. Re-run
      * `wp pp operate inspect` after any such error rather than trusting restore.
      *
+     * `wp pp apply reset` records its touched tokens the same way `execute` does, so a
+     * reset (single-token or reset-all) within the same run is restorable here too — not
+     * just a one-way trip to product defaults.
+     *
      * ## OPTIONS
      *
      * --run-id=<uuid>
@@ -535,6 +539,14 @@ class PP_Apply_Command extends WP_CLI_Command {
             WP_CLI::error('Run token "' . $run_id . '" has no completed PREFLIGHT step. Run `wp pp apply preflight --run-id=' . $run_id . '` first.');
         }
 
+        // Rollback-safety pre-gate: reset mutates the same token store execute()
+        // does (and reset_all_design_tokens is the most destructive apply in the
+        // registry), so it gets the identical precondition — refuse to mutate
+        // unless this run is reversible.
+        if (!pp_operate_run_rollbackable($run_id)) {
+            WP_CLI::error('Refusing to reset: run "' . $run_id . '" has no usable rollback snapshot, so this change could not be undone. Re-run `wp pp operate inspect` and `wp pp apply preflight`.');
+        }
+
         _pp_cli_require_apply_cap();
 
         if (isset($assoc_args['token'])) {
@@ -545,13 +557,23 @@ class PP_Apply_Command extends WP_CLI_Command {
 
         WP_CLI::line(json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
 
-        if ($result['ok']) {
-            pp_operate_record_step($run_id, 'APPLY');
-            $count = count($result['changes']);
-            WP_CLI::success($count > 0 ? "Reset $count token(s) to product defaults." : 'No overrides to reset.');
-        } else {
+        if (!$result['ok']) {
             WP_CLI::halt(1);
         }
+
+        // Record the tokens this reset actually cleared so restore can revert
+        // exactly this run's footprint — same contract as execute(). Without
+        // this, restore's scope stays empty and a reset is unrecoverable
+        // through the tooling even though the pre-apply snapshot holds every
+        // prior value.
+        $touched = array_column($result['changes'], 'token');
+        if (!pp_operate_record_touched_tokens($run_id, $touched)) {
+            WP_CLI::error('Reset persisted, but recording its touched tokens for run "' . $run_id . '" FAILED. `wp pp apply restore` may not be able to revert this change. Run state may be missing or corrupt; re-run `wp pp operate inspect` before making further changes.');
+        }
+
+        pp_operate_record_step($run_id, 'APPLY');
+        $count = count($result['changes']);
+        WP_CLI::success($count > 0 ? "Reset $count token(s) to product defaults." : 'No overrides to reset.');
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.14",
+  "version": "0.16.15",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.14
+Stable tag: 0.16.15
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.14
+Version:          0.16.15
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -1631,6 +1631,88 @@ class OperateTest extends TestCase
         pp_operate_cleanup_run($run_id);
     }
 
+    // ── apply reset rollback trail (#122) ──────────────────────────────────
+
+    public function testApplyResetRecordsTouchedTokensRestorableViaRevert(): void
+    {
+        // Reproduces the fix in PP_Apply_Command::reset(): after a successful
+        // reset, the cleared token names are recorded as touched the same way
+        // execute() records its writes, so pp_revert_tokens() (restore's
+        // underlying primitive) can bring the override back.
+        pp_set_token_override('--color-accent', '#b45309');
+        $run_id = pp_operate_create_run();
+        pp_operate_record_token_snapshot($run_id, pp_get_token_overrides());
+
+        $result = pp_execute_apply('reset_design_token', ['token' => '--color-accent']);
+        $this->assertTrue($result['ok']);
+        $this->assertArrayNotHasKey('--color-accent', pp_get_token_overrides());
+
+        $touched = array_column($result['changes'], 'token');
+        $this->assertTrue(pp_operate_record_touched_tokens($run_id, $touched));
+        $this->assertSame(['--color-accent'], pp_operate_get_touched_tokens($run_id));
+
+        $snapshot = pp_operate_get_token_snapshot($run_id);
+        $this->assertTrue(pp_revert_tokens($snapshot, pp_operate_get_touched_tokens($run_id)));
+        $this->assertSame('#b45309', pp_get_token_overrides()['--color-accent']);
+
+        pp_operate_cleanup_run($run_id);
+    }
+
+    public function testApplyResetAllRecordsEveryClearedTokenRestorableViaRevert(): void
+    {
+        pp_set_token_override('--color-accent', '#b45309');
+        pp_set_token_override('--font-heading', 'Georgia, serif');
+        $run_id = pp_operate_create_run();
+        pp_operate_record_token_snapshot($run_id, pp_get_token_overrides());
+
+        $result = pp_execute_apply('reset_all_design_tokens', []);
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], pp_get_token_overrides());
+
+        $touched = array_column($result['changes'], 'token');
+        pp_operate_record_touched_tokens($run_id, $touched);
+        $this->assertEqualsCanonicalizing(
+            ['--color-accent', '--font-heading'],
+            pp_operate_get_touched_tokens($run_id)
+        );
+
+        $snapshot = pp_operate_get_token_snapshot($run_id);
+        $this->assertTrue(pp_revert_tokens($snapshot, pp_operate_get_touched_tokens($run_id)));
+        $overrides = pp_get_token_overrides();
+        $this->assertSame('#b45309', $overrides['--color-accent']);
+        $this->assertSame('Georgia, serif', $overrides['--font-heading']);
+
+        pp_operate_cleanup_run($run_id);
+    }
+
+    public function testApplyResetWithoutRollbackableSnapshotWouldBeRefused(): void
+    {
+        // The pre-gate added to reset() mirrors execute(): pp_operate_run_rollbackable()
+        // must be true before any mutation is allowed. A run that never captured a
+        // snapshot (no preflight) must fail this check.
+        $run_id = pp_operate_create_run();
+        $this->assertFalse(pp_operate_run_rollbackable($run_id));
+        pp_operate_cleanup_run($run_id);
+    }
+
+    public function testApplyResetMergesTouchedTokensWithPriorExecuteInSameRun(): void
+    {
+        // If execute() already recorded touched tokens earlier in the same run,
+        // reset() recording its own touched tokens must merge (union), not
+        // overwrite — otherwise restore would lose the earlier execute()'s
+        // footprint. pp_operate_record_touched_tokens() dedups/unions by design;
+        // this pins that reset()'s call site doesn't accidentally rely on
+        // replace semantics.
+        $run_id = pp_operate_create_run();
+        pp_operate_record_touched_tokens($run_id, ['--color-accent']);
+        pp_operate_record_touched_tokens($run_id, ['--font-heading']);
+        $this->assertSame(
+            ['--color-accent', '--font-heading'],
+            pp_operate_get_touched_tokens($run_id)
+        );
+        pp_operate_cleanup_run($run_id);
+    }
+
     public function testGetTokenSnapshotLeavesCorruptFileIntact(): void
     {
         $fake_id = wp_generate_uuid4();


### PR DESCRIPTION
## Summary

Closes #122. `wp pp apply reset` mutates the same token store `apply execute` does, but unlike `execute`, it never recorded which tokens it touched — so `apply restore` had an empty scope to work with and a reset could never be undone, even though the run's pre-apply snapshot held every prior value.

## Fix

In `PP_Apply_Command::reset()` (`lib/cli.php`), mirrored `execute()` exactly:
1. Added the `pp_operate_run_rollbackable($run_id)` pre-gate before mutating (reset-all is arguably the most destructive apply in the registry — it carries `impact_warning` — so it gets the same precondition execute() already has).
2. After a successful reset, `array_column($result['changes'], 'token')` + `pp_operate_record_touched_tokens($run_id, $touched)`, erroring loudly (same message pattern as execute) if the write fails.
3. Updated `restore()`'s docblock to note reset is now restorable within the same run.

Verified `pp_operate_record_touched_tokens()` unions (dedups) rather than overwrites, so a reset recording its own touched tokens can't clobber an earlier `execute()`'s footprint in the same run — added a regression test pinning this specifically.

## Test Coverage

4 new PHPUnit tests in `tests/OperateTest.php`:
- Full round trip (set override → reset single token → restore) via the underlying primitives (`pp_execute_apply`, `pp_operate_record_touched_tokens`, `pp_revert_tokens`) — this test harness stubs WP-CLI's dependencies rather than the `WP_CLI` class itself, matching the existing pattern for CLI-command coverage in this file.
- Same round trip for `reset_all_design_tokens` with multiple overrides.
- Rollback-gate precondition (no snapshot → not rollbackable).
- Union-not-overwrite semantics when `execute()` and `reset()` both touch tokens in the same run.

Full suite: 925 PHP / 281 JS passing, no regressions.

## Test plan

- [x] `composer test` — 925/925 passing
- [x] `npm test` — 281/281 passing
- [x] Redaction scan on the diff — clean
- [ ] CI green
