### PR TITLE
Add update_page_slug action and slug param on create_page

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -83,7 +83,7 @@ site-customization permission.
 | /tests/e2e/              | Playwright E2E tests            | Yes — requires Docker (wp-env)   |
 | .wp-env.json             | wp-env Docker config            | Yes — test environment only      |
 | /lib/wp.php              | WP function wrappers (read + write) | Only to add pp_* functions   |
-| /lib/actions.php         | Typed action model (15 actions) | Add actions following the contract |
+| /lib/actions.php         | Typed action model (16 actions) | Add actions following the contract |
 | /lib/apply.php           | Apply layer (file + option mutations) | Add applies following the contract |
 | /lib/cli.php             | WP-CLI `wp pp action` + `wp pp apply` + `wp pp check` + `wp pp integrity` | Yes |
 | /lib/guardrails.php      | CSS conflict detection, surface classification, theme integrity | Extend for new checks |
@@ -226,9 +226,10 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | `pp_site_option($key)`         | Whitelisted option value (blogname, blogdescription, pp_logo_id, pp_logo_alt) or WP_Error |
 | `pp_update_composition($post_id, $composition)` | Writes composition array to post meta (handles JSON serialization). Returns true\|WP_Error |
 | `pp_update_page_title($post_id, $title)` | Updates page title. Returns true\|WP_Error |
+| `pp_update_page_slug($post_id, $slug)` | Updates page slug/permalink (#134). Sanitizes via sanitize_title(); WordPress de-duplicates on collision. Returns the actual resulting slug\|WP_Error |
 | `pp_get_seo_meta($post_id)`   | Returns `{meta_description, seo_title, canonical_url}` for a page (empty strings if unset) |
 | `pp_update_seo_meta($post_id, $meta)` | Shallow-merges page-specific SEO metadata (#41). Validates canonical_url as a URL, length-caps meta_description/seo_title. Returns true\|WP_Error |
-| `pp_create_page($title, $status)` | Creates page with Composition template. Returns post ID\|WP_Error |
+| `pp_create_page($title, $status, $slug)` | Creates page with Composition template. Optional `$slug` (#134) sets the route up front. Returns post ID\|WP_Error |
 | `pp_publish_page($post_id)`    | Sets post_status to 'publish'. Returns true\|WP_Error |
 | `pp_update_site_option($key, $value)` | Updates whitelisted option. Returns true\|WP_Error |
 | `pp_get_style_slots($component_name)` | Returns style_slots from component's schema.json. Returns `[]` for unknown components |
@@ -437,7 +438,7 @@ All mutations go through typed actions. AJAX handlers, WP-CLI, and future AI cal
 **`pp_validate_action()` also rejects bad media URLs.** Any `image_url`/`background_image` value (flat or inside `items[]`) that points into the site's uploads directory must resolve to an actual Media Library attachment AND be an image — a URL to a PDF/video/audio attachment, or to no attachment at all, fails validation with `invalid_media_url` before anything is written. External URLs (outside uploads) are passed through unchecked. This applies uniformly to every caller — AJAX, WP-CLI, `pp_patch_composition()` — not just the AI chat surface.
 
 **Registry functions:**
-- `pp_get_registered_actions()` — all 15 actions
+- `pp_get_registered_actions()` — all 16 actions
 - `pp_get_action($name)` — single action definition or null
 - `pp_validate_action($name, $params)` — structural + semantic validation, returns true|WP_Error
 - `pp_preview_action($name, $params)` — validates, computes diff, never writes
@@ -447,9 +448,10 @@ All mutations go through typed actions. AJAX handlers, WP-CLI, and future AI cal
 
 | Action | Scope | Params | Semantics |
 |---|---|---|---|
-| `create_page` | site | title (req), composition, status | Create. Defaults to draft with empty composition |
+| `create_page` | site | title (req), composition, status, slug | Create. Defaults to draft with empty composition. Optional `slug` sets the canonical route up front — omit to let WordPress derive one from the title |
 | `update_site_option` | site | key (req), value (req) | Replace. Whitelisted: blogname, blogdescription, pp_logo_id (attachment ID), pp_logo_alt |
 | `update_page_title` | page | post_id (req), title (req) | Replace |
+| `update_page_slug` | page | post_id (req), slug (req) | Replace. Sanitized via `sanitize_title()`; WordPress de-duplicates on collision (suffixing `-2`, `-3`, ...) — `changes` always reports the actual resulting slug and permalink, which may differ from what was requested |
 | `update_seo_meta` | page | post_id (req), meta (req) | **Patch.** `meta` is a map of `meta_description`/`seo_title`/`canonical_url` → value, shallow-merged into existing SEO metadata. `seo_title` overrides the rendered `<title>` tag; `canonical_url` overrides the `<link rel="canonical">` tag. Set a key to `""` to clear it |
 | `update_composition` | page | post_id (req), composition (req) | Replace entire array |
 | `publish_page` | page | post_id (req) | Sets status to publish. Idempotent |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.31] — 2026-07-05 — New: Edit a Page's URL Without Touching wp-admin
+
+**PromptingPress could create a page, rename its title, publish it, trash it — but never touch its slug. Once a page was created, its URL was frozen forever unless you dropped into wp-admin, the exact surface the product exists to abstract away. Getting `/product/` instead of the title-derived `/how-promptingpress-works/` meant trashing and recreating the page, losing its ID, composition history, and any inbound links.**
+
+### Added
+- New `update_page_slug` action: changes a page's slug/permalink through the same preview/validate/execute contract as every other page action.
+- `create_page` accepts an optional `slug` param, so the canonical route can be set at creation instead of being derived from the title and then stuck.
+- The AI's page inventory now shows each page's real URL, with an explicit instruction to check it before proposing a slug change — no more guessed or hallucinated URLs.
+
+### For contributors
+- WordPress de-duplicates a colliding slug internally (`-2`, `-3`, ...) — `pp_update_page_slug()` reads back the actual resulting `post_name` afterward rather than assuming the requested one stuck, and both the action's `changes` and the preview surface it, never silently.
+- 9 new PHPUnit tests, including the collision/de-duplication path and the "preview never writes" guarantee.
+
 ## [v0.16.30] — 2026-07-05 — New: FAQ Sections Now Generate Rich-Snippet Structured Data
 
 **The FAQ component renders semantically correct, accessible HTML — but Google can't turn that into an FAQ rich snippet without a matching FAQPage JSON-LD block, and PromptingPress had no way to output structured data at all. Every FAQ section was leaving free SERP real estate on the table.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.30-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.31-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/website-building.md
+++ b/ai-instructions/website-building.md
@@ -15,6 +15,7 @@ Every visual change maps to exactly one mutation surface. Writing to the wrong s
 | Site logo (nav, and footer via `show_logo`) | WordPress option (Media Library attachment) | `update_site_option` action (key `pp_logo_id`, an attachment ID) |
 | Bringing an external image onto the site as a locally-owned asset | Media Library (new attachment) | `import_media` apply (returns `{attachment_id, url}` — pass `url` to `image_url`/`background_image`/`logo_url`; on hero/section/logos also pass `attachment_id` as `image_id` for responsive srcset output) |
 | Page-specific SEO metadata (meta description, `<title>` override, canonical URL) | `_pp_seo_meta` post meta | `update_seo_meta` action (patch; set a key to `""` to clear it) |
+| Page slug / URL (post_name) | WordPress core (`post_name`) | `update_page_slug` action (post_id + slug), or the `slug` param on `create_page` to set the route up front. Always check the URL in the page inventory above before proposing a change — never guess or construct one |
 
 ## What NOT to use
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.30');
+define('PP_VERSION', '0.16.31');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -346,11 +346,12 @@ function _pp_action_preview(string $name, string $scope, array $target, $before,
 pp_register_action('create_page', [
     'scope'       => 'site',
     'description' => 'Creates a new page with the Composition template. Each composition item is {"component": "name", "props": {...}}.',
-    'semantics'   => 'Create. Title is required. Composition defaults to empty array. Status defaults to "draft". Composition items use the same {"component", "props"} shape as elsewhere.',
+    'semantics'   => 'Create. Title is required. Composition defaults to empty array. Status defaults to "draft". Composition items use the same {"component", "props"} shape as elsewhere. Optional slug sets the canonical route up front (#134) — omit to let WordPress derive one from the title.',
     'params'      => [
         'title'       => ['type' => 'string', 'required' => true],
         'composition' => ['type' => 'array',  'required' => false],
         'status'      => ['type' => 'string', 'required' => false],
+        'slug'        => ['type' => 'string', 'required' => false],
     ],
     'validate' => function (array $params) {
         if (trim($params['title']) === '') {
@@ -362,6 +363,9 @@ pp_register_action('create_page', [
             if (is_wp_error($valid)) {
                 return $valid;
             }
+        }
+        if (isset($params['slug']) && sanitize_title($params['slug']) === '') {
+            return new WP_Error('invalid_slug', 'Slug must not be empty after sanitization.');
         }
         return true;
     },
@@ -379,7 +383,8 @@ pp_register_action('create_page', [
     },
     'execute' => function (array $params): array {
         $status = $params['status'] ?? 'draft';
-        $post_id = pp_create_page($params['title'], $status);
+        $slug   = $params['slug'] ?? '';
+        $post_id = pp_create_page($params['title'], $status, $slug);
 
         if (is_wp_error($post_id)) {
             return _pp_action_error('create_page', 'site', $post_id->get_error_message());
@@ -470,6 +475,46 @@ pp_register_action('update_page_title', [
         }
         return _pp_action_result('update_page_title', 'page', ['post_id' => $params['post_id']], [
             ['path' => 'title', 'from' => $current, 'to' => $params['title']],
+        ]);
+    },
+]);
+
+// ── Action: update_page_slug ─────────────────────────────────────────────────
+// Scope: page | Semantics: replace
+
+pp_register_action('update_page_slug', [
+    'scope'       => 'page',
+    'description' => 'Updates a page slug (post_name) / permalink (#134). WordPress de-duplicates the slug internally on collision (suffixing -2, -3, ...) — the result reports the actual slug that was set, which may differ from the one requested.',
+    'semantics'   => 'Replace. Slug is sanitized via sanitize_title() and, on a naming collision with another post, de-duplicated by WordPress core — never silently. The resulting slug is always reported in changes.',
+    'params'      => [
+        'post_id' => ['type' => 'int',    'required' => true],
+        'slug'    => ['type' => 'string', 'required' => true],
+    ],
+    'validate' => function (array $params) {
+        $exists = _pp_validate_page_exists($params['post_id']);
+        if (is_wp_error($exists)) {
+            return $exists;
+        }
+        if (sanitize_title($params['slug']) === '') {
+            return new WP_Error('invalid_slug', 'Slug must not be empty after sanitization.');
+        }
+        return true;
+    },
+    'preview' => function (array $params): array {
+        $current_permalink = get_permalink($params['post_id']);
+        $sanitized = sanitize_title($params['slug']);
+        return _pp_action_preview('update_page_slug', 'page', ['post_id' => $params['post_id']], $current_permalink, $sanitized, [
+            ['path' => 'slug', 'from' => $current_permalink, 'to' => "sanitized to '{$sanitized}' (WordPress may de-duplicate further on collision — not reflected in preview)"],
+        ]);
+    },
+    'execute' => function (array $params): array {
+        $current_permalink = get_permalink($params['post_id']);
+        $result = pp_update_page_slug($params['post_id'], $params['slug']);
+        if (is_wp_error($result)) {
+            return _pp_action_error('update_page_slug', 'page', $result->get_error_message());
+        }
+        return _pp_action_result('update_page_slug', 'page', ['post_id' => $params['post_id']], [
+            ['path' => 'slug', 'from' => $current_permalink, 'to' => $result, 'permalink' => get_permalink($params['post_id'])],
         ]);
     },
 ]);

--- a/lib/ai-context.php
+++ b/lib/ai-context.php
@@ -38,8 +38,9 @@ function pp_ai_system_prompt(): string {
     if ($pages) {
         $parts[] = '## Pages';
         foreach ($pages as $page) {
-            $parts[] = "- {$page['title']} (ID: {$page['id']}, status: {$page['status']})";
+            $parts[] = "- {$page['title']} (ID: {$page['id']}, status: {$page['status']}, URL: {$page['url']})";
         }
+        $parts[] = 'To change a page\'s URL, use the update_page_slug action (post_id + slug) — never guess or construct a URL, and never propose a slug change without confirming the current URL above first.';
     } else {
         $parts[] = '## Pages';
         $parts[] = 'No pages exist yet.';

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -1565,6 +1565,33 @@ function pp_update_page_title(int $post_id, string $title) {
     return true;
 }
 
+/**
+ * Updates a page's slug (post_name) / permalink (#134).
+ *
+ * WordPress's own wp_update_post() de-duplicates post_name internally
+ * (suffixing -2, -3, ... on collision, via wp_unique_post_slug()) — this
+ * reads back the actual resulting slug afterward rather than assuming the
+ * requested one stuck, so a caller always learns the real URL.
+ *
+ * @param int    $post_id  WordPress post ID.
+ * @param string $slug     Desired slug. Sanitized via sanitize_title().
+ * @return string|WP_Error  The resulting (possibly de-duplicated) slug, or WP_Error.
+ */
+function pp_update_page_slug(int $post_id, string $slug) {
+    $sanitized = sanitize_title($slug);
+    if ($sanitized === '') {
+        return new WP_Error('invalid_slug', 'Slug must not be empty after sanitization.');
+    }
+
+    $result = wp_update_post(['ID' => $post_id, 'post_name' => $sanitized], true);
+    if (is_wp_error($result)) {
+        return $result;
+    }
+
+    $post = get_post($post_id);
+    return ($post->post_name ?? '') !== '' ? $post->post_name : $sanitized;
+}
+
 // ── Page-specific SEO metadata (#41) ─────────────────────────────────────────
 // Storage: a single post meta key (_pp_seo_meta, JSON-encoded), the same
 // "one structured meta key" pattern as _pp_composition — not scattered flat
@@ -1700,14 +1727,26 @@ function pp_seo_canonical_url_override(string $canonical_url, $post): string {
  *
  * @param string $title   Page title.
  * @param string $status  Post status (default 'draft').
+ * @param string $slug    Optional slug (#134). Sanitized via sanitize_title().
+ *                        Omit to let WordPress derive one from the title, as before.
  * @return int|WP_Error   New post ID, or WP_Error on failure.
  */
-function pp_create_page(string $title, string $status = 'draft') {
-    $post_id = wp_insert_post([
+function pp_create_page(string $title, string $status = 'draft', string $slug = '') {
+    $args = [
         'post_type'   => 'page',
         'post_title'  => $title,
         'post_status' => $status,
-    ], true);
+    ];
+
+    if ($slug !== '') {
+        $sanitized = sanitize_title($slug);
+        if ($sanitized === '') {
+            return new WP_Error('invalid_slug', 'Slug must not be empty after sanitization.');
+        }
+        $args['post_name'] = $sanitized;
+    }
+
+    $post_id = wp_insert_post($args, true);
 
     if (is_wp_error($post_id)) {
         return $post_id;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.30",
+  "version": "0.16.31",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.30
+Stable tag: 0.16.31
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.30
+Version:          0.16.31
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -2,7 +2,7 @@
 /**
  * tests/ActionsTest.php — PHPUnit tests for the PromptingPress Action Layer
  *
- * Covers: registry functions, wp.php read/write functions, and all 15 actions
+ * Covers: registry functions, wp.php read/write functions, and all 16 actions
  * across validate, preview, and execute paths.
  */
 
@@ -24,13 +24,13 @@ class ActionsTest extends TestCase
 
     // ── Registry tests ─────────────────────────────────────────────────────
 
-    public function testRegistryReturnsAllFifteenActions(): void
+    public function testRegistryReturnsAllSixteenActions(): void
     {
         $actions = pp_get_registered_actions();
-        $this->assertCount(15, $actions);
+        $this->assertCount(16, $actions);
         $expected = [
             'create_page', 'update_site_option', 'update_page_title',
-            'update_seo_meta',
+            'update_page_slug', 'update_seo_meta',
             'update_composition', 'publish_page', 'add_component',
             'remove_component', 'reorder_components', 'update_component',
             'style_component',
@@ -342,6 +342,85 @@ class ActionsTest extends TestCase
         $this->assertEquals('page', $result['scope']);
         $this->assertEquals($id, $result['target']['post_id']);
         $this->assertEquals('Updated Title', $GLOBALS['_pp_test_store']['posts'][$id]['post_title']);
+    }
+
+    // ── Action: update_page_slug (#134) ─────────────────────────────────────
+
+    public function testUpdatePageSlugExecute(): void
+    {
+        $id = pp_create_page('How PromptingPress Works', 'draft');
+        $result = pp_execute_action('update_page_slug', ['post_id' => $id, 'slug' => 'product']);
+        $this->assertTrue($result['ok']);
+        $this->assertEquals('update_page_slug', $result['action']);
+        $this->assertEquals('page', $result['scope']);
+        $this->assertEquals('product', $GLOBALS['_pp_test_store']['posts'][$id]['post_name']);
+        $this->assertSame('product', $result['changes'][0]['to']);
+        $this->assertStringContainsString('/product/', $result['changes'][0]['permalink']);
+    }
+
+    public function testUpdatePageSlugSanitizesInput(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        pp_execute_action('update_page_slug', ['post_id' => $id, 'slug' => 'My Cool Page!']);
+        $this->assertEquals('my-cool-page', $GLOBALS['_pp_test_store']['posts'][$id]['post_name']);
+    }
+
+    public function testUpdatePageSlugReportsDeduplicatedSlugOnCollision(): void
+    {
+        $existing = pp_create_page('First Page', 'publish', 'product');
+        $id = pp_create_page('Second Page', 'draft');
+        $result = pp_execute_action('update_page_slug', ['post_id' => $id, 'slug' => 'product']);
+        $this->assertTrue($result['ok']);
+        // WordPress de-duplicated -- the reported slug must be the REAL one, not the requested one.
+        $this->assertNotEquals('product', $result['changes'][0]['to']);
+        $this->assertEquals('product-2', $result['changes'][0]['to']);
+        $this->assertEquals('product', $GLOBALS['_pp_test_store']['posts'][$existing]['post_name']);
+    }
+
+    public function testUpdatePageSlugRejectsEmptyAfterSanitization(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $result = pp_execute_action('update_page_slug', ['post_id' => $id, 'slug' => '!!!']);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('empty', $result['error']);
+    }
+
+    public function testUpdatePageSlugRejectsNonexistentPage(): void
+    {
+        $result = pp_execute_action('update_page_slug', ['post_id' => 9999, 'slug' => 'x']);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('not found', $result['error']);
+    }
+
+    public function testUpdatePageSlugPreviewDoesNotWrite(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $result = pp_preview_action('update_page_slug', ['post_id' => $id, 'slug' => 'new-slug']);
+        $this->assertTrue($result['ok']);
+        $this->assertArrayNotHasKey('post_name', $GLOBALS['_pp_test_store']['posts'][$id]);
+    }
+
+    public function testCreatePageHonorsSlugParam(): void
+    {
+        $result = pp_execute_action('create_page', ['title' => 'How PromptingPress Works', 'slug' => 'product']);
+        $this->assertTrue($result['ok']);
+        $id = $result['target']['post_id'];
+        $this->assertEquals('product', $GLOBALS['_pp_test_store']['posts'][$id]['post_name']);
+    }
+
+    public function testCreatePageWithoutSlugLeavesPostNameUnset(): void
+    {
+        $result = pp_execute_action('create_page', ['title' => 'A Page']);
+        $this->assertTrue($result['ok']);
+        $id = $result['target']['post_id'];
+        $this->assertArrayNotHasKey('post_name', $GLOBALS['_pp_test_store']['posts'][$id]);
+    }
+
+    public function testCreatePageRejectsSlugThatSanitizesEmpty(): void
+    {
+        $result = pp_execute_action('create_page', ['title' => 'A Page', 'slug' => '!!!']);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('empty', $result['error']);
     }
 
     // ── Action: update_seo_meta (#41) ───────────────────────────────────────

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -134,9 +134,46 @@ if (!function_exists('get_permalink')) {
     function get_permalink($post = 0): string {
         $id = is_int($post) ? $post : 0;
         if ($id) {
+            $slug = $GLOBALS['_pp_test_store']['posts'][$id]['post_name'] ?? '';
+            if ($slug !== '') {
+                return 'https://example.com/' . $slug . '/';
+            }
             return 'https://example.com/?page_id=' . $id;
         }
         return 'https://example.com/test-post/';
+    }
+}
+
+if (!function_exists('sanitize_title')) {
+    function sanitize_title(string $title): string {
+        $slug = strtolower(trim($title));
+        $slug = preg_replace('/[^a-z0-9]+/', '-', $slug) ?? '';
+        return trim($slug, '-');
+    }
+}
+
+// #134 slug de-duplication: mirrors WP core's wp_unique_post_slug() division
+// of responsibility -- wp_insert_post()/wp_update_post() own de-dup, callers
+// (pp_update_page_slug()) just read back the resulting post_name.
+if (!function_exists('_pp_test_unique_slug')) {
+    function _pp_test_unique_slug(string $slug, ?int $exclude_id = null): string {
+        $taken = [];
+        foreach ($GLOBALS['_pp_test_store']['posts'] ?? [] as $id => $post) {
+            if ($exclude_id !== null && $id === $exclude_id) {
+                continue;
+            }
+            if (($post['post_name'] ?? '') !== '') {
+                $taken[] = $post['post_name'];
+            }
+        }
+        if (!in_array($slug, $taken, true)) {
+            return $slug;
+        }
+        $i = 2;
+        while (in_array($slug . '-' . $i, $taken, true)) {
+            $i++;
+        }
+        return $slug . '-' . $i;
     }
 }
 
@@ -292,6 +329,9 @@ if (!function_exists('wp_insert_post')) {
             'post_title'  => $args['post_title'] ?? '',
             'post_status' => $args['post_status'] ?? 'draft',
         ];
+        if (isset($args['post_name']) && $args['post_name'] !== '') {
+            $GLOBALS['_pp_test_store']['posts'][$id]['post_name'] = _pp_test_unique_slug($args['post_name'], $id);
+        }
         return $id;
     }
 }
@@ -304,6 +344,9 @@ if (!function_exists('wp_update_post')) {
                 return new WP_Error('invalid_post', 'Post not found.');
             }
             return 0;
+        }
+        if (isset($args['post_name']) && $args['post_name'] !== '') {
+            $args['post_name'] = _pp_test_unique_slug($args['post_name'], $id);
         }
         foreach ($args as $key => $value) {
             if ($key !== 'ID') {
@@ -515,6 +558,7 @@ if (!function_exists('get_post')) {
         $obj->post_type = $data['post_type'] ?? 'page';
         $obj->post_title = $data['post_title'] ?? '';
         $obj->post_status = $data['post_status'] ?? 'draft';
+        $obj->post_name = $data['post_name'] ?? '';
         return $obj;
     }
 }
@@ -626,6 +670,7 @@ if (!class_exists('WP_Post')) {
         public string $post_type = 'page';
         public string $post_title = '';
         public string $post_status = 'draft';
+        public string $post_name = '';
     }
 }
 


### PR DESCRIPTION
## Summary
- Closes #134. PromptingPress had actions to create a page, rename its title, publish/unpublish/trash it — but none to touch the slug (`post_name`). Once created, a page's URL was frozen unless you dropped into wp-admin, the surface the product exists to abstract away. The team already hit this live: `/product/` 404ing while the intended route was `/how-promptingpress-works/`, resolved only by human clarification (#39).

## What shipped (per the issue's own fix plan)
1. `pp_update_page_slug(int $post_id, string $slug)` in `lib/wp.php`.
2. `update_page_slug` action (page scope; `post_id`, `slug`), same preview/validate/execute contract as `update_page_title`.
3. Optional `slug` param on `create_page` so the AI can set the canonical route up front — directly addresses #39. Omitting it leaves behavior unchanged (WordPress still derives from title).
4. The AI's page inventory now surfaces each page's real URL (it already existed in `pp_composition_pages()`'s return shape but was never actually printed into the system prompt text) with an explicit instruction to check it before proposing a slug change.

## Design note
WordPress de-duplicates a colliding slug internally (`wp_update_post()`/`wp_insert_post()` call `wp_unique_post_slug()`, suffixing `-2`, `-3`, ...) — not reimplemented here. `pp_update_page_slug()` reads back the actual resulting `post_name` afterward rather than trusting the requested value, and both the action's `changes` array and its `preview` step surface this, so a collision is never silent.

## Test plan
- [x] `vendor/bin/phpunit` — 1119 tests green (9 new: execute/sanitization/collision-dedup/empty-after-sanitize/nonexistent-page/preview-no-write for `update_page_slug`, plus `create_page`'s slug param honored/omitted/rejected paths)
- [x] `npm test` — 317 tests green
- [x] Docs: `AI_CONTEXT.md` (actions table + wp.php function reference), `ai-instructions/website-building.md` (mutation-surface table) updated in this PR
- [x] `gstack-redact` — no findings

Not security-sensitive — same page-scoped `edit_post` capability gate as every other page action, routine `sanitize_title()` input handling.