### PR TITLE
Add page-specific SEO metadata action

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -83,7 +83,7 @@ site-customization permission.
 | /tests/e2e/              | Playwright E2E tests            | Yes — requires Docker (wp-env)   |
 | .wp-env.json             | wp-env Docker config            | Yes — test environment only      |
 | /lib/wp.php              | WP function wrappers (read + write) | Only to add pp_* functions   |
-| /lib/actions.php         | Typed action model (14 actions) | Add actions following the contract |
+| /lib/actions.php         | Typed action model (15 actions) | Add actions following the contract |
 | /lib/apply.php           | Apply layer (file + option mutations) | Add applies following the contract |
 | /lib/cli.php             | WP-CLI `wp pp action` + `wp pp apply` + `wp pp check` + `wp pp integrity` | Yes |
 | /lib/guardrails.php      | CSS conflict detection, surface classification, theme integrity | Extend for new checks |
@@ -224,6 +224,8 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | `pp_site_option($key)`         | Whitelisted option value (blogname, blogdescription, pp_logo_id, pp_logo_alt) or WP_Error |
 | `pp_update_composition($post_id, $composition)` | Writes composition array to post meta (handles JSON serialization). Returns true\|WP_Error |
 | `pp_update_page_title($post_id, $title)` | Updates page title. Returns true\|WP_Error |
+| `pp_get_seo_meta($post_id)`   | Returns `{meta_description, seo_title, canonical_url}` for a page (empty strings if unset) |
+| `pp_update_seo_meta($post_id, $meta)` | Shallow-merges page-specific SEO metadata (#41). Validates canonical_url as a URL, length-caps meta_description/seo_title. Returns true\|WP_Error |
 | `pp_create_page($title, $status)` | Creates page with Composition template. Returns post ID\|WP_Error |
 | `pp_publish_page($post_id)`    | Sets post_status to 'publish'. Returns true\|WP_Error |
 | `pp_update_site_option($key, $value)` | Updates whitelisted option. Returns true\|WP_Error |
@@ -433,7 +435,7 @@ All mutations go through typed actions. AJAX handlers, WP-CLI, and future AI cal
 **`pp_validate_action()` also rejects bad media URLs.** Any `image_url`/`background_image` value (flat or inside `items[]`) that points into the site's uploads directory must resolve to an actual Media Library attachment AND be an image — a URL to a PDF/video/audio attachment, or to no attachment at all, fails validation with `invalid_media_url` before anything is written. External URLs (outside uploads) are passed through unchecked. This applies uniformly to every caller — AJAX, WP-CLI, `pp_patch_composition()` — not just the AI chat surface.
 
 **Registry functions:**
-- `pp_get_registered_actions()` — all 14 actions
+- `pp_get_registered_actions()` — all 15 actions
 - `pp_get_action($name)` — single action definition or null
 - `pp_validate_action($name, $params)` — structural + semantic validation, returns true|WP_Error
 - `pp_preview_action($name, $params)` — validates, computes diff, never writes
@@ -446,6 +448,7 @@ All mutations go through typed actions. AJAX handlers, WP-CLI, and future AI cal
 | `create_page` | site | title (req), composition, status | Create. Defaults to draft with empty composition |
 | `update_site_option` | site | key (req), value (req) | Replace. Whitelisted: blogname, blogdescription, pp_logo_id (attachment ID), pp_logo_alt |
 | `update_page_title` | page | post_id (req), title (req) | Replace |
+| `update_seo_meta` | page | post_id (req), meta (req) | **Patch.** `meta` is a map of `meta_description`/`seo_title`/`canonical_url` → value, shallow-merged into existing SEO metadata. `seo_title` overrides the rendered `<title>` tag; `canonical_url` overrides the `<link rel="canonical">` tag. Set a key to `""` to clear it |
 | `update_composition` | page | post_id (req), composition (req) | Replace entire array |
 | `publish_page` | page | post_id (req) | Sets status to publish. Idempotent |
 | `add_component` | page | post_id (req), component (req), props (req), position | Append, or insert at position (0-based) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.29] — 2026-07-05 — New: Page-Specific SEO Metadata
+
+**Composition-backed pages had no first-class way to set a meta description, override the `<title>` tag, or set a canonical URL — real launch work needed a direct `functions.php` patch to get a page-specific meta description onto the site.**
+
+### Added
+- New `update_seo_meta` action: sets `meta_description`, `seo_title` (overrides the rendered `<title>` tag), and `canonical_url` for any page — a patch, so setting one field never touches the others. Set a field to `""` to clear it.
+
+### For contributors
+- Storage mirrors `_pp_composition`'s own pattern: one structured post meta key (`_pp_seo_meta`, JSON-encoded), not scattered flat meta keys, and not folded into the composition array — SEO metadata is page-level, not a layout/content concern.
+- Output integrates with WordPress core's own mechanisms rather than duplicating them: `seo_title` hooks `pre_get_document_title` (short-circuits `wp_get_document_title()`'s own assembly), `canonical_url` hooks the `get_canonical_url` filter (WordPress's own `rel_canonical()` still does the output and escaping — this only substitutes the value), and `meta_description` is a direct `wp_head` tag. No duplicate `<title>`/canonical tags, no reimplemented escaping.
+- `canonical_url` is validated as a real URL; `meta_description`/`seo_title` are length-capped (320/200 chars) — routine input validation, not a new security mechanism.
+- 18 new PHPUnit tests across the action's validate/preview/execute paths and all three render-time hook callbacks (including the "no override set" and "not the current page" pass-through cases).
+
 ## [v0.16.28] — 2026-07-05 — New: Image Focal Point and Aspect Ratio Control
 
 **Every background image cropped from a hardcoded dead-center `background-position`, and every content image rendered at its natural proportions with no way to force a specific box shape. A photo whose subject wasn't centered had no safe-surface remedy — the crop was simply wrong, on every page, every time.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.28-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.29-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/website-building.md
+++ b/ai-instructions/website-building.md
@@ -14,6 +14,7 @@ Every visual change maps to exactly one mutation surface. Writing to the wrong s
 | Site name, tagline | WordPress options | `update_site_option` action |
 | Site logo (nav, and footer via `show_logo`) | WordPress option (Media Library attachment) | `update_site_option` action (key `pp_logo_id`, an attachment ID) |
 | Bringing an external image onto the site as a locally-owned asset | Media Library (new attachment) | `import_media` apply (returns `{attachment_id, url}` — pass `url` to `image_url`/`background_image`/`logo_url`; on hero/section/logos also pass `attachment_id` as `image_id` for responsive srcset output) |
+| Page-specific SEO metadata (meta description, `<title>` override, canonical URL) | `_pp_seo_meta` post meta | `update_seo_meta` action (patch; set a key to `""` to clear it) |
 
 ## What NOT to use
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.28');
+define('PP_VERSION', '0.16.29');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';
@@ -121,3 +121,8 @@ add_action('wp_enqueue_scripts', function () {
         true   // load in footer
     );
 });
+
+// ── Page-specific SEO metadata (#41) ────────────────────────────────────────
+add_action('wp_head', 'pp_seo_meta_description_tag', 1);
+add_filter('pre_get_document_title', 'pp_seo_document_title_override');
+add_filter('get_canonical_url', 'pp_seo_canonical_url_override', 10, 2);

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -474,6 +474,44 @@ pp_register_action('update_page_title', [
     },
 ]);
 
+// ── Action: update_seo_meta ──────────────────────────────────────────────────
+// Scope: page | Semantics: patch
+
+pp_register_action('update_seo_meta', [
+    'scope'       => 'page',
+    'description' => 'Sets page-specific SEO metadata: meta_description, seo_title (overrides the rendered <title> tag), and canonical_url. The first-class, safe-surface alternative to hand-patching theme PHP for per-page metadata (#41).',
+    'semantics'   => 'Patch. meta is shallow-merged into existing SEO metadata; unspecified keys are left unchanged. Set a key to "" to clear it.',
+    'params'      => [
+        'post_id' => ['type' => 'int',   'required' => true],
+        'meta'    => ['type' => 'array', 'required' => true],
+    ],
+    'validate' => function (array $params) {
+        $exists = _pp_validate_page_exists($params['post_id']);
+        if (is_wp_error($exists)) {
+            return $exists;
+        }
+        return _pp_validate_seo_meta($params['meta']);
+    },
+    'preview' => function (array $params): array {
+        $current = pp_get_seo_meta($params['post_id']);
+        $after   = array_merge($current, $params['meta']);
+        return _pp_action_preview('update_seo_meta', 'page', ['post_id' => $params['post_id']], $current, $after, [
+            ['path' => 'seo_meta', 'from' => $current, 'to' => $after],
+        ]);
+    },
+    'execute' => function (array $params): array {
+        $current = pp_get_seo_meta($params['post_id']);
+        $result = pp_update_seo_meta($params['post_id'], $params['meta']);
+        if (is_wp_error($result)) {
+            return _pp_action_error('update_seo_meta', 'page', $result->get_error_message());
+        }
+        $after = pp_get_seo_meta($params['post_id']);
+        return _pp_action_result('update_seo_meta', 'page', ['post_id' => $params['post_id']], [
+            ['path' => 'seo_meta', 'from' => $current, 'to' => $after],
+        ]);
+    },
+]);
+
 // ── Action: update_composition ──────────────────────────────────────────────
 // Scope: page | Semantics: replace entire composition array
 

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -1515,6 +1515,136 @@ function pp_update_page_title(int $post_id, string $title) {
     return true;
 }
 
+// ── Page-specific SEO metadata (#41) ─────────────────────────────────────────
+// Storage: a single post meta key (_pp_seo_meta, JSON-encoded), the same
+// "one structured meta key" pattern as _pp_composition — not scattered flat
+// meta keys, and not folded into the composition array itself (SEO metadata
+// is page-level, not a layout/content concern).
+
+/**
+ * Returns page-specific SEO metadata for a post.
+ *
+ * @param int $post_id  WordPress post ID.
+ * @return array{meta_description: string, seo_title: string, canonical_url: string}
+ */
+function pp_get_seo_meta(int $post_id): array {
+    $defaults = ['meta_description' => '', 'seo_title' => '', 'canonical_url' => ''];
+    $raw = get_post_meta($post_id, '_pp_seo_meta', true);
+    if (!is_string($raw) || $raw === '') {
+        return $defaults;
+    }
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        return $defaults;
+    }
+    return array_merge($defaults, array_intersect_key($decoded, $defaults));
+}
+
+/**
+ * Validates a (possibly partial) SEO meta patch. Shared by the update_seo_meta
+ * action's validate step and pp_update_seo_meta() itself (defense in depth,
+ * same pattern as other write paths in this file).
+ *
+ * @return true|WP_Error
+ */
+function _pp_validate_seo_meta(array $meta) {
+    $allowed_keys = ['meta_description', 'seo_title', 'canonical_url'];
+    $unknown = array_diff(array_keys($meta), $allowed_keys);
+    if (!empty($unknown)) {
+        return new WP_Error('invalid_key', 'Unknown SEO meta key(s): ' . implode(', ', $unknown) . '. Allowed: ' . implode(', ', $allowed_keys) . '.');
+    }
+    if (isset($meta['canonical_url']) && $meta['canonical_url'] !== '' && !filter_var($meta['canonical_url'], FILTER_VALIDATE_URL)) {
+        return new WP_Error('invalid_canonical_url', 'canonical_url must be a valid URL, or an empty string to clear it.');
+    }
+    if (isset($meta['meta_description']) && strlen($meta['meta_description']) > 320) {
+        return new WP_Error('meta_description_too_long', 'meta_description must be 320 characters or fewer.');
+    }
+    if (isset($meta['seo_title']) && strlen($meta['seo_title']) > 200) {
+        return new WP_Error('seo_title_too_long', 'seo_title must be 200 characters or fewer.');
+    }
+    return true;
+}
+
+/**
+ * Writes page-specific SEO metadata for a post. Shallow-merges into existing
+ * values — unspecified keys are left unchanged (same patch semantics as
+ * update_component's props). Pass an empty string to clear a field.
+ *
+ * @param int   $post_id  WordPress post ID.
+ * @param array $meta     Subset of {meta_description, seo_title, canonical_url}.
+ * @return true|WP_Error
+ */
+function pp_update_seo_meta(int $post_id, array $meta) {
+    if (!get_post($post_id)) {
+        return new WP_Error('invalid_post', 'Post not found.');
+    }
+
+    $valid = _pp_validate_seo_meta($meta);
+    if (is_wp_error($valid)) {
+        return $valid;
+    }
+
+    $updated = array_merge(pp_get_seo_meta($post_id), $meta);
+    update_post_meta($post_id, '_pp_seo_meta', wp_json_encode($updated));
+    return true;
+}
+
+/**
+ * Outputs the page-specific meta description tag, if set for the current
+ * page. Hooked to wp_head in functions.php.
+ */
+function pp_seo_meta_description_tag(): void {
+    if (!is_singular()) {
+        return;
+    }
+    $post_id = get_queried_object_id();
+    if (!$post_id) {
+        return;
+    }
+    $meta_description = pp_get_seo_meta($post_id)['meta_description'];
+    if ($meta_description === '') {
+        return;
+    }
+    echo '<meta name="description" content="' . esc_attr($meta_description) . '">' . "\n";
+}
+
+/**
+ * Filters the assembled document <title> to the page-specific seo_title
+ * override, if set. Hooked to the pre_get_document_title filter in
+ * functions.php — returning a non-empty value here short-circuits
+ * wp_get_document_title()'s own title-parts assembly entirely.
+ */
+function pp_seo_document_title_override(string $title): string {
+    if (!is_singular()) {
+        return $title;
+    }
+    $post_id = get_queried_object_id();
+    if (!$post_id) {
+        return $title;
+    }
+    $seo_title = pp_get_seo_meta($post_id)['seo_title'];
+    return $seo_title !== '' ? $seo_title : $title;
+}
+
+/**
+ * Filters the canonical URL to the page-specific canonical_url override, if
+ * set. Hooked to the get_canonical_url filter in functions.php. Returns the
+ * raw (already-validated) URL — WP core's own rel_canonical() escapes it
+ * with esc_url() at output time, so this must not pre-escape (would double-
+ * encode).
+ *
+ * @param string       $canonical_url  WordPress's own computed canonical URL.
+ * @param WP_Post|null $post           The post being rendered.
+ * @return string
+ */
+function pp_seo_canonical_url_override(string $canonical_url, $post): string {
+    if (!$post) {
+        return $canonical_url;
+    }
+    $override = pp_get_seo_meta($post->ID)['canonical_url'];
+    return $override !== '' ? $override : $canonical_url;
+}
+
 /**
  * Creates a new page with the Composition template.
  *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.28",
+  "version": "0.16.29",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.28
+Stable tag: 0.16.29
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.28
+Version:          0.16.29
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -2,7 +2,7 @@
 /**
  * tests/ActionsTest.php — PHPUnit tests for the PromptingPress Action Layer
  *
- * Covers: registry functions, wp.php read/write functions, and all 9 actions
+ * Covers: registry functions, wp.php read/write functions, and all 15 actions
  * across validate, preview, and execute paths.
  */
 
@@ -24,12 +24,13 @@ class ActionsTest extends TestCase
 
     // ── Registry tests ─────────────────────────────────────────────────────
 
-    public function testRegistryReturnsAllFourteenActions(): void
+    public function testRegistryReturnsAllFifteenActions(): void
     {
         $actions = pp_get_registered_actions();
-        $this->assertCount(14, $actions);
+        $this->assertCount(15, $actions);
         $expected = [
             'create_page', 'update_site_option', 'update_page_title',
+            'update_seo_meta',
             'update_composition', 'publish_page', 'add_component',
             'remove_component', 'reorder_components', 'update_component',
             'style_component',
@@ -341,6 +342,170 @@ class ActionsTest extends TestCase
         $this->assertEquals('page', $result['scope']);
         $this->assertEquals($id, $result['target']['post_id']);
         $this->assertEquals('Updated Title', $GLOBALS['_pp_test_store']['posts'][$id]['post_title']);
+    }
+
+    // ── Action: update_seo_meta (#41) ───────────────────────────────────────
+
+    public function testUpdateSeoMetaExecuteSetsAllFields(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $result = pp_execute_action('update_seo_meta', [
+            'post_id' => $id,
+            'meta'    => [
+                'meta_description' => 'A great page.',
+                'seo_title'        => 'Custom SEO Title',
+                'canonical_url'    => 'https://example.com/canonical',
+            ],
+        ]);
+        $this->assertTrue($result['ok']);
+        $this->assertEquals('update_seo_meta', $result['action']);
+        $this->assertEquals('page', $result['scope']);
+        $meta = pp_get_seo_meta($id);
+        $this->assertSame('A great page.', $meta['meta_description']);
+        $this->assertSame('Custom SEO Title', $meta['seo_title']);
+        $this->assertSame('https://example.com/canonical', $meta['canonical_url']);
+    }
+
+    public function testUpdateSeoMetaPatchesWithoutClobberingUnspecifiedKeys(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => 'First', 'seo_title' => 'Kept']]);
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => 'Second']]);
+        $meta = pp_get_seo_meta($id);
+        $this->assertSame('Second', $meta['meta_description']);
+        $this->assertSame('Kept', $meta['seo_title']);
+    }
+
+    public function testUpdateSeoMetaEmptyStringClearsField(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => 'Set']]);
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => '']]);
+        $this->assertSame('', pp_get_seo_meta($id)['meta_description']);
+    }
+
+    public function testUpdateSeoMetaRejectsNonexistentPage(): void
+    {
+        $result = pp_execute_action('update_seo_meta', ['post_id' => 9999, 'meta' => ['meta_description' => 'x']]);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('not found', $result['error']);
+    }
+
+    public function testUpdateSeoMetaRejectsUnknownKey(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $result = pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['og_image' => 'https://example.com/x.jpg']]);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('Unknown SEO meta key', $result['error']);
+    }
+
+    public function testUpdateSeoMetaRejectsInvalidCanonicalUrl(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $result = pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['canonical_url' => 'not-a-url']]);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('canonical_url', $result['error']);
+    }
+
+    public function testUpdateSeoMetaRejectsOverlongMetaDescription(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $result = pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => str_repeat('x', 321)]]);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('320 characters', $result['error']);
+    }
+
+    public function testUpdateSeoMetaPreviewDoesNotWrite(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $result = pp_preview_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => 'Preview only']]);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('', pp_get_seo_meta($id)['meta_description']);
+    }
+
+    public function testGetSeoMetaDefaultsToEmptyStrings(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $meta = pp_get_seo_meta($id);
+        $this->assertSame(['meta_description' => '', 'seo_title' => '', 'canonical_url' => ''], $meta);
+    }
+
+    public function testSeoMetaDescriptionTagOutputsWhenSet(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        pp_update_seo_meta($id, ['meta_description' => 'Come visit <us>']);
+        $GLOBALS['_pp_test_store']['is_singular'] = true;
+        $GLOBALS['_pp_test_store']['queried_object_id'] = $id;
+        ob_start();
+        pp_seo_meta_description_tag();
+        $html = ob_get_clean();
+        $this->assertStringContainsString('<meta name="description" content="Come visit &lt;us&gt;">', $html);
+    }
+
+    public function testSeoMetaDescriptionTagOmittedWhenUnset(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $GLOBALS['_pp_test_store']['is_singular'] = true;
+        $GLOBALS['_pp_test_store']['queried_object_id'] = $id;
+        ob_start();
+        pp_seo_meta_description_tag();
+        $html = ob_get_clean();
+        $this->assertSame('', $html);
+    }
+
+    public function testSeoMetaDescriptionTagOmittedWhenNotSingular(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        pp_update_seo_meta($id, ['meta_description' => 'Set']);
+        $GLOBALS['_pp_test_store']['is_singular'] = false;
+        $GLOBALS['_pp_test_store']['queried_object_id'] = $id;
+        ob_start();
+        pp_seo_meta_description_tag();
+        $html = ob_get_clean();
+        $this->assertSame('', $html);
+    }
+
+    public function testSeoDocumentTitleOverrideReturnsOverrideWhenSet(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        pp_update_seo_meta($id, ['seo_title' => 'Override Title']);
+        $GLOBALS['_pp_test_store']['is_singular'] = true;
+        $GLOBALS['_pp_test_store']['queried_object_id'] = $id;
+        $this->assertSame('Override Title', pp_seo_document_title_override(''));
+    }
+
+    public function testSeoDocumentTitleOverridePassesThroughWhenUnset(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $GLOBALS['_pp_test_store']['is_singular'] = true;
+        $GLOBALS['_pp_test_store']['queried_object_id'] = $id;
+        $this->assertSame('', pp_seo_document_title_override(''));
+    }
+
+    public function testSeoDocumentTitleOverridePassesThroughWhenNotSingular(): void
+    {
+        $GLOBALS['_pp_test_store']['is_singular'] = false;
+        $this->assertSame('Default Title', pp_seo_document_title_override('Default Title'));
+    }
+
+    public function testSeoCanonicalUrlOverrideReturnsOverrideWhenSet(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        pp_update_seo_meta($id, ['canonical_url' => 'https://example.com/custom']);
+        $post = get_post($id);
+        $this->assertSame('https://example.com/custom', pp_seo_canonical_url_override('https://example.com/default', $post));
+    }
+
+    public function testSeoCanonicalUrlOverridePassesThroughWhenUnset(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $post = get_post($id);
+        $this->assertSame('https://example.com/default', pp_seo_canonical_url_override('https://example.com/default', $post));
+    }
+
+    public function testSeoCanonicalUrlOverridePassesThroughWhenNoPost(): void
+    {
+        $this->assertSame('https://example.com/default', pp_seo_canonical_url_override('https://example.com/default', null));
     }
 
     // ── Action: publish_page ──────────────────────────────────────────────

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -489,6 +489,20 @@ if (!function_exists('wp_create_nonce')) {
     function wp_create_nonce($action = -1): string { return 'test_nonce'; }
 }
 
+// #41 SEO metadata hooks: current-page context, controlled via
+// $GLOBALS['_pp_test_store']['is_singular'] (bool) and ['queried_object_id'] (int).
+if (!function_exists('is_singular')) {
+    function is_singular($post_types = ''): bool {
+        return (bool) ($GLOBALS['_pp_test_store']['is_singular'] ?? false);
+    }
+}
+
+if (!function_exists('get_queried_object_id')) {
+    function get_queried_object_id(): int {
+        return (int) ($GLOBALS['_pp_test_store']['queried_object_id'] ?? 0);
+    }
+}
+
 if (!function_exists('get_post')) {
     function get_post($post = null) {
         $id = is_object($post) ? $post->ID : (int) $post;


### PR DESCRIPTION
## Summary
- Closes #41. Composition-backed pages had no first-class way to set page-specific SEO metadata; real launch work required a direct `functions.php` patch. Adds `update_seo_meta`: sets `meta_description`, `seo_title` (overrides the rendered `<title>` tag), and `canonical_url` for any page.

## Design
- **Storage**: single post meta key `_pp_seo_meta` (JSON-encoded), mirroring `_pp_composition`'s own "one structured meta key" pattern rather than scattering flat meta keys or folding this into the composition array (SEO metadata is page-level, not a layout/content concern).
- **Action shape**: page-scoped, patch semantics (shallow merge, unspecified keys unchanged, `""` clears a field) — same pattern as `update_component`'s props merge, applied to a 3-field metadata object instead.
- **Output integrates with WordPress core, doesn't duplicate it**:
  - `seo_title` → `pre_get_document_title` filter (short-circuits `wp_get_document_title()`'s own title-parts assembly)
  - `canonical_url` → `get_canonical_url` filter (WordPress's own `rel_canonical()` still renders and `esc_url()`-escapes the tag — this only substitutes the value)
  - `meta_description` → a direct `wp_head` tag (no core mechanism to hook for this one)
- This precedes #3 (JSON-LD structured data) — the `pp_get_seo_meta()`/`pp_update_seo_meta()` API and `_pp_seo_meta` storage shape are designed to extend cleanly (e.g. adding a `json_ld` key) without a redesign.

## Test plan
- [x] `vendor/bin/phpunit` — 1101 tests green (18 new: action validate/preview/execute paths, all three render-time hook callbacks including "no override set" and "not the current page" pass-through cases)
- [x] `npm test` — 317 tests green
- [x] Docs: `AI_CONTEXT.md` (actions table + wp.php function reference), `ai-instructions/website-building.md` (mutation-surface table) updated in this PR
- [x] `gstack-redact` — no findings

Not security-sensitive — routine input validation (URL format, length caps), no new external fetch or capability logic (inherits the existing page-scoped `edit_post` requirement).