### PR TITLE
Add eyebrow/subheading/heading-alignment section-header pattern

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -317,7 +317,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**85 style slots** across 4 v1 components: hero (30), section (14), grid (19), cta (22).
+**95 style slots** across 4 v1 components: hero (32), section (17), grid (22), cta (24).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
-## [v0.16.20] — 2026-07-05 — Fix: Secondary CTA Buttons No Longer Render Invisible
+## [v0.16.21] — 2026-07-05 — New: Eyebrow Pills and Subheadings for Every Section
+
+**Professional landing pages almost always lead a section with three things: a small kicker label, a centered heading, and a supporting line underneath. PromptingPress could render none of that — every section, grid, and CTA heading was a lone left-aligned line.** That gap was one of the biggest reasons AI-built pages looked template-y instead of designed. Hero already stored an eyebrow value in some pages, but it never actually showed up.
+
+### Added
+- Hero, grid, section, and CTA all support an `eyebrow` — a short label rendered as a styleable pill above the heading (e.g. "NEW", "PLUGIN OFICIAL").
+- Grid and section also get a `subheading` (a supporting line under the title) and a `heading_align` option to center just the heading block — independent of the section's overall layout. (Hero and CTA already had equivalent tools: hero's `subtitle` and layout `variant`, CTA's `text` and layout `variant`.)
+
+### Fixed
+- Hero's `eyebrow` field now actually renders — previously the composition could store a value there with no visible effect.
+
+### For contributors
+- 10 new style slots for eyebrow/subheading colors across the 4 components (95 total, up from 85). New props registered in `pp_register_component_fields()` for `patch`-command addressability, consistent with existing content fields.
+- 15 new PHPUnit tests; fixed 5 existing tests carrying hardcoded slot counts, per-component field-index assertions, or doc-sync counts that this change correctly invalidates.
 
 **Set a CTA or hero's secondary button to "outline," "ghost," or "secondary," and it could render as a solid block of color with text you couldn't read — the button's own background silently overpowered the style it was supposed to have.** This wasn't a rare edge case: it happened to any secondary/outline/ghost button on a CTA block, confirmed on real pages during a benchmark build (an orange button on an orange background, effectively unreadable).
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.20-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.21-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -170,7 +170,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 47 CSS custom properties control the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-85 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 9 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+95 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 9 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -419,7 +419,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.13.1.
 
 **What exists today (v0.13.1):**
-- 11 components with schema contracts and 85 per-instance style slots, plus named recipes
+- 11 components with schema contracts and 95 per-instance style slots, plus named recipes
 - A contract test that guarantees every style slot a component declares actually reaches the page, honored at every breakpoint
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -253,6 +253,19 @@
   max-width: var(--hero-content-width, var(--measure-centered));
 }
 
+.hero__eyebrow {
+  display: inline-block;
+  padding: 0.35rem 0.85rem;
+  margin-bottom: var(--space-sm);
+  border-radius: 3px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--hero-eyebrow-color, var(--color-text));
+  background: var(--hero-eyebrow-bg, var(--color-surface-accent));
+}
+
 .hero__title {
   font-size: var(--hero-title-size, clamp(2.5rem, 5vw, 4rem));
   font-weight: var(--hero-title-weight, var(--font-weight-heading));
@@ -626,9 +639,32 @@
   max-width: 40rem;
 }
 
+.section__header--center {
+  text-align: center;
+}
+
+.section__eyebrow {
+  display: inline-block;
+  padding: 0.35rem 0.85rem;
+  margin-bottom: var(--space-sm);
+  border-radius: 3px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--section-eyebrow-color, var(--color-text));
+  background: var(--section-eyebrow-bg, var(--color-surface-accent));
+}
+
 .section__title {
   font-size: var(--section-title-size, inherit);
   color: var(--section-title-color, var(--color-text));
+  margin-bottom: var(--space-md);
+}
+
+.section__subheading {
+  color: var(--section-subheading-color, var(--color-muted));
+  margin-top: 0;
   margin-bottom: var(--space-md);
 }
 
@@ -827,11 +863,48 @@
   background: var(--grid-bg, transparent);
 }
 
+.grid__header--center {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.grid__eyebrow {
+  display: inline-block;
+  padding: 0.35rem 0.85rem;
+  margin-bottom: var(--space-sm);
+  border-radius: 3px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--grid-eyebrow-color, var(--color-text));
+  background: var(--grid-eyebrow-bg, var(--color-surface-accent));
+}
+
 .grid__heading {
   color: var(--grid-heading-color, var(--color-text));
   font-size: var(--grid-heading-size, inherit);
   max-width: var(--grid-heading-max-width, 40rem);
   margin-bottom: var(--space-lg);
+}
+
+.grid__header--center .grid__heading {
+  max-width: var(--grid-heading-max-width, 40rem);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.grid__subheading {
+  color: var(--grid-subheading-color, var(--color-muted));
+  margin-top: 0;
+  margin-bottom: var(--space-lg);
+  max-width: 40rem;
+}
+
+.grid__header--center .grid__subheading {
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .grid__list {
@@ -1102,6 +1175,19 @@
   display: flex;
   flex-direction: column;
   gap: var(--cta-inner-gap, var(--space-lg));
+}
+
+.cta__eyebrow {
+  display: inline-block;
+  padding: 0.35rem 0.85rem;
+  margin-bottom: var(--space-sm);
+  border-radius: 3px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--cta-eyebrow-color, var(--color-text));
+  background: var(--cta-eyebrow-bg, var(--color-surface-accent));
 }
 
 .cta__title {
@@ -2731,7 +2817,10 @@ main > [data-pp-component] + [data-pp-component] {
   padding-bottom: clamp(4.25rem, 6vw, 5rem);
 }
 
-.hero__eyebrow,
+/* Page-specific texture flourish (4 benchmark pages) layered ON TOP of the
+   general slot-driven background (issue 102) — an operator setting
+   --hero-eyebrow-bg for one of these pages still takes effect as the base
+   layer; only the decorative line pattern is page-specific. */
 #home-hero .hero__eyebrow,
 #how-hero .hero__eyebrow,
 #agencies-hero .hero__eyebrow,
@@ -2740,8 +2829,8 @@ main > [data-pp-component] + [data-pp-component] {
   border-color: var(--color-border);
   background:
     linear-gradient(90deg, rgba(37, 99, 235, 0.06) 1px, transparent 1px) 0 0 / 1.4rem 100%,
-    var(--color-surface-accent);
-  color: var(--color-text);
+    var(--hero-eyebrow-bg, var(--color-surface-accent));
+  color: var(--hero-eyebrow-color, var(--color-text));
 }
 
 .hero .pp-workflow-surface,

--- a/components/cta/cta.php
+++ b/components/cta/cta.php
@@ -10,6 +10,7 @@
 
 $id               = $props['id']               ?? '';
 $title            = $props['title']            ?? '';
+$eyebrow          = $props['eyebrow']          ?? '';
 $text             = $props['text']             ?? '';
 $button_text      = $props['button_text']      ?? 'Get Started';
 $button_url       = $props['button_url']       ?? '#';
@@ -58,6 +59,9 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
     <div class="container">
         <div class="cta__inner">
             <div class="cta__text">
+                <?php if ($eyebrow) : ?>
+                    <span class="cta__eyebrow"><?php echo esc_html($eyebrow); ?></span>
+                <?php endif; ?>
                 <?php if ($title) : ?>
                     <h2 class="cta__title"><?php echo esc_html($title); ?></h2>
                 <?php endif; ?>

--- a/components/cta/schema.json
+++ b/components/cta/schema.json
@@ -13,6 +13,12 @@
       "required": true,
       "description": "CTA headline."
     },
+    "eyebrow": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional short kicker/label rendered as a pill above the title."
+    },
     "text": {
       "type": "string",
       "required": false,
@@ -66,6 +72,8 @@
       "--cta-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the CTA section" },
       "--cta-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
       "--cta-text": { "type": "color", "default": "var(--color-text)", "description": "Title text color" },
+      "--cta-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
+      "--cta-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
       "--cta-title-size": { "type": "length", "default": "inherit", "description": "Title font size" },
       "--cta-body-color": { "type": "color", "default": "var(--color-muted)", "description": "Body text color" },
       "--cta-body-size": { "type": "length", "default": "inherit", "description": "Body text font size" },

--- a/components/grid/grid.php
+++ b/components/grid/grid.php
@@ -9,8 +9,11 @@
  * @var array $props
  */
 
-$id      = $props['id']      ?? '';
-$title   = $props['title']   ?? '';
+$id            = $props['id']            ?? '';
+$title         = $props['title']         ?? '';
+$eyebrow       = $props['eyebrow']       ?? '';
+$subheading    = $props['subheading']    ?? '';
+$heading_align = $props['heading_align'] ?? 'start';
 $items   = $props['items']   ?? [];
 $variant = $props['variant'] ?? 'default';
 $theme   = $props['theme']   ?? 'default';
@@ -25,6 +28,12 @@ if (!in_array($theme, $allowed_themes, true)) {
     $theme = 'default';
 }
 
+$allowed_heading_aligns = ['start', 'center'];
+if (!in_array($heading_align, $allowed_heading_aligns, true)) {
+    $heading_align = 'start';
+}
+$header_align_class = $heading_align === 'center' ? ' grid__header--center' : '';
+
 $is_steps      = $variant === 'steps';
 $variant_class = $is_steps ? ' grid--steps' : '';
 $theme_class   = $theme !== 'default' ? ' grid--' . $theme : '';
@@ -37,8 +46,18 @@ $style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';
 <section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="grid<?php echo esc_attr($variant_class); ?><?php echo esc_attr($theme_class); ?>" data-pp-component="grid"<?php echo $style_attr; ?>>
     <div class="container">
 
-        <?php if ($title) : ?>
-            <h2 class="grid__heading"><?php echo esc_html($title); ?></h2>
+        <?php if ($title || $eyebrow || $subheading) : ?>
+            <div class="grid__header<?php echo esc_attr($header_align_class); ?>">
+                <?php if ($eyebrow) : ?>
+                    <span class="grid__eyebrow"><?php echo esc_html($eyebrow); ?></span>
+                <?php endif; ?>
+                <?php if ($title) : ?>
+                    <h2 class="grid__heading"><?php echo esc_html($title); ?></h2>
+                <?php endif; ?>
+                <?php if ($subheading) : ?>
+                    <p class="grid__subheading"><?php echo esc_html($subheading); ?></p>
+                <?php endif; ?>
+            </div>
         <?php endif; ?>
 
         <?php if (!empty($items)) : ?>

--- a/components/grid/schema.json
+++ b/components/grid/schema.json
@@ -14,6 +14,25 @@
       "default": "",
       "description": "Section heading above the grid. Omit if the context makes it clear."
     },
+    "eyebrow": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional short kicker/label rendered as a pill above the title."
+    },
+    "subheading": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional supporting line below the title."
+    },
+    "heading_align": {
+      "type": "enum",
+      "values": ["start", "center"],
+      "required": false,
+      "default": "start",
+      "description": "Alignment of the eyebrow/title/subheading header block. 'start' = left-aligned (default, unchanged historical behavior). 'center' = centered."
+    },
     "variant": {
       "type": "enum",
       "values": ["default", "steps"],
@@ -53,6 +72,9 @@
       "--grid-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the grid section" },
       "--grid-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
       "--grid-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Heading text color" },
+      "--grid-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
+      "--grid-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
+      "--grid-subheading-color": { "type": "color", "default": "var(--color-muted)", "description": "Subheading text color" },
       "--grid-heading-size": { "type": "length", "default": "inherit", "description": "Heading font size" },
       "--grid-heading-max-width": { "type": "length", "default": "40rem", "description": "Heading maximum width — increase to let long headings use available horizontal space" },
       "--grid-gap": { "type": "length", "default": "var(--space-lg)", "description": "Gap between grid cards" },

--- a/components/hero/hero.php
+++ b/components/hero/hero.php
@@ -9,6 +9,7 @@
 
 $id        = $props['id']        ?? '';
 $title     = $props['title']    ?? 'Default Title';
+$eyebrow   = $props['eyebrow']  ?? '';
 $subtitle  = $props['subtitle'] ?? '';
 $cta_text  = $props['cta_text'] ?? '';
 $cta_url   = $props['cta_url']  ?? '#';
@@ -89,6 +90,9 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
     <div class="container">
         <div class="hero__inner">
             <div class="hero__content">
+                <?php if ($eyebrow) : ?>
+                    <span class="hero__eyebrow"><?php echo esc_html($eyebrow); ?></span>
+                <?php endif; ?>
                 <h1 class="hero__title"><?php echo esc_html($title); ?></h1>
 
                 <?php if ($subtitle) : ?>

--- a/components/hero/schema.json
+++ b/components/hero/schema.json
@@ -13,6 +13,12 @@
       "required": true,
       "description": "Primary headline text."
     },
+    "eyebrow": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional short kicker/label rendered as a pill above the title (e.g. \"NEW\", \"PLUGIN OFICIAL\")."
+    },
     "subtitle": {
       "type": "string",
       "required": false,
@@ -120,6 +126,8 @@
       "--hero-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the hero section" },
       "--hero-bg": { "type": "gradient", "default": "var(--color-bg)", "description": "Background color or gradient. Note: also used as the outline button's hover text color, which is invalid CSS if set to a gradient — that hover color falls back to inherited text color when this is a gradient (a narrow, isolated cosmetic limitation, not a broken page)." },
       "--hero-text": { "type": "color", "default": "var(--color-text)", "description": "Title and subtitle text color" },
+      "--hero-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
+      "--hero-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
       "--hero-accent": { "type": "color", "default": "var(--color-accent)", "description": "Button background and border color" },
       "--hero-accent-hover": { "type": "color", "default": "var(--color-accent-hover)", "description": "Button hover background color" },
       "--hero-cta2-bg": { "type": "color", "default": "(varies by cta2_variant)", "description": "Second CTA button background color, independent of the primary button. Applies whatever cta2_variant is set to." },

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -14,6 +14,25 @@
       "default": "",
       "description": "Section heading. Omit to render the body without a heading."
     },
+    "eyebrow": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional short kicker/label rendered as a pill above the title."
+    },
+    "subheading": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional supporting line below the title (distinct from body, the section's main content)."
+    },
+    "heading_align": {
+      "type": "enum",
+      "values": ["start", "center"],
+      "required": false,
+      "default": "start",
+      "description": "Alignment of the eyebrow/title/subheading header block. 'start' = left-aligned (default, unchanged historical behavior). 'center' = centered."
+    },
     "body": {
       "type": "string",
       "required": true,
@@ -64,6 +83,9 @@
       "--section-accent": { "type": "color", "default": "var(--color-accent)", "description": "Link color" },
       "--section-title-size": { "type": "length", "default": "inherit", "description": "Title font size" },
       "--section-title-color": { "type": "color", "default": "var(--color-text)", "description": "Title text color" },
+      "--section-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
+      "--section-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
+      "--section-subheading-color": { "type": "color", "default": "var(--color-muted)", "description": "Subheading text color" },
       "--section-body-width": { "type": "length", "default": "42rem", "description": "Max width of the content column" },
       "--section-border-color": { "type": "color", "default": "transparent", "description": "Top and bottom border color" },
       "--section-border-width": { "type": "length", "default": "0", "description": "Top and bottom border width" },

--- a/components/section/section.php
+++ b/components/section/section.php
@@ -10,6 +10,9 @@
 
 $id               = $props['id']               ?? '';
 $title            = $props['title']            ?? '';
+$eyebrow          = $props['eyebrow']          ?? '';
+$subheading       = $props['subheading']       ?? '';
+$heading_align    = $props['heading_align']    ?? 'start';
 $body             = $props['body']             ?? '';
 $image_url        = $props['image_url']        ?? '';
 $image_alt        = $props['image_alt']        ?? '';
@@ -32,6 +35,12 @@ $allowed_variants = ['default', 'dark', 'inverted'];
 if (!in_array($variant, $allowed_variants, true)) {
     $variant = 'default';
 }
+
+$allowed_heading_aligns = ['start', 'center'];
+if (!in_array($heading_align, $allowed_heading_aligns, true)) {
+    $heading_align = 'start';
+}
+$header_align_class = $heading_align === 'center' ? ' section__header--center' : '';
 
 $variant_class = $variant !== 'default' ? ' pp-section--' . $variant : '';
 $bg_image_class = $background_image ? ' section--has-bg-image' : '';
@@ -58,8 +67,18 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
         <?php if ($layout === 'text-only' || $layout === 'centered') : ?>
 
             <div class="section__body">
-                <?php if ($title) : ?>
-                    <h2 class="section__title"><?php echo esc_html($title); ?></h2>
+                <?php if ($title || $eyebrow || $subheading) : ?>
+                    <div class="section__header<?php echo esc_attr($header_align_class); ?>">
+                        <?php if ($eyebrow) : ?>
+                            <span class="section__eyebrow"><?php echo esc_html($eyebrow); ?></span>
+                        <?php endif; ?>
+                        <?php if ($title) : ?>
+                            <h2 class="section__title"><?php echo esc_html($title); ?></h2>
+                        <?php endif; ?>
+                        <?php if ($subheading) : ?>
+                            <p class="section__subheading"><?php echo esc_html($subheading); ?></p>
+                        <?php endif; ?>
+                    </div>
                 <?php endif; ?>
                 <div class="section__content">
                     <?php echo wp_kses_post($body); ?>
@@ -81,8 +100,18 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                 <?php endif; ?>
 
                 <div class="section__body">
-                    <?php if ($title) : ?>
-                        <h2 class="section__title"><?php echo esc_html($title); ?></h2>
+                    <?php if ($title || $eyebrow || $subheading) : ?>
+                        <div class="section__header<?php echo esc_attr($header_align_class); ?>">
+                            <?php if ($eyebrow) : ?>
+                                <span class="section__eyebrow"><?php echo esc_html($eyebrow); ?></span>
+                            <?php endif; ?>
+                            <?php if ($title) : ?>
+                                <h2 class="section__title"><?php echo esc_html($title); ?></h2>
+                            <?php endif; ?>
+                            <?php if ($subheading) : ?>
+                                <p class="section__subheading"><?php echo esc_html($subheading); ?></p>
+                            <?php endif; ?>
+                        </div>
                     <?php endif; ?>
                     <div class="section__content">
                         <?php echo wp_kses_post($body); ?>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.20');
+define('PP_VERSION', '0.16.21');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -1170,11 +1170,15 @@ pp_register_component_fields('hero', [
 ]);
 
 pp_register_component_fields('section', [
-    ['name' => 'title', 'type' => 'string'],
-    ['name' => 'body',  'type' => 'html'],
+    ['name' => 'title',      'type' => 'string'],
+    ['name' => 'eyebrow',    'type' => 'string'],
+    ['name' => 'subheading', 'type' => 'string'],
+    ['name' => 'body',       'type' => 'html'],
 ]);
 
 pp_register_component_fields('grid', [
+    ['name' => 'eyebrow',           'type' => 'string'],
+    ['name' => 'subheading',        'type' => 'string'],
     ['name' => 'items[].title',     'type' => 'string'],
     ['name' => 'items[].text',      'type' => 'string'],
     ['name' => 'items[].link_url',  'type' => 'url'],
@@ -1188,6 +1192,7 @@ pp_register_component_fields('faq', [
 
 pp_register_component_fields('cta', [
     ['name' => 'title',       'type' => 'string'],
+    ['name' => 'eyebrow',     'type' => 'string'],
     ['name' => 'text',        'type' => 'string'],
     ['name' => 'button_text', 'type' => 'string'],
     ['name' => 'button_url',  'type' => 'url'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.20",
+  "version": "0.16.21",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.20
+Stable tag: 0.16.21
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.20
+Version:          0.16.21
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1063,4 +1063,145 @@ class ComponentPropsTest extends TestCase
         $this->assertStringContainsString('background-image:url(data:image/svg+xml,', $html);
         $this->assertStringNotContainsString('background-image:url();', $html);
     }
+
+    // ── Section-header pattern: eyebrow + subheading + alignment (#102/#85) ──
+
+    private function gridProps(array $extra = []): array
+    {
+        return array_merge(['items' => [['title' => 'Item', 'text' => 'Text']]], $extra);
+    }
+
+    private function sectionProps(array $extra = []): array
+    {
+        return array_merge(['body' => '<p>Body</p>'], $extra);
+    }
+
+    public function testHeroEyebrowRenders(): void
+    {
+        // Regression pin for #85: hero's eyebrow prop now actually renders.
+        $html = $this->render('hero', ['title' => 'T', 'eyebrow' => 'NEW']);
+        $this->assertStringContainsString('class="hero__eyebrow"', $html);
+        $this->assertStringContainsString('>NEW<', $html);
+    }
+
+    public function testHeroEyebrowOmittedWhenUnset(): void
+    {
+        $html = $this->render('hero', ['title' => 'T']);
+        $this->assertStringNotContainsString('hero__eyebrow', $html);
+    }
+
+    public function testGridEyebrowSubheadingAndCenterAlignRender(): void
+    {
+        $html = $this->render('grid', $this->gridProps([
+            'title' => 'Heading',
+            'eyebrow' => 'KICKER',
+            'subheading' => 'Supporting line',
+            'heading_align' => 'center',
+        ]));
+        $this->assertStringContainsString('class="grid__header grid__header--center"', $html);
+        $this->assertStringContainsString('class="grid__eyebrow">KICKER<', $html);
+        $this->assertStringContainsString('class="grid__heading">Heading<', $html);
+        $this->assertStringContainsString('class="grid__subheading">Supporting line<', $html);
+    }
+
+    public function testGridHeaderAlignDefaultsToStartAndOmitsCenterClass(): void
+    {
+        $html = $this->render('grid', $this->gridProps(['title' => 'Heading']));
+        $this->assertStringContainsString('class="grid__header">', $html);
+        $this->assertStringNotContainsString('grid__header--center', $html);
+    }
+
+    public function testGridHeaderAlignInvalidFallsBackToStart(): void
+    {
+        $html = $this->render('grid', $this->gridProps(['title' => 'Heading', 'heading_align' => 'end']));
+        $this->assertStringNotContainsString('grid__header--center', $html);
+    }
+
+    public function testGridHeaderOmittedWhenNoTitleEyebrowOrSubheading(): void
+    {
+        $html = $this->render('grid', $this->gridProps());
+        $this->assertStringNotContainsString('grid__header', $html);
+    }
+
+    public function testSectionEyebrowSubheadingAndCenterAlignRenderTextOnly(): void
+    {
+        $html = $this->render('section', $this->sectionProps([
+            'title' => 'Heading',
+            'eyebrow' => 'KICKER',
+            'subheading' => 'Supporting line',
+            'heading_align' => 'center',
+        ]));
+        $this->assertStringContainsString('class="section__header section__header--center"', $html);
+        $this->assertStringContainsString('class="section__eyebrow">KICKER<', $html);
+        $this->assertStringContainsString('class="section__subheading">Supporting line<', $html);
+    }
+
+    public function testSectionEyebrowRendersInImageLayout(): void
+    {
+        // The image-left/image-right layout has a SEPARATE title block in
+        // section.php — must also carry the header pattern, not just text-only.
+        $html = $this->render('section', $this->sectionProps([
+            'title' => 'Heading',
+            'eyebrow' => 'KICKER',
+            'layout' => 'image-left',
+            'image_url' => 'https://example.com/img.jpg',
+        ]));
+        $this->assertStringContainsString('class="section__eyebrow">KICKER<', $html);
+    }
+
+    public function testCtaEyebrowRenders(): void
+    {
+        $html = $this->render('cta', $this->ctaProps(['eyebrow' => 'KICKER']));
+        $this->assertStringContainsString('class="cta__eyebrow">KICKER<', $html);
+    }
+
+    public function testCtaEyebrowOmittedWhenUnset(): void
+    {
+        $html = $this->render('cta', $this->ctaProps());
+        $this->assertStringNotContainsString('cta__eyebrow', $html);
+    }
+
+    public function testHeroSchemaDeclaresEyebrowSlots(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/hero/schema.json'), true);
+        $slots = $schema['styling']['style_slots'];
+        $this->assertArrayHasKey('--hero-eyebrow-color', $slots);
+        $this->assertArrayHasKey('--hero-eyebrow-bg', $slots);
+    }
+
+    public function testGridSchemaDeclaresHeaderSlots(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/grid/schema.json'), true);
+        $slots = $schema['styling']['style_slots'];
+        foreach (['--grid-eyebrow-color', '--grid-eyebrow-bg', '--grid-subheading-color'] as $name) {
+            $this->assertArrayHasKey($name, $slots, "grid must declare {$name}.");
+        }
+    }
+
+    public function testSectionSchemaDeclaresHeaderSlots(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/section/schema.json'), true);
+        $slots = $schema['styling']['style_slots'];
+        foreach (['--section-eyebrow-color', '--section-eyebrow-bg', '--section-subheading-color'] as $name) {
+            $this->assertArrayHasKey($name, $slots, "section must declare {$name}.");
+        }
+    }
+
+    public function testCtaSchemaDeclaresEyebrowSlots(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/cta/schema.json'), true);
+        $slots = $schema['styling']['style_slots'];
+        $this->assertArrayHasKey('--cta-eyebrow-color', $slots);
+        $this->assertArrayHasKey('--cta-eyebrow-bg', $slots);
+    }
+
+    public function testGridEyebrowRejectsInjectionInStyleSlot(): void
+    {
+        $html = $this->render('grid', $this->gridProps([
+            'title' => 'H',
+            'eyebrow' => 'KICKER',
+            '__pp_style' => ['--grid-eyebrow-color' => '#fff; background:url(evil)'],
+        ]));
+        $this->assertStringNotContainsString('url(evil)', $html);
+    }
 }

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -954,15 +954,19 @@ class OperateTest extends TestCase
         $this->assertSame('url', $hero[4]['type']);
 
         $section = pp_get_component_fields('section');
-        $this->assertCount(2, $section);
-        $this->assertSame('body', $section[1]['name']);
-        $this->assertSame('html', $section[1]['type']);
+        $this->assertCount(4, $section);
+        $this->assertSame('eyebrow', $section[1]['name']);
+        $this->assertSame('subheading', $section[2]['name']);
+        $this->assertSame('body', $section[3]['name']);
+        $this->assertSame('html', $section[3]['type']);
 
         $grid = pp_get_component_fields('grid');
-        $this->assertCount(4, $grid);
-        $this->assertSame('items[].title', $grid[0]['name']);
-        $this->assertSame('items[].link_url', $grid[2]['name']);
-        $this->assertSame('items[].link_text', $grid[3]['name']);
+        $this->assertCount(6, $grid);
+        $this->assertSame('eyebrow', $grid[0]['name']);
+        $this->assertSame('subheading', $grid[1]['name']);
+        $this->assertSame('items[].title', $grid[2]['name']);
+        $this->assertSame('items[].link_url', $grid[4]['name']);
+        $this->assertSame('items[].link_text', $grid[5]['name']);
 
         $faq = pp_get_component_fields('faq');
         $this->assertCount(2, $faq);
@@ -970,11 +974,12 @@ class OperateTest extends TestCase
         $this->assertSame('items[].answer', $faq[1]['name']);
 
         $cta = pp_get_component_fields('cta');
-        $this->assertCount(4, $cta);
+        $this->assertCount(5, $cta);
         $this->assertSame('title', $cta[0]['name']);
-        $this->assertSame('text', $cta[1]['name']);
-        $this->assertSame('button_text', $cta[2]['name']);
-        $this->assertSame('button_url', $cta[3]['name']);
+        $this->assertSame('eyebrow', $cta[1]['name']);
+        $this->assertSame('text', $cta[2]['name']);
+        $this->assertSame('button_text', $cta[3]['name']);
+        $this->assertSame('button_url', $cta[4]['name']);
 
         // Unmapped type returns empty array.
         $unknown = pp_get_component_fields('nonexistent');
@@ -1458,7 +1463,7 @@ class OperateTest extends TestCase
         $result = pp_inspect_composition($post_id);
         $this->assertCount(1, $result);
         $this->assertArrayHasKey('style_slots', $result[0]);
-        $this->assertCount(30, $result[0]['style_slots']); // hero has 30 slots (24 + 6 cta2-*, #111)
+        $this->assertCount(32, $result[0]['style_slots']); // hero has 32 slots (30 + 2 eyebrow-*, #102)
 
         // Verify slot structure.
         $first_slot = $result[0]['style_slots'][0];

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -188,10 +188,10 @@ class SchemaValidationTest extends TestCase
     public function testStyleSlotsExistForV1Components(): void
     {
         $expected = [
-            'hero'    => 30,
-            'section' => 14,
-            'grid'    => 19,
-            'cta'     => 22,
+            'hero'    => 32,
+            'section' => 17,
+            'grid'    => 22,
+            'cta'     => 24,
         ];
 
         foreach ($expected as $component => $count) {

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -70,8 +70,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('schema declares 85 total style slots', () => {
-        expect(allSlots.length).toBe(85);
+    test('schema declares 95 total style slots', () => {
+        expect(allSlots.length).toBe(95);
     });
 
     allSlots.forEach(({ component, slotName }) => {


### PR DESCRIPTION
## Summary

Closes #102, closes #85. Section/grid/cta headings were a bare left-aligned `<h2>` with no eyebrow, no subhead, and no way to center just the header — one of the largest contributors to the "looks like a template" gap the issue's benchmark evidence describes. Also fixes #85 as a direct consequence: hero's `eyebrow` was already a registered, patchable field with real composition data behind it, but `schema.json` never declared it and `hero.php` never rendered it.

## Design decisions

- **Reuse existing equivalents, don't duplicate.** Hero already has `subtitle` (subhead) and a `variant` prop that already centers everything (`centered`); CTA already has `text` (subhead) and a `variant` that already centers (`full-width`) or left-aligns (`inline`). Verified both empirically against their actual CSS before deciding — adding new `subheading`/`heading_align` props to hero/CTA would have created two competing mechanisms for the same thing. Only `eyebrow` is genuinely new to hero/CTA.
- **Grid and section get all three** (`eyebrow`, `subheading`, `heading_align`) — neither has an existing subhead or per-header-only alignment control.
- **`heading_align` is a prop, not a slot** — matches the existing convention that structural/layout choices (`variant`, `layout`, `split_ratio`) are validated enum props, not style slots.
- **Eyebrow pill styling reuses `--color-surface-accent`** — a design token whose own base.css comment already said "Accent-washed backgrounds, eyebrows," confirming this was the intended purpose. Also found and consolidated orphaned page-specific `.hero__eyebrow` CSS (4 benchmark pages) that had color/background hardcoded with no general base rule behind it — restructured so those pages' decorative texture layers on top of the new slot-driven values instead of hardcoding over them (avoiding yet another silent-slot-override bug).

## Test Coverage

15 new PHPUnit tests (schema-slot assertions, render tests per component including section's two separate title-rendering code paths, alignment defaulting/fallback, injection rejection) plus fixes to 5 existing tests carrying hardcoded slot counts, per-component field-index assertions, or doc-sync counts (schema-derived total: 85 → 95 style slots).

Empirically verified via real-browser computed styles that eyebrow pill styling, center alignment, and subheading color all render correctly.

Full suite: 989 PHP / 303 JS passing, no regressions (one JS flake confirmed transient on re-run, unrelated to this diff — a known vitest intermittency also seen twice earlier this session).

## Test plan

- [x] `composer test` — 989/989 passing
- [x] `npm test` — 303/303 passing (transient flake on one run, clean on re-run)
- [x] Redaction scan on the diff — clean
- [x] Empirically verified eyebrow/subheading/center-alignment rendering via real-browser computed styles
- [ ] CI green
