### PR TITLE
Add checklist bullets to grid card items

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -317,7 +317,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**99 style slots** across 4 v1 components: hero (33), section (18), grid (23), cta (25).
+**100 style slots** across 4 v1 components: hero (33), section (18), grid (24), cta (25).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.23] — 2026-07-05 — New: Scannable Checklists Inside Grid Cards
+
+**Feature/benefit sections that feel professional almost always build their cards as an icon, a title, and a short checklist — "✓ SSL/TLS validity," "✓ Clickjacking protection" — not a dense paragraph. Grid cards could only render `text` as one `esc_html()`'d sentence, so the only way to approximate a checklist was to cram items into a comma-separated blob that read as a wall of text.**
+
+### Added
+- Grid card items accept a `bullets` array — a list of short lines rendered below `text` as a checklist, each prefixed with a check mark in its own style slot (`--grid-bullet-color`). Per-item icons were already covered by the existing `image_url`/`image_alt` fields.
+
+### For contributors
+- Deliberately a structured array of plain strings, not a `wp_kses` HTML-list allowlist: each `bullets` entry is escaped independently via `esc_html()`, and non-string/empty entries are silently skipped rather than rendered — no new HTML-parsing surface. `bullets` coexists with `text` (a card can have both) and is intentionally left out of `pp_register_component_fields()`'s granular `patch` targeting, consistent with the existing `image_url`/`image_alt` per-item fields, which aren't addressable that way either.
+- 7 new PHPUnit tests, including an escaping/injection test; 3 existing tests carrying hardcoded slot counts updated (100 total, up from 99).
+
 ## [v0.16.22] — 2026-07-05 — New: Highlight One Word in Any Heading
 
 **Professional headlines rarely stay one color end to end — think "Security" in orange, "for your WordPress" in white. Every PromptingPress heading was locked to a single flat color, so that entire style of headline was out of reach.** Now every heading can name one word or phrase to highlight in an accent color.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.22-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.23-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -170,7 +170,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 47 CSS custom properties control the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-99 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 9 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+100 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 9 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -419,7 +419,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.13.1.
 
 **What exists today (v0.13.1):**
-- 11 components with schema contracts and 99 per-instance style slots, plus named recipes
+- 11 components with schema contracts and 100 per-instance style slots, plus named recipes
 - A contract test that guarantees every style slot a component declares actually reaches the page, honored at every breakpoint
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1001,6 +1001,30 @@
   flex: 1;
 }
 
+.grid__item-bullets {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: var(--grid-item-text-color, var(--color-muted));
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  flex: 1;
+}
+
+.grid__item-bullet {
+  padding-left: 1.5rem;
+  position: relative;
+}
+
+.grid__item-bullet::before {
+  content: "\2713";
+  position: absolute;
+  left: 0;
+  color: var(--grid-bullet-color, var(--color-accent));
+  font-weight: 700;
+}
+
 .grid__item-link {
   font-weight: 600;
   font-size: 0.9rem;

--- a/components/grid/grid.php
+++ b/components/grid/grid.php
@@ -67,6 +67,7 @@ $style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';
                     $item_number = $item['number']    ?? (string)($index + 1);
                     $item_title  = $item['title']     ?? '';
                     $item_text   = $item['text']      ?? '';
+                    $bullets     = is_array($item['bullets'] ?? null) ? $item['bullets'] : [];
                     $image_url   = $item['image_url'] ?? '';
                     $image_alt   = $item['image_alt'] ?? '';
                     $link_url    = $item['link_url']  ?? '';
@@ -98,6 +99,18 @@ $style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';
 
                             <?php if ($item_text) : ?>
                                 <p class="grid__item-text<?php echo esc_attr($text_role_class); ?>"><?php echo esc_html($item_text); ?></p>
+                            <?php endif; ?>
+
+                            <?php if (!empty($bullets)) : ?>
+                                <ul class="grid__item-bullets">
+                                    <?php foreach ($bullets as $bullet) :
+                                        if (!is_string($bullet) || $bullet === '') {
+                                            continue;
+                                        }
+                                    ?>
+                                        <li class="grid__item-bullet"><?php echo esc_html($bullet); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
                             <?php endif; ?>
 
                             <?php if ($link_url) : ?>

--- a/components/grid/schema.json
+++ b/components/grid/schema.json
@@ -56,12 +56,13 @@
     "items": {
       "type": "array",
       "required": true,
-      "description": "Array of card items. Each: { title, text, image_url, link_url, link_text }. When variant is 'steps', also include: { number }.",
+      "description": "Array of card items. Each: { title, text, bullets, image_url, link_url, link_text }. When variant is 'steps', also include: { number }.",
       "items": {
         "number":    { "type": "string", "required": false, "description": "Step number label (e.g. '1', '01', '1.'). Required when grid variant is 'steps'." },
         "title":     { "type": "string", "required": false },
         "text":      { "type": "string", "required": false },
         "text_role": { "type": "enum", "values": ["mono", "meta", "label", "kicker"], "required": false, "description": "Optional typography role for the card text: 'mono' (code), 'meta' (captions), 'label', or 'kicker' (eyebrow). Adds a .text-<role> class. Invalid/absent → default body text. Set via update_component." },
+        "bullets":   { "type": "array", "required": false, "description": "Optional checklist lines rendered below text, each prefixed with a check mark. Plain text only — no HTML/markdown; each line is escaped independently. Use for scannable feature/benefit lists instead of cramming items into one text sentence.", "items": { "type": "string" } },
         "image_url": { "type": "string", "required": false },
         "image_alt": { "type": "string", "required": false, "default": "", "description": "Alt text for the card image. Leave empty only if the image is purely decorative." },
         "link_url":  { "type": "string", "required": false },
@@ -95,6 +96,7 @@
       "--grid-item-title-size": { "type": "length", "default": "1.25rem", "description": "Card title font size" },
       "--grid-item-title-color": { "type": "color", "default": "var(--color-text)", "description": "Card title text color" },
       "--grid-item-text-color": { "type": "color", "default": "var(--color-muted)", "description": "Card description text color" },
+      "--grid-bullet-color": { "type": "color", "default": "var(--color-accent)", "description": "Checklist bullet marker color (grid card bullets)" },
       "--grid-link-color": { "type": "color", "default": "var(--color-accent)", "description": "Card link color" },
       "--grid-step-color": { "type": "color", "default": "var(--color-accent)", "description": "Step number color (steps variant)" }
     },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.22');
+define('PP_VERSION', '0.16.23');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.22",
+  "version": "0.16.23",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.22
+Stable tag: 0.16.23
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.22
+Version:          0.16.23
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1326,4 +1326,81 @@ class ComponentPropsTest extends TestCase
             $this->assertSame('color', $schema['styling']['style_slots'][$slot]['type']);
         }
     }
+
+    // ── Grid card checklist bullets (#103) ──────────────────────────────
+
+    public function testGridCardBulletsRenderAsList(): void
+    {
+        $html = $this->render('grid', $this->gridProps([
+            'items' => [[
+                'title' => 'Security',
+                'bullets' => ['HTTP security headers', 'SSL/TLS validity', 'Clickjacking protection'],
+            ]],
+        ]));
+        $this->assertStringContainsString('<ul class="grid__item-bullets">', $html);
+        $this->assertStringContainsString('<li class="grid__item-bullet">HTTP security headers</li>', $html);
+        $this->assertStringContainsString('<li class="grid__item-bullet">SSL/TLS validity</li>', $html);
+        $this->assertStringContainsString('<li class="grid__item-bullet">Clickjacking protection</li>', $html);
+    }
+
+    public function testGridCardBulletsOmittedWhenUnset(): void
+    {
+        $html = $this->render('grid', $this->gridProps([
+            'items' => [['title' => 'Security', 'text' => 'Plain description']],
+        ]));
+        $this->assertStringNotContainsString('grid__item-bullets', $html);
+    }
+
+    public function testGridCardBulletsCoexistWithText(): void
+    {
+        $html = $this->render('grid', $this->gridProps([
+            'items' => [[
+                'title' => 'Security',
+                'text' => 'Plain description',
+                'bullets' => ['One item'],
+            ]],
+        ]));
+        $this->assertStringContainsString('class="grid__item-text">Plain description<', $html);
+        $this->assertStringContainsString('<li class="grid__item-bullet">One item</li>', $html);
+    }
+
+    public function testGridCardBulletsSkipNonStringAndEmptyEntries(): void
+    {
+        $html = $this->render('grid', $this->gridProps([
+            'items' => [[
+                'title' => 'Security',
+                'bullets' => ['Valid line', '', 123, ['nested' => 'array'], null],
+            ]],
+        ]));
+        $this->assertStringContainsString('<li class="grid__item-bullet">Valid line</li>', $html);
+        $this->assertSame(1, substr_count($html, 'grid__item-bullet"'));
+    }
+
+    public function testGridCardBulletsIgnoredWhenNotAnArray(): void
+    {
+        $html = $this->render('grid', $this->gridProps([
+            'items' => [['title' => 'Security', 'bullets' => 'not an array']],
+        ]));
+        $this->assertStringNotContainsString('grid__item-bullets', $html);
+    }
+
+    public function testGridCardBulletsEscapeEachLine(): void
+    {
+        $html = $this->render('grid', $this->gridProps([
+            'items' => [[
+                'title' => 'Security',
+                'bullets' => ['<script>alert(1)</script>'],
+            ]],
+        ]));
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $html);
+    }
+
+    public function testGridSchemaDeclaresBulletColorSlot(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/grid/schema.json'), true);
+        $slots = $schema['styling']['style_slots'];
+        $this->assertArrayHasKey('--grid-bullet-color', $slots);
+        $this->assertSame('color', $slots['--grid-bullet-color']['type']);
+    }
 }

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -190,7 +190,7 @@ class SchemaValidationTest extends TestCase
         $expected = [
             'hero'    => 33,
             'section' => 18,
-            'grid'    => 23,
+            'grid'    => 24,
             'cta'     => 25,
         ];
 

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -70,8 +70,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('schema declares 99 total style slots', () => {
-        expect(allSlots.length).toBe(99);
+    test('schema declares 100 total style slots', () => {
+        expect(allSlots.length).toBe(100);
     });
 
     allSlots.forEach(({ component, slotName }) => {


### PR DESCRIPTION
## Summary
- Closes #103. Grid card items now accept a `bullets` array — short checklist lines rendered below `text`, each prefixed with a check mark (`--grid-bullet-color` slot).
- Per-item icons were already covered by the existing `image_url`/`image_alt` fields, so no new icon field was needed.

## Security notes
- Structured plain-string array, not an HTML allowlist: each `bullets` entry goes through `esc_html()` independently; non-string/empty entries are silently skipped. No new HTML-parsing surface.
- `bullets` is intentionally not registered in `pp_register_component_fields()` (granular `patch` targeting), consistent with `image_url`/`image_alt`.

## Test plan
- [x] `vendor/bin/phpunit` — 1010 tests green (7 new: render, omission, coexistence with `text`, non-string/empty filtering, non-array guard, XSS escaping, schema slot declaration)
- [x] `npm test` — 308 tests green (slot-count sync: 99 → 100)
- [x] Docs synced: AI_CONTEXT.md, README.md (2 locations), version bump to 0.16.23 across all 5 files, CHANGELOG entry added
- [x] `gstack-redact` — no findings