### PR TITLE
Add search results template (heading, listing, pagination, empty state)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -211,6 +211,8 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | `pp_the_loop($query, $cb)`    | Iterates query, calls $cb() per post            |
 | `pp_main_query()`             | Returns the request's main WP_Query — already correctly filtered for the current route (archive, is_home). Prefer over a fresh `pp_posts()` query when rendering "the listing for this route" (#126) |
 | `pp_pagination()`             | Returns pagination `<nav>` HTML for the main query, or `''` if there's only one page (#126) |
+| `pp_search_query()`           | Returns the raw search query string for the current search request (issue 138) |
+| `pp_result_count()`           | Returns `found_posts` from the main query — the full match count across all pages (issue 138) |
 | `pp_is_front_page()`          | bool — true on front page                       |
 | `pp_body_classes()`           | Space-separated body class string               |
 | `pp_excerpt($length)`         | Trimmed excerpt (default 55 words)              |
@@ -283,8 +285,9 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | templates/single.php       | single.php          | (automatic for posts)  | No                 |
 | templates/archive.php      | archive.php         | (automatic for category/tag/date/author archives) | No |
 | templates/home.php         | home.php            | (automatic for the posts index, is_home) | No   |
+| templates/search.php       | search.php          | (automatic for search requests, `?s=`) | No     |
 
-`home.php`/`archive.php` iterate `pp_main_query()` (the request's real main query, already correctly filtered for whichever archive/index this is) via `pp_the_loop()`, and render `pp_pagination()` under the grid when there's more than one page (#126).
+`home.php`/`archive.php`/`search.php` iterate `pp_main_query()` (the request's real main query, already correctly filtered for whichever archive/index/search this is) via `pp_the_loop()`, and render `pp_pagination()` under the grid when there's more than one page (#126). `search.php` additionally uses `pp_search_query()`/`pp_result_count()` for its heading and empty state (issue 138).
 
 Both `front-page.php` and `composition.php` read `_pp_composition` post meta and render
 components via `pp_composition()`. No page using these templates has hardcoded component structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.33] — 2026-07-05 — Fix: Search Returned One Result's Content Instead of a Results List
+
+**A search request had no dedicated template, so it fell through WordPress's template hierarchy to the single-page template and rendered the first matched result's content as a full standalone page — no "N results for…" heading, no results list, no pagination, and no empty state when nothing matched.**
+
+### Fixed
+- Added `templates/search.php` (+ root `search.php` delegator): a heading naming the query and match state, a grid of matching posts/pages with links and excerpts (reusing the archive/blog-listing grid pattern from #126), pagination, and an explicit empty state instead of a blank hero/section.
+
+### For contributors
+- New `pp_search_query()` and `pp_result_count()` wrappers in `lib/wp.php`, keeping the "templates call only pp_* functions" invariant; `pp_result_count()` reads `found_posts` off the main query (the full match count, not just the current page's post count).
+- Reuses `pp_main_query()`/`pp_the_loop()`/`pp_pagination()` from #126 as-is — WordPress's search query already includes both posts and pages by default, so no new query-building logic was needed.
+- 4 new PHPUnit tests; verified live on the dev site with a matching-term search (results + no pagination for 2 results) and a no-match search (empty state).
+
 ## [v0.16.32] — 2026-07-05 — Fix: Blog Listing Showed One Post's Content Instead of a Grid
 
 **Visiting the posts page (or any category/tag archive) rendered a single post's title and content as if it were a static page, with no grid, no pagination, and no respect for the category/tag filter — a category archive showed every post on the site regardless of its actual category.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.32-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.33-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.32');
+define('PP_VERSION', '0.16.33');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -145,6 +145,27 @@ function pp_pagination(): string {
 }
 
 /**
+ * Returns the raw search query string for the current search request (issue 138).
+ *
+ * @return string
+ */
+function pp_search_query(): string {
+    return get_search_query();
+}
+
+/**
+ * Returns the total number of matched posts for the current main query
+ * (issue 138) — `found_posts` reflects the full result count across all
+ * pages, unlike `pp_main_query()->posts`, which only holds the current page.
+ *
+ * @return int
+ */
+function pp_result_count(): int {
+    global $wp_query;
+    return (int) ($wp_query->found_posts ?? 0);
+}
+
+/**
  * Returns true when the current page is the configured front page.
  */
 function pp_is_front_page(): bool {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.32",
+  "version": "0.16.33",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.32
+Stable tag: 0.16.33
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/search.php
+++ b/search.php
@@ -1,0 +1,1 @@
+<?php get_template_part('templates/search'); ?>

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.32
+Version:          0.16.33
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/templates/search.php
+++ b/templates/search.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * templates/search.php — Search Results Template
+ *
+ * Renders a search results listing: a heading naming the query, a grid of
+ * matching posts/pages with links and excerpts, pagination, and an explicit
+ * empty state. Without this template, WordPress's search.php → index.php
+ * template hierarchy fell through to templates/page.php, which renders
+ * pp_page_title()/pp_page_content() against the global $post — on a search
+ * request that global is the first matched result, so a search rendered one
+ * result as a full standalone page instead of a results list (issue 138).
+ *
+ * No WordPress functions are called here — only pp_* wrappers from lib/wp.php.
+ */
+
+require_once get_template_directory() . '/templates/base.php';
+
+pp_base_template(function () {
+
+    $query = pp_search_query();
+    $count = pp_result_count();
+
+    pp_get_component('hero', [
+        'title'   => $count > 0
+            ? sprintf('Results for "%s"', $query)
+            : sprintf('No results for "%s"', $query),
+        'variant' => 'left',
+    ]);
+
+    $items = [];
+    pp_the_loop(pp_main_query(), function () use (&$items) {
+        $items[] = [
+            'title'     => pp_page_title(),
+            'text'      => pp_excerpt(25),
+            'image_url' => pp_thumbnail_url('medium'),
+            'link_url'  => pp_permalink(),
+            'link_text' => 'View',
+        ];
+    });
+
+    if (!empty($items)) {
+        pp_get_component('grid', [
+            'items' => $items,
+        ]);
+        $pagination = pp_pagination();
+        if ($pagination !== '') {
+            echo '<div class="container">' . $pagination . '</div>';
+        }
+    } else {
+        pp_get_component('section', [
+            'body'   => '<p>Nothing matched your search. Try a different term.</p>',
+            'layout' => 'text-only',
+        ]);
+    }
+
+});

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -183,6 +183,34 @@ class ActionsTest extends TestCase
         $this->assertStringNotContainsString('Previous', $html);
     }
 
+    // ── pp_search_query() / pp_result_count() tests (issue 138) ─────────────
+
+    public function testPpSearchQueryReturnsTheCurrentSearchTerm(): void
+    {
+        $GLOBALS['_pp_test_store']['search_query'] = 'pricing';
+        $this->assertSame('pricing', pp_search_query());
+    }
+
+    public function testPpSearchQueryReturnsEmptyStringWhenUnset(): void
+    {
+        unset($GLOBALS['_pp_test_store']['search_query']);
+        $this->assertSame('', pp_search_query());
+    }
+
+    public function testPpResultCountReturnsFoundPostsFromMainQuery(): void
+    {
+        $GLOBALS['wp_query'] = new WP_Query();
+        $GLOBALS['wp_query']->found_posts = 7;
+        $this->assertSame(7, pp_result_count());
+    }
+
+    public function testPpResultCountReturnsZeroForNoMatches(): void
+    {
+        $GLOBALS['wp_query'] = new WP_Query();
+        $GLOBALS['wp_query']->found_posts = 0;
+        $this->assertSame(0, pp_result_count());
+    }
+
     // ── wp.php write function tests ────────────────────────────────────────
 
     public function testPpUpdateCompositionRoundTrips(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -228,6 +228,14 @@ if (!function_exists('paginate_links')) {
     }
 }
 
+// issue 138: search-results stub. Tests set the query string via
+// $GLOBALS['_pp_test_store']['search_query'].
+if (!function_exists('get_search_query')) {
+    function get_search_query(bool $escaped = true): string {
+        return $GLOBALS['_pp_test_store']['search_query'] ?? '';
+    }
+}
+
 if (!function_exists('wp_nav_menu')) {
     function wp_nav_menu(array $args = []): void {
         echo '<ul><li><a href="#">Test Link</a></li></ul>';
@@ -744,6 +752,7 @@ if (!class_exists('WP_Query')) {
     class WP_Query {
         public array $posts = [];
         public int $max_num_pages = 1; // #126: read by pp_pagination()
+        public int $found_posts = 0; // issue 138: read by pp_result_count()
 
         public function __construct(array $args = []) {
             // Support meta_query IN comparison for _wp_attached_file lookups.


### PR DESCRIPTION
## Summary
- `templates/search.php` (+ root `search.php` delegator) replaces the previous fallthrough to the single-page template, which rendered the first search match as a full standalone page.
- Reuses `pp_main_query()`/`pp_the_loop()`/`pp_pagination()` from #126 as-is — WordPress's own search query already covers both posts and pages.
- New `pp_search_query()`/`pp_result_count()` wrappers in `lib/wp.php` for the heading and empty state.

## Test plan
- [x] 1128 PHPUnit tests pass (4 new for `pp_search_query()`/`pp_result_count()`)
- [x] 317 Vitest tests pass
- [x] Verified live on dev.promptingpress.com: search for a matching term shows a titled results grid, no pagination for 2 results
- [x] Verified a no-match search renders the "Nothing matched your search" empty state, not an empty hero/section
- [x] Test posts cleaned up from dev afterward
- [x] Redaction scan clean

Closes #138