### PR TITLE
Add regression guard for dark-surface foreground colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.19] — 2026-07-05 — Fix: Dark-Surface Sections Can't Silently Lose Their Text Color Anymore
+
+**A previous production build needed a one-off CSS patch after a dark-band heading rendered nearly invisible — later page styling had quietly overridden the color a dark surface needs to stay readable.** The immediate cause (FAQ headings specifically) was already fixed. This closes the door on the whole class of bug: every component's dark-surface text — headings, body copy, links — is now guaranteed to route through a per-instance color slot, everywhere it's rendered, not just in the one place someone happened to test.
+
+### For contributors
+- Audited every styled component (hero, cta, grid, section, faq, stats) for any dark-surface (`--inverted`, or a background-image scrim) text-color rule that bypasses its component's style slots. Found none remaining — the FAQ gap #100 already closed was the only real one; grid's apparent gap on non-`--steps` inverted cards turned out to be a correct design (individual cards intentionally stay light-surfaced there, so dark text is correct).
+- Added a new keystone test to `tests/StyleSlotContractTest.php` (`testDarkSurfaceVariantsRouteForegroundColorsThroughSlots`) that scans every dark-surface descendant selector in the stylesheet and fails the build if any of them hardcodes a foreground color instead of routing through `var(--{component}-*, ...)` — verified it actually catches a regression by deliberately breaking a real rule and confirming the test failed, then restoring it. This is a durable guard, not a one-time fix: the next component that adds an inverted variant gets this check automatically.
+- `--dark` variants are deliberately out of scope for this guard — this theme's actual token values (`--color-surface: #f4f7fb`) show "dark" is really just a barely-tinted near-white surface, not a genuine contrast risk, despite a couple of schemas historically describing it as "dark."
+
 ## [v0.16.18] — 2026-07-05 — New: FAQ and Stats Can Finally Match Your Brand
 
 **Every section-level component could be re-colored to fit a page except two: FAQ and the stats row.** Put an FAQ block on a dark band and the heading turned nearly invisible, with no safe way to fix it — the underlying CSS had a comment admitting exactly that: "faq has no heading-color slot, so it keeps the token." Stats had the same problem: the big numbers were locked to the global accent color with no way to match a specific brand's palette for that one section.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.18-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.19-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.18');
+define('PP_VERSION', '0.16.19');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.18",
+  "version": "0.16.19",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.18
+Stable tag: 0.16.19
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.18
+Version:          0.16.19
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/StyleSlotContractTest.php
+++ b/tests/StyleSlotContractTest.php
@@ -170,6 +170,67 @@ class StyleSlotContractTest extends TestCase
         }
     }
 
+    /**
+     * 4. Dark-surface foreground authority (#61): a genuinely dark surface
+     * (`--inverted`, or `--has-bg-image`'s dark scrim) must not hardcode a
+     * foreground `color:` on a specific descendant element — it must route
+     * through that component's own `--{component}-*` slot so an AI can fix
+     * contrast on that instance without a one-off late-cascade patch (the
+     * production incident, PP-004/Ink-2, that #61 was filed from).
+     *
+     * `--dark` is deliberately EXCLUDED: per this theme's actual token values
+     * (base.css), `--color-surface` (#f4f7fb) is a barely-tinted near-white,
+     * not a real contrast risk — several schemas even call it "surface
+     * background with borders" rather than "dark." Only `--inverted`
+     * (`--color-bg-inverted` = #0f172a) and `--has-bg-image` (dark scrim
+     * overlay) are genuine low-contrast risks.
+     *
+     * Scope/limitation: only checks selectors with a DESCENDANT combinator
+     * (e.g. `.grid--inverted .grid__heading`) — a bare `.{component}--inverted
+     * { color: ... }` sets an ambient/inherited default for whatever isn't
+     * otherwise more-specifically slotted (several components additionally
+     * redefine a shared token like `--color-muted` at that scope for exactly
+     * this purpose), and is not itself the final authority for any specific
+     * rendered text role. Requiring it to be slotted too would false-fail on
+     * that legitimate pattern without closing any real gap, since the actual
+     * rendered elements are covered by their own descendant-selector checks.
+     */
+    public function testDarkSurfaceVariantsRouteForegroundColorsThroughSlots(): void
+    {
+        $css = $this->stripComments($this->css);
+        preg_match_all('/([^{}]+)\{([^{}]*)\}/s', $css, $rules, PREG_SET_ORDER);
+
+        $variantPattern = '/\.(hero|cta|grid|section|faq|stats|pp-section)[a-z_-]*--(inverted|has-bg-image)\S*\s+\S/i';
+        $checked = 0;
+
+        foreach ($rules as $rule) {
+            $selector = trim($rule[1]);
+            $body     = $rule[2];
+
+            if (!preg_match($variantPattern, $selector, $m)) {
+                continue; // not a dark-surface descendant selector
+            }
+            $component = strtolower($m[1]) === 'pp-section' ? 'section' : strtolower($m[1]);
+
+            if (!preg_match('/(?<![-a-z])color\s*:\s*([^;}]+)/i', $body, $colorMatch)) {
+                continue; // this rule doesn't set color at all
+            }
+            $value = trim($colorMatch[1]);
+            $checked++;
+
+            $this->assertMatchesRegularExpression(
+                '/var\(\s*--' . preg_quote($component, '/') . '-/',
+                $value,
+                "Rule `{$selector}` sets `color` to `{$value}` on a dark-surface descendant "
+                . "without routing through a --{$component}-* slot. Dark-surface foreground "
+                . "colors must be fixable via safe surfaces without a late-cascade patch (#61)."
+            );
+        }
+
+        // Fail-closed: this guard is only meaningful if it actually examined something.
+        $this->assertGreaterThan(0, $checked, 'No dark-surface descendant color rules found — the #61 guard would pass vacuously.');
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     /**


### PR DESCRIPTION
## Summary

Closes #61. The referenced production incident (PP-004, dark-band headings on Ink/Ink-2 surfaces needing a one-off `components.css` cascade patch) happened on an external site build, not in this repo, so there was no reproducible bug to fix directly here. Per discussion, scoped this to: (1) a systematic audit confirming no other component has the same gap that made faq's heading unreadable on a dark surface pre-#100, and (2) a durable automated test closing the door on this bug class recurring.

## Audit findings

Checked every styled component's `--inverted`/`--has-bg-image` variant (the only genuinely low-contrast-risk surfaces — ground-truthed against actual token values: `--color-surface: #f4f7fb` is a barely-tinted near-white, so `--dark` variants were never actually a contrast risk despite a couple of schemas describing it as "dark"):

- **hero**: no `--dark`/`--inverted` variant exists at all (only layout variants) — not applicable.
- **cta, grid, section**: already fully routed through slots (`--cta-text`, `--cta-body-color`, `--grid-heading-color`, `--grid-item-title-color`, `--grid-item-text-color`, `--section-title-color`, `--section-text`, `--section-accent`) — no gap found.
- **grid's apparent gap**: `.grid--inverted .grid__item-title`/`.grid__item-text` only have explicit overrides scoped to `.grid--inverted.grid--steps`. Traced this fully — it's correct by design: individual cards on a non-`--steps` inverted grid intentionally stay light-surfaced (`background: var(--grid-card-bg, var(--color-bg))`), so the base slot's `var(--color-text)` fallback is genuinely correct there, not a bug.
- **faq**: the one real gap, already closed by #100.
- **stats**: already fully routed through slots by #100.

## What this PR adds

A new keystone test, `testDarkSurfaceVariantsRouteForegroundColorsThroughSlots` in `tests/StyleSlotContractTest.php`: scans every `--inverted`/`--has-bg-image` descendant selector in the stylesheet (i.e. targeting a specific rendered element, not the bare container-level ambient default) and fails the build if any sets `color` without routing through that component's own `var(--{component}-*, ...)` slot.

Verified this test actually works (not just passes vacuously) by deliberately reverting `.grid--inverted .grid__heading`'s slot binding, confirming the test failed with a clear message, then restoring it.

## Test Coverage

1 new keystone test (21 assertions — one per dark-surface descendant color rule currently in the stylesheet). Full suite: 966 PHP / 281 JS passing, no regressions.

## Test plan

- [x] `composer test` — 966/966 passing
- [x] `npm test` — 281/281 passing
- [x] Redaction scan on the diff — clean
- [x] Manually confirmed the new test catches a real regression (see above)
- [ ] CI green
