### PR TITLE
Reconcile AI-facing instructions with accumulated capability drift

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -139,11 +139,15 @@ If adding background-image support to another component, follow this exact patte
 
 **Anchor IDs:** All 8 section-level components (hero, section, stats, grid, logos, cta, embed, testimonials) accept an `id` prop that renders as the HTML `id` attribute on the root `<section>` element. Use for anchor navigation.
 
-**Hero:** Variants `left`, `centered`, `split` (inline image), `cover` (fullscreen background-image with overlay). Supports dual CTA buttons (`cta_text` + `cta2_text`); secondary renders as outline/ghost style. Composition props: `spacing` (compact/default/spacious), `width` (narrow/default/full), `split_ratio` (50-50/60-40/40-60, split variant only), `vertical_align` (top/center/bottom, cover and split only), `proof` (HTML string for trust signals like logos/ratings, rendered after CTA group). Hero content uses `--measure-centered` (56rem) as default max-width.
+**Hero:** Variants `left`, `centered`, `split` (inline image), `cover` (fullscreen background-image with overlay). Supports dual CTA buttons (`cta_text` + `cta2_text`), each with an independent `cta_variant`/`cta2_variant` (`primary`/`secondary`/`outline`/`ghost`; secondary defaults to `outline`). Composition props: `spacing` (compact/default/spacious), `width` (narrow/default/full), `split_ratio` (50-50/60-40/40-60, split variant only), `vertical_align` (top/center/bottom, cover and split only), `proof` (HTML string for trust signals like logos/ratings, rendered after CTA group). Hero content uses `--measure-centered` (56rem) as default max-width.
 
 **Nav/Footer:** Supports image logos via `logo_id` (Media Library attachment ID, not a URL) + `logo_alt`. Resolution: `logo_id` prop → `pp_logo_id` site option → WP `custom_logo` theme-mod → `logo_text` (text) wordmark. Footer logo is opt-in via `show_logo` (default off). Set the site-wide logo through the `update_site_option` action with key `pp_logo_id`.
 
-**Grid:** Variants `default` (card grid), `steps` (numbered process steps with arrow connectors at desktop). `theme` controls background color independently of layout variant.
+**Grid:** Variants `default` (card grid), `steps` (numbered process cards — filled circular number badge, subtle connector line between badges at desktop). `theme` controls background color independently of layout variant. Card items accept `bullets` — a checklist of plain-text lines rendered below `text`, each prefixed with a check mark.
+
+**Section headers (hero, section, grid, cta, testimonials):** `eyebrow` renders a short kicker label as a pill above the title. `subheading` (section, grid, cta, testimonials — hero uses `subtitle` instead) renders a supporting line below the title. `heading_align` (`start` default, or `center`) centers the eyebrow/title/subheading block, independent of the component's own layout variant.
+
+**title_accent (hero, section, grid, cta, faq, stats, testimonials):** All seven heading-bearing components accept `title_accent` — an exact, case-sensitive substring of `title` rendered in a per-component accent color slot (e.g. `--hero-title-accent-color`). It is a structured plain-text mechanism, not an HTML allowlist: if `title_accent` isn't a literal substring of `title`, it is silently ignored and `title` renders in full.
 
 **CSS invariant:** Component CSS in `components.css` must use only CSS variables from `base.css` — never raw hex values. Color decisions belong to the design tokens, not to individual components.
 

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -38,17 +38,18 @@ See `AI_CONTEXT.md` → Component index for the current list. As of last update:
 
 | Name    | Required props                          | Optional props (selection)                              |
 |---------|-----------------------------------------|---------------------------------------------------------|
-| hero    | title                                   | subtitle, cta_text, cta_url, cta2_text, cta2_url, variant, spacing, width, split_ratio, vertical_align, proof |
-| section | body                                    | title, layout, variant, background_image                |
-| faq     | items[] {question, answer}              | title                                                   |
-| grid    | items[] {title, text, ...}              | title, variant, theme                                   |
+| hero    | title                                   | title_accent, eyebrow, subtitle, cta_text, cta_url, cta2_text, cta2_url, cta_variant, cta2_variant, variant, spacing, width, split_ratio, vertical_align, proof |
+| section | body                                    | title, title_accent, eyebrow, subheading, heading_align, layout, variant, background_image |
+| faq     | items[] {question, answer}              | title, title_accent                                     |
+| grid    | items[] {title, text, ...}              | title, title_accent, eyebrow, subheading, heading_align, variant, theme |
 | table   | headers[], rows[][]                     | title, caption                                          |
-| cta     | title, button_text, button_url          | text, variant, theme, background_image                  |
+| cta     | title, button_text, button_url          | title_accent, eyebrow, text, variant, theme, background_image, button_variant |
 | nav     | (no required props)                     | logo_text, logo_id, logo_alt                            |
-| footer  | (no required props)                     | location                                                |
-| stats   | items[] {number, label}                 | title, variant, background_image                        |
+| footer  | (no required props)                     | location, show_logo, logo_text, logo_id, logo_alt       |
+| stats   | items[] {number, label}                 | title, title_accent, variant, background_image          |
 | logos   | items[] {image_url, image_alt}          | title, variant                                          |
 | embed   | content                                 | title, variant                                          |
+| testimonials | items[] {quote}                    | title, title_accent, eyebrow, subheading, heading_align, variant, theme |
 
 ### section.variant
 
@@ -79,7 +80,7 @@ Example — alternating section rhythm:
 
 ### grid.variant: "steps"
 
-Renders numbered process cards. Use for How-It-Works or sequential flows.
+Renders numbered process cards. Use for How-It-Works or sequential flows. Cards get a filled circular number badge and a subtle connector line between badges at desktop (1024px+).
 
 - Set `variant: "steps"` on the grid
 - Include a `number` field on each item (`"1"`, `"01"`, `"Step 1"`, etc.)
@@ -99,6 +100,28 @@ Renders numbered process cards. Use for How-It-Works or sequential flows.
   }
 }
 ```
+
+### grid items[].bullets
+
+Renders a checklist below the card's `text`, each line prefixed with a check mark — use for scannable feature/benefit lists instead of a dense paragraph. Plain text lines only, no HTML/markdown.
+
+```json
+{ "component": "grid", "props": { "title": "Security", "items": [
+  { "title": "Perimeter security", "bullets": ["HTTP security headers", "SSL/TLS validity", "Clickjacking protection"] }
+]}}
+```
+
+### title_accent (hero, section, grid, cta, faq, stats, testimonials)
+
+All seven heading-bearing components accept `title_accent`: an exact, case-sensitive substring of `title` to render in an accent color. It must match `title` literally or it is silently ignored (no accent rendered, `title` still shows in full).
+
+```json
+{ "component": "hero", "props": { "title": "Fast and Safe WordPress", "title_accent": "Fast" } }
+```
+
+### eyebrow / subheading / heading_align (hero, section, grid, cta, testimonials)
+
+`eyebrow` renders a short kicker label as a pill above the title (e.g. `"NEW"`). `subheading` renders a supporting line below the title (section, grid, cta, testimonials only — hero uses `subtitle` instead). `heading_align` (`start` default, or `center`) centers the eyebrow/title/subheading header block — independent of the component's overall layout.
 
 Always verify against `components/{name}/schema.json` before writing — the source of truth.
 

--- a/ai-instructions/style-component.md
+++ b/ai-instructions/style-component.md
@@ -83,8 +83,8 @@ Check that `current` values reflect your changes and the `active_recipe` shows c
 The `shadow` type is bounded: a preset (`var(--shadow-none\|sm\|md\|lg)` or `none`)
 or a single-layer `box-shadow` (2-4 px/rem lengths plus an rgb/rgba/hsl/hsla color).
 `inset`, multi-layer shadows, and `url()` are rejected. The hero, section, grid (card),
-and cta components each expose namespaced `*-border-color`, `*-border-width`, `*-radius`,
-and `*-shadow` slots.
+cta, and testimonials (card) components each expose namespaced `*-border-color`,
+`*-border-width`, `*-radius`, and `*-shadow` slots.
 
 > **Button and text styling are PROPS, not style slots.** A CTA's button style
 > (`button_variant`: primary/secondary/outline/ghost) and a grid item's typography
@@ -106,6 +106,7 @@ and `*-shadow` slots.
 | grid | `dense-cards` | Compact card layout with tight spacing |
 | cta | `dark-bold` | Dark background with large title |
 | cta | `accent-framed` | Accent border with rounded corners |
+| testimonials | `dark-showcase` | Dark background with light cards |
 
 ---
 

--- a/components/cta/README.md
+++ b/components/cta/README.md
@@ -6,11 +6,16 @@ Call-to-action block. Place at the bottom of a page or between sections to drive
 
 | Prop          | Type   | Required | Default        | Description |
 |---------------|--------|----------|----------------|-------------|
+| `id`          | string | No       | `''`           | HTML id for anchor linking |
 | `title`       | string | Yes      | —              | CTA headline |
+| `title_accent`| string | No       | `''`           | Exact substring of `title` to render in an accent color |
+| `eyebrow`     | string | No       | `''`           | Short kicker/label rendered as a pill above the title |
 | `text`        | string | No       | `''`           | Supporting body text |
 | `button_text` | string | Yes      | —              | Button label |
 | `button_url`  | string | Yes      | —              | Button URL |
 | `variant`     | enum   | No       | `'full-width'` | Layout variant |
+| `theme`       | enum   | No       | `'default'`    | Background color: `default` / `dark` / `inverted` (independent of `variant`) |
+| `background_image` | string | No | `''`           | Optional background image URL with dark overlay for text readability |
 | `button_variant` | enum | No      | `'primary'`    | Button style: `primary` / `secondary` / `outline` / `ghost` |
 
 ## Layout variants

--- a/components/embed/README.md
+++ b/components/embed/README.md
@@ -8,6 +8,7 @@ This is the only sanctioned way to introduce arbitrary plugin-rendered content i
 
 | Prop      | Type   | Required | Default | Description |
 |-----------|--------|----------|---------|-------------|
+| `id`      | string | No       | `''`    | HTML id for anchor linking |
 | `title`   | string | No       | `''`    | Optional heading above the embedded content |
 | `content` | string | Yes      | —       | WP shortcode or pre-rendered HTML |
 

--- a/components/faq/README.md
+++ b/components/faq/README.md
@@ -4,10 +4,11 @@ FAQ accordion using native HTML `<details>`/`<summary>` elements. No JavaScript 
 
 ## Props
 
-| Prop    | Type   | Required | Default                          | Description |
-|---------|--------|----------|----------------------------------|-------------|
-| `title` | string | No       | `'Frequently Asked Questions'`   | Section heading |
-| `items` | array  | Yes      | —                                | Array of `{ question, answer }` objects |
+| Prop           | Type   | Required | Default                          | Description |
+|----------------|--------|----------|----------------------------------|-------------|
+| `title`        | string | No       | `'Frequently Asked Questions'`   | Section heading |
+| `title_accent` | string | No       | `''`                             | Exact substring of `title` to render in an accent color |
+| `items`        | array  | Yes      | —                                | Array of `{ question, answer }` objects |
 
 Each item in `items`:
 

--- a/components/footer/README.md
+++ b/components/footer/README.md
@@ -4,9 +4,13 @@ Site footer. Renders a WP nav menu (by theme location) and a copyright line usin
 
 ## Props
 
-| Prop       | Type   | Required | Default    | Description |
-|------------|--------|----------|------------|-------------|
-| `location` | string | No       | `'footer'` | WP theme location slug |
+| Prop        | Type   | Required | Default    | Description |
+|-------------|--------|----------|------------|-------------|
+| `location`  | string | No       | `'footer'` | WP theme location slug |
+| `show_logo` | bool   | No       | `false`    | Whether to render the site logo in the footer (opt-in) |
+| `logo_text` | string | No       | —          | Logo text (falls back to site title) |
+| `logo_id`   | int    | No       | —          | Media Library attachment ID for an image logo (takes priority over `logo_text`) |
+| `logo_alt`  | string | No       | —          | Alt text for the image logo |
 
 ## Usage
 

--- a/components/grid/README.md
+++ b/components/grid/README.md
@@ -4,21 +4,31 @@ Responsive card grid for discrete content objects. Use this for blog post listin
 
 ## Props
 
-| Prop    | Type   | Required | Default | Description |
-|---------|--------|----------|---------|-------------|
-| `title` | string | No       | `''`    | Section heading above the grid |
-| `items` | array  | Yes      | —       | Array of card objects |
+| Prop            | Type   | Required | Default   | Description |
+|-----------------|--------|----------|-----------|-------------|
+| `id`            | string | No       | `''`      | HTML id for anchor linking |
+| `title`         | string | No       | `''`      | Section heading above the grid |
+| `title_accent`  | string | No       | `''`      | Exact substring of `title` to render in an accent color |
+| `eyebrow`       | string | No       | `''`      | Short kicker/label rendered as a pill above the title |
+| `subheading`    | string | No       | `''`      | Supporting line below the title |
+| `heading_align` | enum   | No       | `'start'` | Header block alignment: `start` / `center` |
+| `variant`       | enum   | No       | `'default'` | Layout: `default` (card grid) / `steps` (numbered process cards) |
+| `theme`         | enum   | No       | `'default'` | Background color: `default` / `dark` / `inverted` (independent of `variant`) |
+| `items`         | array  | Yes      | —         | Array of card objects |
 
 Each item in `items`:
 
 | Key         | Type   | Required | Default        | Description |
 |-------------|--------|----------|----------------|-------------|
+| `number`    | string | No*      | —              | Step number label, e.g. `'1'`. *Required when `variant` is `'steps'`. |
 | `title`     | string | No       | `''`           | Card heading (h3) |
 | `text`      | string | No       | `''`           | Card body text |
+| `bullets`   | array  | No       | —              | Checklist lines rendered below `text`, each prefixed with a check mark. Plain text only. |
+| `text_role` | enum   | No       | —              | Typography role for the card text: `mono` / `meta` / `label` / `kicker` |
 | `image_url` | string | No       | `''`           | Card image URL |
+| `image_alt` | string | No       | `''`           | Alt text for the card image |
 | `link_url`  | string | No       | `''`           | Card link URL (shown only if set) |
 | `link_text` | string | No       | `'Read more'`  | Card link label |
-| `text_role` | enum   | No       | —              | Typography role for the card text: `mono` / `meta` / `label` / `kicker` |
 
 ## Responsive behavior
 
@@ -27,6 +37,10 @@ Each item in `items`:
 | Mobile     | 1       |
 | Tablet (md 768px+) | 2  |
 | Desktop (lg 1024px+) | 3 |
+
+## Steps variant
+
+Set `variant: 'steps'` for a numbered process/how-it-works layout. Cards get a filled circular number badge and a subtle connector line between badges at desktop (1024px+). `theme` still controls background color independently of the steps layout.
 
 ## Usage
 
@@ -42,6 +56,18 @@ pp_get_component('grid', [
             'link_text' => 'Read post',
         ];
     }, $posts),
+]);
+
+// Feature card with a checklist instead of a paragraph
+pp_get_component('grid', [
+    'title' => 'Security',
+    'items' => [
+        [
+            'title'   => 'Perimeter security',
+            'bullets' => ['HTTP security headers', 'SSL/TLS validity', 'Clickjacking protection'],
+        ],
+        // ...
+    ],
 ]);
 
 // Feature list (content cards, not decoration)

--- a/components/hero/README.md
+++ b/components/hero/README.md
@@ -4,20 +4,34 @@ Full-width hero section with headline, optional subtitle, optional CTA button, a
 
 ## Props
 
-| Prop        | Type   | Required | Default      | Description |
-|-------------|--------|----------|--------------|-------------|
-| `title`     | string | Yes      | —            | Primary headline text |
-| `subtitle`  | string | No       | `''`         | Supporting subheadline |
-| `cta_text`  | string | No       | `''`         | CTA button label (hidden if empty) |
-| `cta_url`   | string | No       | `'#'`        | CTA button URL |
-| `variant`   | enum   | No       | `'centered'` | Layout: `left`, `centered`, or `split` |
-| `image_url` | string | No       | `''`         | Image URL (only used in `split` variant) |
+| Prop            | Type   | Required | Default      | Description |
+|-----------------|--------|----------|--------------|-------------|
+| `id`            | string | No       | `''`         | HTML id for anchor linking |
+| `title`         | string | Yes      | —            | Primary headline text |
+| `title_accent`  | string | No       | `''`         | Exact substring of `title` to render in an accent color |
+| `eyebrow`       | string | No       | `''`         | Short kicker/label rendered as a pill above the title |
+| `subtitle`      | string | No       | `''`         | Supporting subheadline |
+| `cta_text`      | string | No       | `''`         | Primary CTA button label (both buttons hidden if empty) |
+| `cta_url`       | string | No       | `'#'`        | Primary CTA button URL |
+| `cta2_text`     | string | No       | `''`         | Secondary CTA button label (only shown when `cta_text` is set) |
+| `cta2_url`      | string | No       | `'#'`        | Secondary CTA button URL |
+| `cta_variant`   | enum   | No       | `'primary'`  | Primary button style: `primary` / `secondary` / `outline` / `ghost` |
+| `cta2_variant`  | enum   | No       | `'outline'`  | Secondary button style: `primary` / `secondary` / `outline` / `ghost` |
+| `variant`       | enum   | No       | `'centered'` | Layout: `left`, `centered`, `split`, or `cover` |
+| `image_url`     | string | No       | `''`         | Image URL — inline image in `split` variant, background image in `cover` variant |
+| `image_alt`     | string | No       | `''`         | Alt text for the `split` variant image |
+| `spacing`       | enum   | No       | `'default'`  | Vertical padding: `default` / `compact` / `spacious` |
+| `width`         | enum   | No       | `'default'`  | Content width: `default` / `narrow` (56rem) / `full` |
+| `split_ratio`   | enum   | No       | `'50-50'`    | Column ratio for `split` variant: `50-50` / `60-40` / `40-60` |
+| `vertical_align`| enum   | No       | `'center'`   | Vertical content alignment for `cover`/`split` variants: `top` / `center` / `bottom` |
+| `proof`         | string | No       | `''`         | HTML string for trust signals (logos, ratings), rendered after the CTA group |
 
 ## Variants
 
 - **centered** — All content centered horizontally. Best for homepage hero.
 - **left** — Content aligned left. Best for interior page headers.
 - **split** — Text on left, image on right (two-column at lg+). Best for feature introductions.
+- **cover** — Fullscreen background image with a dark overlay and light text. Best for high-impact landing pages.
 
 ## Usage
 

--- a/components/logos/README.md
+++ b/components/logos/README.md
@@ -6,6 +6,7 @@ A flex-wrap image grid. Use for client logo strips (items without labels) or ico
 
 | Prop    | Type   | Required | Default | Description |
 |---------|--------|----------|---------|-------------|
+| `id`    | string | No       | `''`    | HTML id for anchor linking |
 | `title` | string | No       | `''`    | Optional heading above the grid |
 | `items` | array  | Yes      | —       | Array of image items |
 

--- a/components/nav/README.md
+++ b/components/nav/README.md
@@ -8,6 +8,8 @@ Site header with logo, primary navigation menu, and a hamburger toggle for mobil
 |-------------|--------|----------|-------------|-------------|
 | `location`  | string | No       | `'primary'` | WP theme location slug |
 | `logo_text` | string | No       | —           | Logo text (falls back to site title) |
+| `logo_id`   | int    | No       | —           | Media Library attachment ID for an image logo (takes priority over `logo_text`) |
+| `logo_alt`  | string | No       | —           | Alt text for the image logo |
 
 ## Behavior
 

--- a/components/section/README.md
+++ b/components/section/README.md
@@ -4,21 +4,35 @@ Generic text + optional image section. Use this for "what is this", "how it work
 
 ## Props
 
-| Prop        | Type   | Required | Default       | Description |
-|-------------|--------|----------|---------------|-------------|
-| `title`     | string | No       | `''`          | Section heading (h2) |
-| `body`      | string | Yes      | —             | HTML body content (wp_kses_post filtered) |
-| `image_url` | string | No       | `''`          | Image URL (required for image-left / image-right) |
-| `image_alt` | string | No       | `''`          | Image alt text |
-| `layout`    | enum   | No       | `'text-only'` | Layout variant |
+| Prop               | Type   | Required | Default       | Description |
+|--------------------|--------|----------|---------------|-------------|
+| `id`               | string | No       | `''`          | HTML id for anchor linking |
+| `title`            | string | No       | `''`          | Section heading (h2) |
+| `title_accent`     | string | No       | `''`          | Exact substring of `title` to render in an accent color |
+| `eyebrow`          | string | No       | `''`          | Short kicker/label rendered as a pill above the title |
+| `subheading`       | string | No       | `''`          | Supporting line below the title |
+| `heading_align`    | enum   | No       | `'start'`     | Header block alignment: `start` / `center` |
+| `body`             | string | Yes      | —             | HTML body content (wp_kses_post filtered) |
+| `image_url`        | string | No       | `''`          | Image URL (required for image-left / image-right) |
+| `image_alt`        | string | No       | `''`          | Image alt text |
+| `layout`           | enum   | No       | `'text-only'` | Layout variant |
+| `variant`          | enum   | No       | `'default'`   | Background color: `default` / `dark` / `inverted` |
+| `background_image` | string | No       | `''`          | Optional background image URL with dark overlay for text readability |
 
 ## Variants
 
+Layout (`layout`):
 - **text-only** — Full-width text column. Used for articles and prose content.
 - **image-left** — Two-column at md+: image on left, text on right.
 - **image-right** — Two-column at md+: text on left, image on right.
+- **centered** — Text constrained to a narrower centered column. Use for short intros and taglines, not multi-paragraph content.
 
-If `image_url` is empty, the layout always falls back to `text-only`.
+If `image_url` is empty, image-left/image-right layouts fall back to `text-only`.
+
+Background color (`variant`), independent of layout:
+- **default** — Page background.
+- **dark** — Surface background with borders.
+- **inverted** — Inverted background for strong contrast.
 
 ## Usage
 

--- a/components/stats/README.md
+++ b/components/stats/README.md
@@ -4,10 +4,14 @@ A horizontal row of large-number metrics with labels. Use for quantified social 
 
 ## Props
 
-| Prop    | Type   | Required | Default | Description |
-|---------|--------|----------|---------|-------------|
-| `title` | string | No       | `''`    | Optional heading above the stats row |
-| `items` | array  | Yes      | —       | Array of `{ number, label }` objects |
+| Prop            | Type   | Required | Default | Description |
+|-----------------|--------|----------|---------|-------------|
+| `id`            | string | No       | `''`    | HTML id for anchor linking |
+| `title`         | string | No       | `''`    | Optional heading above the stats row |
+| `title_accent`  | string | No       | `''`    | Exact substring of `title` to render in an accent color |
+| `variant`       | enum   | No       | `'default'` | Background color: `default` / `dark` / `inverted` |
+| `background_image` | string | No  | `''`    | Optional background image URL with dark overlay for text readability |
+| `items`         | array  | Yes      | —       | Array of `{ number, label }` objects |
 
 Each item:
 


### PR DESCRIPTION
## Summary
Audit triggered by a direct user question: AI-facing docs (ai-instructions/*.md, per-component README.md) were not being updated in the same PR as capability changes, despite the standing rule that they should be. This PR is the correction, treated as a correctness bug per explicit instruction, not optional doc debt.

- `ai-instructions/composition.md`: "Valid component names" table was missing `testimonials` entirely and every prop added this session (`title_accent`, `eyebrow`, `subheading`, `heading_align`, `bullets`). Added reference subsections for each.
- `ai-instructions/style-component.md`: card border/radius/shadow slot list and recipe table were missing `testimonials`.
- `AI_CONTEXT.md`: "Grid:" capability line still described the old triangle-arrow steps design (already fixed in code by #177, doc never caught up); added shared header-pattern and `title_accent` capability paragraphs that never existed.
- Every component `README.md` prop table audited against `schema.json` and corrected. Several gaps (hero's `cta_variant`/`cta2_variant`/`eyebrow`, section's entire `variant` axis, cta's `theme`/`background_image`, nav/footer's `logo_id`/`logo_alt`/`show_logo`) predate this session — this wasn't just the 3 most recent PRs, it was accumulated drift.

## Process note
Ran `/document-generate` and `/document-release` per explicit request; treated this as Step 1 (research) + Step 3 (reference correction) of Diataxis since the task was fixing existing reference tables' accuracy, not authoring new tutorials/how-tos. No VERSION bump — docs-only, same precedent as PR #174.

## Test plan
- [x] `vendor/bin/phpunit` — 1029 tests green (no test changes needed, docs-only)
- [x] `npm test` — 310 tests green
- [x] `gstack-redact` — no findings