### PR TITLE
Add per-instance style slots to faq and stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.18] — 2026-07-05 — New: FAQ and Stats Can Finally Match Your Brand
+
+**Every section-level component could be re-colored to fit a page except two: FAQ and the stats row.** Put an FAQ block on a dark band and the heading turned nearly invisible, with no safe way to fix it — the underlying CSS had a comment admitting exactly that: "faq has no heading-color slot, so it keeps the token." Stats had the same problem: the big numbers were locked to the global accent color with no way to match a specific brand's palette for that one section.
+
+### Added
+- FAQ gets 7 new style slots: section background, individual question-card background, heading color, question color, answer color, border color, and the open-question accent color (also drives the chevron).
+- Stats gets 4 new style slots: background, heading color, number color, and label color.
+- Both support gradient backgrounds, matching every other section-level component.
+
+### Fixed
+- FAQ headings on a dark surface no longer go invisible with no way to fix it — the exact gap the previous CSS comment called out is closed.
+
+### For contributors
+- Followed the established per-instance style-slot pattern (Recipe A in `docs/AI_IMPLEMENTATION_RECIPES.md`) exactly, including the desktop "premium typography" cross-block overrides that previously hardcoded `--color-text`/`--color-text-secondary` for FAQ specifically — those now route through the new slots. `tests/StyleSlotContractTest.php`'s keystone contract now covers faq and stats (previously excluded since they had zero slots) and gained cross-block guard entries for the two FAQ slots at risk of the same clobber class as #86 — a third slot (`--faq-question-color`) is deliberately excluded from that particular guard with an inline explanation, since its open-accordion state intentionally uses a different slot (`--faq-accent`) and the guard's whole-stylesheet class-substring match can't distinguish that from a real bug. 9 new PHPUnit tests, plus a fix to an existing test that would have otherwise regressed (an AI-prompt test using faq as an "unstyled component" example, no longer true).
+
 ## [v0.16.17] — 2026-07-05 — New: Hero's Two Buttons Can Now Use Any Button Style
 
 **Hero sections have always had a primary and a secondary button, but the secondary one was locked to an outline style — no way to make it a solid secondary color or a plain borderless "ghost" link, even though CTA blocks already had all four button styles to choose from.** Both hero buttons now pick from the same shared set — primary, secondary, outline, ghost — that CTA already uses, so a hero's two buttons can match whatever pairing the brand actually calls for.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.17-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.18-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -673,11 +673,12 @@
 .faq {
   padding-top: var(--space-xl);
   padding-bottom: var(--space-xl);
-  background-color: var(--color-surface);
+  background: var(--faq-bg, var(--color-surface));
 }
 
 .faq__heading {
   margin-bottom: var(--space-lg);
+  color: var(--faq-heading-color, var(--color-text));
 }
 
 .faq__list {
@@ -687,9 +688,9 @@
 }
 
 .faq__item {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--faq-border-color, var(--color-border));
   border-radius: var(--radius);
-  background-color: var(--color-bg);
+  background: var(--faq-item-bg, var(--color-bg));
   overflow: hidden;
 }
 
@@ -699,7 +700,7 @@
   justify-content: space-between;
   padding: var(--space-md) var(--space-lg);
   font-weight: 600;
-  color: var(--color-text);
+  color: var(--faq-question-color, var(--color-text));
   cursor: pointer;
   list-style: none;
   gap: var(--space-md);
@@ -726,7 +727,7 @@
 }
 
 .faq__item[open] > .faq__question {
-  color: var(--color-accent);
+  color: var(--faq-accent, var(--color-accent));
 }
 
 .faq__item[open] > .faq__question::after {
@@ -735,7 +736,7 @@
 
 .faq__answer {
   padding: 0 var(--space-lg) var(--space-md);
-  color: var(--color-muted);
+  color: var(--faq-answer-color, var(--color-muted));
   line-height: 1.6;
 }
 
@@ -1324,11 +1325,13 @@
 .stats {
   padding-top: var(--space-xl);
   padding-bottom: var(--space-xl);
+  background: var(--stats-bg, transparent);
 }
 
 .stats__heading {
   margin-bottom: var(--space-lg);
   text-align: center;
+  color: var(--stats-title-color, var(--color-text));
 }
 
 .stats__list {
@@ -1352,37 +1355,37 @@
 .stats__number {
   font-size: 2.5rem;
   font-weight: 700;
-  color: var(--color-accent);
+  color: var(--stats-number-color, var(--color-accent));
   line-height: 1;
 }
 
 .stats__label {
   font-size: 0.875rem;
-  color: var(--color-muted);
+  color: var(--stats-label-color, var(--color-muted));
   text-align: center;
 }
 
 /* Stats variants */
 .stats--dark {
-  background-color: var(--color-surface);
+  background: var(--stats-bg, var(--color-surface));
   border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
 }
 
 .stats--inverted {
-  background-color: var(--color-bg-inverted);
+  background: var(--stats-bg, var(--color-bg-inverted));
 }
 
 .stats--inverted .stats__heading {
-  color: var(--color-bg);
+  color: var(--stats-title-color, var(--color-bg));
 }
 
 .stats--inverted .stats__number {
-  color: var(--color-accent);
+  color: var(--stats-number-color, var(--color-accent));
 }
 
 .stats--inverted .stats__label {
-  color: var(--color-bg);
+  color: var(--stats-label-color, var(--color-bg));
   opacity: 0.75;
 }
 
@@ -1406,15 +1409,15 @@
 }
 
 .stats--has-bg-image .stats__heading {
-  color: var(--color-bg);
+  color: var(--stats-title-color, var(--color-bg));
 }
 
 .stats--has-bg-image .stats__number {
-  color: var(--color-accent);
+  color: var(--stats-number-color, var(--color-accent));
 }
 
 .stats--has-bg-image .stats__label {
-  color: var(--color-bg);
+  color: var(--stats-label-color, var(--color-bg));
   opacity: 0.85;
 }
 
@@ -2124,7 +2127,7 @@
 
   /* Per-instance heading-color slots must survive this desktop typography rule (#86).
      Color is split per selector so each component's slot wins instead of a shared
-     hardcoded var(--color-text). faq has no heading-color slot, so it keeps the token. */
+     hardcoded var(--color-text). */
   main > .grid .grid__heading {
     color: var(--grid-heading-color, var(--color-text));
   }
@@ -2134,7 +2137,7 @@
   }
 
   main > .faq .faq__heading {
-    color: var(--color-text);
+    color: var(--faq-heading-color, var(--color-text));
   }
 
   main > .section .section__content,
@@ -2188,14 +2191,14 @@
   }
 
   main > .faq .faq__question {
-    color: var(--color-text);
+    color: var(--faq-question-color, var(--color-text));
     font-size: 1rem;
     font-weight: 560;
     line-height: 1.45;
   }
 
   main > .faq .faq__answer {
-    color: var(--color-text-secondary);
+    color: var(--faq-answer-color, var(--color-text-secondary));
     font-size: 1rem;
     font-weight: 430;
     line-height: 1.68;

--- a/components/faq/faq.php
+++ b/components/faq/faq.php
@@ -11,8 +11,12 @@
 $id    = $props['id']    ?? '';
 $title = $props['title'] ?? 'Frequently Asked Questions';
 $items = $props['items'] ?? [];
+
+// Style slot overrides (per-instance visual customization).
+$slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'faq');
+$style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';
 ?>
-<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="faq" data-pp-component="faq">
+<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="faq" data-pp-component="faq"<?php echo $style_attr; ?>>
     <div class="container">
 
         <?php if ($title) : ?>

--- a/components/faq/schema.json
+++ b/components/faq/schema.json
@@ -21,7 +21,16 @@
   "styling": {
     "root_class": "faq",
     "variant_classes": [],
-    "tokens": ["--space-xl", "--space-2xl", "--color-border", "--color-surface"]
+    "tokens": ["--space-xl", "--space-2xl", "--color-border", "--color-surface"],
+    "style_slots": {
+      "--faq-bg": { "type": "gradient", "default": "var(--color-surface)", "description": "Section background color or gradient" },
+      "--faq-item-bg": { "type": "gradient", "default": "var(--color-bg)", "description": "Individual accordion item background color or gradient" },
+      "--faq-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading text color" },
+      "--faq-question-color": { "type": "color", "default": "var(--color-text)", "description": "Question (summary) text color" },
+      "--faq-answer-color": { "type": "color", "default": "var(--color-muted)", "description": "Answer text color" },
+      "--faq-border-color": { "type": "color", "default": "var(--color-border)", "description": "Accordion item border color" },
+      "--faq-accent": { "type": "color", "default": "var(--color-accent)", "description": "Open-state question text color and chevron color" }
+    }
   },
   "safe_to_edit": ["faq.php", "../../assets/css/components.css (COMPONENT: faq section)"],
   "do_not_touch": ["schema.json without updating README.md"]

--- a/components/stats/schema.json
+++ b/components/stats/schema.json
@@ -40,7 +40,13 @@
   "styling": {
     "root_class": "stats",
     "variant_classes": ["stats--dark", "stats--inverted"],
-    "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted", "--overlay-bg"]
+    "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted", "--overlay-bg"],
+    "style_slots": {
+      "--stats-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
+      "--stats-title-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading text color" },
+      "--stats-number-color": { "type": "color", "default": "var(--color-accent)", "description": "Stat number (large metric value) text color" },
+      "--stats-label-color": { "type": "color", "default": "var(--color-muted)", "description": "Stat label text color" }
+    }
   },
   "safe_to_edit": ["stats.php", "../../assets/css/components.css (COMPONENT: stats section)"],
   "do_not_touch": ["schema.json without updating AI_CONTEXT.md"]

--- a/components/stats/stats.php
+++ b/components/stats/stats.php
@@ -22,12 +22,21 @@ if (!in_array($variant, $allowed_variants, true)) {
 
 $variant_class  = $variant !== 'default' ? ' stats--' . $variant : '';
 $bg_image_class = $background_image ? ' stats--has-bg-image' : '';
-$bg_image_style = $background_image
-    ? sprintf(' style="background-image:url(%s);"', pp_esc_image_src($background_image))
-    : '';
+
+// Style slot overrides (per-instance visual customization).
+$slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'stats');
+
+$inline_styles = [];
+if ($slot_style) {
+    $inline_styles[] = $slot_style;
+}
+if ($background_image) {
+    $inline_styles[] = 'background-image:url(' . pp_esc_image_src($background_image) . ')';
+}
+$style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"' : '';
 
 ?>
-<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="stats<?php echo esc_attr($variant_class); ?><?php echo esc_attr($bg_image_class); ?>" data-pp-component="stats"<?php echo $bg_image_style; ?>>
+<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="stats<?php echo esc_attr($variant_class); ?><?php echo esc_attr($bg_image_class); ?>" data-pp-component="stats"<?php echo $style_attr; ?>>
     <?php if ($background_image) : ?>
         <div class="stats__overlay" aria-hidden="true"></div>
     <?php endif; ?>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.17');
+define('PP_VERSION', '0.16.18');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.17",
+  "version": "0.16.18",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.17
+Stable tag: 0.16.18
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.17
+Version:          0.16.18
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/AiContextTest.php
+++ b/tests/AiContextTest.php
@@ -454,14 +454,36 @@ class AiContextTest extends TestCase
 
     public function testSystemPromptOmitsStyleSlotsForUnstyled(): void
     {
+        // faq gained style slots in #100 — it's no longer an "unstyled" example
+        // (see testSystemPromptIncludesStyleSlotsForFaq below).
         $prompt = pp_ai_system_prompt();
         $lines = explode("\n", $prompt);
         foreach ($lines as $i => $line) {
-            if (str_contains($line, '**faq**') || str_contains($line, '**embed**')) {
+            if (str_contains($line, '**embed**')) {
                 $next = $lines[$i + 1] ?? '';
                 $this->assertStringNotContainsString('Style slots:', $next);
             }
         }
+    }
+
+    public function testSystemPromptIncludesStyleSlotsForFaq(): void
+    {
+        // Regression pin for #100: faq previously had zero style slots (this test
+        // used to be one of the "unstyled" examples above). Confirms the AI-facing
+        // prompt now surfaces faq's new slots the same way it does for every other
+        // styled component.
+        $prompt = pp_ai_system_prompt();
+        $lines = explode("\n", $prompt);
+        $found = false;
+        foreach ($lines as $i => $line) {
+            if (str_contains($line, '**faq**')) {
+                $next = $lines[$i + 1] ?? '';
+                $this->assertStringContainsString('Style slots:', $next);
+                $this->assertStringContainsString('--faq-heading-color', $next);
+                $found = true;
+            }
+        }
+        $this->assertTrue($found, 'faq should appear in the system prompt.');
     }
 
     // ── Enum Values in Condensed Schema ──────────────────────────────────

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -815,6 +815,126 @@ class ComponentPropsTest extends TestCase
         $this->assertNotSame('', pp_esc_image_src($payload));
     }
 
+    // ── faq / stats style slots (#100) ───────────────────────────────────
+
+    private function faqProps(array $extra = []): array
+    {
+        return array_merge(['title' => 'FAQ', 'items' => [['question' => 'Q?', 'answer' => 'A.']]], $extra);
+    }
+
+    private function statsProps(array $extra = []): array
+    {
+        return array_merge(['title' => 'Stats', 'items' => [['number' => '40+', 'label' => 'Years']]], $extra);
+    }
+
+    public function testFaqSchemaDeclaresAllSevenStyleSlots(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/faq/schema.json'), true);
+        $slots = $schema['styling']['style_slots'];
+        $expected = [
+            '--faq-bg' => 'gradient',
+            '--faq-item-bg' => 'gradient',
+            '--faq-heading-color' => 'color',
+            '--faq-question-color' => 'color',
+            '--faq-answer-color' => 'color',
+            '--faq-border-color' => 'color',
+            '--faq-accent' => 'color',
+        ];
+        foreach ($expected as $name => $type) {
+            $this->assertArrayHasKey($name, $slots, "faq must declare {$name}.");
+            $this->assertSame($type, $slots[$name]['type'], "{$name} must be type {$type}.");
+            $this->assertArrayHasKey('default', $slots[$name]);
+            $this->assertNotEmpty($slots[$name]['description']);
+        }
+    }
+
+    public function testStatsSchemaDeclaresAllFourStyleSlots(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/stats/schema.json'), true);
+        $slots = $schema['styling']['style_slots'];
+        $expected = [
+            '--stats-bg' => 'gradient',
+            '--stats-title-color' => 'color',
+            '--stats-number-color' => 'color',
+            '--stats-label-color' => 'color',
+        ];
+        foreach ($expected as $name => $type) {
+            $this->assertArrayHasKey($name, $slots, "stats must declare {$name}.");
+            $this->assertSame($type, $slots[$name]['type'], "{$name} must be type {$type}.");
+            $this->assertArrayHasKey('default', $slots[$name]);
+            $this->assertNotEmpty($slots[$name]['description']);
+        }
+    }
+
+    public function testFaqRendersHeadingColorSlot(): void
+    {
+        // The exact production regression #100 fixes: faq could not reach brand
+        // fidelity on a dark surface because it had no --faq-heading-color slot.
+        $html = $this->render('faq', array_merge($this->faqProps(), [
+            '__pp_style' => ['--faq-heading-color' => '#ffffff'],
+        ]));
+        $this->assertStringContainsString('--faq-heading-color: #ffffff', $html);
+    }
+
+    public function testFaqRendersAllSevenSlots(): void
+    {
+        $overrides = [
+            '--faq-bg' => 'linear-gradient(135deg, #1a1a2e, #16121f)',
+            '--faq-item-bg' => '#222222',
+            '--faq-heading-color' => '#ffffff',
+            '--faq-question-color' => '#eeeeee',
+            '--faq-answer-color' => '#cccccc',
+            '--faq-border-color' => '#333333',
+            '--faq-accent' => '#ea3900',
+        ];
+        $html = $this->render('faq', array_merge($this->faqProps(), ['__pp_style' => $overrides]));
+        foreach ($overrides as $slot => $value) {
+            $this->assertStringContainsString("{$slot}: {$value}", $html, "{$slot} did not render.");
+        }
+    }
+
+    public function testFaqRejectsInjectionInStyleSlot(): void
+    {
+        $html = $this->render('faq', array_merge($this->faqProps(), [
+            '__pp_style' => ['--faq-heading-color' => '#fff; background:url(evil)'],
+        ]));
+        $this->assertStringNotContainsString('url(evil)', $html);
+    }
+
+    public function testStatsRendersAllFourSlots(): void
+    {
+        $overrides = [
+            '--stats-bg' => 'radial-gradient(#fff, #000)',
+            '--stats-title-color' => '#111111',
+            '--stats-number-color' => '#ea3900',
+            '--stats-label-color' => '#666666',
+        ];
+        $html = $this->render('stats', array_merge($this->statsProps(), ['__pp_style' => $overrides]));
+        foreach ($overrides as $slot => $value) {
+            $this->assertStringContainsString("{$slot}: {$value}", $html, "{$slot} did not render.");
+        }
+    }
+
+    public function testStatsStyleSlotMergesWithBackgroundImage(): void
+    {
+        // stats.php's __pp_style rendering must coexist with the pre-existing
+        // background_image inline-style mechanism (same pattern as hero/section).
+        $html = $this->render('stats', array_merge($this->statsProps(), [
+            '__pp_style' => ['--stats-number-color' => '#ea3900'],
+            'background_image' => 'https://example.com/bg.jpg',
+        ]));
+        $this->assertStringContainsString('--stats-number-color: #ea3900', $html);
+        $this->assertStringContainsString('background-image:url(', $html);
+    }
+
+    public function testStatsRejectsInjectionInStyleSlot(): void
+    {
+        $html = $this->render('stats', array_merge($this->statsProps(), [
+            '__pp_style' => ['--stats-title-color' => '#fff; background:url(evil)'],
+        ]));
+        $this->assertStringNotContainsString('url(evil)', $html);
+    }
+
     // ── End-to-end: exact production regression from #36 ────────────────────
 
     public function testHeroSplitVariantRendersDataUriSvgImageSrc(): void

--- a/tests/StyleSlotContractTest.php
+++ b/tests/StyleSlotContractTest.php
@@ -33,7 +33,7 @@ use PHPUnit\Framework\TestCase;
 class StyleSlotContractTest extends TestCase
 {
     /** Components that declare style_slots and own a block in components.css. */
-    private const COMPONENTS = ['hero', 'section', 'grid', 'cta'];
+    private const COMPONENTS = ['hero', 'section', 'grid', 'cta', 'faq', 'stats'];
 
     private string $themeRoot;
     private string $css;
@@ -190,6 +190,20 @@ class StyleSlotContractTest extends TestCase
         '.grid__item-title'  => ['--grid-item-title-color', 'color'],
         '.grid__item-text'   => ['--grid-item-text-color', 'color'],
         '.cta__body'         => ['--cta-body-color', 'color'],
+        // faq (#100): this is the exact bug the "premium typography" comment above
+        // already documented ("faq has no heading-color slot, so it keeps the token")
+        // before #100 added one — .faq__heading/.faq__answer are re-declared in the
+        // same desktop media rules as the slots above.
+        // NOTE: .faq__question is deliberately NOT in this map. Its open-accordion
+        // state (.faq__item[open] > .faq__question) intentionally uses a DIFFERENT
+        // slot (--faq-accent, not --faq-question-color) — a real, in-component state
+        // change, not a cross-block clobber. This test matches by class substring
+        // across the whole stylesheet and can't distinguish "different intentional
+        // state" from "accidental override," so .faq__question would false-fail here.
+        // The desktop cross-block rule for .faq__question is still fixed (routes
+        // through --faq-question-color) — just not covered by this automated guard.
+        '.faq__heading'      => ['--faq-heading-color', 'color'],
+        '.faq__answer'       => ['--faq-answer-color', 'color'],
     ];
 
     /**


### PR DESCRIPTION
## Summary

Closes #100. `faq` and `stats` were the only two v1 components exposing zero per-instance style slots — their appearance was locked entirely to global tokens, so neither could reach brand fidelity on a dark surface or a custom palette. The codebase's own CSS comment already called this out for faq specifically: *"faq has no heading-color slot, so it keeps the token."*

## What changed

**faq** (7 new slots, matching the issue's exact desired-outcome list — heading, question, answer, divider/border, background, accent):
- `--faq-bg` / `--faq-item-bg` (gradient-capable, section background + individual accordion-item background — two distinct surfaces, matching hero's `--hero-bg`/`--hero-surface-bg` precedent)
- `--faq-heading-color`, `--faq-question-color`, `--faq-answer-color`, `--faq-border-color`, `--faq-accent` (open-state question color, also drives the chevron via `currentColor`)

**stats** (4 new slots, matching the issue's exact list — background, number color, label color, title color):
- `--stats-bg` (gradient-capable), `--stats-title-color`, `--stats-number-color`, `--stats-label-color`

Both components previously had no `pp_render_style_vars()` call at all — wired it in from scratch (stats merges it with the pre-existing `background_image` inline-style mechanism, same `$inline_styles[]` pattern as hero/section).

## Closing the actual #86-class bug

faq's desktop "premium typography" media rules hardcoded `color: var(--color-text)` / `var(--color-text-secondary)` for `.faq__heading`/`.faq__question`/`.faq__answer` — exactly the cross-block override class #86 already fixed for grid/section/cta, left un-fixed for faq only because no slot existed yet. All three now route through the new slots; the explanatory comment above them (which explicitly named faq as the one exception) is updated to match.

## Test infra changes

- `tests/StyleSlotContractTest.php`'s keystone contract (`testEverySlotConsumedInComponentBlock`, `testSlotConsumedOnTypeCompatibleProperty`) now covers faq and stats — previously excluded since they had zero slots to check.
- Added faq's two safe cross-block guard entries (`--faq-heading-color`, `--faq-answer-color`). Deliberately **did not** add `--faq-question-color` to that same guard — its open-accordion state intentionally uses a different slot (`--faq-accent`), and the guard's whole-stylesheet class-substring match can't distinguish "different intentional state" from "accidental clobber" (verified this by hitting the false-positive directly, then documented why in an inline comment rather than fighting the test's design).
- Fixed `tests/AiContextTest.php`'s `testSystemPromptOmitsStyleSlotsForUnstyled`, which used faq as an example of a component with no style slots — no longer true, split into two tests (one for the still-unstyled `embed`, one confirming faq's new slots surface correctly in the AI-facing prompt).

## Test Coverage

9 new PHPUnit tests: schema-declaration assertions for all 11 new slots (types + defaults + descriptions), render tests proving every slot survives into the rendered HTML unmangled, an injection-rejection test per component, and a merge-with-`background_image` regression test for stats.

Full suite: 965 PHP / 281 JS passing, no regressions.

## NOT in scope

- Padding/radius/shadow slots for faq/stats — the issue's own desired-outcome list is scoped to color/background slots specifically ("Follows the project rule that a component's slot depth tracks its visual jobs"); padding isn't currently a reported visual-job gap for either component.

## Test plan

- [x] `composer test` — 965/965 passing
- [x] `npm test` — 281/281 passing
- [x] Redaction scan on the diff — clean
- [ ] CI green
