### PR TITLE
Wire enqueue_font to the site's font-family design tokens

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -266,12 +266,14 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | `update_design_token` | design | option: `pp_token_overrides` | token (string, required), value (string, required) |
 | `reset_design_token` | design | option: `pp_token_overrides` | token (string, required) |
 | `reset_all_design_tokens` | design | option: `pp_token_overrides` | (none) |
-| `enqueue_font` | design | option: `pp_font_urls` | url (string, required, HTTPS only). Max 5 fonts |
+| `enqueue_font` | design | option: `pp_font_urls` (+ `pp_token_overrides` when `apply_to` given) | url (string, required, HTTPS only, max 5 fonts), family (string, optional), apply_to (string, optional: `heading`\|`body`\|`both`) |
 | `remove_font` | design | option: `pp_font_urls` | url (string, required) |
 | `reset_fonts` | design | option: `pp_font_urls` | (none) |
 | `import_media` | media | media library (new attachment) | url (string, required, HTTPS + image extension only), alt (string, optional) |
 
 **Media import (`import_media`):** Sideloads an external image URL into the media library — the only sanctioned way to bring an external image onto the site as a locally-owned asset (image props otherwise only accept a raw URL string). SSRF safety comes from WordPress core's `wp_safe_remote_get()` (used internally by `download_url()`), which validates the URL and every redirect hop against private/reserved IP ranges — not reimplemented here. Restricted beyond WordPress's default upload mime allowlist to images only (jpg/png/gif/webp), with a 10MB size cap. Returns `{attachment_id, url}` on success — use the returned `url` as the value for an `image_url`/`background_image`/`logo_url` prop.
+
+**Enqueuing a font alone does not change any visible typography (issue 135).** The theme's real typography levers are the `--font-heading`/`--font-body` design tokens (not `--font-family-*`) — loading a `<link>` for a webfont stylesheet has no effect until something points a token at the family it defines. Pass `family` (the CSS font-family name the stylesheet defines) with `apply_to` to `enqueue_font` and it sets the matching token(s) to `"{family}, system-ui, sans-serif"` in the same call — "use Poppins for headings" is one `enqueue_font` call, not `enqueue_font` + a separate `update_design_token`. Omit `family` and the result still returns a best-effort `family`/`family_source: "derived"` suggestion parsed from the URL's `family=` query param (Google/Bunny Fonts convention), without writing any token — useful for confirming the guess before a follow-up call. `apply_to` without any resolvable family (explicit or derivable) is a validation error (`missing_family`), not a silent no-op.
 
 **CLI:** `wp pp apply list\|preview\|execute\|restore\|reset` (requires manage_options capability). `restore` rolls a run's token changes back to its pre-apply snapshot; `reset` clears overrides to product defaults.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.37] — 2026-07-05 — New: `enqueue_font` Can Now Wire a Font Into the Site's Typography Tokens
+
+**`enqueue_font` loaded a webfont's `<link>` and nothing else — the site's actual typography comes from the `--font-heading`/`--font-body` design tokens, which `enqueue_font` never touched. "Use Poppins for headings" required a second, undocumented `update_design_token` call with the exact CSS family name the stylesheet defined, a coupling an AI could easily get wrong or skip — leaving the font downloaded but invisible.**
+
+### Added
+- `enqueue_font` gains two optional params: `family` (the CSS font-family name the stylesheet defines) and `apply_to` (`heading` | `body` | `both`). When both are given, the same call also sets the matching `--font-heading`/`--font-body` token(s) to `"{family}, system-ui, sans-serif"`.
+- When `family` is omitted, `enqueue_font` best-effort derives one from the URL's `family=` query parameter (the Google/Bunny Fonts convention) and returns it in the result as `family`/`family_source: "derived"` — a suggestion, with no token written — so the caller can confirm before a follow-up call. `apply_to` without any resolvable family (explicit or derivable) is now a validation error (`missing_family`) instead of a silent no-op.
+- Preview shows both the font-URL addition and the token change together, so approving the step reflects the real visual effect, not just "a stylesheet loaded."
+
+### For contributors
+- New `_pp_derive_font_family_from_url()` and `_pp_font_apply_to_tokens()` helpers in `lib/apply.php`. The real token names are `--font-heading`/`--font-body` (not `--font-family-*`) — `ai-instructions/website-building.md` and `AI_CONTEXT.md` now name them explicitly for anyone proposing an `apply_to` value.
+- No new subsystem: the token write reuses the same `pp_set_token_override()` the `update_design_token` apply already uses, so cache invalidation and the `pp_token_overrides` storage shape are unchanged.
+- 11 new PHPUnit tests, including derivation from both the CSS2 weight-axis URL format and `+`-encoded multi-word family names, and confirming preview never writes.
+
 ## [v0.16.36] — 2026-07-05 — Regression Test: Preview/Execute Parity for Invalid Media URLs
 
 **Issue 130 asked for proposal previews to reject a hallucinated/typo'd media URL with the same error execute would give, instead of showing a clean diff for a step guaranteed to fail. Investigating found this already true in the current codebase — the earlier #124 media-URL validation work moved the check into the shared `pp_validate_action()` gate that both `pp_preview_action()` and `pp_execute_action()` call, so preview and execute have been failing identically since #124 shipped. What was missing was a regression test actually proving it, and this issue's own acceptance criteria named exactly that test.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.36-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.37-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/website-building.md
+++ b/ai-instructions/website-building.md
@@ -16,6 +16,7 @@ Every visual change maps to exactly one mutation surface. Writing to the wrong s
 | Bringing an external image onto the site as a locally-owned asset | Media Library (new attachment) | `import_media` apply (returns `{attachment_id, url}` — pass `url` to `image_url`/`background_image`/`logo_url`; on hero/section/logos also pass `attachment_id` as `image_id` for responsive srcset output) |
 | Page-specific SEO metadata (meta description, `<title>` override, canonical URL) | `_pp_seo_meta` post meta | `update_seo_meta` action (patch; set a key to `""` to clear it) |
 | Page slug / URL (post_name) | WordPress core (`post_name`) | `update_page_slug` action (post_id + slug), or the `slug` param on `create_page` to set the route up front. Always check the URL in the page inventory above before proposing a change — never guess or construct one |
+| Custom/webfont loading and typography ("use Poppins for headings") | `pp_font_urls` option + `pp_token_overrides` option | `enqueue_font` apply with `url` + `family` + `apply_to` (`heading`\|`body`\|`both`) — one call both loads the stylesheet and points `--font-heading`/`--font-body` at it. `enqueue_font` with only `url` loads the font but changes nothing visible; it is not a substitute for `apply_to` |
 
 ## What NOT to use
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.36');
+define('PP_VERSION', '0.16.37');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/apply.php
+++ b/lib/apply.php
@@ -312,6 +312,57 @@ function _pp_validate_font_family(string $value): bool {
 }
 
 /**
+ * Best-effort extraction of the CSS font-family name from a Google/Bunny
+ * Fonts stylesheet URL's `family` query parameter (issue 135), e.g.
+ * `family=Roboto:wght@400;700` -> "Roboto", `family=Open+Sans` -> "Open Sans".
+ * Only the first family is used when the URL requests several. Returns ''
+ * when there is no `family` param or it doesn't parse as one.
+ *
+ * @param  string $url  Font stylesheet URL.
+ * @return string       Derived family name, or ''.
+ */
+function _pp_derive_font_family_from_url(string $url): string {
+    $query = parse_url($url, PHP_URL_QUERY);
+    if (!$query) {
+        return '';
+    }
+    parse_str($query, $query_params);
+    $family = $query_params['family'] ?? '';
+    if ($family === '') {
+        return '';
+    }
+    // Google's legacy API allows multiple families separated by '|'; the
+    // CSS2 API allows a weight/style axis suffix after ':'. Only the first
+    // family name (before either separator) is meaningful here.
+    $family = explode('|', $family)[0];
+    $family = explode(':', $family)[0];
+    $family = str_replace('+', ' ', $family);
+    return trim($family);
+}
+
+/**
+ * Maps an enqueue_font `apply_to` value to the design token(s) it targets
+ * (issue 135). `--font-heading`/`--font-body` are the theme's real token
+ * names (assets/css/base.css) — not the `--font-family-*` naming an AI
+ * might guess.
+ *
+ * @param  string $apply_to  'heading' | 'body' | 'both'.
+ * @return string[]          Token names, or [] for an unrecognized value.
+ */
+function _pp_font_apply_to_tokens(string $apply_to): array {
+    switch ($apply_to) {
+        case 'heading':
+            return ['--font-heading'];
+        case 'body':
+            return ['--font-body'];
+        case 'both':
+            return ['--font-heading', '--font-body'];
+        default:
+            return [];
+    }
+}
+
+/**
  * Validates a CSS duration value.
  * Accepts: numeric value with time unit (ms, s).
  */
@@ -948,9 +999,11 @@ pp_register_apply('reset_all_design_tokens', [
 pp_register_apply('enqueue_font', [
     'domain'      => 'design',
     'target'      => ['type' => 'option', 'key' => 'pp_font_urls'],
-    'description' => 'Adds a web font URL (e.g. Google Fonts, Bunny Fonts) to the site. Max 5 fonts.',
+    'description' => 'Adds a web font URL (e.g. Google Fonts, Bunny Fonts) to the site. Max 5 fonts. Loading the stylesheet alone changes nothing visible — pass family (the CSS font-family name the stylesheet defines) with apply_to ("heading" | "body" | "both") to also point the matching --font-heading/--font-body design token(s) at it in the same call. Omit family and the result returns a best-effort family derived from the URL as a suggestion, without changing any token.',
     'params'      => [
-        'url' => ['type' => 'string', 'required' => true],
+        'url'      => ['type' => 'string', 'required' => true],
+        'family'   => ['type' => 'string', 'required' => false],
+        'apply_to' => ['type' => 'string', 'required' => false],
     ],
 
     'validate' => function (array $params) {
@@ -968,17 +1021,48 @@ pp_register_apply('enqueue_font', [
         if (count($current) >= 5) {
             return new WP_Error('font_limit', 'Maximum 5 font URLs allowed. Remove one first.');
         }
+
+        $family = $params['family'] ?? '';
+        if ($family !== '' && !_pp_validate_font_family($family)) {
+            return new WP_Error('invalid_font_family', 'family must be a comma-separated list of font names.');
+        }
+
+        $apply_to = $params['apply_to'] ?? '';
+        if ($apply_to !== '') {
+            if (!in_array($apply_to, ['heading', 'body', 'both'], true)) {
+                return new WP_Error('invalid_apply_to', 'apply_to must be "heading", "body", or "both".');
+            }
+            if ($family === '' && _pp_derive_font_family_from_url($url) === '') {
+                return new WP_Error('missing_family', 'apply_to requires family — no family name could be derived from this URL, so pass one explicitly.');
+            }
+        }
+
         return true;
     },
 
     'preview' => function (array $params) {
         $current = pp_get_font_urls();
         $after = array_merge($current, [$params['url']]);
+        $changes = [['action' => 'add', 'url' => $params['url']]];
+
+        $family = $params['family'] ?? '';
+        if ($family === '') {
+            $family = _pp_derive_font_family_from_url($params['url']);
+        }
+        $apply_to = $params['apply_to'] ?? '';
+        if ($apply_to !== '' && $family !== '') {
+            $tokens = pp_design_tokens();
+            $value = $family . ', system-ui, sans-serif';
+            foreach (_pp_font_apply_to_tokens($apply_to) as $token) {
+                $changes[] = ['token' => $token, 'from' => $tokens[$token]['value'] ?? null, 'to' => $value];
+            }
+        }
+
         return _pp_apply_preview(
             'enqueue_font', 'design',
             ['type' => 'option', 'key' => 'pp_font_urls'],
             $current, $after,
-            [['action' => 'add', 'url' => $params['url']]]
+            $changes
         );
     },
 
@@ -986,11 +1070,38 @@ pp_register_apply('enqueue_font', [
         $current = pp_get_font_urls();
         $current[] = $params['url'];
         pp_set_font_urls($current);
-        return _pp_apply_result(
+        $changes = [['action' => 'add', 'url' => $params['url']]];
+
+        $family = $params['family'] ?? '';
+        $family_source = $family !== '' ? 'explicit' : null;
+        if ($family === '') {
+            $family = _pp_derive_font_family_from_url($params['url']);
+            if ($family !== '') {
+                $family_source = 'derived';
+            }
+        }
+
+        $apply_to = $params['apply_to'] ?? '';
+        if ($apply_to !== '' && $family !== '') {
+            $tokens = pp_design_tokens();
+            $value = $family . ', system-ui, sans-serif';
+            foreach (_pp_font_apply_to_tokens($apply_to) as $token) {
+                $old_value = $tokens[$token]['value'] ?? null;
+                pp_set_token_override($token, $value);
+                $changes[] = ['token' => $token, 'from' => $old_value, 'to' => $value];
+            }
+        }
+
+        $result = _pp_apply_result(
             'enqueue_font', 'design',
             ['type' => 'option', 'key' => 'pp_font_urls'],
-            [['action' => 'add', 'url' => $params['url']]]
+            $changes
         );
+        if ($family !== '') {
+            $result['family'] = $family;
+            $result['family_source'] = $family_source;
+        }
+        return $result;
     },
 ]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.36",
+  "version": "0.16.37",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.36
+Stable tag: 0.16.37
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.36
+Version:          0.16.37
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ApplyTest.php
+++ b/tests/ApplyTest.php
@@ -1404,6 +1404,142 @@ class ApplyTest extends TestCase
         $this->assertContains('https://fonts.googleapis.com/css2?family=Inter', pp_get_font_urls());
     }
 
+    // ── Font family / apply_to tests (issue 135) ────────────────────────────
+
+    public function testEnqueueFontUrlOnlyReturnsDerivedFamilySuggestion(): void
+    {
+        pp_set_font_urls([]);
+        $result = pp_execute_apply('enqueue_font', ['url' => 'https://fonts.googleapis.com/css2?family=Inter']);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('Inter', $result['family']);
+        $this->assertSame('derived', $result['family_source']);
+        // A suggestion only — no token should have been written.
+        $tokens = pp_design_tokens();
+        $this->assertSame('system-ui, sans-serif', $tokens['--font-heading']['value']);
+    }
+
+    public function testEnqueueFontDerivesFamilyWithWeightAxisSuffix(): void
+    {
+        pp_set_font_urls([]);
+        $result = pp_execute_apply('enqueue_font', ['url' => 'https://fonts.googleapis.com/css2?family=Roboto:wght@400;700']);
+        $this->assertSame('Roboto', $result['family']);
+    }
+
+    public function testEnqueueFontDerivesFamilyWithPlusEncodedSpaces(): void
+    {
+        pp_set_font_urls([]);
+        $result = pp_execute_apply('enqueue_font', ['url' => 'https://fonts.googleapis.com/css2?family=Open+Sans']);
+        $this->assertSame('Open Sans', $result['family']);
+    }
+
+    public function testEnqueueFontNoFamilyWhenUrlHasNoFamilyParam(): void
+    {
+        pp_set_font_urls([]);
+        $result = pp_execute_apply('enqueue_font', ['url' => 'https://example.com/custom-font.css']);
+        $this->assertTrue($result['ok']);
+        $this->assertArrayNotHasKey('family', $result);
+    }
+
+    public function testEnqueueFontRejectsApplyToWithoutFamilyWhenNoneDerivable(): void
+    {
+        pp_set_font_urls([]);
+        $result = pp_validate_apply('enqueue_font', [
+            'url'      => 'https://example.com/custom-font.css',
+            'apply_to' => 'heading',
+        ]);
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('missing_family', $result->get_error_code());
+    }
+
+    public function testEnqueueFontRejectsInvalidApplyTo(): void
+    {
+        pp_set_font_urls([]);
+        $result = pp_validate_apply('enqueue_font', [
+            'url'      => 'https://fonts.googleapis.com/css2?family=Inter',
+            'apply_to' => 'sidebar',
+        ]);
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('invalid_apply_to', $result->get_error_code());
+    }
+
+    public function testEnqueueFontRejectsEmptyExplicitFamily(): void
+    {
+        pp_set_font_urls([]);
+        $result = pp_validate_apply('enqueue_font', [
+            'url'    => 'https://fonts.googleapis.com/css2?family=Inter',
+            'family' => '   ',
+        ]);
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('invalid_font_family', $result->get_error_code());
+    }
+
+    public function testEnqueueFontWithFamilyAndApplyToHeadingSetsToken(): void
+    {
+        pp_set_font_urls([]);
+        $result = pp_execute_apply('enqueue_font', [
+            'url'      => 'https://fonts.googleapis.com/css2?family=Poppins',
+            'family'   => 'Poppins',
+            'apply_to' => 'heading',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('Poppins', $result['family']);
+        $this->assertSame('explicit', $result['family_source']);
+
+        $tokens = pp_design_tokens();
+        $this->assertSame('Poppins, system-ui, sans-serif', $tokens['--font-heading']['value']);
+        $this->assertSame('system-ui, sans-serif', $tokens['--font-body']['value']);
+    }
+
+    public function testEnqueueFontWithApplyToBodySetsBothTokens(): void
+    {
+        pp_set_font_urls([]);
+        pp_execute_apply('enqueue_font', [
+            'url'      => 'https://fonts.googleapis.com/css2?family=Poppins',
+            'family'   => 'Poppins',
+            'apply_to' => 'both',
+        ]);
+
+        $tokens = pp_design_tokens();
+        $this->assertSame('Poppins, system-ui, sans-serif', $tokens['--font-heading']['value']);
+        $this->assertSame('Poppins, system-ui, sans-serif', $tokens['--font-body']['value']);
+    }
+
+    public function testEnqueueFontExplicitFamilyOverridesDerivedOne(): void
+    {
+        pp_set_font_urls([]);
+        // URL derives to "Inter", but an explicit family always wins.
+        $result = pp_execute_apply('enqueue_font', [
+            'url'      => 'https://fonts.googleapis.com/css2?family=Inter',
+            'family'   => 'Custom Name',
+            'apply_to' => 'heading',
+        ]);
+
+        $this->assertSame('Custom Name', $result['family']);
+        $tokens = pp_design_tokens();
+        $this->assertSame('Custom Name, system-ui, sans-serif', $tokens['--font-heading']['value']);
+    }
+
+    public function testEnqueueFontPreviewShowsTokenChangeAlongsideUrlAdd(): void
+    {
+        pp_set_font_urls([]);
+        $preview = pp_preview_apply('enqueue_font', [
+            'url'      => 'https://fonts.googleapis.com/css2?family=Poppins',
+            'family'   => 'Poppins',
+            'apply_to' => 'heading',
+        ]);
+
+        $this->assertIsArray($preview);
+        $this->assertCount(2, $preview['changes']);
+        $this->assertSame('add', $preview['changes'][0]['action']);
+        $this->assertSame('--font-heading', $preview['changes'][1]['token']);
+        $this->assertSame('Poppins, system-ui, sans-serif', $preview['changes'][1]['to']);
+
+        // Preview must never write.
+        $tokens = pp_design_tokens();
+        $this->assertSame('system-ui, sans-serif', $tokens['--font-heading']['value']);
+    }
+
     public function testRemoveFontExecute(): void
     {
         pp_set_font_urls(['https://fonts.googleapis.com/css2?family=Inter']);


### PR DESCRIPTION
## Summary
`enqueue_font` loaded a webfont stylesheet `<link>` and nothing else — the site's actual typography comes from the `--font-heading`/`--font-body` design tokens, which `enqueue_font` never touched. "Use Poppins for headings" required a second, undocumented `update_design_token` call with the exact CSS family name.

- `enqueue_font` gains optional `family` + `apply_to` (`heading`|`body`|`both`) params; when both given, sets the matching token(s) to `"{family}, system-ui, sans-serif"` in the same call.
- When `family` is omitted, best-effort derives one from the URL's `family=` query param (Google/Bunny convention) and returns it as a suggestion (`family_source: "derived"`) without writing any token.
- `apply_to` without a resolvable family is now a validation error (`missing_family`), not a silent no-op.
- Preview shows both the URL addition and the token change together.

Note: the issue text referenced `--font-family-heading`/`--font-family-body` and a "family-derivation/coherence machinery" — verified against actual code that the real tokens are `--font-heading`/`--font-body`, and that the referenced coherence machinery is unrelated color-hue derivation for palette families, not fonts. Implemented against the real token names and reused the actual shared token writer (`pp_set_token_override()`) instead.

## Test plan
- [x] 1159 PHPUnit tests pass (11 new)
- [x] 317 Vitest tests pass
- [x] Redaction scan clean
- [x] Verified the new apply description/params surface correctly in the AI system prompt via a standalone script

Closes #135