### PR TITLE
Make AI chat page targeting explicit and user-controlled

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -569,6 +569,12 @@ The chat uses POST-based SSE streaming (nonce in request body, never in URL):
 | `pp_ai_stream` | Read/stream | SSE endpoint, AJAX chat fallback |
 | `pp_ai_execute` | Mutate | Action/apply execution from chat |
 
+### Page targeting (issue 136)
+
+Which page a chat conversation edits is explicit and user-controlled, never inferred silently. A `<select id="pp-ai-page-select">` in the chat header (populated from `pp_composition_pages()`) sets `activePageId` in the JS, persisted in the same localStorage entry as the conversation. `activePageId` is sent as `page_id` with every request — the AI's proposed `post_id` action params drive the actual writes, so an unresolved or wrong target here is a real correctness risk, not cosmetic.
+
+Sending a message with no page selected is blocked client-side (no `page_id: null` request is ever sent); the chat shows an inline prompt directing the user to the selector. `ppChatDetectPageId(text, pages)` (longest-title-substring match, same heuristic as before this issue) still runs on every message, but purely as a suggestion: if it finds a candidate different from the current selection, a non-blocking "Switch to it for next message?" chip appears — clicking it updates the selector, but the message that was just sent always used whatever was explicitly selected at send time. Detection never mutates `activePageId` on its own. Every proposal card names its target page ("Target page: <Title>"), captured at request time so it can't drift if the selector changes while a response is still streaming.
+
 ### System prompt contents
 
 Assembled by `pp_ai_system_prompt()`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.38] — 2026-07-05 — Fix: AI Chat Now Targets an Explicit, User-Chosen Page
+
+**Which page a chat request mutated was inferred entirely by matching the last message against page titles as substrings — "tell me about pricing" could match a page titled "About", "make the hero bigger" matched nothing and silently reused whatever page was last targeted, and the user had no way to see or correct which page was about to change before a proposal wrote to it.**
+
+### Added
+- A page selector in the chat header sets the conversation's target page explicitly; it persists across reloads and is sent with every request. Sending with no page selected is now blocked client-side — a `page_id: null` request is never sent — with an inline prompt directing the user to the selector.
+- Title-substring detection still runs on every message, but only as a suggestion: when it disagrees with the current selection, a non-blocking "Switch to it for next message?" chip appears. It never silently retargets the conversation.
+- Every proposal card now names its target page ("Target page: <Title>"), captured at the moment the request was sent so it can't drift if the selector changes mid-response.
+
+### For contributors
+- `detectPageId` moved out of the chat IIFE into a pure, testable top-level function (`ppChatDetectPageId`), alongside two new helpers (`ppChatFindPageById`, `ppChatShouldSuggestPageSwitch`) — all three exported for tests, following the file's existing `ppChat*` testable-helper convention.
+- 18 new Vitest tests for the three pure functions (substring-collision resolution, untitled-page exclusion, suggestion-vs-authority semantics), plus an existing localStorage-restore fixture updated to seed an active page now that sending requires one.
+- Verified live: page selector populated from real composition pages, blocked/prompted send with nothing selected, detected-page hint text, explicit-selection-wins-over-detection on send, and the switch-suggestion chip correctly updating the selector on click.
+
 ## [v0.16.37] — 2026-07-05 — New: `enqueue_font` Can Now Wire a Font Into the Site's Typography Tokens
 
 **`enqueue_font` loaded a webfont's `<link>` and nothing else — the site's actual typography comes from the `--font-heading`/`--font-body` design tokens, which `enqueue_font` never touched. "Use Poppins for headings" required a second, undocumented `update_design_token` call with the exact CSS family name the stylesheet defined, a coupling an AI could easily get wrong or skip — leaving the font downloaded but invisible.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.37-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.38-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/pp-ai-chat.css
+++ b/assets/css/pp-ai-chat.css
@@ -313,6 +313,19 @@ body.pp-ai-chat-page #wpfooter {
     color: #d63638;
 }
 
+.pp-ai-page-switch-suggestion {
+    color: #1d2327;
+    background: #f0f6fc;
+    border: 1px solid #c3c4c7;
+    border-radius: 6px;
+    padding: 8px 12px;
+    text-align: left;
+}
+
+.pp-ai-page-switch-btn {
+    margin-left: 6px;
+}
+
 /* ── Proposal Cards ───────────────────────────────────────────────────────── */
 
 .pp-ai-proposal-card {
@@ -332,6 +345,13 @@ body.pp-ai-chat-page #wpfooter {
     margin-bottom: 12px;
     text-transform: uppercase;
     letter-spacing: 0.5px;
+}
+
+.pp-ai-proposal-target-page {
+    font-size: 12px;
+    font-weight: 600;
+    color: #2271b1;
+    margin-bottom: 8px;
 }
 
 .pp-ai-proposal-step {

--- a/assets/js/pp-ai-chat.js
+++ b/assets/js/pp-ai-chat.js
@@ -19,6 +19,55 @@ function ppChatGetImpactWarning(name) {
     return warnings[name] || null;
 }
 
+/**
+ * Finds the page whose title is the longest substring match in the given
+ * (already-lowercased) text. Pure and side-effect-free (issue 136) — the
+ * caller decides what to do with the result; this function never sets the
+ * active page itself. Skips untitled pages. Returns null for no match, no
+ * text, or an empty pages list.
+ */
+function ppChatDetectPageId(lowerText, pages) {
+    if (!pages || !pages.length || !lowerText) return null;
+
+    var bestMatch = null;
+    var bestLen = 0;
+
+    for (var i = 0; i < pages.length; i++) {
+        var page = pages[i];
+        var title = (page.title || '').toLowerCase();
+        if (!title) continue; // skip untitled pages
+        if (lowerText.indexOf(title) !== -1 && title.length > bestLen) {
+            bestMatch = page.id;
+            bestLen = title.length;
+        }
+    }
+
+    return bestMatch;
+}
+
+/**
+ * Looks up a page object by id in the pages list. Returns null when pageId
+ * is falsy or no page in the list has a matching id.
+ */
+function ppChatFindPageById(pageId, pages) {
+    if (!pageId || !pages) return null;
+    for (var i = 0; i < pages.length; i++) {
+        if (pages[i].id === pageId) return pages[i];
+    }
+    return null;
+}
+
+/**
+ * Decides whether a detected page should be surfaced as a "switch?"
+ * suggestion (issue 136): only when detection found a page AND it differs
+ * from the currently active selection. Detection must never be treated as
+ * authoritative on its own — the explicit selection always wins, this only
+ * flags a disagreement for the user to act on (or ignore).
+ */
+function ppChatShouldSuggestPageSwitch(activePageId, detectedPageId) {
+    return !!detectedPageId && detectedPageId !== activePageId;
+}
+
 function ppChatFormatDiffValue(val) {
     if (val === null || val === undefined) return '(none)';
     if (typeof val === 'object') {
@@ -261,6 +310,7 @@ function ppChatAppendValidationItems(container, items, className) {
 
     var providerSelect = document.getElementById('pp-ai-provider-select');
     var modelSelect    = document.getElementById('pp-ai-model-select');
+    var pageSelectEl   = document.getElementById('pp-ai-page-select');
 
     var switchRetryCount = 0;
 
@@ -337,6 +387,32 @@ function ppChatAppendValidationItems(container, items, className) {
                 modelSelect.appendChild(opt);
             });
         }
+    }
+
+    // ── Page Selector (issue 136) ───────────────────────────────────────
+    //
+    // The active page is explicit and user-controlled via this selector,
+    // never inferred silently. detectPageId (below) only ever surfaces a
+    // suggestion for the user to accept or ignore.
+
+    if (pageSelectEl) {
+        pageSelectEl.addEventListener('change', function () {
+            activePageId = this.value || null;
+            saveState();
+        });
+    }
+
+    /**
+     * Reflects activePageId in the <select>. If activePageId points at a
+     * page no longer in config.pages (e.g. trashed since it was selected),
+     * resets to no selection rather than silently keeping a stale target.
+     */
+    function syncPageSelectValue() {
+        if (!pageSelectEl) return;
+        if (activePageId && !ppChatFindPageById(activePageId, config.pages || [])) {
+            activePageId = null;
+        }
+        pageSelectEl.value = activePageId || '';
     }
 
     // ── Persistence ───────────────────────────────────────────────────
@@ -684,7 +760,7 @@ function ppChatAppendValidationItems(container, items, className) {
         .then(function (r) { return r.json(); });
     }
 
-    function renderProposal(proposal) {
+    function renderProposal(proposal, pageId) {
         var card = document.createElement('div');
         card.className = 'pp-ai-proposal-card';
 
@@ -692,6 +768,18 @@ function ppChatAppendValidationItems(container, items, className) {
         title.className = 'pp-ai-proposal-title';
         title.textContent = 'Proposed Changes';
         card.appendChild(title);
+
+        // Names the page this request targeted (issue 136) — the AI's
+        // proposed post_id params drive the actual writes, so the user must
+        // be able to see which page that is before approving, not just infer
+        // it from the diff.
+        var targetPage = ppChatFindPageById(pageId, config.pages || []);
+        if (targetPage) {
+            var pageLabel = document.createElement('div');
+            pageLabel.className = 'pp-ai-proposal-target-page';
+            pageLabel.textContent = 'Target page: ' + (targetPage.title || '(untitled)');
+            card.appendChild(pageLabel);
+        }
 
         var steps = proposal.steps || [];
 
@@ -845,6 +933,52 @@ function ppChatAppendValidationItems(container, items, className) {
         div.className = 'pp-ai-status' + (isError ? ' pp-ai-status-error' : '');
         if (isError) div.setAttribute('role', 'alert');
         div.textContent = text;
+        messagesEl.appendChild(div);
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+    }
+
+    /**
+     * Blocks sending: no page is selected. Directs the user to the selector
+     * instead of proceeding with page_id: null (issue 136). If detection
+     * found a candidate, names it as a hint — it is never auto-selected.
+     */
+    function showPageSelectionPrompt(detectedPageId, pages) {
+        var detectedPage = ppChatFindPageById(detectedPageId, pages);
+        var text = detectedPage
+            ? 'Select a page before sending — did you mean "' + detectedPage.title + '"? Choose it from the page dropdown above.'
+            : 'Select a page before sending, using the page dropdown above.';
+        addStatusMessage(text, true);
+        if (pageSelectEl) pageSelectEl.focus();
+    }
+
+    /**
+     * Non-blocking: the message was sent using the current selection, but
+     * detection disagrees with it. Surfaces a one-click way to switch the
+     * selection for the NEXT message — never retargets silently, and never
+     * blocks or alters the request that was just sent (issue 136).
+     */
+    function maybeShowPageSwitchSuggestion(detectedPageId, pages) {
+        if (!ppChatShouldSuggestPageSwitch(activePageId, detectedPageId)) return;
+
+        var detectedPage = ppChatFindPageById(detectedPageId, pages);
+        if (!detectedPage) return;
+
+        var div = document.createElement('div');
+        div.className = 'pp-ai-status pp-ai-page-switch-suggestion';
+        div.appendChild(document.createTextNode('This message mentioned "' + detectedPage.title + '". '));
+
+        var switchBtn = document.createElement('button');
+        switchBtn.type = 'button';
+        switchBtn.className = 'button pp-ai-page-switch-btn';
+        switchBtn.textContent = 'Switch to it for next message?';
+        switchBtn.addEventListener('click', function () {
+            activePageId = detectedPage.id;
+            syncPageSelectValue();
+            saveState();
+            div.remove();
+        });
+        div.appendChild(switchBtn);
+
         messagesEl.appendChild(div);
         messagesEl.scrollTop = messagesEl.scrollHeight;
     }
@@ -1110,12 +1244,27 @@ function ppChatAppendValidationItems(container, items, className) {
     function sendMessage(text) {
         if (isStreaming || !text.trim()) return;
 
+        var trimmed = text.trim();
+        var pages = config.pages || [];
+        var detectedPageId = ppChatDetectPageId(trimmed.toLowerCase(), pages);
+
+        // The active page is explicit and user-controlled (issue 136) —
+        // detection is a suggestion only, never an authority. Without an
+        // explicit selection, block sending rather than proposing changes
+        // against page_id: null (or silently reusing a stale prior target).
+        if (!activePageId) {
+            showPageSelectionPrompt(detectedPageId, pages);
+            return;
+        }
+
+        maybeShowPageSwitchSuggestion(detectedPageId, pages);
+
         isStreaming = true;
         sendBtn.disabled = true;
         inputEl.disabled = true;
 
-        conversation.push({ role: 'user', content: text.trim() });
-        addMessage('user', text.trim());
+        conversation.push({ role: 'user', content: trimmed });
+        addMessage('user', trimmed);
         inputEl.value = '';
         saveState();
 
@@ -1123,11 +1272,11 @@ function ppChatAppendValidationItems(container, items, className) {
     }
 
     function streamChat(messages) {
-        var detected = detectPageId(messages);
-        if (detected) {
-            activePageId = detected;
-            saveState();
-        }
+        // Captured once per request: renderProposal() (in this closure's
+        // async callbacks) must label the page actually targeted by THIS
+        // request, not whatever activePageId happens to be by the time the
+        // response arrives — the selector can change while streaming.
+        var requestPageId = activePageId;
 
         var body = JSON.stringify({
             messages: messages,
@@ -1190,7 +1339,7 @@ function ppChatAppendValidationItems(container, items, className) {
 
                             if (data.done && data.proposal) {
                                 proposalReceived = true;
-                                renderProposal(data.proposal);
+                                renderProposal(data.proposal, requestPageId);
                             }
 
                             if (data.done && data.truncated && !data.proposal) {
@@ -1212,7 +1361,7 @@ function ppChatAppendValidationItems(container, items, className) {
         })
         .catch(function (err) {
             // SSE failed, try AJAX fallback
-            ajaxFallback(messages, msgBody);
+            ajaxFallback(messages, msgBody, requestPageId);
         });
     }
 
@@ -1311,7 +1460,7 @@ function ppChatAppendValidationItems(container, items, className) {
 
     // ── AJAX Fallback ──────────────────────────────────────────────────
 
-    function ajaxFallback(messages, msgBody) {
+    function ajaxFallback(messages, msgBody, requestPageId) {
         var data = new FormData();
         data.append('action', 'pp_ai_chat');
         data.append('nonce', config.streamNonce);
@@ -1334,7 +1483,7 @@ function ppChatAppendValidationItems(container, items, className) {
                 conversation.push({ role: 'assistant', content: resp.data.content });
 
                 if (resp.data.proposal) {
-                    renderProposal(resp.data.proposal);
+                    renderProposal(resp.data.proposal, requestPageId);
                 } else if (looksLikeIncompleteProposal(resp.data.content)) {
                     addStatusMessage(
                         'The response may have been cut short before the proposal could be generated. Try sending your request again, or simplify it.',
@@ -1354,31 +1503,6 @@ function ppChatAppendValidationItems(container, items, className) {
         .catch(function () {
             handleStreamError(msgBody, 'Connection failed. Please try again.');
         });
-    }
-
-    // ── Page Detection ─────────────────────────────────────────────────
-
-    function detectPageId(messages) {
-        if (!config.pages || !config.pages.length) return null;
-
-        var lastMsg = messages[messages.length - 1];
-        if (!lastMsg || lastMsg.role !== 'user') return null;
-
-        var text = lastMsg.content.toLowerCase();
-        var bestMatch = null;
-        var bestLen = 0;
-
-        for (var i = 0; i < config.pages.length; i++) {
-            var page = config.pages[i];
-            var title = (page.title || '').toLowerCase();
-            if (!title) continue; // skip untitled pages
-            if (text.indexOf(title) !== -1 && title.length > bestLen) {
-                bestMatch = page.id;
-                bestLen = title.length;
-            }
-        }
-
-        return bestMatch;
     }
 
     // ── Restore Previous Conversation ─────────────────────────────────
@@ -1445,6 +1569,7 @@ function ppChatAppendValidationItems(container, items, className) {
         inputEl.disabled = false;
         inputEl.value = '';
         inputEl.focus();
+        syncPageSelectValue();
     }
 
     // ── Event Handlers ─────────────────────────────────────────────────
@@ -1474,6 +1599,7 @@ function ppChatAppendValidationItems(container, items, className) {
         // restored transcript, not a broken widget (#140 adversarial review).
         conversation = [];
     }
+    syncPageSelectValue();
     inputEl.focus();
 
 })();
@@ -1489,6 +1615,9 @@ if (typeof module !== 'undefined' && module.exports) {
         getErrorStepClass: ppChatGetErrorStepClass,
         getStatusMessage: ppChatGetStatusMessage,
         appendValidationItems: ppChatAppendValidationItems,
-        buildCompositionSummary: ppChatBuildCompositionSummary
+        buildCompositionSummary: ppChatBuildCompositionSummary,
+        detectPageId: ppChatDetectPageId,
+        findPageById: ppChatFindPageById,
+        shouldSuggestPageSwitch: ppChatShouldSuggestPageSwitch
     };
 }

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.37');
+define('PP_VERSION', '0.16.38');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/ai-chat.php
+++ b/lib/ai-chat.php
@@ -150,8 +150,18 @@ function pp_ai_chat_page(): void {
                     }
                 }
                 ?>
+                <?php $pp_ai_chat_pages = pp_composition_pages(); ?>
                 <div class="pp-ai-chat-header">
                     <h2>AI Chat</h2>
+                    <label for="pp-ai-page-select" class="screen-reader-text"><?php esc_html_e('Target Page', 'promptingpress'); ?></label>
+                    <select id="pp-ai-page-select" class="pp-ai-chat-selector" title="<?php esc_attr_e('Which page this conversation edits', 'promptingpress'); ?>">
+                        <option value=""><?php esc_html_e('— Select a page —', 'promptingpress'); ?></option>
+                        <?php foreach ($pp_ai_chat_pages as $pp_ai_chat_page_item): ?>
+                            <option value="<?php echo esc_attr($pp_ai_chat_page_item['id']); ?>">
+                                <?php echo esc_html($pp_ai_chat_page_item['title'] !== '' ? $pp_ai_chat_page_item['title'] : '(untitled)'); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
                     <?php if ($is_multi_provider): ?>
                         <label for="pp-ai-provider-select" class="screen-reader-text"><?php esc_html_e('AI Provider', 'promptingpress'); ?></label>
                         <select id="pp-ai-provider-select" class="pp-ai-chat-selector">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.37",
+  "version": "0.16.38",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.37
+Stable tag: 0.16.38
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.37
+Version:          0.16.38
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/pp-ai-chat-page-target.test.js
+++ b/tests/js/pp-ai-chat-page-target.test.js
@@ -1,0 +1,142 @@
+/**
+ * Tests for page-targeting helpers in assets/js/pp-ai-chat.js (issue 136)
+ *
+ * Covers the pure functions backing the explicit page selector:
+ *   detectPageId            — longest-substring title match, pure (no side effects)
+ *   findPageById            — page lookup by id
+ *   shouldSuggestPageSwitch — detection-vs-active-selection disagreement
+ *
+ * These replace the old detectPageId(messages), which read window state
+ * directly and doubled as the mechanism that silently reassigned the active
+ * page — the bug this issue fixes. The new functions are pure: callers decide
+ * what to do with the result, and nothing here ever mutates page selection.
+ */
+
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!DOCTYPE html><html><body>' +
+    '<div id="pp-ai-messages"></div>' +
+    '<textarea id="pp-ai-input"></textarea>' +
+    '<button id="pp-ai-send"></button>' +
+    '</body></html>', { url: 'http://localhost' });
+
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.localStorage = dom.window.localStorage;
+global.FormData = dom.window.FormData;
+global.fetch = function () { return Promise.resolve({ json: function () { return Promise.resolve({}); } }); };
+
+dom.window.ppAiChat = {
+    configured: true,
+    ajaxUrl: '/wp-admin/admin-ajax.php',
+    executeNonce: 'test-nonce',
+    siteUrl: 'http://page-target.example.com',
+    streamUrl: '/wp-admin/admin-ajax.php?action=pp_ai_stream',
+    streamNonce: 'stream-nonce'
+};
+global.window.ppAiChat = dom.window.ppAiChat;
+
+const {
+    detectPageId,
+    findPageById,
+    shouldSuggestPageSwitch,
+} = require('../../assets/js/pp-ai-chat.js');
+
+const pages = [
+    { id: 1, title: 'About' },
+    { id: 2, title: 'About the Team' },
+    { id: 3, title: 'Pricing' },
+    { id: 4, title: '' }, // untitled page — must never match
+];
+
+// ─── detectPageId ──────────────────────────────────────────────────────────
+
+describe('detectPageId', function () {
+    test('matches a page whose title is a substring of the text', function () {
+        expect(detectPageId('please make the pricing page bolder', pages)).toBe(3);
+    });
+
+    test('picks the longest matching title on substring collision', function () {
+        // "About" is a substring of "About the Team" — the longer, more
+        // specific title must win, not whichever page comes first in the list.
+        expect(detectPageId('tell me about the team roster', pages)).toBe(2);
+    });
+
+    test('shorter title still matches when the longer one is absent', function () {
+        expect(detectPageId('what is this page about anyway', pages)).toBe(1);
+    });
+
+    test('returns null when no page title appears in the text', function () {
+        expect(detectPageId('make the hero bigger', pages)).toBeNull();
+    });
+
+    test('returns null for empty text', function () {
+        expect(detectPageId('', pages)).toBeNull();
+    });
+
+    test('returns null for an empty pages list', function () {
+        expect(detectPageId('about pricing', [])).toBeNull();
+    });
+
+    test('returns null when pages is not provided', function () {
+        expect(detectPageId('about pricing', null)).toBeNull();
+    });
+
+    test('never matches an untitled page', function () {
+        // A page with an empty title must not turn every message into a match.
+        expect(detectPageId('anything at all', pages)).toBeNull();
+    });
+
+    test('title comparison is case-insensitive even when the text is already lowercased', function () {
+        // Contract: the caller pre-lowercases text (matches sendMessage's
+        // usage — detectPageId itself does not lowercase its text argument),
+        // but title comparison always lowercases the title side regardless
+        // of how it's cased in config.pages.
+        var mixedCaseTitlePages = [{ id: 3, title: 'PRICING' }];
+        expect(detectPageId('the pricing page please', mixedCaseTitlePages)).toBe(3);
+    });
+});
+
+// ─── findPageById ──────────────────────────────────────────────────────────
+
+describe('findPageById', function () {
+    test('finds a page by id', function () {
+        expect(findPageById(3, pages)).toEqual({ id: 3, title: 'Pricing' });
+    });
+
+    test('returns null for an id not in the list', function () {
+        expect(findPageById(999, pages)).toBeNull();
+    });
+
+    test('returns null for a null id', function () {
+        expect(findPageById(null, pages)).toBeNull();
+    });
+
+    test('returns null when pages is not provided', function () {
+        expect(findPageById(1, null)).toBeNull();
+    });
+});
+
+// ─── shouldSuggestPageSwitch ────────────────────────────────────────────────
+
+describe('shouldSuggestPageSwitch', function () {
+    test('suggests a switch when detection disagrees with the active page', function () {
+        expect(shouldSuggestPageSwitch(1, 3)).toBe(true);
+    });
+
+    test('suggests a switch when nothing is active but something was detected', function () {
+        expect(shouldSuggestPageSwitch(null, 3)).toBe(true);
+    });
+
+    test('does not suggest when detection agrees with the active page', function () {
+        expect(shouldSuggestPageSwitch(3, 3)).toBe(false);
+    });
+
+    test('does not suggest when nothing was detected', function () {
+        expect(shouldSuggestPageSwitch(1, null)).toBe(false);
+    });
+
+    test('does not suggest when neither is set', function () {
+        expect(shouldSuggestPageSwitch(null, null)).toBe(false);
+    });
+});

--- a/tests/js/pp-ai-chat-restore.test.js
+++ b/tests/js/pp-ai-chat-restore.test.js
@@ -53,7 +53,11 @@ const conversation = [
     { role: 'user', content: '[Applied changes: hero updated]' },
 ];
 
-localStorage.setItem(STORAGE_KEY, JSON.stringify({ conversation: conversation, activePageId: null }));
+// issue 136: sendMessage() now blocks when no page is selected, so this
+// fixture restores an already-active page — the persistence assertions
+// below are about internal-message handling, not page selection.
+dom.window.ppAiChat.pages = [{ id: 1, title: 'Test Page' }];
+localStorage.setItem(STORAGE_KEY, JSON.stringify({ conversation: conversation, activePageId: 1 }));
 
 require('../../assets/js/pp-ai-chat.js');
 


### PR DESCRIPTION
## Summary
Which page a chat request mutated was inferred entirely by matching the last message against page titles as substrings — "tell me about pricing" could match a page titled "About", "make the hero bigger" matched nothing and silently reused whatever page was last targeted, and the user had no way to see or correct the target before a proposal wrote to it.

- New page `<select>` in the chat header sets `activePageId` explicitly; persisted, sent with every request.
- Sending with no page selected is blocked client-side (no `page_id: null` request) with an inline prompt.
- Title-substring detection still runs but is a suggestion only — a non-blocking "Switch to it for next message?" chip appears on disagreement; it never silently retargets.
- Every proposal card names its target page, captured at request time so it can't drift mid-stream.
- `detectPageId` moved out of the IIFE into a pure, testable `ppChatDetectPageId`, alongside two new helpers, following the file's existing testable-helper convention.

## Test plan
- [x] 1159 PHPUnit tests pass
- [x] 335 Vitest tests pass (18 new for the pure page-targeting functions; 1 existing fixture updated since sending now requires an active page)
- [x] Verified live on dev.promptingpress.com (authenticated wp-admin session): page selector populated from real pages, blocked+prompted send with nothing selected, correct detected-page hint text, explicit selection wins over detection on send, switch-suggestion chip updates the selector on click
- [x] Redaction scan clean

Closes #136