### PR TITLE
Add import_media apply for external image sideloading

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -256,6 +256,9 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | `enqueue_font` | design | option: `pp_font_urls` | url (string, required, HTTPS only). Max 5 fonts |
 | `remove_font` | design | option: `pp_font_urls` | url (string, required) |
 | `reset_fonts` | design | option: `pp_font_urls` | (none) |
+| `import_media` | media | media library (new attachment) | url (string, required, HTTPS + image extension only), alt (string, optional) |
+
+**Media import (`import_media`):** Sideloads an external image URL into the media library — the only sanctioned way to bring an external image onto the site as a locally-owned asset (image props otherwise only accept a raw URL string). SSRF safety comes from WordPress core's `wp_safe_remote_get()` (used internally by `download_url()`), which validates the URL and every redirect hop against private/reserved IP ranges — not reimplemented here. Restricted beyond WordPress's default upload mime allowlist to images only (jpg/png/gif/webp), with a 10MB size cap. Returns `{attachment_id, url}` on success — use the returned `url` as the value for an `image_url`/`background_image`/`logo_url` prop.
 
 **CLI:** `wp pp apply list\|preview\|execute\|restore\|reset` (requires manage_options capability). `restore` rolls a run's token changes back to its pre-apply snapshot; `reset` clears overrides to product defaults.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.26] — 2026-07-05 — New: Bring External Images In as Owned Media
+
+**Image props (`image_url`, `background_image`, `logo_url`) only ever accepted a raw external URL. The only way to get a brand's real logo or photo onto the site was to hotlink it — fragile, unoptimized, and broken the moment the source moves — or drop out of the product surface entirely and use wp-admin media upload directly.**
+
+### Added
+- New `import_media` apply: sideloads an external HTTPS image URL into the media library and returns `{attachment_id, url}`. Pass the returned `url` into any `image_url`/`background_image`/`logo_url` prop to reference a locally-owned, locally-optimized asset instead of a hotlink.
+
+### For contributors
+- SSRF safety is WordPress core's job, not reimplemented: `download_url()` (used internally) fetches via `wp_safe_remote_get()`, which validates the URL **and every redirect hop** against private/reserved IP ranges, non-http(s) schemes, and disallowed ports — the same mechanism WordPress itself uses for oEmbed and update checks. This apply adds three things on top: HTTPS-only + a plausible-extension pre-check (fast fail, no network use for obviously-wrong URLs), a real post-download mime check restricted to images (WordPress's default upload mime allowlist is much broader — PDFs, docs, zips — deliberately narrowed here), and a 10MB size cap that `download_url()` doesn't itself enforce.
+- Deliberately scoped narrow: no new host-allowlist subsystem, no generic remote-fetch capability. Gated by the existing blanket `manage_options` requirement for all applies — no new capability logic needed.
+- 15 new PHPUnit tests, including SSRF-rejection propagation (a mocked `WP_Error` from `download_url()`/`wp_safe_remote_head()`, simulating a redirect to a private/internal destination), oversized-file rejection, and content-vs-extension type-mismatch rejection.
+
 ## [v0.16.25] — 2026-07-05 — Fix: Grid Steps No Longer Look Like a Draft
 
 **The `steps` variant of the grid component — the numbered "how it works" layout every marketing page reaches for — rendered as bare floating numbers over a dead-space background, with an arrow connector that had actually been invisible in production the whole time. Every page using it needed manual CSS rescue to look finished.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.25-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.26-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/website-building.md
+++ b/ai-instructions/website-building.md
@@ -13,6 +13,7 @@ Every visual change maps to exactly one mutation surface. Writing to the wrong s
 | Component-specific CSS (spacing, layout) | `assets/css/components.css` | Direct file edit (BEM classes, token values only) |
 | Site name, tagline | WordPress options | `update_site_option` action |
 | Site logo (nav, and footer via `show_logo`) | WordPress option (Media Library attachment) | `update_site_option` action (key `pp_logo_id`, an attachment ID) |
+| Bringing an external image onto the site as a locally-owned asset | Media Library (new attachment) | `import_media` apply (returns `{attachment_id, url}` — pass the `url` to an `image_url`/`background_image`/`logo_url` prop) |
 
 ## What NOT to use
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.25');
+define('PP_VERSION', '0.16.26');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/apply.php
+++ b/lib/apply.php
@@ -7,10 +7,11 @@
  *
  * Apply definition contract:
  *   name        => string (unique, snake_case)
- *   domain      => 'design' (future: other domains)
- *   target      => ['type' => 'file'|'option', ...type-specific keys]
+ *   domain      => 'design'|'media' (future: other domains)
+ *   target      => ['type' => 'file'|'option'|'media', ...type-specific keys]
  *                   file:   ['type' => 'file', 'path' => string]  (relative to theme root)
  *                   option: ['type' => 'option', 'key' => string] (wp_options key)
+ *                   media:  ['type' => 'media']                  (new media library attachment)
  *   description => string (one sentence, caller-facing)
  *   params      => [param_name => ['type' => string, 'required' => bool], ...]
  *   validate    => callable(array $params): true|WP_Error
@@ -1002,6 +1003,145 @@ pp_register_apply('reset_fonts', [
         );
     },
 ]);
+
+// ── Apply: import_media ──────────────────────────────────────────────────
+// Domain: media | Target: media library (new attachment)
+// Sideloads an external image URL into the media library. The only sanctioned
+// path to bring an external image onto the site as a locally-owned asset —
+// image props otherwise only accept a raw URL string (#105).
+//
+// SSRF safety is WordPress core's job, not reinvented here: download_url()
+// fetches via wp_safe_remote_get(), which validates the URL AND every
+// redirect hop against private/reserved IP ranges, non-http(s) schemes, and
+// disallowed ports (see wp_http_validate_url() in wp-includes/http.php).
+// This apply adds: HTTPS-only + plausible-extension pre-check (fast fail,
+// no network use for obviously-wrong URLs), a real post-download mime check
+// restricted to images (WordPress's default upload mime allowlist is much
+// broader — PDFs, docs, zips — which this apply deliberately narrows), and
+// a size cap that download_url() does not itself enforce.
+
+pp_register_apply('import_media', [
+    'domain'      => 'media',
+    'target'      => ['type' => 'media'],
+    'description' => 'Sideloads an external image URL into the media library. Returns the new attachment id and local URL.',
+    'params'      => [
+        'url' => ['type' => 'string', 'required' => true],
+        'alt' => ['type' => 'string', 'required' => false],
+    ],
+
+    'validate' => function (array $params) {
+        $url = $params['url'] ?? '';
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return new WP_Error('invalid_url', 'Value must be a valid URL.');
+        }
+        if (!preg_match('/^https:\/\//i', $url)) {
+            return new WP_Error('invalid_url', 'Media URL must use HTTPS.');
+        }
+        if (!_pp_url_has_allowed_image_extension($url)) {
+            return new WP_Error('unsupported_type', 'URL must end in a supported image extension: jpg, jpeg, png, gif, webp.');
+        }
+        return true;
+    },
+
+    'preview' => function (array $params) {
+        $url = $params['url'];
+        // A HEAD request, not a download -- still routed through WordPress's
+        // SSRF-safe fetch path (wp_safe_remote_head validates the URL and
+        // every redirect hop the same way wp_safe_remote_get does).
+        $response = wp_safe_remote_head($url, ['timeout' => 10]);
+        if (is_wp_error($response)) {
+            return $response;
+        }
+        $content_type = wp_remote_retrieve_header($response, 'content-type');
+        if (!is_string($content_type) || !str_starts_with($content_type, 'image/')) {
+            return new WP_Error('unsupported_type', 'URL does not serve an image content type.');
+        }
+        return _pp_apply_preview(
+            'import_media', 'media',
+            ['type' => 'media'],
+            [],
+            ['url' => $url, 'alt' => $params['alt'] ?? '', 'content_type' => $content_type],
+            [['action' => 'import', 'url' => $url]]
+        );
+    },
+
+    'apply' => function (array $params) {
+        $url = $params['url'];
+        $alt = $params['alt'] ?? '';
+
+        // Guarded like WP core's own admin-context checks: these files aren't
+        // autoloaded outside wp-admin (CLI, AJAX, cron). media_handle_sideload()
+        // is the outermost of the three real functions this apply calls, and
+        // the PHPUnit test harness stubs it directly -- if it's already
+        // defined (real WP admin context, or the test stub), none of these
+        // three files need loading.
+        if (!function_exists('media_handle_sideload')) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+            require_once ABSPATH . 'wp-admin/includes/media.php';
+            require_once ABSPATH . 'wp-admin/includes/image.php';
+        }
+
+        // download_url() streams via wp_safe_remote_get() to a temp file --
+        // SSRF protection (private IPs, redirect re-validation, protocol/port
+        // restriction) is inherited from WordPress core, not reimplemented.
+        $tmp_file = download_url($url, 30);
+        if (is_wp_error($tmp_file)) {
+            return _pp_apply_error('import_media', 'media', ['type' => 'media'], $tmp_file->get_error_message());
+        }
+
+        $max_bytes = 10 * MB_IN_BYTES;
+        if (filesize($tmp_file) > $max_bytes) {
+            @unlink($tmp_file);
+            return _pp_apply_error('import_media', 'media', ['type' => 'media'], 'Image exceeds the 10MB size limit.');
+        }
+
+        $filename = sanitize_file_name(basename((string) parse_url($url, PHP_URL_PATH)));
+        $filetype = wp_check_filetype_and_ext($tmp_file, $filename);
+        $allowed_mimes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+        if (empty($filetype['type']) || !in_array($filetype['type'], $allowed_mimes, true)) {
+            @unlink($tmp_file);
+            return _pp_apply_error('import_media', 'media', ['type' => 'media'], 'The downloaded file is not a supported image type (jpg, png, gif, webp).');
+        }
+
+        $file_array = [
+            'name'     => $filename,
+            'tmp_name' => $tmp_file,
+        ];
+
+        $attachment_id = media_handle_sideload($file_array, 0);
+        if (is_wp_error($attachment_id)) {
+            @unlink($tmp_file);
+            return _pp_apply_error('import_media', 'media', ['type' => 'media'], $attachment_id->get_error_message());
+        }
+
+        if ($alt !== '') {
+            update_post_meta($attachment_id, '_wp_attachment_image_alt', $alt);
+        }
+
+        return _pp_apply_result(
+            'import_media', 'media',
+            ['type' => 'media'],
+            [[
+                'action'        => 'import',
+                'attachment_id' => $attachment_id,
+                'url'           => wp_get_attachment_url($attachment_id),
+                'source_url'    => $url,
+            ]]
+        );
+    },
+]);
+
+/**
+ * Checks whether a URL's path ends in a recognized, safe image extension.
+ * Query strings are excluded (PHP_URL_PATH). Used as a fast pre-fetch
+ * sanity check -- the real, authoritative type check happens post-download
+ * via wp_check_filetype_and_ext() against the actual file bytes.
+ */
+function _pp_url_has_allowed_image_extension(string $url): bool {
+    $path = (string) parse_url($url, PHP_URL_PATH);
+    $ext  = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+    return in_array($ext, ['jpg', 'jpeg', 'png', 'gif', 'webp'], true);
+}
 
 // ── Deployment Manifest (Sync Safeguard) ───────────────────────────────────
 

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -308,6 +308,8 @@ class PP_Apply_Command extends WP_CLI_Command {
                     $target_label = 'file:' . ($def['target']['path'] ?? '');
                 } elseif ($def['target']['type'] === 'option') {
                     $target_label = 'option:' . ($def['target']['key'] ?? '');
+                } elseif ($def['target']['type'] === 'media') {
+                    $target_label = 'media library';
                 }
             }
             $rows[] = [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.25",
+  "version": "0.16.26",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.25
+Stable tag: 0.16.26
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.25
+Version:          0.16.26
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ApplyTest.php
+++ b/tests/ApplyTest.php
@@ -780,7 +780,7 @@ class ApplyTest extends TestCase
         foreach ($applies as $name => $def) {
             $this->assertArrayHasKey('target', $def, "Apply '$name' should have 'target' key");
             $this->assertArrayHasKey('type', $def['target'], "Apply '$name' target should have 'type' key");
-            $this->assertContains($def['target']['type'], ['file', 'option'], "Apply '$name' target type should be 'file' or 'option'");
+            $this->assertContains($def['target']['type'], ['file', 'option', 'media'], "Apply '$name' target type should be 'file', 'option', or 'media'");
             $this->assertArrayNotHasKey('target_file', $def, "Apply '$name' should not have legacy 'target_file' key");
         }
     }
@@ -1314,6 +1314,174 @@ class ApplyTest extends TestCase
         $result = pp_execute_apply('reset_fonts', []);
         $this->assertTrue($result['ok']);
         $this->assertEmpty(pp_get_font_urls());
+    }
+
+    // ── import_media apply tests (#105) ──────────────────────────────────────
+    // SSRF safety itself is WordPress core's job (wp_safe_remote_get /
+    // wp_http_validate_url) -- these tests prove OUR code correctly respects
+    // and propagates whatever core decides, rather than re-testing core.
+
+    private function resetImportMediaTestStore(): void
+    {
+        unset(
+            $GLOBALS['_pp_test_store']['download_url_result'],
+            $GLOBALS['_pp_test_store']['download_url_size'],
+            $GLOBALS['_pp_test_store']['filetype_result'],
+            $GLOBALS['_pp_test_store']['media_sideload_result'],
+            $GLOBALS['_pp_test_store']['safe_remote_head_result']
+        );
+        $GLOBALS['_pp_test_store']['download_url_calls']       = [];
+        $GLOBALS['_pp_test_store']['media_sideload_calls']     = [];
+        $GLOBALS['_pp_test_store']['safe_remote_head_calls']   = [];
+    }
+
+    public function testImportMediaValidUrl(): void
+    {
+        $this->resetImportMediaTestStore();
+        $result = pp_validate_apply('import_media', ['url' => 'https://example.com/logo.png']);
+        $this->assertTrue($result);
+    }
+
+    public function testImportMediaRejectsNonHttps(): void
+    {
+        $this->resetImportMediaTestStore();
+        $result = pp_validate_apply('import_media', ['url' => 'http://example.com/logo.png']);
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertEquals('invalid_url', $result->get_error_code());
+    }
+
+    public function testImportMediaRejectsInvalidUrl(): void
+    {
+        $this->resetImportMediaTestStore();
+        $result = pp_validate_apply('import_media', ['url' => 'not-a-url']);
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertEquals('invalid_url', $result->get_error_code());
+    }
+
+    public function testImportMediaRejectsUnsupportedExtension(): void
+    {
+        $this->resetImportMediaTestStore();
+        $result = pp_validate_apply('import_media', ['url' => 'https://example.com/payload.exe']);
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertEquals('unsupported_type', $result->get_error_code());
+    }
+
+    public function testImportMediaRejectsNoExtension(): void
+    {
+        $this->resetImportMediaTestStore();
+        $result = pp_validate_apply('import_media', ['url' => 'https://example.com/image']);
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertEquals('unsupported_type', $result->get_error_code());
+    }
+
+    public function testImportMediaExecuteSuccess(): void
+    {
+        $this->resetImportMediaTestStore();
+        $result = pp_execute_apply('import_media', ['url' => 'https://example.com/logo.jpg', 'alt' => 'Logo']);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('media', $result['domain']);
+        $change = $result['changes'][0];
+        $this->assertArrayHasKey('attachment_id', $change);
+        $this->assertArrayHasKey('url', $change);
+        $this->assertSame('https://example.com/logo.jpg', $change['source_url']);
+        // alt text was persisted against the new attachment.
+        $meta = $GLOBALS['_pp_test_store']['post_meta'][$change['attachment_id']]['_wp_attachment_image_alt'] ?? null;
+        $this->assertSame('Logo', $meta);
+    }
+
+    public function testImportMediaExecuteRejectsSsrfUnsafeDestination(): void
+    {
+        // Simulates wp_safe_remote_get() rejecting the URL or one of its
+        // redirect hops (private IP, disallowed port, non-http(s) scheme) --
+        // download_url() surfaces this as a WP_Error, which our apply must
+        // propagate as a failed result, not silently swallow or retry unsafely.
+        $this->resetImportMediaTestStore();
+        $GLOBALS['_pp_test_store']['download_url_result'] =
+            new WP_Error('http_request_failed', 'A valid URL was not provided.');
+        $result = pp_execute_apply('import_media', ['url' => 'https://example.com/logo.jpg']);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('A valid URL was not provided.', $result['error']);
+        $this->assertEmpty($GLOBALS['_pp_test_store']['media_sideload_calls']);
+    }
+
+    public function testImportMediaExecuteRejectsOversizedFile(): void
+    {
+        $this->resetImportMediaTestStore();
+        $GLOBALS['_pp_test_store']['download_url_size'] = 11 * 1024 * 1024; // 11MB > 10MB cap
+        $result = pp_execute_apply('import_media', ['url' => 'https://example.com/logo.jpg']);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('10MB', $result['error']);
+        $this->assertEmpty($GLOBALS['_pp_test_store']['media_sideload_calls']);
+    }
+
+    public function testImportMediaExecuteRejectsTypeMismatch(): void
+    {
+        // The URL's extension passed the pre-fetch check, but the actual
+        // downloaded bytes aren't a supported image type -- must be rejected
+        // on real content, not just the URL's claimed extension.
+        $this->resetImportMediaTestStore();
+        $GLOBALS['_pp_test_store']['filetype_result'] = ['ext' => false, 'type' => false, 'proper_filename' => false];
+        $result = pp_execute_apply('import_media', ['url' => 'https://example.com/logo.jpg']);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('not a supported image type', $result['error']);
+        $this->assertEmpty($GLOBALS['_pp_test_store']['media_sideload_calls']);
+    }
+
+    public function testImportMediaExecuteRejectsDisallowedMimeEvenIfDetected(): void
+    {
+        $this->resetImportMediaTestStore();
+        $GLOBALS['_pp_test_store']['filetype_result'] =
+            ['ext' => 'pdf', 'type' => 'application/pdf', 'proper_filename' => false];
+        $result = pp_execute_apply('import_media', ['url' => 'https://example.com/logo.jpg']);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('not a supported image type', $result['error']);
+    }
+
+    public function testImportMediaExecuteRejectsSideloadFailure(): void
+    {
+        $this->resetImportMediaTestStore();
+        $GLOBALS['_pp_test_store']['media_sideload_result'] =
+            new WP_Error('upload_error', 'Could not write file to disk.');
+        $result = pp_execute_apply('import_media', ['url' => 'https://example.com/logo.jpg']);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('Could not write file to disk.', $result['error']);
+    }
+
+    public function testImportMediaPreviewSuccess(): void
+    {
+        $this->resetImportMediaTestStore();
+        $result = pp_preview_apply('import_media', ['url' => 'https://example.com/logo.jpg', 'alt' => 'Logo']);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('https://example.com/logo.jpg', $result['after']['url']);
+        $this->assertSame('Logo', $result['after']['alt']);
+        $this->assertEmpty($GLOBALS['_pp_test_store']['media_sideload_calls']);
+    }
+
+    public function testImportMediaPreviewRejectsNonImageContentType(): void
+    {
+        $this->resetImportMediaTestStore();
+        $GLOBALS['_pp_test_store']['safe_remote_head_result'] = ['headers' => ['content-type' => 'text/html']];
+        $result = pp_preview_apply('import_media', ['url' => 'https://example.com/logo.jpg']);
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertEquals('unsupported_type', $result->get_error_code());
+    }
+
+    public function testImportMediaPreviewRejectsSsrfUnsafeDestination(): void
+    {
+        // Same rejection path as execute -- a redirect to a private/internal
+        // destination must be rejected during preview too, not just apply.
+        $this->resetImportMediaTestStore();
+        $GLOBALS['_pp_test_store']['safe_remote_head_result'] =
+            new WP_Error('http_request_failed', 'A valid URL was not provided.');
+        $result = pp_preview_apply('import_media', ['url' => 'https://example.com/logo.jpg']);
+        $this->assertInstanceOf(WP_Error::class, $result);
+    }
+
+    public function testImportMediaRegisteredWithMediaDomain(): void
+    {
+        $apply = pp_get_apply('import_media');
+        $this->assertSame('media', $apply['domain']);
+        $this->assertSame('media', $apply['target']['type']);
     }
 
     // ── _pp_hash_all_theme_files() tests ────────────────────────────────────

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -706,6 +706,78 @@ if (!function_exists('wp_get_attachment_metadata')) {
     }
 }
 
+// ── import_media apply stubs (#105) ──────────────────────────────────────────
+// Controlled via $GLOBALS['_pp_test_store']['download_url_result'|'download_url_size'
+// |'filetype_result'|'media_sideload_result'|'safe_remote_head_result'] so tests
+// can simulate SSRF rejection, redirect rejection, oversized files, and
+// type-mismatch without any real network access or filesystem writes outside
+// a real (tiny) temp file that download_url() itself creates.
+
+if (!defined('MB_IN_BYTES')) {
+    define('MB_IN_BYTES', 1048576);
+}
+
+if (!function_exists('download_url')) {
+    function download_url(string $url, int $timeout = 300) {
+        $GLOBALS['_pp_test_store']['download_url_calls'][] = ['url' => $url, 'timeout' => $timeout];
+        $result = $GLOBALS['_pp_test_store']['download_url_result'] ?? null;
+        if ($result instanceof WP_Error) {
+            return $result;
+        }
+        $size = $GLOBALS['_pp_test_store']['download_url_size'] ?? 1024;
+        $tmp = tempnam(sys_get_temp_dir(), 'pp_test_download_');
+        file_put_contents($tmp, str_repeat('x', $size));
+        return $tmp;
+    }
+}
+
+if (!function_exists('wp_check_filetype_and_ext')) {
+    function wp_check_filetype_and_ext(string $file, string $filename, $mimes = null): array {
+        return $GLOBALS['_pp_test_store']['filetype_result']
+            ?? ['ext' => 'jpg', 'type' => 'image/jpeg', 'proper_filename' => false];
+    }
+}
+
+if (!function_exists('media_handle_sideload')) {
+    function media_handle_sideload(array $file_array, int $post_id = 0, $desc = null, array $post_data = []) {
+        $GLOBALS['_pp_test_store']['media_sideload_calls'][] = $file_array;
+        $result = $GLOBALS['_pp_test_store']['media_sideload_result'] ?? null;
+        if ($result instanceof WP_Error) {
+            return $result;
+        }
+        if (is_int($result)) {
+            return $result;
+        }
+        $id = $GLOBALS['_pp_test_store']['next_id']++;
+        $GLOBALS['_pp_test_store']['attachment_urls'][$id] =
+            'https://example.com/wp-content/uploads/' . basename($file_array['name']);
+        return $id;
+    }
+}
+
+if (!function_exists('wp_safe_remote_head')) {
+    function wp_safe_remote_head(string $url, array $args = []) {
+        $GLOBALS['_pp_test_store']['safe_remote_head_calls'][] = $url;
+        return $GLOBALS['_pp_test_store']['safe_remote_head_result']
+            ?? ['headers' => ['content-type' => 'image/jpeg']];
+    }
+}
+
+if (!function_exists('wp_remote_retrieve_header')) {
+    function wp_remote_retrieve_header($response, string $header) {
+        if (is_wp_error($response) || !is_array($response)) {
+            return '';
+        }
+        return $response['headers'][$header] ?? '';
+    }
+}
+
+if (!function_exists('sanitize_file_name')) {
+    function sanitize_file_name(string $filename): string {
+        return preg_replace('/[^a-zA-Z0-9._-]/', '-', $filename) ?? $filename;
+    }
+}
+
 if (!function_exists('selected')) {
     function selected($selected, $current = true, bool $echo = true): string {
         $result = ($selected == $current) ? ' selected="selected"' : '';


### PR DESCRIPTION
## Summary
- Closes #105. New `import_media` apply: sideloads an external HTTPS image URL into the media library, returns `{attachment_id, url}` for use in `image_url`/`background_image`/`logo_url` props.

## Security model (SSRF) — please review
- **Baseline: WordPress core's `wp_safe_remote_get()`**, used internally by `download_url()`. It validates the request URL **and every redirect hop** against private/reserved IPv4 ranges (127.x, 10.x, 0.x, 172.16-31.x, 192.168.x), rejects non-http(s) schemes and userinfo-in-URL, and restricts ports to 80/443/8080 by default. This is the same mechanism WordPress itself uses for oEmbed and update checks — not reimplemented here, deliberately.
- **Added on top of that baseline** (per scoped review before implementation): HTTPS-only + plausible-extension pre-check before any network call; a real post-download mime check via `wp_check_filetype_and_ext()` restricted to `image/jpeg|png|gif|webp` (WordPress's default upload mime allowlist is much broader — PDFs, docs, zips — deliberately narrowed here since this apply is image-only); a 10MB size cap (`download_url()` doesn't enforce one itself).
- **Deliberately not built:** no per-site host allowlist, no generic remote-fetch subsystem. Capability gating uses the existing blanket `manage_options` requirement for all applies — no new capability logic.

## Test plan
- [x] `vendor/bin/phpunit` — 1044 tests green (15 new: URL/extension validation, SSRF-rejection propagation via mocked `WP_Error` from `download_url()`/`wp_safe_remote_head()` simulating a redirect to a private/internal destination, oversized-file rejection, content-vs-extension type-mismatch rejection, sideload-failure propagation, alt-text persistence, preview path)
- [x] `npm test` — 310 tests green
- [x] Docs: AI_CONTEXT.md (registered-applies table + capability paragraph), ai-instructions/website-building.md (mutation-surface table) updated in this PR
- [x] Version bump to 0.16.26 across all 5 files, CHANGELOG entry added
- [x] `gstack-redact` — no findings

**security-sensitive — holding for explicit approval before merge, per standing policy.**