### PR TITLE
Add regression test for preview/execute parity on invalid media URLs (issue 130)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -445,7 +445,7 @@ All mutations go through typed actions. AJAX handlers, WP-CLI, and future AI cal
 
 **Execute always validates first.** Callers never need to pre-validate.
 
-**`pp_validate_action()` also rejects bad media URLs.** Any `image_url`/`background_image` value (flat or inside `items[]`) that points into the site's uploads directory must resolve to an actual Media Library attachment AND be an image — a URL to a PDF/video/audio attachment, or to no attachment at all, fails validation with `invalid_media_url` before anything is written. External URLs (outside uploads) are passed through unchecked. This applies uniformly to every caller — AJAX, WP-CLI, `pp_patch_composition()` — not just the AI chat surface.
+**`pp_validate_action()` also rejects bad media URLs.** Any `image_url`/`background_image` value (flat or inside `items[]`) that points into the site's uploads directory must resolve to an actual Media Library attachment AND be an image — a URL to a PDF/video/audio attachment, or to no attachment at all, fails validation with `invalid_media_url` before anything is written. External URLs (outside uploads) are passed through unchecked. This applies uniformly to every caller — AJAX, WP-CLI, `pp_patch_composition()` — not just the AI chat surface. Because both `pp_preview_action()` and `pp_execute_action()` call `pp_validate_action()`, a proposal preview rejects an invalid media URL with the identical error `pp_ai_execute` would give — the chat never shows a clean preview diff for a step guaranteed to fail (issue 130).
 
 **Registry functions:**
 - `pp_get_registered_actions()` — all 16 actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.36] — 2026-07-05 — Regression Test: Preview/Execute Parity for Invalid Media URLs
+
+**Issue 130 asked for proposal previews to reject a hallucinated/typo'd media URL with the same error execute would give, instead of showing a clean diff for a step guaranteed to fail. Investigating found this already true in the current codebase — the earlier #124 media-URL validation work moved the check into the shared `pp_validate_action()` gate that both `pp_preview_action()` and `pp_execute_action()` call, so preview and execute have been failing identically since #124 shipped. What was missing was a regression test actually proving it, and this issue's own acceptance criteria named exactly that test.**
+
+### For contributors
+- New `testPreviewRejectsInvalidMediaUrlIdenticallyToExecute` in `tests/ActionsTest.php`: calls `pp_preview_action()` and `pp_execute_action()` with the identical params (an uploads-path `image_url` with no matching attachment) and asserts both reject with the same `invalid_media_url` error and message.
+- `AI_CONTEXT.md`'s existing media-URL-validation paragraph now names the preview/execute parity property explicitly.
+- No production code changed — this closes out issue 130 with the missing test coverage rather than re-implementing behavior that already existed.
+
 ## [v0.16.35] — 2026-07-05 — New: Guardrail Warning for Empty Structured-Content Sections
 
 **A FAQ section with no questions, a grid with no cards, or a table with no rows is schema-valid — every prop passes its own validation — but renders as an obvious dead block on the live page ("No questions yet.", "Nothing here yet."). Nothing in the page check flagged it, so an operator could trust a passing `wp pp check page` result while the frontend still showed a visibly unfinished section.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.35-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.36-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.35');
+define('PP_VERSION', '0.16.36');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.35",
+  "version": "0.16.36",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.35
+Stable tag: 0.16.36
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.35
+Version:          0.16.36
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -913,6 +913,31 @@ class ActionsTest extends TestCase
         $this->assertArrayNotHasKey('image_url', $comp[0]['props']);
     }
 
+    public function testPreviewRejectsInvalidMediaUrlIdenticallyToExecute(): void
+    {
+        // Regression for issue 130: a proposal preview must not show a clean
+        // diff for a step guaranteed to fail at execute — both must reject a
+        // hallucinated/typo'd uploads URL with the same error, because both
+        // pp_preview_action() and pp_execute_action() route through the same
+        // pp_validate_action() gate. No page is created — the media-URL
+        // check runs before the action's own semantic validate (which is
+        // where a real post_id would otherwise be required), so this proves
+        // preview fails at the same point execute does, not just eventually.
+        $params = [
+            'post_id'         => 999999,
+            'component_index' => 0,
+            'props'           => ['image_url' => 'https://example.com/wp-content/uploads/2026/06/hero-imge.png'],
+        ];
+
+        $preview = pp_preview_action('update_component', $params);
+        $execute = pp_execute_action('update_component', $params);
+
+        $this->assertInstanceOf(WP_Error::class, $preview);
+        $this->assertSame('invalid_media_url', $preview->get_error_code());
+        $this->assertFalse($execute['ok']);
+        $this->assertSame($preview->get_error_message(), $execute['error']);
+    }
+
     // ── Preview tests ──────────────────────────────────────────────────────
 
     public function testPreviewNeverWrites(): void


### PR DESCRIPTION
## Summary
Issue 130 asked for proposal previews to reject a hallucinated/typo'd media URL identically to execute, instead of showing a clean diff for a step guaranteed to fail.

**Investigation found this already works.** The earlier #124 media-URL validation work moved `_pp_validate_media_urls_in_params()` into the shared `pp_validate_action()` gate, and both `pp_preview_action()` and `pp_execute_action()` call that gate — so preview/execute parity has existed since #124 shipped. Verified empirically before writing any test.

What was actually missing: the regression test the issue's own acceptance criteria named, proving the parity holds. This PR adds exactly that (no production code changes) and makes the parity property explicit in `AI_CONTEXT.md`.

## Test plan
- [x] New test `testPreviewRejectsInvalidMediaUrlIdenticallyToExecute` passes immediately (proving the behavior pre-existed)
- [x] 1148 PHPUnit tests pass, 317 Vitest tests pass
- [x] Redaction scan clean

Closes #130