### PR TITLE
Fix blog listing showing single post instead of a post grid

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -209,6 +209,8 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | `pp_nav_menu($location)`      | Renders WP nav menu (no output if unassigned)   |
 | `pp_posts($args)`             | Returns WP_Query object                         |
 | `pp_the_loop($query, $cb)`    | Iterates query, calls $cb() per post            |
+| `pp_main_query()`             | Returns the request's main WP_Query — already correctly filtered for the current route (archive, is_home). Prefer over a fresh `pp_posts()` query when rendering "the listing for this route" (#126) |
+| `pp_pagination()`             | Returns pagination `<nav>` HTML for the main query, or `''` if there's only one page (#126) |
 | `pp_is_front_page()`          | bool — true on front page                       |
 | `pp_body_classes()`           | Space-separated body class string               |
 | `pp_excerpt($length)`         | Trimmed excerpt (default 55 words)              |
@@ -279,7 +281,10 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | templates/composition.php  | composition.php     | Composition            | ✅ Yes             |
 | templates/page.php         | page.php            | Default Template       | No                 |
 | templates/single.php       | single.php          | (automatic for posts)  | No                 |
-| templates/archive.php      | archive.php         | (automatic for archives) | No               |
+| templates/archive.php      | archive.php         | (automatic for category/tag/date/author archives) | No |
+| templates/home.php         | home.php            | (automatic for the posts index, is_home) | No   |
+
+`home.php`/`archive.php` iterate `pp_main_query()` (the request's real main query, already correctly filtered for whichever archive/index this is) via `pp_the_loop()`, and render `pp_pagination()` under the grid when there's more than one page (#126).
 
 Both `front-page.php` and `composition.php` read `_pp_composition` post meta and render
 components via `pp_composition()`. No page using these templates has hardcoded component structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.32] — 2026-07-05 — Fix: Blog Listing Showed One Post's Content Instead of a Grid
+
+**Visiting the posts page (or any category/tag archive) rendered a single post's title and content as if it were a static page, with no grid, no pagination, and no respect for the category/tag filter — a category archive showed every post on the site regardless of its actual category.**
+
+### Fixed
+- `templates/archive.php` now iterates WordPress's own already-filtered main query instead of constructing a fresh `WP_Query` with hardcoded/approximated args — the fresh query is what caused a category archive to show all posts, since it never applied the category filter.
+- Added `templates/home.php` (and a root `home.php` delegator) for the dedicated posts-index case (`is_home`), which previously fell through to the single-page template and rendered one post's content in place of a listing.
+- Pagination now renders on both the archive and posts-index templates, wired to WordPress's own `paginate_links()` and the real page count.
+
+### For contributors
+- New `pp_main_query()` (wraps `global $wp_query`) and `pp_pagination()` (wraps `paginate_links()`) helpers in `lib/wp.php`, preserving the "only lib/wp.php calls WP core" invariant.
+- Per-page post count now follows the site's actual "Blog pages show at most" setting (Settings → Reading) rather than a hardcoded number, since it's the real main query rather than a fresh one with its own `posts_per_page` arg.
+- 5 new PHPUnit tests; verified live on the dev site with 13 posts across two pages and a dedicated test category to confirm archive filtering.
+
 ## [v0.16.31] — 2026-07-05 — New: Edit a Page's URL Without Touching wp-admin
 
 **PromptingPress could create a page, rename its title, publish it, trash it — but never touch its slug. Once a page was created, its URL was frozen forever unless you dropped into wp-admin, the exact surface the product exists to abstract away. Getting `/product/` instead of the title-derived `/how-promptingpress-works/` meant trashing and recreating the page, losing its ID, composition history, and any inbound links.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.31-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.32-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2064,6 +2064,53 @@
 .section--centered .section__title {
   text-align: center;
 }
+
+/* ==========================================================================
+   SHARED: Pagination
+   Renders under the post grid on the blog index / archives (issue 126).
+   ========================================================================== */
+
+.pp-pagination {
+  padding: var(--space-lg) 0;
+}
+
+.pp-pagination__list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  list-style: none;
+}
+
+.pp-pagination__list a.page-numbers,
+.pp-pagination__list span.page-numbers {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  padding: 0 var(--space-sm);
+  border-radius: var(--radius);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.pp-pagination__list a.page-numbers:hover {
+  background: var(--color-surface);
+}
+
+.pp-pagination__list span.page-numbers.current {
+  background: var(--color-accent);
+  color: var(--color-bg);
+}
+
+.pp-pagination__list a.page-numbers.dots {
+  color: var(--color-muted);
+}
+
 /* Homepage closing CTA headline fix: title-left, action copy-right on desktop. */
 @media (min-width: 768px) {
   #home-cta.cta--inline .cta__inner {

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.31');
+define('PP_VERSION', '0.16.32');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/home.php
+++ b/home.php
@@ -1,0 +1,1 @@
+<?php get_template_part('templates/home'); ?>

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -97,6 +97,54 @@ function pp_the_loop(\WP_Query $query, callable $cb): void {
 }
 
 /**
+ * Returns the main WP_Query for the current request (#126).
+ *
+ * WordPress already builds and filters this query correctly for the route —
+ * category/tag/date/author archives, the posts index (is_home) — before any
+ * template loads. Prefer this over pp_posts() with a fresh WP_Query when
+ * rendering "the listing for this route": a fresh query can only approximate
+ * the archive context (and easily gets it wrong, e.g. showing every post on
+ * a category archive), where the main query already has it exactly right.
+ *
+ * @return \WP_Query
+ */
+function pp_main_query(): \WP_Query {
+    global $wp_query;
+    return $wp_query;
+}
+
+/**
+ * Returns pagination markup for the current main query (#126), or '' when
+ * there's only one page. Wraps paginate_links() — the only place in the
+ * theme this is called, keeping the "only lib/wp.php touches WP" invariant.
+ *
+ * @return string  A <nav> element with page links, or ''.
+ */
+function pp_pagination(): string {
+    global $wp_query;
+    $total = (int) ($wp_query->max_num_pages ?? 1);
+    if ($total <= 1) {
+        return '';
+    }
+
+    $links = paginate_links([
+        'total'     => $total,
+        'current'   => max(1, (int) get_query_var('paged')),
+        'prev_text' => '← Previous',
+        'next_text' => 'Next →',
+        'type'      => 'array',
+    ]);
+
+    if (empty($links)) {
+        return '';
+    }
+
+    return '<nav class="pp-pagination" aria-label="Posts pagination"><ul class="pp-pagination__list"><li>'
+        . implode('</li><li>', $links)
+        . '</li></ul></nav>';
+}
+
+/**
  * Returns true when the current page is the configured front page.
  */
 function pp_is_front_page(): bool {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.31",
+  "version": "0.16.32",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.31
+Stable tag: 0.16.32
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.31
+Version:          0.16.32
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/templates/archive.php
+++ b/templates/archive.php
@@ -29,11 +29,11 @@ pp_base_template(function () {
         'variant' => 'left',
     ]);
 
-    // Iterate WordPress's own main query for this route (#126) — it is
+    // Iterate WordPress's own main query for this route (issue 126) — it is
     // already correctly filtered for whichever archive this is (category,
-    // tag, date, author). A fresh WP_Query here can only approximate that
-    // context and easily gets it wrong (e.g. a hardcoded post_type showing
-    // every post on a category archive, regardless of category).
+    // tag, date, author). A fresh query object here can only approximate
+    // that context and easily gets it wrong (e.g. a hardcoded post_type
+    // showing every post on a category archive, regardless of category).
     $items = [];
     pp_the_loop(pp_main_query(), function () use (&$items) {
         $items[] = [

--- a/templates/archive.php
+++ b/templates/archive.php
@@ -29,15 +29,13 @@ pp_base_template(function () {
         'variant' => 'left',
     ]);
 
-    // Build grid items from the main query loop.
+    // Iterate WordPress's own main query for this route (#126) — it is
+    // already correctly filtered for whichever archive this is (category,
+    // tag, date, author). A fresh WP_Query here can only approximate that
+    // context and easily gets it wrong (e.g. a hardcoded post_type showing
+    // every post on a category archive, regardless of category).
     $items = [];
-    $query = pp_posts([
-        'post_type'      => 'post',
-        'posts_per_page' => 12,
-        'paged'          => max(1, get_query_var('paged')),
-    ]);
-
-    pp_the_loop($query, function () use (&$items) {
+    pp_the_loop(pp_main_query(), function () use (&$items) {
         $items[] = [
             'title'     => pp_page_title(),
             'text'      => pp_excerpt(25),
@@ -51,6 +49,10 @@ pp_base_template(function () {
         pp_get_component('grid', [
             'items' => $items,
         ]);
+        $pagination = pp_pagination();
+        if ($pagination !== '') {
+            echo '<div class="container">' . $pagination . '</div>';
+        }
     } else {
         pp_get_component('section', [
             'body'   => '<p>No posts found.</p>',

--- a/templates/home.php
+++ b/templates/home.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * templates/home.php — Blog Posts Index Template
+ *
+ * Renders the site's posts index (is_home): a grid of recent posts with
+ * pagination. Without this template, WordPress's home.php → index.php
+ * template hierarchy fell through to templates/page.php, which renders
+ * pp_page_title()/pp_page_content() against the global $post — on the
+ * posts index that global is the FIRST post in the main query, so the
+ * blog index rendered that one post's title as a hero and its full
+ * content as the body instead of a listing (#126).
+ *
+ * No WordPress functions are called here — only pp_* wrappers from lib/wp.php.
+ */
+
+require_once get_template_directory() . '/templates/base.php';
+
+pp_base_template(function () {
+
+    pp_get_component('hero', [
+        'title'   => 'Blog',
+        'variant' => 'left',
+    ]);
+
+    // Iterate WordPress's own main query for this route (#126) — already
+    // correctly built and paginated for the posts index.
+    $items = [];
+    pp_the_loop(pp_main_query(), function () use (&$items) {
+        $items[] = [
+            'title'     => pp_page_title(),
+            'text'      => pp_excerpt(25),
+            'image_url' => pp_thumbnail_url('medium'),
+            'link_url'  => pp_permalink(),
+            'link_text' => 'Read post',
+        ];
+    });
+
+    if (!empty($items)) {
+        pp_get_component('grid', [
+            'items' => $items,
+        ]);
+        $pagination = pp_pagination();
+        if ($pagination !== '') {
+            echo '<div class="container">' . $pagination . '</div>';
+        }
+    } else {
+        pp_get_component('section', [
+            'body'   => '<p>No posts found.</p>',
+            'layout' => 'text-only',
+        ]);
+    }
+
+});

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -134,6 +134,55 @@ class ActionsTest extends TestCase
         $this->assertEquals('Comp Page', $posts[0]->post_title);
     }
 
+    // ── pp_main_query() / pp_pagination() tests (#126) ──────────────────────
+
+    public function testPpMainQueryReturnsGlobalWpQuery(): void
+    {
+        $GLOBALS['wp_query'] = new WP_Query();
+        $this->assertSame($GLOBALS['wp_query'], pp_main_query());
+    }
+
+    public function testPpPaginationReturnsEmptyStringForSinglePage(): void
+    {
+        $GLOBALS['wp_query'] = new WP_Query();
+        $GLOBALS['wp_query']->max_num_pages = 1;
+        $this->assertSame('', pp_pagination());
+    }
+
+    public function testPpPaginationRendersNavForMultiplePages(): void
+    {
+        $GLOBALS['wp_query'] = new WP_Query();
+        $GLOBALS['wp_query']->max_num_pages = 3;
+        $GLOBALS['_pp_test_store']['query_vars']['paged'] = 1;
+        $html = pp_pagination();
+        $this->assertStringContainsString('<nav class="pp-pagination"', $html);
+        $this->assertStringContainsString('class="pp-pagination__list"', $html);
+        $this->assertStringContainsString('current">1<', $html);
+        $this->assertStringContainsString('>2<', $html);
+        $this->assertStringContainsString('>3<', $html);
+    }
+
+    public function testPpPaginationReflectsCurrentPage(): void
+    {
+        $GLOBALS['wp_query'] = new WP_Query();
+        $GLOBALS['wp_query']->max_num_pages = 3;
+        $GLOBALS['_pp_test_store']['query_vars']['paged'] = 2;
+        $html = pp_pagination();
+        $this->assertStringContainsString('current">2<', $html);
+        $this->assertStringContainsString('Previous', $html);
+        $this->assertStringContainsString('Next', $html);
+    }
+
+    public function testPpPaginationDefaultsToPageOneWhenPagedUnset(): void
+    {
+        $GLOBALS['wp_query'] = new WP_Query();
+        $GLOBALS['wp_query']->max_num_pages = 2;
+        unset($GLOBALS['_pp_test_store']['query_vars']['paged']);
+        $html = pp_pagination();
+        $this->assertStringContainsString('current">1<', $html);
+        $this->assertStringNotContainsString('Previous', $html);
+    }
+
     // ── wp.php write function tests ────────────────────────────────────────
 
     public function testPpUpdateCompositionRoundTrips(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -195,6 +195,39 @@ if (!function_exists('is_front_page')) {
     }
 }
 
+// #126 main-query / pagination stubs. Tests control the current "route"
+// query via $GLOBALS['wp_query'] (a WP_Query-like object) directly, and
+// the current page number via $GLOBALS['_pp_test_store']['query_vars'].
+if (!function_exists('get_query_var')) {
+    function get_query_var(string $var, $default = '') {
+        return $GLOBALS['_pp_test_store']['query_vars'][$var] ?? $default;
+    }
+}
+
+if (!function_exists('paginate_links')) {
+    function paginate_links(array $args = []) {
+        $total   = (int) ($args['total'] ?? 1);
+        $current = (int) ($args['current'] ?? 1);
+        $type    = $args['type'] ?? 'plain';
+        if ($total <= 1) {
+            return $type === 'array' ? [] : '';
+        }
+        $links = [];
+        if ($current > 1) {
+            $links[] = '<a class="prev page-numbers" href="#">' . ($args['prev_text'] ?? 'Previous') . '</a>';
+        }
+        for ($i = 1; $i <= $total; $i++) {
+            $links[] = $i === $current
+                ? '<span aria-current="page" class="page-numbers current">' . $i . '</span>'
+                : '<a class="page-numbers" href="#">' . $i . '</a>';
+        }
+        if ($current < $total) {
+            $links[] = '<a class="next page-numbers" href="#">' . ($args['next_text'] ?? 'Next') . '</a>';
+        }
+        return $type === 'array' ? $links : implode('', $links);
+    }
+}
+
 if (!function_exists('wp_nav_menu')) {
     function wp_nav_menu(array $args = []): void {
         echo '<ul><li><a href="#">Test Link</a></li></ul>';
@@ -710,6 +743,7 @@ if (!function_exists('wp_get_upload_dir')) {
 if (!class_exists('WP_Query')) {
     class WP_Query {
         public array $posts = [];
+        public int $max_num_pages = 1; // #126: read by pp_pagination()
 
         public function __construct(array $args = []) {
             // Support meta_query IN comparison for _wp_attached_file lookups.


### PR DESCRIPTION
## Summary
- `templates/archive.php` now iterates WordPress's real main query (`pp_main_query()`) instead of a fresh `WP_Query` with hardcoded/approximated args — fixes category/tag archives showing every post on the site regardless of the actual filter.
- New `templates/home.php` (+ root `home.php` delegator) covers the `is_home` posts-index case, which previously fell through to the single-page template and rendered one post's content as if it were a static page.
- New `pp_pagination()` helper wired into both templates, backed by WordPress's own `paginate_links()`.

## Test plan
- [x] 1124 PHPUnit tests pass (5 new for `pp_main_query()`/`pp_pagination()`)
- [x] 317 Vitest tests pass
- [x] Verified live on dev.promptingpress.com: 13 test posts across 2 pages, pagination links correct, page 2 shows the remaining 3 posts
- [x] Verified a dedicated test category archive shows only its 2 assigned posts, not all 13 — confirms the original bug is fixed
- [x] Test data (posts, category, Blog page, `page_for_posts` option) cleaned up from dev afterward
- [x] Redaction scan clean

Closes #126