### PR TITLE
Add testimonials component

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -121,12 +121,13 @@ site-customization permission.
 | stats     | components/stats/stats.php     | Horizontal row of large-number metrics + labels  | items[] (req) {number, label}, title, variant, background_image, id |
 | logos     | components/logos/logos.php     | Flex-wrap image grid — logo strips or icon tiles | items[] (req) {image_url, image_alt, label?}, title, variant, id |
 | embed     | components/embed/embed.php     | WP shortcode / plugin content wrapper            | content (req), title, variant, id                  |
+| testimonials | components/testimonials/testimonials.php | Customer quotes with attribution — card grid or single-column stack | items[] (req) {quote (req), author, role, company, image_url, image_alt}, title, variant, theme, id |
 
 ### Component capabilities reference
 
-**Variants (color themes):** Most section-level components support `variant` with values `default`, `dark`, `inverted`. CTA and grid are exceptions — see below.
+**Variants (color themes):** Most section-level components support `variant` with values `default`, `dark`, `inverted`. CTA, grid, and testimonials are exceptions — see below.
 
-**Two components have dual-axis control.** CTA and grid both use `variant` for layout and `theme` for color, because they need independent control of both. CTA: `variant` = layout (`full-width`, `inline`), `theme` = color (`default`, `dark`, `inverted`). Grid: `variant` = layout (`default`, `steps`), `theme` = color (`default`, `dark`, `inverted`). Every other component uses `variant` for color because it has only one layout. If a future component needs both layout and color control, follow the same pattern.
+**Three components have dual-axis control.** CTA, grid, and testimonials all use `variant` for layout and `theme` for color, because they need independent control of both. CTA: `variant` = layout (`full-width`, `inline`), `theme` = color (`default`, `dark`, `inverted`). Grid: `variant` = layout (`default`, `steps`), `theme` = color (`default`, `dark`, `inverted`). Testimonials: `variant` = layout (`grid`, `stack`), `theme` = color (`default`, `dark`, `inverted`). Every other component uses `variant` for color because it has only one layout. If a future component needs both layout and color control, follow the same pattern.
 
 **Background images:** hero (via `cover` variant + `image_url`), section (`background_image` prop), cta (`background_image` prop), and stats (`background_image` prop) support CSS background-image with a dark overlay and light text. All four use the same implementation pattern:
 - `background-image` inline style on the root `<section>` element
@@ -136,7 +137,7 @@ site-customization permission.
 
 If adding background-image support to another component, follow this exact pattern.
 
-**Anchor IDs:** All 7 section-level components (hero, section, stats, grid, logos, cta, embed) accept an `id` prop that renders as the HTML `id` attribute on the root `<section>` element. Use for anchor navigation.
+**Anchor IDs:** All 8 section-level components (hero, section, stats, grid, logos, cta, embed, testimonials) accept an `id` prop that renders as the HTML `id` attribute on the root `<section>` element. Use for anchor navigation.
 
 **Hero:** Variants `left`, `centered`, `split` (inline image), `cover` (fullscreen background-image with overlay). Supports dual CTA buttons (`cta_text` + `cta2_text`); secondary renders as outline/ghost style. Composition props: `spacing` (compact/default/spacious), `width` (narrow/default/full), `split_ratio` (50-50/60-40/40-60, split variant only), `vertical_align` (top/center/bottom, cover and split only), `proof` (HTML string for trust signals like logos/ratings, rendered after CTA group). Hero content uses `--measure-centered` (56rem) as default max-width.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.24] — 2026-07-05 — New: Testimonials Component
+
+**Testimonials are one of the most common homepage sections, and PromptingPress had no way to build one. The only workaround was embedding raw `<blockquote>` HTML inside a `section` body — no structured attribution, no per-quote styling, no way to reorder or selectively show individual quotes, and a wall of text instead of card separation.**
+
+### Added
+- New `testimonials` component: customer quotes with structured attribution (`author`, `role`, `company`, optional avatar). `grid` variant lays out quote cards 1-col mobile / 2-3 col desktop; `stack` variant is a single centered column for one or two large pull-quotes. Same header pattern as grid/section/cta (`eyebrow`, `title`/`title_accent`, `subheading`, `heading_align`) and the same dual-axis `variant` (layout) / `theme` (color) control as grid and CTA.
+- Base `blockquote` styling (accent border, italic, muted color) added to `base.css` — it's a standard HTML element other components already pass through `wp_kses_post()` (e.g. FAQ answers), so it should look intentional everywhere, not just inside the new component.
+
+### For contributors
+- Quote text and all attribution fields are plain strings run through `esc_html()` individually — no HTML allowlist, consistent with how every other component's text content is handled.
+- 12th component; registered in `pp_register_component_fields()` (title/eyebrow/subheading/items[].quote/author/role/company) and `_pp_pick_nested_match_field()` (matches nested items by `quote`, the one required per-item field) for `patch`-command addressability, consistent with existing components.
+- 19 new PHPUnit tests. Component count updated in AI_CONTEXT.md and README.md (12, up from 11); style-slot totals tracked by the existing "4 v1 components" tests are unaffected since testimonials sits outside that tracked set, same as faq/stats.
+
 ## [v0.16.23] — 2026-07-05 — New: Scannable Checklists Inside Grid Cards
 
 **Feature/benefit sections that feel professional almost always build their cards as an icon, a title, and a short checklist — "✓ SSL/TLS validity," "✓ Clickjacking protection" — not a dense paragraph. Grid cards could only render `text` as one `esc_html()`'d sentence, so the only way to approximate a checklist was to cram items into a comma-separated blob that read as a wall of text.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.23-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.24-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -127,7 +127,7 @@ No blocks. No shortcodes. No visual-builder serialization. AI can read, write, d
 
 ### 🧩 Typed components — contracts, not conventions
 
-11 components, each isolated in its own directory with a `schema.json`:
+12 components, each isolated in its own directory with a `schema.json`:
 
 | Component | Purpose | Key props |
 |-----------|---------|-----------|
@@ -140,6 +140,7 @@ No blocks. No shortcodes. No visual-builder serialization. AI can read, write, d
 | logos | Flex-wrap image strip for partner/client logos | `items[]` |
 | table | Data/comparison table, horizontal scroll on mobile | `headers[]`, `rows[][]` |
 | embed | WordPress shortcode / plugin content wrapper | `content` |
+| testimonials | Customer quotes with attribution — card grid or single-column stack | `items[]` |
 | nav | Site header with hamburger mobile nav | -- |
 | footer | Site footer with nav menu and copyright | -- |
 
@@ -265,7 +266,7 @@ the HANDOFF report.
 
 ```
 1. Agent reads AI_CONTEXT.md
-   → learns: 11 components, schema contracts, action layer, composition format
+   → learns: 12 components, schema contracts, action layer, composition format
 
 2. Agent inspects the page
    $ wp pp operate inspect-composition 74
@@ -419,7 +420,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.13.1.
 
 **What exists today (v0.13.1):**
-- 11 components with schema contracts and 100 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 100 per-instance style slots, plus named recipes
 - A contract test that guarantees every style slot a component declares actually reaches the page, honored at every breakpoint
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -210,6 +210,18 @@ pre {
   border-radius: var(--radius);
 }
 
+blockquote {
+  margin: 0 0 var(--space-md);
+  padding-left: var(--space-md);
+  border-left: 3px solid var(--color-accent);
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+blockquote:last-child {
+  margin-bottom: 0;
+}
+
 /* ==========================================================================
    4. Links
    ========================================================================== */

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1782,6 +1782,216 @@
 }
 
 /* ==========================================================================
+   COMPONENT: testimonials
+   Customer quotes with attribution. 'grid' variant: 1-col → 2-col md →
+   3-col lg card grid. 'stack' variant: single centered column, no card
+   chrome, for one or two large pull-quotes.
+   ========================================================================== */
+
+.testimonials {
+  padding-top: var(--testimonials-padding-top, var(--space-xl));
+  padding-bottom: var(--testimonials-padding-bottom, var(--space-xl));
+  background: var(--testimonials-bg, transparent);
+}
+
+.testimonials__header--center {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.testimonials__eyebrow {
+  display: inline-block;
+  padding: 0.35rem 0.85rem;
+  margin-bottom: var(--space-sm);
+  border-radius: 3px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--testimonials-eyebrow-color, var(--color-text));
+  background: var(--testimonials-eyebrow-bg, var(--color-surface-accent));
+}
+
+.testimonials__heading {
+  color: var(--testimonials-heading-color, var(--color-text));
+  max-width: 40rem;
+  margin-bottom: var(--space-lg);
+}
+
+.testimonials__heading-accent {
+  color: var(--testimonials-heading-accent-color, var(--color-accent));
+}
+
+.testimonials__header--center .testimonials__heading {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.testimonials__subheading {
+  color: var(--testimonials-subheading-color, var(--color-muted));
+  margin-top: 0;
+  margin-bottom: var(--space-lg);
+  max-width: 40rem;
+}
+
+.testimonials__header--center .testimonials__subheading {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.testimonials__list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--testimonials-gap, var(--space-lg));
+}
+
+@media (min-width: 768px) {
+  .testimonials__list {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .testimonials__list {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.testimonials__item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  margin: 0;
+  padding: var(--testimonials-card-padding, var(--space-lg));
+  background: var(--testimonials-card-bg, var(--color-surface));
+  border: var(--testimonials-card-border-width, 1px) solid var(--testimonials-card-border, var(--color-border));
+  border-radius: var(--testimonials-card-radius, var(--radius));
+  box-shadow: var(--testimonials-card-shadow, none);
+}
+
+.testimonials__quote {
+  margin: 0;
+  padding: 0;
+  border-left: none;
+  font-style: normal;
+  color: var(--testimonials-quote-color, var(--color-text));
+  flex: 1;
+}
+
+.testimonials__quote p {
+  margin: 0;
+  position: relative;
+  padding-left: 1.75rem;
+}
+
+.testimonials__quote p::before {
+  content: "\201C";
+  position: absolute;
+  left: 0;
+  top: -0.1em;
+  font-size: 1.75em;
+  line-height: 1;
+  font-weight: 700;
+  color: var(--testimonials-quote-mark-color, var(--color-accent));
+}
+
+.testimonials__attribution {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.testimonials__avatar {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.testimonials__attribution-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.testimonials__author {
+  font-weight: 700;
+  color: var(--testimonials-author-color, var(--color-text));
+}
+
+.testimonials__meta {
+  font-size: 0.875rem;
+  color: var(--testimonials-meta-color, var(--color-muted));
+}
+
+.testimonials__empty {
+  grid-column: 1 / -1;
+  padding: var(--space-md) 0;
+}
+
+/* Stack variant: single centered column, no card chrome, larger quotes */
+.testimonials--stack .testimonials__list {
+  grid-template-columns: 1fr;
+  max-width: 42rem;
+  margin: 0 auto;
+}
+
+.testimonials--stack .testimonials__item {
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  text-align: center;
+  align-items: center;
+}
+
+.testimonials--stack .testimonials__quote {
+  font-size: 1.375rem;
+}
+
+.testimonials--stack .testimonials__quote p {
+  padding-left: 0;
+}
+
+.testimonials--stack .testimonials__quote p::before {
+  display: block;
+  position: static;
+  margin-bottom: var(--space-sm);
+}
+
+/* Theme variants */
+.testimonials--dark {
+  background: var(--testimonials-bg, var(--color-surface));
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.testimonials--inverted {
+  background: var(--testimonials-bg, var(--color-bg-inverted));
+}
+
+.testimonials--inverted .testimonials__heading {
+  color: var(--testimonials-heading-color, var(--color-bg));
+}
+
+.testimonials--inverted .testimonials__item {
+  background: var(--testimonials-card-bg, var(--color-bg));
+}
+
+.testimonials--inverted.testimonials--stack .testimonials__item {
+  background: transparent;
+}
+
+.testimonials--inverted.testimonials--stack .testimonials__quote {
+  color: var(--testimonials-quote-color, var(--color-bg));
+}
+
+.testimonials--inverted.testimonials--stack .testimonials__author {
+  color: var(--testimonials-author-color, var(--color-bg));
+}
+
+/* ==========================================================================
    SHARED: Adjacent-Sibling Rhythm
    Tightens vertical padding between consecutive section-level components
    inside <main>. First component keeps its own padding naturally (the `+`

--- a/components/testimonials/README.md
+++ b/components/testimonials/README.md
@@ -1,0 +1,62 @@
+# Component: testimonials
+
+Customer quotes with attribution, for social-proof sections. Use this instead of embedding `<blockquote>` HTML inside a `section` body — it gives each quote its own structured attribution (author, role, company, avatar) and lets AI reorder or restyle individual testimonials.
+
+## Props
+
+| Prop            | Type   | Required | Default | Description |
+|-----------------|--------|----------|---------|-------------|
+| `id`            | string | No       | `''`    | HTML id for anchor linking |
+| `title`         | string | No       | `''`    | Section heading |
+| `title_accent`  | string | No       | `''`    | Exact substring of `title` to render in an accent color |
+| `eyebrow`       | string | No       | `''`    | Short kicker/label above the title |
+| `subheading`    | string | No       | `''`    | Supporting line below the title |
+| `heading_align` | enum   | No       | `start` | `start` or `center` |
+| `variant`       | enum   | No       | `grid`  | Layout: `grid` (card grid) or `stack` (single centered column) |
+| `theme`         | enum   | No       | `default` | Background color: `default` / `dark` / `inverted` |
+| `items`         | array  | Yes      | —       | Array of testimonial objects |
+
+Each item in `items`:
+
+| Key         | Type   | Required | Default | Description |
+|-------------|--------|----------|---------|-------------|
+| `quote`     | string | Yes      | —       | The testimonial text. Plain text — escaped, no HTML. |
+| `author`    | string | No       | `''`    | Name of the person quoted |
+| `role`      | string | No       | `''`    | The author's job title |
+| `company`   | string | No       | `''`    | The author's company or organization |
+| `image_url` | string | No       | `''`    | Optional avatar image URL |
+| `image_alt` | string | No       | `''`    | Alt text for the avatar |
+
+`variant` and `theme` are independent axes, same pattern as `grid` and `cta`: `variant` controls layout, `theme` controls background color.
+
+## Usage
+
+```php
+pp_get_component('testimonials', [
+    'title' => 'What our clients say',
+    'items' => [
+        [
+            'quote'   => 'PromptingPress cut our page-build time in half.',
+            'author'  => 'Jane Doe',
+            'role'    => 'CEO',
+            'company' => 'Acme Inc.',
+        ],
+        [
+            'quote'  => 'The AI never touches raw HTML — it just works.',
+            'author' => 'John Smith',
+        ],
+    ],
+]);
+
+// Single large pull-quote
+pp_get_component('testimonials', [
+    'variant' => 'stack',
+    'items' => [
+        ['quote' => 'The best WordPress theme for AI-first sites.', 'author' => 'Ada Lovelace'],
+    ],
+]);
+```
+
+## CSS
+
+Styles in `assets/css/components.css` under the `COMPONENT: testimonials` block. Base `blockquote` styling (border-left accent, italic, muted color) lives in `base.css` since `blockquote` is a standard HTML element other components can pass through `wp_kses_post()`; the component overrides it for card presentation.

--- a/components/testimonials/schema.json
+++ b/components/testimonials/schema.json
@@ -1,0 +1,110 @@
+{
+  "component": "testimonials",
+  "description": "Customer quotes with attribution — for social proof sections. 'grid' variant lays out quote cards 1-col mobile / 2-3 col desktop; 'stack' variant is a single centered column for one or two large quotes.",
+  "props": {
+    "id": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional HTML id attribute for anchor linking (e.g. navigation anchors)."
+    },
+    "title": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Section heading above the testimonials. Omit if the context makes it clear."
+    },
+    "title_accent": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional exact substring of title to render in an accent color. Must match title exactly (case-sensitive) or it is ignored."
+    },
+    "eyebrow": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional short kicker/label rendered as a pill above the title."
+    },
+    "subheading": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional supporting line below the title."
+    },
+    "heading_align": {
+      "type": "enum",
+      "values": ["start", "center"],
+      "required": false,
+      "default": "start",
+      "description": "Alignment of the eyebrow/title/subheading header block. 'start' = left-aligned (default). 'center' = centered."
+    },
+    "variant": {
+      "type": "enum",
+      "values": ["grid", "stack"],
+      "required": false,
+      "default": "grid",
+      "description": "Layout. 'grid' = card grid, 1-col mobile / 2-3 col desktop. 'stack' = single centered column, for one or two large pull-quotes."
+    },
+    "theme": {
+      "type": "enum",
+      "values": ["default", "dark", "inverted"],
+      "required": false,
+      "default": "default",
+      "description": "Background color. Independent of variant (layout). 'default' = page background. 'dark' = surface background with borders. 'inverted' = inverted background for strong contrast."
+    },
+    "items": {
+      "type": "array",
+      "required": true,
+      "description": "Array of testimonial items. Each: { quote (req), author, role, company, image_url, image_alt }.",
+      "items": {
+        "quote":     { "type": "string", "required": true,  "description": "The testimonial text. Plain text — escaped, no HTML." },
+        "author":    { "type": "string", "required": false, "description": "Name of the person quoted." },
+        "role":      { "type": "string", "required": false, "description": "The author's job title, e.g. 'CEO'." },
+        "company":   { "type": "string", "required": false, "description": "The author's company or organization." },
+        "image_url": { "type": "string", "required": false, "description": "Optional avatar image URL." },
+        "image_alt": { "type": "string", "required": false, "default": "", "description": "Alt text for the avatar. Use the author's name; empty string only if image is purely decorative." }
+      }
+    }
+  },
+  "styling": {
+    "root_class": "testimonials",
+    "variant_classes": ["testimonials--stack", "testimonials--dark", "testimonials--inverted"],
+    "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-surface", "--color-border", "--color-bg-inverted"],
+    "style_slots": {
+      "--testimonials-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the section" },
+      "--testimonials-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the section" },
+      "--testimonials-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
+      "--testimonials-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Heading text color" },
+      "--testimonials-heading-accent-color": { "type": "color", "default": "var(--color-accent)", "description": "Color of the title_accent substring within the heading, if set" },
+      "--testimonials-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
+      "--testimonials-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
+      "--testimonials-subheading-color": { "type": "color", "default": "var(--color-muted)", "description": "Subheading text color" },
+      "--testimonials-gap": { "type": "length", "default": "var(--space-lg)", "description": "Gap between testimonial cards (grid variant) or between stacked quotes (stack variant)" },
+      "--testimonials-card-bg": { "type": "gradient", "default": "var(--color-surface)", "description": "Card background color or gradient" },
+      "--testimonials-card-border": { "type": "color", "default": "var(--color-border)", "description": "Card border color" },
+      "--testimonials-card-border-width": { "type": "length", "default": "1px", "description": "Card border width" },
+      "--testimonials-card-radius": { "type": "length", "default": "var(--radius)", "description": "Card border radius" },
+      "--testimonials-card-shadow": { "type": "shadow", "default": "none", "description": "Card box shadow / glow (preset var(--shadow-sm|md|lg) or a bounded box-shadow)" },
+      "--testimonials-card-padding": { "type": "length", "default": "var(--space-lg)", "description": "Card padding" },
+      "--testimonials-quote-color": { "type": "color", "default": "var(--color-text)", "description": "Quote text color" },
+      "--testimonials-quote-mark-color": { "type": "color", "default": "var(--color-accent)", "description": "Decorative opening quote-mark glyph color" },
+      "--testimonials-author-color": { "type": "color", "default": "var(--color-text)", "description": "Author name text color" },
+      "--testimonials-meta-color": { "type": "color", "default": "var(--color-muted)", "description": "Author role/company line color" }
+    },
+    "recipes": {
+      "dark-showcase": {
+        "description": "Dark background with light cards for a strong social-proof section",
+        "slots": {
+          "--testimonials-bg": "#1a1a2e",
+          "--testimonials-heading-color": "#f0f0f0",
+          "--testimonials-card-bg": "#ffffff",
+          "--testimonials-gap": "2.5rem",
+          "--testimonials-card-radius": "1rem"
+        }
+      }
+    }
+  },
+  "safe_to_edit": ["testimonials.php", "../../assets/css/components.css (COMPONENT: testimonials section)"],
+  "do_not_touch": ["schema.json without updating AI_CONTEXT.md"]
+}

--- a/components/testimonials/testimonials.php
+++ b/components/testimonials/testimonials.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * components/testimonials/testimonials.php
+ *
+ * Customer quotes with attribution, for social-proof sections.
+ * Props: see schema.json
+ *
+ * @var array $props
+ */
+
+$id            = $props['id']            ?? '';
+$title         = $props['title']         ?? '';
+$title_accent  = $props['title_accent']  ?? '';
+$eyebrow       = $props['eyebrow']       ?? '';
+$subheading    = $props['subheading']    ?? '';
+$heading_align = $props['heading_align'] ?? 'start';
+$items   = $props['items']   ?? [];
+$variant = $props['variant'] ?? 'grid';
+$theme   = $props['theme']   ?? 'default';
+
+$allowed_variants = ['grid', 'stack'];
+if (!in_array($variant, $allowed_variants, true)) {
+    $variant = 'grid';
+}
+
+$allowed_themes = ['default', 'dark', 'inverted'];
+if (!in_array($theme, $allowed_themes, true)) {
+    $theme = 'default';
+}
+
+$allowed_heading_aligns = ['start', 'center'];
+if (!in_array($heading_align, $allowed_heading_aligns, true)) {
+    $heading_align = 'start';
+}
+$header_align_class = $heading_align === 'center' ? ' testimonials__header--center' : '';
+
+$is_stack      = $variant === 'stack';
+$variant_class = $is_stack ? ' testimonials--stack' : '';
+$theme_class   = $theme !== 'default' ? ' testimonials--' . $theme : '';
+
+// Style slot overrides (per-instance visual customization).
+$slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'testimonials');
+$style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';
+
+?>
+<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="testimonials<?php echo esc_attr($variant_class); ?><?php echo esc_attr($theme_class); ?>" data-pp-component="testimonials"<?php echo $style_attr; ?>>
+    <div class="container">
+
+        <?php if ($title || $eyebrow || $subheading) : ?>
+            <div class="testimonials__header<?php echo esc_attr($header_align_class); ?>">
+                <?php if ($eyebrow) : ?>
+                    <span class="testimonials__eyebrow"><?php echo esc_html($eyebrow); ?></span>
+                <?php endif; ?>
+                <?php if ($title) : ?>
+                    <h2 class="testimonials__heading"><?php echo pp_render_heading_with_accent($title, $title_accent, 'testimonials__heading-accent'); ?></h2>
+                <?php endif; ?>
+                <?php if ($subheading) : ?>
+                    <p class="testimonials__subheading"><?php echo esc_html($subheading); ?></p>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if (!empty($items)) : ?>
+            <div class="testimonials__list" data-pp-count="<?php echo esc_attr(count($items)); ?>">
+                <?php foreach ($items as $item) :
+                    $quote     = $item['quote']     ?? '';
+                    $author    = $item['author']    ?? '';
+                    $role      = $item['role']      ?? '';
+                    $company   = $item['company']   ?? '';
+                    $image_url = $item['image_url'] ?? '';
+                    $image_alt = $item['image_alt'] ?? '';
+                    if (!$quote) continue;
+
+                    $meta = '';
+                    if ($role && $company) {
+                        $meta = $role . ', ' . $company;
+                    } elseif ($role) {
+                        $meta = $role;
+                    } elseif ($company) {
+                        $meta = $company;
+                    }
+                ?>
+                    <figure class="testimonials__item">
+                        <blockquote class="testimonials__quote">
+                            <p><?php echo esc_html($quote); ?></p>
+                        </blockquote>
+                        <?php if ($author || $meta || $image_url) : ?>
+                            <figcaption class="testimonials__attribution">
+                                <?php if ($image_url) : ?>
+                                    <img
+                                        src="<?php echo pp_esc_image_src($image_url); ?>"
+                                        alt="<?php echo esc_attr($image_alt); ?>"
+                                        class="testimonials__avatar"
+                                        loading="lazy"
+                                    >
+                                <?php endif; ?>
+                                <span class="testimonials__attribution-text">
+                                    <?php if ($author) : ?>
+                                        <span class="testimonials__author"><?php echo esc_html($author); ?></span>
+                                    <?php endif; ?>
+                                    <?php if ($meta) : ?>
+                                        <span class="testimonials__meta"><?php echo esc_html($meta); ?></span>
+                                    <?php endif; ?>
+                                </span>
+                            </figcaption>
+                        <?php endif; ?>
+                    </figure>
+                <?php endforeach; ?>
+            </div>
+        <?php else : ?>
+            <p class="testimonials__empty text-muted">No testimonials yet.</p>
+        <?php endif; ?>
+
+    </div>
+</section>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.23');
+define('PP_VERSION', '0.16.24');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -1198,6 +1198,16 @@ pp_register_component_fields('cta', [
     ['name' => 'button_url',  'type' => 'url'],
 ]);
 
+pp_register_component_fields('testimonials', [
+    ['name' => 'title',            'type' => 'string'],
+    ['name' => 'eyebrow',          'type' => 'string'],
+    ['name' => 'subheading',       'type' => 'string'],
+    ['name' => 'items[].quote',    'type' => 'string'],
+    ['name' => 'items[].author',   'type' => 'string'],
+    ['name' => 'items[].role',     'type' => 'string'],
+    ['name' => 'items[].company',  'type' => 'string'],
+]);
+
 // ── Inspect Composition ──────────────────────────────────────────────────
 
 /**
@@ -1324,8 +1334,9 @@ function pp_inspect_composition(int $post_id): array|WP_Error {
  */
 function _pp_pick_nested_match_field(string $component_type): ?string {
     $match_map = [
-        'grid' => 'title',
-        'faq'  => 'question',
+        'grid'         => 'title',
+        'faq'          => 'question',
+        'testimonials' => 'quote',
     ];
     return $match_map[$component_type] ?? null;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.23",
+  "version": "0.16.24",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.23
+Stable tag: 0.16.24
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.23
+Version:          0.16.24
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1403,4 +1403,179 @@ class ComponentPropsTest extends TestCase
         $this->assertArrayHasKey('--grid-bullet-color', $slots);
         $this->assertSame('color', $slots['--grid-bullet-color']['type']);
     }
+
+    // ── Testimonials component (#1) ─────────────────────────────────────
+
+    private function testimonialsProps(array $extra = []): array
+    {
+        return array_merge(['items' => [['quote' => 'Great product.']]], $extra);
+    }
+
+    public function testTestimonialsRendersQuoteAndAttribution(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps([
+            'items' => [[
+                'quote' => 'PromptingPress cut our build time in half.',
+                'author' => 'Jane Doe',
+                'role' => 'CEO',
+                'company' => 'Acme Inc.',
+            ]],
+        ]));
+        $this->assertStringContainsString('class="testimonials__quote"', $html);
+        $this->assertStringContainsString('PromptingPress cut our build time in half.', $html);
+        $this->assertStringContainsString('class="testimonials__author">Jane Doe<', $html);
+        $this->assertStringContainsString('class="testimonials__meta">CEO, Acme Inc.<', $html);
+    }
+
+    public function testTestimonialsMetaFallsBackToRoleOnly(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps([
+            'items' => [['quote' => 'Q', 'author' => 'A', 'role' => 'CEO']],
+        ]));
+        $this->assertStringContainsString('class="testimonials__meta">CEO<', $html);
+    }
+
+    public function testTestimonialsMetaFallsBackToCompanyOnly(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps([
+            'items' => [['quote' => 'Q', 'author' => 'A', 'company' => 'Acme']],
+        ]));
+        $this->assertStringContainsString('class="testimonials__meta">Acme<', $html);
+    }
+
+    public function testTestimonialsOmitsAttributionWhenNoAuthorRoleCompanyOrImage(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps([
+            'items' => [['quote' => 'Just a quote.']],
+        ]));
+        $this->assertStringNotContainsString('testimonials__attribution', $html);
+    }
+
+    public function testTestimonialsSkipsItemsWithoutQuote(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps([
+            'items' => [['author' => 'No Quote Here'], ['quote' => 'Real quote', 'author' => 'Real Author']],
+        ]));
+        $this->assertStringNotContainsString('No Quote Here', $html);
+        $this->assertStringContainsString('Real quote', $html);
+    }
+
+    public function testTestimonialsRendersAvatarWhenImageUrlSet(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps([
+            'items' => [['quote' => 'Q', 'author' => 'A', 'image_url' => 'https://example.com/a.jpg', 'image_alt' => 'A photo']],
+        ]));
+        $this->assertStringContainsString('class="testimonials__avatar"', $html);
+        $this->assertStringContainsString('alt="A photo"', $html);
+    }
+
+    public function testTestimonialsEscapesQuoteAndAttribution(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps([
+            'items' => [[
+                'quote' => '<script>alert(1)</script>',
+                'author' => '<img src=x onerror=alert(1)>',
+                'role' => '<b>bold</b>',
+            ]],
+        ]));
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringNotContainsString('<img src=x onerror=alert(1)>', $html);
+        $this->assertStringNotContainsString('<b>bold</b>', $html);
+        $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $html);
+    }
+
+    public function testTestimonialsEmptyStateRendersWhenNoItems(): void
+    {
+        $html = $this->render('testimonials', ['items' => []]);
+        $this->assertStringContainsString('testimonials__empty', $html);
+    }
+
+    public function testTestimonialsHeaderEyebrowSubheadingAndCenterAlignRender(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps([
+            'title' => 'Heading',
+            'eyebrow' => 'KICKER',
+            'subheading' => 'Supporting line',
+            'heading_align' => 'center',
+        ]));
+        $this->assertStringContainsString('class="testimonials__header testimonials__header--center"', $html);
+        $this->assertStringContainsString('class="testimonials__eyebrow">KICKER<', $html);
+        $this->assertStringContainsString('class="testimonials__heading">Heading<', $html);
+        $this->assertStringContainsString('class="testimonials__subheading">Supporting line<', $html);
+    }
+
+    public function testTestimonialsHeaderOmittedWhenNoTitleEyebrowOrSubheading(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps());
+        $this->assertStringNotContainsString('testimonials__header', $html);
+    }
+
+    public function testTestimonialsTitleAccentRenders(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps(['title' => 'Fast and Safe', 'title_accent' => 'Fast']));
+        $this->assertStringContainsString('<span class="testimonials__heading-accent">Fast</span> and Safe', $html);
+    }
+
+    public function testTestimonialsVariantDefaultsToGrid(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps());
+        $this->assertStringNotContainsString('testimonials--stack', $html);
+    }
+
+    public function testTestimonialsVariantStackAddsClass(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps(['variant' => 'stack']));
+        $this->assertStringContainsString('class="testimonials testimonials--stack"', $html);
+    }
+
+    public function testTestimonialsInvalidVariantFallsBackToGrid(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps(['variant' => 'carousel']));
+        $this->assertStringNotContainsString('testimonials--carousel', $html);
+        $this->assertStringNotContainsString('testimonials--stack', $html);
+    }
+
+    public function testTestimonialsThemeAddsClass(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps(['theme' => 'inverted']));
+        $this->assertStringContainsString('testimonials--inverted', $html);
+    }
+
+    public function testTestimonialsInvalidThemeFallsBackToDefault(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps(['theme' => 'neon']));
+        $this->assertStringNotContainsString('testimonials--neon', $html);
+    }
+
+    public function testTestimonialsRejectsInjectionInStyleSlot(): void
+    {
+        $html = $this->render('testimonials', $this->testimonialsProps([
+            '__pp_style' => ['--testimonials-quote-color' => '#fff; background:url(evil)'],
+        ]));
+        $this->assertStringNotContainsString('url(evil)', $html);
+    }
+
+    public function testTestimonialsSchemaDeclaresAllStyleSlots(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/testimonials/schema.json'), true);
+        $this->assertArrayHasKey('styling', $schema);
+        $slots = $schema['styling']['style_slots'];
+        foreach ([
+            '--testimonials-padding-top', '--testimonials-padding-bottom', '--testimonials-bg',
+            '--testimonials-heading-color', '--testimonials-heading-accent-color',
+            '--testimonials-eyebrow-color', '--testimonials-eyebrow-bg', '--testimonials-subheading-color',
+            '--testimonials-gap', '--testimonials-card-bg', '--testimonials-card-border',
+            '--testimonials-card-border-width', '--testimonials-card-radius', '--testimonials-card-shadow',
+            '--testimonials-card-padding', '--testimonials-quote-color', '--testimonials-quote-mark-color',
+            '--testimonials-author-color', '--testimonials-meta-color',
+        ] as $slot) {
+            $this->assertArrayHasKey($slot, $slots, "testimonials must declare {$slot}.");
+        }
+    }
+
+    public function testTestimonialsSchemaRequiresQuoteOnItems(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/testimonials/schema.json'), true);
+        $this->assertTrue($schema['props']['items']['items']['quote']['required']);
+    }
 }

--- a/tests/StyleSlotContractTest.php
+++ b/tests/StyleSlotContractTest.php
@@ -33,7 +33,7 @@ use PHPUnit\Framework\TestCase;
 class StyleSlotContractTest extends TestCase
 {
     /** Components that declare style_slots and own a block in components.css. */
-    private const COMPONENTS = ['hero', 'section', 'grid', 'cta', 'faq', 'stats'];
+    private const COMPONENTS = ['hero', 'section', 'grid', 'cta', 'faq', 'stats', 'testimonials'];
 
     private string $themeRoot;
     private string $css;


### PR DESCRIPTION
## Summary
- Closes #1. New `testimonials` component: customer quotes with structured attribution (author, role, company, optional avatar) instead of raw `<blockquote>` HTML embedded in a `section` body.
- `grid` variant (1-col mobile / 2-3 col desktop card grid) and `stack` variant (single centered column for one or two large pull-quotes). Same header pattern as grid/section/cta (`eyebrow`, `title`/`title_accent`, `subheading`, `heading_align`) and the same dual-axis `variant`(layout)/`theme`(color) control as grid/CTA.
- Added base `blockquote` styling to `base.css` per the issue's suggestion — it's a standard element other components (FAQ answers, section body) already pass through `wp_kses_post()`.

## Security notes
- Quote text and every attribution field (`author`, `role`, `company`) are plain strings, each escaped independently via `esc_html()` — no HTML allowlist, consistent with every other component's text content.

## Test plan
- [x] `vendor/bin/phpunit` — 1029 tests green (19 new: render, attribution fallback logic, empty-quote skip, empty state, header pattern, title_accent, variant/theme validation + fallback, style-slot injection rejection, XSS escaping, schema slot/required-field assertions)
- [x] `npm test` — 308 tests green (unaffected — testimonials sits outside the "4 v1 components" tracked slot-count set, same as faq/stats)
- [x] Docs synced: AI_CONTEXT.md (component index, dual-axis section, anchor-ID count), README.md (component table + 3 count mentions), component `README.md`, version bump to 0.16.24 across all 5 files, CHANGELOG entry added
- [x] `gstack-redact` — no findings
- [x] Manually rendered component output via PHP CLI to confirm HTML structure/escaping