### PR TITLE
Add responsive image output for hero/section/logos

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -110,8 +110,8 @@ site-customization permission.
 
 | Component | File                           | Description                                      | Key props                                          |
 |-----------|--------------------------------|--------------------------------------------------|----------------------------------------------------|
-| hero      | components/hero/hero.php       | Full-width headline + optional CTA and image     | title (req), subtitle, cta_text, cta_url, cta2_text, cta2_url, variant, image_url, image_alt, spacing, width, split_ratio, vertical_align, proof, id |
-| section   | components/section/section.php | Text + optional image. 3 layout variants         | body (req), title, image_url, image_alt, layout, variant, background_image, id |
+| hero      | components/hero/hero.php       | Full-width headline + optional CTA and image     | title (req), title_accent, eyebrow, subtitle, cta_text, cta_url, cta2_text, cta2_url, cta_variant, cta2_variant, variant, image_url, image_id, image_alt, spacing, width, split_ratio, vertical_align, proof, id |
+| section   | components/section/section.php | Text + optional image. 3 layout variants         | body (req), title, title_accent, eyebrow, subheading, heading_align, image_url, image_id, image_alt, layout, variant, background_image, id |
 | faq       | components/faq/faq.php         | Native details/summary accordion. Zero JS.       | items[] (req) {question, answer}, title            |
 | grid      | components/grid/grid.php       | Responsive card grid for real content objects    | items[] (req) {title, text, image_url, link_url, link_text}, title, variant, theme, id |
 | table     | components/table/table.php     | Data/comparison table, horizontal scroll mobile  | headers[] (req), rows[][] (req), title, caption    |
@@ -119,7 +119,7 @@ site-customization permission.
 | nav       | components/nav/nav.php         | Site header, logo, hamburger mobile nav          | location, logo_text, logo_id, logo_alt             |
 | footer    | components/footer/footer.php   | Site footer with nav menu and copyright          | location                                           |
 | stats     | components/stats/stats.php     | Horizontal row of large-number metrics + labels  | items[] (req) {number, label}, title, variant, background_image, id |
-| logos     | components/logos/logos.php     | Flex-wrap image grid — logo strips or icon tiles | items[] (req) {image_url, image_alt, label?}, title, variant, id |
+| logos     | components/logos/logos.php     | Flex-wrap image grid — logo strips or icon tiles | items[] (req) {image_url, image_alt, image_id?, label?}, title, variant, id |
 | embed     | components/embed/embed.php     | WP shortcode / plugin content wrapper            | content (req), title, variant, id                  |
 | testimonials | components/testimonials/testimonials.php | Customer quotes with attribution — card grid or single-column stack | items[] (req) {quote (req), author, role, company, image_url, image_alt}, title, variant, theme, id |
 
@@ -136,6 +136,8 @@ site-customization permission.
 - Text colors switch to `var(--color-bg)` for contrast
 
 If adding background-image support to another component, follow this exact pattern.
+
+**Responsive images (hero, section, logos):** `image_url` (hero's `split` variant, section's `image-left`/`image-right` layouts, each logos item) has a companion `image_id` — a Media Library attachment ID, not a URL. When `image_id` resolves to a real attachment, the `<img>` renders responsively via `wp_get_attachment_image()` (real `srcset`/`sizes`); when unset or unresolvable, the plain `image_url` renders exactly as before. Get an attachment ID via the `import_media` apply. Not used for `background_image`/`cover` (CSS `background-image`, not an `<img>` tag).
 
 **Anchor IDs:** All 8 section-level components (hero, section, stats, grid, logos, cta, embed, testimonials) accept an `id` prop that renders as the HTML `id` attribute on the root `<section>` element. Use for anchor navigation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.27] — 2026-07-05 — New: Real Responsive Images on Hero, Section, and Logos
+
+**Every image on the site shipped as a single fixed `<img src>` — one resolution to every device, oversized on mobile or blurry if downscaled. A page with a hero image, a section image, and a logo strip produced zero `<picture>` elements and zero images with `srcset`/`sizes`, a real quality and performance gap on any image-heavy page.**
+
+### Added
+- Hero's `split` image, section's `image-left`/`image-right` image, and each logos item now accept a companion `image_id` — a Media Library attachment ID (from the `import_media` apply, shipped last release). When it resolves to a real attachment, the image renders responsively via WordPress's own `wp_get_attachment_image()`, with real `srcset`/`sizes` generated from registered image sizes.
+
+### For contributors
+- Fully backward compatible: `image_id` is optional and additive. Any composition that only ever set `image_url` (hotlinked or local) keeps rendering the exact same plain `<img>` tag as before — the new `pp_render_responsive_image()` helper in `lib/wp.php` falls back automatically when `image_id` is unset or doesn't resolve (deleted attachment, wrong id), with no error and no visible difference.
+- Deliberately scoped to `<img>`-tag image props only (hero/section/logos) — `background_image`/`cover` variants render via CSS `background-image:url()`, a different mechanism (`image-set()`) not touched here.
+- 13 new PHPUnit tests: the shared helper's three branches (attachment resolves, attachment doesn't resolve, no id at all) plus one integration test per component confirming both the responsive and plain-`<img>` paths render correctly.
+
 ## [v0.16.26] — 2026-07-05 — New: Bring External Images In as Owned Media
 
 **Image props (`image_url`, `background_image`, `logo_url`) only ever accepted a raw external URL. The only way to get a brand's real logo or photo onto the site was to hotlink it — fragile, unoptimized, and broken the moment the source moves — or drop out of the product surface entirely and use wp-admin media upload directly.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.26-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.27-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -38,8 +38,8 @@ See `AI_CONTEXT.md` → Component index for the current list. As of last update:
 
 | Name    | Required props                          | Optional props (selection)                              |
 |---------|-----------------------------------------|---------------------------------------------------------|
-| hero    | title                                   | title_accent, eyebrow, subtitle, cta_text, cta_url, cta2_text, cta2_url, cta_variant, cta2_variant, variant, spacing, width, split_ratio, vertical_align, proof |
-| section | body                                    | title, title_accent, eyebrow, subheading, heading_align, layout, variant, background_image |
+| hero    | title                                   | title_accent, eyebrow, subtitle, cta_text, cta_url, cta2_text, cta2_url, cta_variant, cta2_variant, variant, image_url, image_id, image_alt, spacing, width, split_ratio, vertical_align, proof |
+| section | body                                    | title, title_accent, eyebrow, subheading, heading_align, layout, variant, image_url, image_id, image_alt, background_image |
 | faq     | items[] {question, answer}              | title, title_accent                                     |
 | grid    | items[] {title, text, ...}              | title, title_accent, eyebrow, subheading, heading_align, variant, theme |
 | table   | headers[], rows[][]                     | title, caption                                          |
@@ -47,7 +47,7 @@ See `AI_CONTEXT.md` → Component index for the current list. As of last update:
 | nav     | (no required props)                     | logo_text, logo_id, logo_alt                            |
 | footer  | (no required props)                     | location, show_logo, logo_text, logo_id, logo_alt       |
 | stats   | items[] {number, label}                 | title, title_accent, variant, background_image          |
-| logos   | items[] {image_url, image_alt}          | title, variant                                          |
+| logos   | items[] {image_url, image_alt, image_id?} | title, variant                                        |
 | embed   | content                                 | title, variant                                          |
 | testimonials | items[] {quote}                    | title, title_accent, eyebrow, subheading, heading_align, variant, theme |
 
@@ -122,6 +122,23 @@ All seven heading-bearing components accept `title_accent`: an exact, case-sensi
 ### eyebrow / subheading / heading_align (hero, section, grid, cta, testimonials)
 
 `eyebrow` renders a short kicker label as a pill above the title (e.g. `"NEW"`). `subheading` renders a supporting line below the title (section, grid, cta, testimonials only — hero uses `subtitle` instead). `heading_align` (`start` default, or `center`) centers the eyebrow/title/subheading header block — independent of the component's overall layout.
+
+### image_id (hero, section, logos items) — responsive images (#107)
+
+Every `image_url` field on hero, section, and logos items has a companion `image_id` — a Media Library attachment ID, not a URL. When `image_id` resolves to a real attachment, the image renders responsively via `wp_get_attachment_image()` (real `srcset`/`sizes`, WordPress-generated). When `image_id` is unset or doesn't resolve, the plain `image_url` renders exactly as before — always set `image_url` too, even when you have an `image_id`, as the fallback.
+
+Get an attachment id (and its canonical local URL) via the `import_media` apply — sideloads an external image URL into the media library:
+
+```bash
+wp pp apply execute import_media --params='{"url":"https://example.com/logo.png","alt":"Client logo"}'
+# => {"attachment_id": 123, "url": "https://yoursite.com/wp-content/uploads/2026/07/logo.png"}
+```
+
+Then set both fields on the component:
+
+```json
+{ "component": "hero", "props": { "variant": "split", "image_url": "https://yoursite.com/wp-content/uploads/2026/07/logo.png", "image_id": 123, "image_alt": "Client logo" } }
+```
 
 Always verify against `components/{name}/schema.json` before writing — the source of truth.
 

--- a/ai-instructions/website-building.md
+++ b/ai-instructions/website-building.md
@@ -13,7 +13,7 @@ Every visual change maps to exactly one mutation surface. Writing to the wrong s
 | Component-specific CSS (spacing, layout) | `assets/css/components.css` | Direct file edit (BEM classes, token values only) |
 | Site name, tagline | WordPress options | `update_site_option` action |
 | Site logo (nav, and footer via `show_logo`) | WordPress option (Media Library attachment) | `update_site_option` action (key `pp_logo_id`, an attachment ID) |
-| Bringing an external image onto the site as a locally-owned asset | Media Library (new attachment) | `import_media` apply (returns `{attachment_id, url}` — pass the `url` to an `image_url`/`background_image`/`logo_url` prop) |
+| Bringing an external image onto the site as a locally-owned asset | Media Library (new attachment) | `import_media` apply (returns `{attachment_id, url}` — pass `url` to `image_url`/`background_image`/`logo_url`; on hero/section/logos also pass `attachment_id` as `image_id` for responsive srcset output) |
 
 ## What NOT to use
 

--- a/components/hero/README.md
+++ b/components/hero/README.md
@@ -19,6 +19,7 @@ Full-width hero section with headline, optional subtitle, optional CTA button, a
 | `cta2_variant`  | enum   | No       | `'outline'`  | Secondary button style: `primary` / `secondary` / `outline` / `ghost` |
 | `variant`       | enum   | No       | `'centered'` | Layout: `left`, `centered`, `split`, or `cover` |
 | `image_url`     | string | No       | `''`         | Image URL — inline image in `split` variant, background image in `cover` variant |
+| `image_id`      | int    | No       | `0`          | Media Library attachment ID for the `split` variant image. When set and it resolves, renders responsively (`srcset`/`sizes`) via `wp_get_attachment_image()`; falls back to `image_url` otherwise |
 | `image_alt`     | string | No       | `''`         | Alt text for the `split` variant image |
 | `spacing`       | enum   | No       | `'default'`  | Vertical padding: `default` / `compact` / `spacious` |
 | `width`         | enum   | No       | `'default'`  | Content width: `default` / `narrow` (56rem) / `full` |

--- a/components/hero/hero.php
+++ b/components/hero/hero.php
@@ -21,6 +21,7 @@ $cta2_variant = $props['cta2_variant'] ?? 'outline';
 $variant   = $props['variant']   ?? 'centered';
 $image_url = $props['image_url'] ?? '';
 $image_alt = $props['image_alt'] ?? '';
+$image_id  = (int) ($props['image_id'] ?? 0);
 $spacing         = $props['spacing']         ?? 'default';
 $width           = $props['width']           ?? 'default';
 $split_ratio     = $props['split_ratio']     ?? '50-50';
@@ -124,12 +125,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                 </div>
             <?php elseif ($variant === 'split' && $image_url) : ?>
                 <div class="hero__image-wrap">
-                    <img
-                        src="<?php echo pp_esc_image_src($image_url); ?>"
-                        alt="<?php echo esc_attr($image_alt); ?>"
-                        class="hero__image"
-                        loading="eager"
-                    >
+                    <?php echo pp_render_responsive_image($image_url, $image_alt, 'hero__image', 'eager', $image_id); ?>
                 </div>
             <?php endif; ?>
         </div>

--- a/components/hero/schema.json
+++ b/components/hero/schema.json
@@ -88,6 +88,12 @@
       "default": "",
       "description": "Alt text for the split variant image. Use a descriptive string for meaningful images; leave empty only if image is purely decorative."
     },
+    "image_id": {
+      "type": "number",
+      "required": false,
+      "default": 0,
+      "description": "Media Library attachment ID for the split variant image (NOT a URL). When it resolves to a real attachment, the image renders responsively with srcset/sizes via wp_get_attachment_image() instead of a single fixed-size <img>. Falls back to image_url when unset or unresolvable. Get an attachment id via the import_media apply."
+    },
     "spacing": {
       "type": "enum",
       "values": ["default", "compact", "spacious"],

--- a/components/logos/README.md
+++ b/components/logos/README.md
@@ -16,6 +16,7 @@ Each item:
 |-------------|--------|----------|-------------|
 | `image_url` | string | Yes      | Image or icon URL |
 | `image_alt` | string | Yes      | Alt text — use the logo or category name |
+| `image_id`  | int    | No       | Media Library attachment ID. When set and it resolves, renders responsively (`srcset`/`sizes`) via `wp_get_attachment_image()`; falls back to `image_url` otherwise |
 | `label`     | string | No       | Text label below the image. Omit for logo-only rows. |
 
 ## Usage — logo strip (no labels)

--- a/components/logos/logos.php
+++ b/components/logos/logos.php
@@ -34,16 +34,12 @@ $variant_class = $variant !== 'default' ? ' logos--' . $variant : '';
                 <?php foreach ($items as $item) :
                     $image_url = $item['image_url'] ?? '';
                     $image_alt = $item['image_alt'] ?? '';
+                    $image_id  = (int) ($item['image_id'] ?? 0);
                     $label     = $item['label']     ?? '';
                 ?>
                     <?php if ($image_url) : ?>
                         <li class="logos__item<?php echo $label ? ' logos__item--labeled' : ''; ?>">
-                            <img
-                                src="<?php echo pp_esc_image_src($image_url); ?>"
-                                alt="<?php echo esc_attr($image_alt); ?>"
-                                class="logos__image"
-                                loading="lazy"
-                            >
+                            <?php echo pp_render_responsive_image($image_url, $image_alt, 'logos__image', 'lazy', $image_id); ?>
                             <?php if ($label) : ?>
                                 <span class="logos__label"><?php echo esc_html($label); ?></span>
                             <?php endif; ?>

--- a/components/logos/schema.json
+++ b/components/logos/schema.json
@@ -24,10 +24,11 @@
     "items": {
       "type": "array",
       "required": true,
-      "description": "Array of image items. Each: { image_url: string, image_alt: string, label?: string }. Omit label for pure logo display; include label for icon+category tiles.",
+      "description": "Array of image items. Each: { image_url: string, image_alt: string, image_id?: number, label?: string }. Omit label for pure logo display; include label for icon+category tiles.",
       "items": {
         "image_url": { "type": "string", "required": true,  "description": "Image or icon URL." },
         "image_alt": { "type": "string", "required": true,  "description": "Alt text. Use the logo or category name; empty string only for decorative images." },
+        "image_id":  { "type": "number", "required": false, "default": 0, "description": "Media Library attachment ID (NOT a URL). When it resolves to a real attachment, the image renders responsively with srcset/sizes via wp_get_attachment_image() instead of a single fixed-size <img>. Falls back to image_url when unset or unresolvable. Get an attachment id via the import_media apply." },
         "label":     { "type": "string", "required": false, "description": "Text label below the image. Omit for logo-only rows." }
       }
     }

--- a/components/section/README.md
+++ b/components/section/README.md
@@ -14,6 +14,7 @@ Generic text + optional image section. Use this for "what is this", "how it work
 | `heading_align`    | enum   | No       | `'start'`     | Header block alignment: `start` / `center` |
 | `body`             | string | Yes      | —             | HTML body content (wp_kses_post filtered) |
 | `image_url`        | string | No       | `''`          | Image URL (required for image-left / image-right) |
+| `image_id`         | int    | No       | `0`           | Media Library attachment ID for the image. When set and it resolves, renders responsively (`srcset`/`sizes`) via `wp_get_attachment_image()`; falls back to `image_url` otherwise |
 | `image_alt`        | string | No       | `''`          | Image alt text |
 | `layout`           | enum   | No       | `'text-only'` | Layout variant |
 | `variant`          | enum   | No       | `'default'`   | Background color: `default` / `dark` / `inverted` |

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -56,6 +56,12 @@
       "default": "",
       "description": "Alt text for the image. Use empty string for decorative images."
     },
+    "image_id": {
+      "type": "number",
+      "required": false,
+      "default": 0,
+      "description": "Media Library attachment ID for the image (NOT a URL). When it resolves to a real attachment, the image renders responsively with srcset/sizes via wp_get_attachment_image() instead of a single fixed-size <img>. Falls back to image_url when unset or unresolvable. Get an attachment id via the import_media apply."
+    },
     "layout": {
       "type": "enum",
       "values": ["text-only", "image-left", "image-right", "centered"],

--- a/components/section/section.php
+++ b/components/section/section.php
@@ -17,6 +17,7 @@ $heading_align    = $props['heading_align']    ?? 'start';
 $body             = $props['body']             ?? '';
 $image_url        = $props['image_url']        ?? '';
 $image_alt        = $props['image_alt']        ?? '';
+$image_id         = (int) ($props['image_id']  ?? 0);
 $layout           = $props['layout']           ?? 'text-only';
 $variant          = $props['variant']          ?? 'default';
 $background_image = $props['background_image'] ?? '';
@@ -91,12 +92,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
             <div class="section__grid">
                 <?php if ($layout === 'image-left') : ?>
                     <div class="section__image-wrap">
-                        <img
-                            src="<?php echo pp_esc_image_src($image_url); ?>"
-                            alt="<?php echo esc_attr($image_alt); ?>"
-                            class="section__image"
-                            loading="lazy"
-                        >
+                        <?php echo pp_render_responsive_image($image_url, $image_alt, 'section__image', 'lazy', $image_id); ?>
                     </div>
                 <?php endif; ?>
 
@@ -121,12 +117,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
 
                 <?php if ($layout === 'image-right') : ?>
                     <div class="section__image-wrap">
-                        <img
-                            src="<?php echo pp_esc_image_src($image_url); ?>"
-                            alt="<?php echo esc_attr($image_alt); ?>"
-                            class="section__image"
-                            loading="lazy"
-                        >
+                        <?php echo pp_render_responsive_image($image_url, $image_alt, 'section__image', 'lazy', $image_id); ?>
                     </div>
                 <?php endif; ?>
             </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.26');
+define('PP_VERSION', '0.16.27');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -635,6 +635,49 @@ function pp_esc_image_src(string $url, int $depth = 0): string {
 }
 
 /**
+ * Renders a component's <img> tag, responsively when possible.
+ *
+ * When $attachment_id resolves to a real, existing attachment,
+ * renders via wp_get_attachment_image() so WordPress emits srcset/sizes
+ * from its registered image sizes (#107). Falls back to a plain
+ * <img src> using $url when no attachment id is set, or it doesn't
+ * resolve to anything (deleted attachment, wrong id) — every composition
+ * that only ever set a raw image_url (hotlinked or otherwise) keeps
+ * rendering exactly as before this function existed.
+ *
+ * @param string $url            Fallback image URL.
+ * @param string $alt            Alt text.
+ * @param string $class          CSS class for the <img> tag.
+ * @param string $loading        'lazy' or 'eager'.
+ * @param int    $attachment_id  Optional Media Library attachment ID.
+ * @return string  Full <img> HTML, already escaped.
+ */
+function pp_render_responsive_image(string $url, string $alt, string $class, string $loading, int $attachment_id = 0): string {
+    if ($attachment_id > 0) {
+        $html = wp_get_attachment_image($attachment_id, 'large', false, [
+            'class'   => $class,
+            'alt'     => $alt,
+            'loading' => $loading,
+        ]);
+        if ($html !== '') {
+            return $html;
+        }
+    }
+
+    if ($url === '') {
+        return '';
+    }
+
+    return sprintf(
+        '<img src="%s" alt="%s" class="%s" loading="%s">',
+        pp_esc_image_src($url),
+        esc_attr($alt),
+        esc_attr($class),
+        esc_attr($loading)
+    );
+}
+
+/**
  * True if decoded SVG markup contains no script-executing constructs.
  * See the security note on pp_esc_image_src() — this is the primary
  * defense, not defense in depth, because a data: URI is reachable as a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.26",
+  "version": "0.16.27",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.26
+Stable tag: 0.16.27
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.26
+Version:          0.16.27
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1578,4 +1578,114 @@ class ComponentPropsTest extends TestCase
         $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/testimonials/schema.json'), true);
         $this->assertTrue($schema['props']['items']['items']['quote']['required']);
     }
+
+    // ── pp_render_responsive_image() + responsive image output (#107) ────────
+
+    public function testRenderResponsiveImageFallsBackToPlainImgWithoutAttachmentId(): void
+    {
+        $html = pp_render_responsive_image('https://example.com/photo.jpg', 'A photo', 'hero__image', 'eager');
+        $this->assertStringContainsString('<img src="https://example.com/photo.jpg"', $html);
+        $this->assertStringContainsString('alt="A photo"', $html);
+        $this->assertStringContainsString('class="hero__image"', $html);
+        $this->assertStringContainsString('loading="eager"', $html);
+        $this->assertStringNotContainsString('srcset', $html);
+    }
+
+    public function testRenderResponsiveImageUsesAttachmentWhenIdResolves(): void
+    {
+        $GLOBALS['_pp_test_store']['attachment_urls'][42] = 'https://example.com/wp-content/uploads/photo.jpg';
+        $html = pp_render_responsive_image('https://example.com/fallback.jpg', 'A photo', 'hero__image', 'eager', 42);
+        $this->assertStringContainsString('srcset=', $html);
+        $this->assertStringContainsString('https://example.com/wp-content/uploads/photo.jpg', $html);
+        $this->assertStringNotContainsString('fallback.jpg', $html);
+    }
+
+    public function testRenderResponsiveImageFallsBackWhenAttachmentIdUnresolvable(): void
+    {
+        // id 999 was never sideloaded into the test store's attachment map --
+        // matches a deleted attachment or a stale/wrong id in real usage.
+        $html = pp_render_responsive_image('https://example.com/fallback.jpg', 'A photo', 'hero__image', 'eager', 999);
+        $this->assertStringContainsString('<img src="https://example.com/fallback.jpg"', $html);
+        $this->assertStringNotContainsString('srcset', $html);
+    }
+
+    public function testRenderResponsiveImageEmptyUrlAndNoIdRendersNothing(): void
+    {
+        $this->assertSame('', pp_render_responsive_image('', 'alt', 'class', 'lazy'));
+    }
+
+    public function testHeroSplitImageRendersPlainImgWithoutImageId(): void
+    {
+        $html = $this->render('hero', $this->heroProps([
+            'variant' => 'split', 'image_url' => 'https://example.com/photo.jpg', 'image_alt' => 'Photo',
+        ]));
+        $this->assertStringContainsString('<img src="https://example.com/photo.jpg"', $html);
+        $this->assertStringNotContainsString('srcset', $html);
+    }
+
+    public function testHeroSplitImageRendersResponsivelyWithImageId(): void
+    {
+        $GLOBALS['_pp_test_store']['attachment_urls'][7] = 'https://example.com/wp-content/uploads/hero.jpg';
+        $html = $this->render('hero', $this->heroProps([
+            'variant' => 'split', 'image_url' => 'https://example.com/fallback.jpg', 'image_id' => 7,
+        ]));
+        $this->assertStringContainsString('srcset=', $html);
+        $this->assertStringContainsString('hero.jpg', $html);
+    }
+
+    public function testSectionImageLeftRendersResponsivelyWithImageId(): void
+    {
+        $GLOBALS['_pp_test_store']['attachment_urls'][8] = 'https://example.com/wp-content/uploads/section.jpg';
+        $html = $this->render('section', $this->sectionProps([
+            'layout' => 'image-left', 'image_url' => 'https://example.com/fallback.jpg', 'image_id' => 8,
+        ]));
+        $this->assertStringContainsString('srcset=', $html);
+        $this->assertStringContainsString('section.jpg', $html);
+    }
+
+    public function testSectionImageRightWithoutImageIdRendersPlainImg(): void
+    {
+        $html = $this->render('section', $this->sectionProps([
+            'layout' => 'image-right', 'image_url' => 'https://example.com/photo.jpg',
+        ]));
+        $this->assertStringContainsString('<img src="https://example.com/photo.jpg"', $html);
+        $this->assertStringNotContainsString('srcset', $html);
+    }
+
+    public function testLogosItemRendersResponsivelyWithImageId(): void
+    {
+        $GLOBALS['_pp_test_store']['attachment_urls'][9] = 'https://example.com/wp-content/uploads/logo.png';
+        $html = $this->render('logos', [
+            'items' => [['image_url' => 'https://example.com/fallback.png', 'image_alt' => 'Logo', 'image_id' => 9]],
+        ]);
+        $this->assertStringContainsString('srcset=', $html);
+        $this->assertStringContainsString('logo.png', $html);
+    }
+
+    public function testLogosItemWithoutImageIdRendersPlainImg(): void
+    {
+        $html = $this->render('logos', [
+            'items' => [['image_url' => 'https://example.com/logo.png', 'image_alt' => 'Logo']],
+        ]);
+        $this->assertStringContainsString('<img src="https://example.com/logo.png"', $html);
+        $this->assertStringNotContainsString('srcset', $html);
+    }
+
+    public function testHeroSchemaDeclaresImageId(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/hero/schema.json'), true);
+        $this->assertArrayHasKey('image_id', $schema['props']);
+    }
+
+    public function testSectionSchemaDeclaresImageId(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/section/schema.json'), true);
+        $this->assertArrayHasKey('image_id', $schema['props']);
+    }
+
+    public function testLogosSchemaDeclaresItemImageId(): void
+    {
+        $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/logos/schema.json'), true);
+        $this->assertArrayHasKey('image_id', $schema['props']['items']['items']);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -536,6 +536,26 @@ if (!function_exists('wp_get_attachment_image_url')) {
     }
 }
 
+// pp_render_responsive_image() (#107): resolves via the same attachment_urls
+// map. An id with no entry returns '' -- matching real WP's behavior when an
+// attachment doesn't exist -- so the caller's plain-<img> fallback kicks in.
+if (!function_exists('wp_get_attachment_image')) {
+    function wp_get_attachment_image($attachment_id, $size = 'thumbnail', $icon = false, $attr = ''): string {
+        $url = $GLOBALS['_pp_test_store']['attachment_urls'][(int) $attachment_id] ?? false;
+        if (!$url) {
+            return '';
+        }
+        $attrs   = is_array($attr) ? $attr : [];
+        $class   = $attrs['class'] ?? '';
+        $alt     = $attrs['alt'] ?? '';
+        $loading = $attrs['loading'] ?? '';
+        return sprintf(
+            '<img src="%s" srcset="%s 1x, %s 2x" sizes="(max-width: 600px) 100vw, 50vw" class="%s" alt="%s" loading="%s">',
+            $url, $url, $url, $class, $alt, $loading
+        );
+    }
+}
+
 if (!function_exists('wp_attachment_is_image')) {
     function wp_attachment_is_image($attachment_id = null): bool {
         return !empty($GLOBALS['_pp_test_store']['attachment_is_image'][(int) $attachment_id]);


### PR DESCRIPTION
## Summary
- Closes #107. Hero's `split` image, section's `image-left`/`image-right` image, and each logos item now accept an optional `image_id` (Media Library attachment ID, pairs with the `import_media` apply from #105). When it resolves, the image renders responsively via WordPress's own `wp_get_attachment_image()` — real `srcset`/`sizes` from registered image sizes.
- Fully backward compatible: `image_id` is additive. Any composition that only sets `image_url` renders the exact same plain `<img>` tag as before, via the new `pp_render_responsive_image()` helper's fallback branch.
- Scoped to `<img>`-tag props only (hero/section/logos), not `background_image`/`cover` (CSS `background-image`, different mechanism, out of scope for this issue).

## Test plan
- [x] `vendor/bin/phpunit` — 1057 tests green (13 new: the shared helper's three branches — attachment resolves, attachment doesn't resolve/deleted, no id at all — plus one integration test per component for both the responsive and plain-`<img>` paths, plus schema declaration checks)
- [x] `npm test` — 310 tests green
- [x] Docs: AI_CONTEXT.md (component index rows + new capability paragraph), ai-instructions/composition.md (new `image_id` reference section) and website-building.md, and all three affected component README.md files updated in this PR
- [x] `gstack-redact` — no findings

Not security-sensitive (additive prop, no new external fetch — that's #105's job, already merged and reviewed).