### PR TITLE
Add selectable button variants to hero's two CTA buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.17] — 2026-07-05 — New: Hero's Two Buttons Can Now Use Any Button Style
+
+**Hero sections have always had a primary and a secondary button, but the secondary one was locked to an outline style — no way to make it a solid secondary color or a plain borderless "ghost" link, even though CTA blocks already had all four button styles to choose from.** Both hero buttons now pick from the same shared set — primary, secondary, outline, ghost — that CTA already uses, so a hero's two buttons can match whatever pairing the brand actually calls for.
+
+### Added
+- Hero's primary and secondary buttons each get their own style choice (`cta_variant` and `cta2_variant`) — primary, secondary, outline, or ghost. The secondary button still defaults to outline, so every existing page renders exactly as before unless you choose otherwise.
+
+### For contributors
+- Reuses the shared `.btn`/`.btn--*` primitive from v0.12.0 exactly as CTA does — hero's CSS already anticipated `.btn--secondary`/`.btn--ghost` on its buttons (the accent-fill exclusion selector already listed them), so no CSS changes were needed, only wiring the new props through to the existing markup. Audited grid and section for the same gap (#93's stated scope): grid's only link surface is a plain per-card text link (`.grid__item-link`, no padding/background/border), not a button, and section has no button/link prop at all — neither is an eligible migration target, so neither was touched. 7 new PHPUnit tests.
+
 ## [v0.16.16] — 2026-07-05 — New: Gradient Backgrounds Across Hero, CTA, Grid, and Section
 
 **Set a hero, CTA, grid, or section background to a gradient — the kind of treatment that shows up in most real brand books — and it used to just get rejected.** The safe style-surface only accepted flat colors (hex, rgb, hsl), so a request like "make the hero background a dark diagonal gradient" had no way through: you'd have to settle for a flat color and lose the brand's actual look. Several of these same components already render a gradient by *default* — you just couldn't set your own.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.16-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.17-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/components/hero/hero.php
+++ b/components/hero/hero.php
@@ -14,6 +14,8 @@ $cta_text  = $props['cta_text'] ?? '';
 $cta_url   = $props['cta_url']  ?? '#';
 $cta2_text = $props['cta2_text'] ?? '';
 $cta2_url  = $props['cta2_url']  ?? '#';
+$cta_variant  = $props['cta_variant']  ?? 'primary';
+$cta2_variant = $props['cta2_variant'] ?? 'outline';
 $variant   = $props['variant']   ?? 'centered';
 $image_url = $props['image_url'] ?? '';
 $image_alt = $props['image_alt'] ?? '';
@@ -28,6 +30,18 @@ $allowed_variants = ['left', 'centered', 'split', 'cover'];
 if (!in_array($variant, $allowed_variants, true)) {
     $variant = 'centered';
 }
+
+// Validate CTA button variants (same shared .btn--* primitive as components/cta/cta.php).
+$allowed_button_variants = ['primary', 'secondary', 'outline', 'ghost'];
+if (!in_array($cta_variant, $allowed_button_variants, true)) {
+    $cta_variant = 'primary';
+}
+if (!in_array($cta2_variant, $allowed_button_variants, true)) {
+    $cta2_variant = 'outline';
+}
+// primary is the bare .btn; other variants add a .btn--{variant} modifier.
+$cta_variant_class  = $cta_variant !== 'primary' ? ' btn--' . $cta_variant : '';
+$cta2_variant_class = $cta2_variant !== 'primary' ? ' btn--' . $cta2_variant : '';
 
 // Validate spacing/width props.
 $allowed_spacings = ['default', 'compact', 'spacious'];
@@ -83,11 +97,11 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
 
                 <?php if ($cta_text) : ?>
                     <div class="hero__cta-group">
-                        <a href="<?php echo esc_url($cta_url); ?>" class="hero__cta btn">
+                        <a href="<?php echo esc_url($cta_url); ?>" class="hero__cta btn<?php echo esc_attr($cta_variant_class); ?>">
                             <?php echo esc_html($cta_text); ?>
                         </a>
                         <?php if ($cta2_text) : ?>
-                            <a href="<?php echo esc_url($cta2_url); ?>" class="hero__cta btn btn--outline">
+                            <a href="<?php echo esc_url($cta2_url); ?>" class="hero__cta btn<?php echo esc_attr($cta2_variant_class); ?>">
                                 <?php echo esc_html($cta2_text); ?>
                             </a>
                         <?php endif; ?>

--- a/components/hero/schema.json
+++ b/components/hero/schema.json
@@ -43,6 +43,20 @@
       "default": "#",
       "description": "Secondary CTA button URL."
     },
+    "cta_variant": {
+      "type": "enum",
+      "values": ["primary", "secondary", "outline", "ghost"],
+      "required": false,
+      "default": "primary",
+      "description": "Primary CTA button style. 'primary' = filled accent (bare .btn). 'secondary' = muted surface fill. 'outline' = accent border, transparent fill. 'ghost' = borderless text button. Set via update_component (a prop, not a style slot)."
+    },
+    "cta2_variant": {
+      "type": "enum",
+      "values": ["primary", "secondary", "outline", "ghost"],
+      "required": false,
+      "default": "outline",
+      "description": "Secondary CTA button style — defaults to 'outline' to match the historical always-outline second button. 'primary' = filled accent. 'secondary' = muted surface fill. 'ghost' = borderless text button. Set via update_component (a prop, not a style slot)."
+    },
     "variant": {
       "type": "enum",
       "values": ["left", "centered", "split", "cover"],

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.16');
+define('PP_VERSION', '0.16.17');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.16",
+  "version": "0.16.17",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.16
+Stable tag: 0.16.17
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.16
+Version:          0.16.17
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -307,6 +307,62 @@ class ComponentPropsTest extends TestCase
         $this->assertStringNotContainsString('btn--', $html);
     }
 
+    // ── Hero CTA variants (props, set via update_component) — #93 ───────────
+    // Extends the shared .btn--*/--btn-* primitive (established for CTA above)
+    // to hero's two CTA buttons, which previously hardcoded bare .btn / .btn--outline
+    // with no way to select secondary/ghost. cta2_variant defaults to 'outline'
+    // to preserve the historical always-outline second button.
+
+    private function heroProps(array $extra = []): array
+    {
+        return array_merge(['title' => 'T', 'cta_text' => 'Go', 'cta2_text' => 'Learn more'], $extra);
+    }
+
+    public function testHeroCtaVariantDefaultsToPrimary(): void
+    {
+        $html = $this->render('hero', $this->heroProps());
+        $this->assertMatchesRegularExpression('/class="hero__cta btn"[^-]/', $html . ' ');
+    }
+
+    public function testHeroCta2VariantDefaultsToOutline(): void
+    {
+        // Preserves pre-#93 behavior: an unset cta2_variant still renders outline.
+        $html = $this->render('hero', $this->heroProps());
+        $this->assertStringContainsString('class="hero__cta btn btn--outline"', $html);
+    }
+
+    public function testHeroCtaVariantSecondary(): void
+    {
+        $html = $this->render('hero', $this->heroProps(['cta_variant' => 'secondary']));
+        $this->assertStringContainsString('class="hero__cta btn btn--secondary"', $html);
+    }
+
+    public function testHeroCtaVariantGhost(): void
+    {
+        $html = $this->render('hero', $this->heroProps(['cta_variant' => 'ghost']));
+        $this->assertStringContainsString('class="hero__cta btn btn--ghost"', $html);
+    }
+
+    public function testHeroCta2VariantPrimary(): void
+    {
+        $html = $this->render('hero', $this->heroProps(['cta2_variant' => 'primary']));
+        $this->assertStringContainsString('class="hero__cta btn"', $html);
+        // Neither button should carry a btn-- modifier now.
+        $this->assertSame(0, substr_count($html, 'btn--'));
+    }
+
+    public function testHeroCtaVariantInvalidFallsBackToPrimary(): void
+    {
+        $html = $this->render('hero', $this->heroProps(['cta_variant' => 'neon']));
+        $this->assertMatchesRegularExpression('/class="hero__cta btn"[^-]/', $html . ' ');
+    }
+
+    public function testHeroCta2VariantInvalidFallsBackToOutline(): void
+    {
+        $html = $this->render('hero', $this->heroProps(['cta2_variant' => 'neon']));
+        $this->assertStringContainsString('class="hero__cta btn btn--outline"', $html);
+    }
+
     // ── CRITICAL regression: button enrichment must not break --cta-accent ──
     //
     // The shared .btn was tokenized with --btn-* defaults. Existing compositions


### PR DESCRIPTION
## Summary

Closes #93. v0.12.0 introduced the shared `--btn-*`/`.btn--*` button primitive and wired a `button_variant` prop into CTA (primary/secondary/outline/ghost). Hero already rendered both its buttons through `.btn`/`.btn--outline`, but never exposed a way to *select* the variant — the primary was always bare `.btn`, the secondary was always hardcoded `.btn--outline`.

## What changed

- Added `cta_variant` (default `primary`) and `cta2_variant` (default `outline`) props to `components/hero/schema.json`, mirroring CTA's `button_variant` exactly (same enum values, same validate-and-fallback pattern).
- Wired both into `components/hero/hero.php`'s markup, replacing the hardcoded classes.
- `cta2_variant` defaults to `outline` specifically to preserve every existing page's rendered output — nothing changes unless a caller explicitly sets a different variant.
- **No CSS changes needed.** Hero's existing accent-fill exclusion selector (`.hero .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary)`) already anticipated secondary/ghost variants appearing on hero buttons — it was just never reachable until now.

## Audit of the issue's full stated scope (hero, grid, section)

- **Hero**: eligible, migrated (above).
- **Grid**: its only link surface is a plain per-card text link (`.grid__item-link` — font-weight/color only, no padding/background/border). This is a genuinely different UI pattern from a button, and the issue requires "preserve existing visual behavior" — forcing it into `.btn` styling would be a visual regression, not a migration. Not touched.
- **Section**: has no button/link prop in its schema at all (`body` is rendered rich content via `wp_kses_post()`, which could contain an author-authored `<a>`, but that's arbitrary content, not a structured component prop). Nothing to migrate.

## Test Coverage

7 new PHPUnit tests in `tests/ComponentPropsTest.php`, mirroring the existing CTA `button_variant` test block exactly: default-to-primary, default-cta2-to-outline (regression pin for pre-#93 behavior), secondary, ghost, both-primary (no `btn--` modifier at all), and invalid-value fallback for both props.

Full suite: 956 PHP / 281 JS passing, no regressions.

## Test plan

- [x] `composer test` — 956/956 passing
- [x] `npm test` — 281/281 passing
- [x] Redaction scan on the diff — clean
- [ ] CI green
