### PR TITLE
Fix grid steps variant weak default layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.25] — 2026-07-05 — Fix: Grid Steps No Longer Look Like a Draft
+
+**The `steps` variant of the grid component — the numbered "how it works" layout every marketing page reaches for — rendered as bare floating numbers over a dead-space background, with an arrow connector that had actually been invisible in production the whole time. Every page using it needed manual CSS rescue to look finished.**
+
+### Fixed
+- Steps cards now use the same visible card chrome (background, border, radius) as the default grid variant, closing the gap between "technically has a `steps` option" and "looks intentionally designed."
+- The step number is now a filled circular badge instead of a bare number floating in dead space, with a tightened gap to the title/text below it.
+- The arrow connector between steps — which had silently stopped rendering after an unrelated later rule clipped it with `overflow: hidden` — is replaced with a subtle horizontal line between badges at desktop, instead of restoring the noisy triangle.
+
+### For contributors
+- Root cause: `.grid--steps` had THREE separate declaration sites — the canonical `COMPONENT: grid` block, plus two undocumented, unscoped "rescue" overrides bolted on elsewhere in `components.css` (interleaved with unrelated hero proof-content CSS, using raw rgba magic-number colors instead of tokens). The canonical block stayed weak while the actually-rendered page defaults silently diverged from it — exactly the kind of drift that makes a component's own defaults untrustworthy. Consolidated to a single declaration site inside the canonical block; new css-lint test (`grid--steps only declared inside the COMPONENT: grid block`) guards against this recurring.
+- Verified before/after via a real redeploy to the dev environment (release zip → `/var/www/dev-promptingpress`) and browser screenshots of the site's actual "Cómo funciona" 3-step section, both at desktop and mobile, plus the two other live pages using `theme: dark` — not just static CSS reasoning.
+- `--grid-step-color`'s description updated to reflect its new role (badge background, not bare number color) — same slot, same default, no schema break.
+
 ## [v0.16.24] — 2026-07-05 — New: Testimonials Component
 
 **Testimonials are one of the most common homepage sections, and PromptingPress had no way to build one. The only workaround was embedding raw `<blockquote>` HTML inside a `section` body — no structured attribution, no per-quote styling, no way to reorder or selectively show individual quotes, and a wall of text instead of card separation.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.24-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.25-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1044,45 +1044,46 @@
   padding: var(--space-md) 0;
 }
 
-/* Steps variant */
+/* Steps variant: same card chrome as the default grid, plus a numbered badge. */
 .grid--steps .grid__item {
-  background-color: transparent;
-  border: none;
-  border-radius: 0;
-  overflow: visible;
-  padding: var(--space-md) 0;
-}
-
-.grid--steps .grid__item:hover {
-  transform: none;
+  position: relative;
+  padding: var(--space-lg) var(--space-md) var(--space-md);
 }
 
 .grid--steps .pp-step-number {
-  display: block;
-  font-size: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  margin-bottom: var(--space-md);
+  border-radius: 50%;
+  background: var(--grid-step-color, var(--color-accent));
+  color: var(--color-bg);
+  font-size: 1.25rem;
   font-weight: 700;
   line-height: 1;
-  color: var(--grid-step-color, var(--color-accent));
-  margin-bottom: var(--space-sm);
 }
 
-/* Steps connectors: arrow between cards at desktop */
-@media (min-width: 1024px) {
-  .grid--steps .grid__item {
-    position: relative;
+@media (max-width: 767px) {
+  .grid--steps .pp-step-number {
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: 1.125rem;
   }
+}
 
+/* Steps connector: a thin line between badges at desktop, replacing the old
+   triangle arrow (already invisible in practice, and flagged as noisy — #56). */
+@media (min-width: 1024px) {
   .grid--steps .grid__item:not(:last-child)::after {
     content: "";
     position: absolute;
-    right: calc(-1 * var(--space-lg));
-    top: 50%;
-    transform: translateX(50%) translateY(-50%);
-    width: 0;
-    height: 0;
-    border-top: 8px solid transparent;
-    border-bottom: 8px solid transparent;
-    border-left: 10px solid var(--color-muted);
+    top: calc(var(--space-lg) + 1.375rem);
+    left: 100%;
+    width: var(--grid-gap, var(--space-lg));
+    height: 1px;
+    background: var(--grid-card-border, var(--color-border));
   }
 }
 
@@ -1103,19 +1104,6 @@
 
 .grid--inverted .grid__item {
   background: var(--grid-card-bg, var(--color-bg));
-}
-
-.grid--inverted.grid--steps .grid__item {
-  background-color: transparent;
-}
-
-.grid--inverted.grid--steps .grid__item-title {
-  color: var(--grid-item-title-color, var(--color-bg));
-}
-
-.grid--inverted.grid--steps .grid__item-text {
-  color: var(--grid-item-text-color, var(--color-bg));
-  opacity: 0.75;
 }
 
 /* ==========================================================================
@@ -2239,44 +2227,6 @@
   color: var(--color-muted);
 }
 
-.grid--steps .grid__item {
-  position: relative;
-  overflow: hidden;
-  border-color: var(--color-border);
-  background:
-    linear-gradient(90deg, rgba(49, 87, 244, 0.04) 1px, transparent 1px) 0 0 / 3rem 100%,
-    linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface) 100%);
-}
-
-.grid--steps .grid__item::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  height: 2px;
-  background: linear-gradient(90deg, var(--color-accent), color-mix(in srgb, var(--color-accent) 14%, transparent));
-}
-
-.grid--steps .pp-step-number {
-  display: inline-grid;
-  place-items: center;
-  width: 3.25rem;
-  height: 3.25rem;
-  margin-bottom: 1.25rem;
-  border: 1px solid var(--color-border-accent);
-  border-radius: 4px;
-  background: var(--color-surface-accent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
-  color: var(--color-accent);
-  font-size: 1.45rem;
-  font-weight: 640;
-}
-
-.grid--steps .grid__item-title {
-  color: var(--grid-item-title-color, var(--color-text));
-}
-
 @media (max-width: 767px) {
   .hero .pp-workflow-surface {
     background:
@@ -2291,12 +2241,6 @@
   .hero .pp-workflow-step::after {
     top: 1rem;
     right: 1rem;
-  }
-
-  .grid--steps .pp-step-number {
-    width: 2.8rem;
-    height: 2.8rem;
-    font-size: 1.25rem;
   }
 }
 /* Explicit hero surface motif layer properties. */
@@ -2328,12 +2272,6 @@
   background:
     linear-gradient(90deg, rgba(37, 99, 235, 0.07) 1px, transparent 1px) 0 0 / 1.35rem 100%,
     var(--color-bg);
-}
-
-.grid--steps .grid__item {
-  background:
-    linear-gradient(90deg, rgba(37, 99, 235, 0.045) 1px, transparent 1px) 0 0 / 3rem 100%,
-    linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface) 100%);
 }
 
 @media (max-width: 767px) {

--- a/components/grid/schema.json
+++ b/components/grid/schema.json
@@ -98,7 +98,7 @@
       "--grid-item-text-color": { "type": "color", "default": "var(--color-muted)", "description": "Card description text color" },
       "--grid-bullet-color": { "type": "color", "default": "var(--color-accent)", "description": "Checklist bullet marker color (grid card bullets)" },
       "--grid-link-color": { "type": "color", "default": "var(--color-accent)", "description": "Card link color" },
-      "--grid-step-color": { "type": "color", "default": "var(--color-accent)", "description": "Step number color (steps variant)" }
+      "--grid-step-color": { "type": "color", "default": "var(--color-accent)", "description": "Step badge background color (steps variant); the number text always renders in --color-bg for contrast" }
     },
     "recipes": {
       "dark-showcase": {

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.24');
+define('PP_VERSION', '0.16.25');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.24",
+  "version": "0.16.25",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.24
+Stable tag: 0.16.25
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.24
+Version:          0.16.25
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -119,6 +119,34 @@ describe('CSS lint: secondary/ghost buttons never get a filled gradient', () => 
     });
 });
 
+describe('CSS lint: grid--steps only declared inside the COMPONENT: grid block (#56)', () => {
+    // Regression guard: before #56, `.grid--steps .grid__item` and
+    // `.grid--steps .pp-step-number` were each declared a SECOND time,
+    // scattered elsewhere in the file as undocumented, unscoped "rescue"
+    // overrides with raw rgba magic-number colors — one of which set
+    // `overflow: hidden` and silently clipped the arrow connector. The
+    // canonical block stayed weak while real page defaults quietly diverged
+    // from it. Every declaration of these selectors must live inside the
+    // COMPONENT: grid block (responsive variants of the SAME rule, e.g. a
+    // max-width media query tweak, are fine) — none may leak outside it.
+    const stripped = stripComments(COMPONENTS_CSS);
+    // Locate the block against the RAW css — the "COMPONENT: grid" marker
+    // lives inside a comment, so it would vanish if matched post-strip.
+    const blockMatch = COMPONENTS_CSS.match(/COMPONENT:\s*grid\b([\s\S]*?)(?=\/\*\s*={5,}[\s\S]*?COMPONENT:|$)/);
+    const gridBlock = stripComments(blockMatch ? blockMatch[1] : '');
+
+    test.each(['.grid--steps .grid__item', '.grid--steps .pp-step-number'])(
+        '%s is never declared outside the COMPONENT: grid block',
+        (selector) => {
+            const pattern = new RegExp(selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\{', 'g');
+            const totalCount = (stripped.match(pattern) || []).length;
+            const inBlockCount = (gridBlock.match(pattern) || []).length;
+            expect(inBlockCount).toBeGreaterThan(0);
+            expect(totalCount).toBe(inBlockCount);
+        }
+    );
+});
+
 describe('CSS lint: no raw hex in components.css', () => {
     test('components.css has no raw hex color values', () => {
         const stripped = stripComments(COMPONENTS_CSS);


### PR DESCRIPTION
## Summary
- Closes #56. The `grid` component's `steps` variant produced a visually weak layout by design: bare floating numbers over dead space, and an arrow connector that had silently stopped rendering in production (a later, unscoped rule set `overflow: hidden` and clipped it).
- Root cause: `.grid--steps` had **three separate declaration sites** in `components.css` — the canonical `COMPONENT: grid` block, plus two undocumented "rescue" overrides bolted on elsewhere in the file (interleaved with unrelated hero proof-content CSS, using raw rgba magic-number colors instead of design tokens). The canonical block stayed weak while the actually-rendered default silently diverged from it.
- Consolidated to a single declaration site: steps cards now use the same visible card chrome (background/border/radius) as the default grid variant, the step number is a filled circular badge, spacing between badge and title is tightened, and the arrow connector is replaced with a subtle line between badges at desktop.

## Verification
Redeployed a fresh release build to the dev environment (`/var/www/dev-promptingpress`) and viewed the live "Cómo funciona" 3-step section in a real browser — not just static CSS reasoning:
- Desktop (1280px): before showed bare numbered squares with visible dead space and a graph-paper background texture; after shows proper cards with circular badges and a working (subtle) connector line — confirmed via `getComputedStyle` on the `::after` pseudo-element.
- Mobile (390px): single column, no connector (as intended), smaller badges.
- Two other live pages using `theme: dark` — no regression, cards render correctly against the dark section background.

## Security notes
None — CSS/schema-description only, no new user input surface.

## Test plan
- [x] `vendor/bin/phpunit` — 1029 tests green
- [x] `npm test` — 310 tests green (2 new: css-lint guard asserting `.grid--steps .grid__item` / `.grid--steps .pp-step-number` are never declared outside the `COMPONENT: grid` block — verified it actually catches the regression by deliberately reintroducing a duplicate and confirming the test fails, then reverting)
- [x] Version bump to 0.16.25 across all 5 files, CHANGELOG entry added
- [x] `gstack-redact` — no findings