### PR TITLE
Add Stop button and first-token watchdog fallback to AI chat

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -560,7 +560,9 @@ The chat uses POST-based SSE streaming (nonce in request body, never in URL):
 4. Response chunks forwarded as SSE events: `data: {"content":"..."}\n\n`
 5. Final event includes parsed proposal if the response contains one: `data: {"done":true,"proposal":{...}}\n\n`
 
-**AJAX fallback:** If SSE fails, chat JS retries via `wp_ajax_pp_ai_chat` which returns the complete response as JSON.
+**AJAX fallback:** If SSE fails, chat JS retries via `wp_ajax_pp_ai_chat` which returns the complete response as JSON. Two distinct triggers (issue 139): a rejected `fetch` (network failure), or a **first-token watchdog** — if no `data:` line arrives within 15s of the request starting, the client aborts the SSE attempt and falls back automatically, since a proxy/CDN that buffers the whole response returns HTTP 200 with no usable stream, which does not reject the fetch on its own. A "Streaming unavailable — using compatibility mode." note marks the switch.
+
+**Stop button:** Sending creates an `AbortController` for the request; a Stop button (swapped in for Send while streaming) calls `abort()` and finalizes whatever partial text has arrived, leaving it in place with input re-enabled — an intentional stop is never treated as a failure and never triggers the AJAX fallback. A module-level `currentRequestId` counter guards every async callback (fetch `.then`/`.catch`, the fallback's response handlers) against firing into a conversation that's since been abandoned via "New Chat".
 
 ### Nonce separation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.39] — 2026-07-05 — New: Stop Button and Automatic Fallback for Stuck AI Responses
+
+**A long, wrong, or runaway chat response had no way to be interrupted — the send button and input were simply disabled until the request finished or the 120s server timeout hit. Separately, a proxy/CDN that buffers the whole streaming response (or middleware stripping `text/event-stream`) returns HTTP 200 with no usable stream, which doesn't reject the request — on those hosts the chat would sit in an indefinite "thinking" state, even though a working non-streaming fallback endpoint already existed and was simply never reached.**
+
+### Added
+- A Stop button (swapped in for Send while a response streams) aborts the request and finalizes whatever partial text has arrived, leaving it in place with input re-enabled. An intentional stop is treated as a cancellation, not a failure — it never triggers the non-streaming fallback.
+- A first-token watchdog: if no token arrives within 15 seconds of a request starting, the client aborts the stalled SSE attempt and automatically retries via the existing non-streaming endpoint, surfacing a "Streaming unavailable — using compatibility mode." note.
+
+### For contributors
+- `streamChat()` now creates an `AbortController` per request and a module-level `currentRequestId` counter that every async callback (fetch `.then`/`.catch`, the fallback's response handlers) checks before touching shared state — without it, an aborted-but-still-in-flight request's callback could fire after "New Chat" already reset the conversation, re-populating it with stale partial text.
+- 3 new Vitest tests covering the exact race conditions this touches: Stop mid-stream (assert `abort` fired, no fallback), a stalled stream with zero tokens (assert the fallback engages once the watchdog elapses), and the existing happy path (assert nothing changes when tokens arrive normally).
+- Verified live on the dev site: Stop button appears/disappears correctly across a real streaming round-trip with no console errors or stuck UI state.
+
 ## [v0.16.38] — 2026-07-05 — Fix: AI Chat Now Targets an Explicit, User-Chosen Page
 
 **Which page a chat request mutated was inferred entirely by matching the last message against page titles as substrings — "tell me about pricing" could match a page titled "About", "make the hero bigger" matched nothing and silently reused whatever page was last targeted, and the user had no way to see or correct which page was about to change before a proposal wrote to it.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.38-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.39-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/pp-ai-chat.css
+++ b/assets/css/pp-ai-chat.css
@@ -615,6 +615,17 @@ body.pp-ai-chat-page #wpfooter {
     border-radius: 4px;
 }
 
+.pp-ai-stop {
+    background: #fff;
+    border-color: #d63638;
+    color: #d63638;
+}
+
+.pp-ai-stop:hover {
+    background: #d63638;
+    color: #fff;
+}
+
 #pp-ai-chat-app .button:disabled {
     opacity: 0.6;
     cursor: not-allowed;

--- a/assets/js/pp-ai-chat.js
+++ b/assets/js/pp-ai-chat.js
@@ -302,6 +302,7 @@ function ppChatAppendValidationItems(container, items, className) {
     var messagesEl = document.getElementById('pp-ai-messages');
     var inputEl    = document.getElementById('pp-ai-input');
     var sendBtn    = document.getElementById('pp-ai-send');
+    var stopBtn    = document.getElementById('pp-ai-stop');
     var newChatBtn = document.getElementById('pp-ai-new-chat');
 
     if (!messagesEl || !inputEl || !sendBtn) return;
@@ -456,6 +457,41 @@ function ppChatAppendValidationItems(container, items, className) {
     var conversation = [];
     var isStreaming = false;
     var activePageId = null;
+
+    // issue 139: set to the current request's stop function while a stream
+    // is in flight, so the Stop button (wired once at init) can reach
+    // whichever streamChat() closure is currently active. null when idle.
+    var activeStopHandler = null;
+
+    // issue 139: bumped whenever a request is abandoned (New Chat mid-stream)
+    // rather than intentionally stopped-and-finalized. A request's async
+    // callbacks (fetch .then/.catch, ajaxFallback's response handlers) check
+    // their captured id against this counter before touching shared state —
+    // without it, an abandoned request's callback could still fire AFTER
+    // resetChat() has already cleared the conversation, re-populating it
+    // with the old request's partial text.
+    var currentRequestId = 0;
+
+    /**
+     * Toggles Send/Stop/input for the duration of a request, in one place
+     * so every entry/exit point (send, finish, error, fallback, reset) stays
+     * consistent (issue 139 — a Stop button is only useful if it's never
+     * left visible after the request it belongs to has already ended).
+     */
+    function setStreamingUiState(active) {
+        isStreaming = active;
+        sendBtn.disabled = active;
+        inputEl.disabled = active;
+        if (stopBtn) {
+            stopBtn.style.display = active ? '' : 'none';
+        }
+    }
+
+    if (stopBtn) {
+        stopBtn.addEventListener('click', function () {
+            if (activeStopHandler) activeStopHandler();
+        });
+    }
 
     // ── Markdown Rendering ────────────────────────────────────────────
 
@@ -1259,19 +1295,24 @@ function ppChatAppendValidationItems(container, items, className) {
 
         maybeShowPageSwitchSuggestion(detectedPageId, pages);
 
-        isStreaming = true;
-        sendBtn.disabled = true;
-        inputEl.disabled = true;
+        setStreamingUiState(true);
 
         conversation.push({ role: 'user', content: trimmed });
         addMessage('user', trimmed);
         inputEl.value = '';
         saveState();
 
-        streamChat(conversation);
+        var myRequestId = ++currentRequestId;
+        streamChat(conversation, myRequestId);
     }
 
-    function streamChat(messages) {
+    // First-token watchdog (issue 139): a proxy/CDN that buffers the whole
+    // response, or middleware stripping text/event-stream, returns HTTP 200
+    // with no usable stream — that does NOT reject the fetch, so this is the
+    // only way to detect it and fall back to the non-streaming endpoint.
+    var FIRST_TOKEN_WATCHDOG_MS = 15000;
+
+    function streamChat(messages, myRequestId) {
         // Captured once per request: renderProposal() (in this closure's
         // async callbacks) must label the page actually targeted by THIS
         // request, not whatever activePageId happens to be by the time the
@@ -1288,11 +1329,28 @@ function ppChatAppendValidationItems(container, items, className) {
         var fullText = '';
         var proposalReceived = false;
 
+        var controller = new AbortController();
+        var userStopped = false;
+        var firstTokenReceived = false;
+
+        activeStopHandler = function () {
+            userStopped = true;
+            controller.abort();
+        };
+
+        var watchdogTimer = setTimeout(function () {
+            if (firstTokenReceived || myRequestId !== currentRequestId) return;
+            activeStopHandler = null;
+            controller.abort();
+            ajaxFallback(messages, msgBody, requestPageId, myRequestId);
+        }, FIRST_TOKEN_WATCHDOG_MS);
+
         fetch(config.streamUrl, {
             method: 'POST',
             credentials: 'same-origin',
             headers: { 'Content-Type': 'application/json' },
-            body: body
+            body: body,
+            signal: controller.signal
         })
         .then(function (response) {
             if (!response.ok) {
@@ -1305,7 +1363,11 @@ function ppChatAppendValidationItems(container, items, className) {
 
             function pump() {
                 return reader.read().then(function (result) {
+                    if (myRequestId !== currentRequestId) return; // abandoned (New Chat mid-stream)
+
                     if (result.done) {
+                        clearTimeout(watchdogTimer);
+                        activeStopHandler = null;
                         finishStream(msgBody, fullText, proposalReceived);
                         return;
                     }
@@ -1325,8 +1387,11 @@ function ppChatAppendValidationItems(container, items, className) {
                         var jsonStr = line.substring(6);
                         try {
                             var data = JSON.parse(jsonStr);
+                            firstTokenReceived = true;
+                            clearTimeout(watchdogTimer);
 
                             if (data.error) {
+                                activeStopHandler = null;
                                 handleStreamError(msgBody, data.error);
                                 return;
                             }
@@ -1360,8 +1425,28 @@ function ppChatAppendValidationItems(container, items, className) {
             return pump();
         })
         .catch(function (err) {
-            // SSE failed, try AJAX fallback
-            ajaxFallback(messages, msgBody, requestPageId);
+            clearTimeout(watchdogTimer);
+            activeStopHandler = null;
+
+            if (myRequestId !== currentRequestId) return; // abandoned (New Chat mid-stream)
+
+            if (userStopped) {
+                // issue 139: user clicked Stop — finalize the partial
+                // message in place; this was an intentional cancellation,
+                // not a failure, so never fall back to the AJAX endpoint.
+                finishStream(msgBody, fullText, proposalReceived);
+                return;
+            }
+
+            if (err.name === 'AbortError') {
+                // The watchdog already aborted and triggered ajaxFallback
+                // itself, synchronously, before this rejection could fire —
+                // nothing left to do here.
+                return;
+            }
+
+            // Genuine SSE failure — try AJAX fallback.
+            ajaxFallback(messages, msgBody, requestPageId, myRequestId);
         });
     }
 
@@ -1391,9 +1476,7 @@ function ppChatAppendValidationItems(container, items, className) {
             }
         }
         saveState();
-        isStreaming = false;
-        sendBtn.disabled = false;
-        inputEl.disabled = false;
+        setStreamingUiState(false);
         inputEl.focus();
     }
 
@@ -1453,14 +1536,17 @@ function ppChatAppendValidationItems(container, items, className) {
             msgBody.appendChild(link);
         }
 
-        isStreaming = false;
-        sendBtn.disabled = false;
-        inputEl.disabled = false;
+        setStreamingUiState(false);
     }
 
     // ── AJAX Fallback ──────────────────────────────────────────────────
 
-    function ajaxFallback(messages, msgBody, requestPageId) {
+    function ajaxFallback(messages, msgBody, requestPageId, myRequestId) {
+        // issue 139: a subtle note when the non-streaming fallback engages —
+        // for supportability, so a slow/no-typing-effect response doesn't
+        // look like a silent bug.
+        addStatusMessage('Streaming unavailable — using compatibility mode.', false);
+
         var data = new FormData();
         data.append('action', 'pp_ai_chat');
         data.append('nonce', config.streamNonce);
@@ -1477,6 +1563,8 @@ function ppChatAppendValidationItems(container, items, className) {
         })
         .then(function (r) { return r.json(); })
         .then(function (resp) {
+            if (myRequestId !== currentRequestId) return; // abandoned (New Chat mid-stream)
+
             if (resp.success) {
                 setMarkdownContent(msgBody, resp.data.content);
                 msgBody.classList.remove('pp-ai-msg-streaming');
@@ -1495,12 +1583,11 @@ function ppChatAppendValidationItems(container, items, className) {
             }
 
             saveState();
-            isStreaming = false;
-            sendBtn.disabled = false;
-            inputEl.disabled = false;
+            setStreamingUiState(false);
             inputEl.focus();
         })
         .catch(function () {
+            if (myRequestId !== currentRequestId) return; // abandoned (New Chat mid-stream)
             handleStreamError(msgBody, 'Connection failed. Please try again.');
         });
     }
@@ -1560,13 +1647,21 @@ function ppChatAppendValidationItems(container, items, className) {
     // ── New Chat ──────────────────────────────────────────────────────
 
     function resetChat() {
+        // Starting a new chat mid-stream must not leave an orphaned request
+        // running in the background, nor let its callbacks land in the
+        // fresh conversation once they eventually fire (issue 139) — bumping
+        // currentRequestId makes every one of that request's async callbacks
+        // (fetch .then/.catch, ajaxFallback's handlers) a no-op once they
+        // check their captured id against it.
+        currentRequestId++;
+        if (activeStopHandler) activeStopHandler();
+        activeStopHandler = null;
+
         conversation = [];
         activePageId = null;
-        isStreaming = false;
         clearState();
         messagesEl.innerHTML = '';
-        sendBtn.disabled = false;
-        inputEl.disabled = false;
+        setStreamingUiState(false);
         inputEl.value = '';
         inputEl.focus();
         syncPageSelectValue();

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.38');
+define('PP_VERSION', '0.16.39');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/ai-chat.php
+++ b/lib/ai-chat.php
@@ -189,6 +189,7 @@ function pp_ai_chat_page(): void {
                     <label for="pp-ai-input" class="screen-reader-text"><?php esc_html_e('Chat message', 'promptingpress'); ?></label>
                     <textarea id="pp-ai-input" placeholder="Ask about your site or request a change..." rows="2"></textarea>
                     <button id="pp-ai-send" class="button button-primary">Send</button>
+                    <button id="pp-ai-stop" class="button pp-ai-stop" style="display:none;" title="<?php esc_attr_e('Stop the current response', 'promptingpress'); ?>">Stop</button>
                 </div>
             <?php endif; ?>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.38",
+  "version": "0.16.39",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.38
+Stable tag: 0.16.39
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.38
+Version:          0.16.39
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/pp-ai-chat-stop-fallback.test.js
+++ b/tests/js/pp-ai-chat-stop-fallback.test.js
@@ -1,0 +1,233 @@
+/**
+ * Tests for Stop/cancel and first-token-watchdog fallback in
+ * assets/js/pp-ai-chat.js (issue 139)
+ *
+ * Covers:
+ *   - Clicking Stop mid-stream aborts the network request, finalizes the
+ *     partial message, and never falls back to the non-streaming endpoint
+ *     (an intentional cancellation is not a failure).
+ *   - A stream that never emits a `data:` token (simulated proxy-buffered
+ *     200) triggers the non-streaming fallback once the watchdog window
+ *     elapses, without the user doing anything.
+ *   - The existing streaming happy path (tokens arrive before the watchdog)
+ *     is unaffected — no fallback engages, no Stop-related state leaks.
+ *
+ * global.fetch is mocked per-test so each streamChat() request's timing
+ * (when/whether tokens arrive, whether it hangs) is fully controlled.
+ */
+
+const { JSDOM } = require('jsdom');
+
+/**
+ * Drains the native Promise microtask queue. An abort rejection propagates
+ * through several .then()/pump() hops before reaching streamChat's outer
+ * .catch — none of them are timer-based, so vi.advanceTimersByTimeAsync
+ * alone doesn't guarantee they've all settled.
+ */
+async function flushMicrotasks() {
+    for (var i = 0; i < 20; i++) {
+        await Promise.resolve();
+    }
+}
+
+function encode(str) {
+    return new TextEncoder().encode(str);
+}
+
+/**
+ * A controllable "reader" mimicking ReadableStreamDefaultReader: each call
+ * to .read() resolves with the next queued chunk, or hangs forever (never
+ * resolves) once the queue is exhausted and `hang` is true — simulating a
+ * buffered proxy that never delivers anything after the initial response.
+ *
+ * Mirrors real fetch semantics: aborting AFTER the response promise has
+ * already resolved (headers arrived) doesn't reject that promise — it
+ * rejects the next reader.read() call instead. `signal` (optional) wires
+ * that up for the hanging case.
+ */
+function makeReader(chunks, hang, signal) {
+    var i = 0;
+    return {
+        read: function () {
+            if (i < chunks.length) {
+                var chunk = chunks[i++];
+                return Promise.resolve({ done: false, value: encode(chunk) });
+            }
+            if (hang) {
+                return new Promise(function (resolve, reject) {
+                    if (signal) {
+                        signal.addEventListener('abort', function () {
+                            var err = new Error('The operation was aborted.');
+                            err.name = 'AbortError';
+                            reject(err);
+                        });
+                    }
+                });
+            }
+            return Promise.resolve({ done: true, value: undefined });
+        }
+    };
+}
+
+describe('Stop button and first-token watchdog fallback (issue 139)', function () {
+    var dom, window, document, ajaxCalls, streamFetchBehavior;
+
+    beforeEach(function () {
+        vi.useFakeTimers();
+
+        dom = new JSDOM('<!DOCTYPE html><html><body>' +
+            '<div id="pp-ai-messages"></div>' +
+            '<select id="pp-ai-page-select"></select>' +
+            '<textarea id="pp-ai-input"></textarea>' +
+            '<button id="pp-ai-send"></button>' +
+            '<button id="pp-ai-stop" style="display:none;"></button>' +
+            '</body></html>', { url: 'http://localhost' });
+
+        window = dom.window;
+        document = dom.window.document;
+
+        global.window = window;
+        global.document = document;
+        global.HTMLElement = window.HTMLElement;
+        global.localStorage = window.localStorage;
+        global.FormData = window.FormData;
+        global.TextDecoder = window.TextDecoder || require('util').TextDecoder;
+
+        ajaxCalls = [];
+        streamFetchBehavior = null; // set per-test before sending
+
+        global.fetch = function (url, opts) {
+            if (url.indexOf('ai-stream') !== -1 || url === '/stream') {
+                return streamFetchBehavior(opts);
+            }
+            // AJAX fallback endpoint
+            ajaxCalls.push(opts);
+            return Promise.resolve({
+                json: function () {
+                    return Promise.resolve({ success: true, data: { content: 'Fallback response text.' } });
+                }
+            });
+        };
+
+        window.ppAiChat = {
+            configured: true,
+            ajaxUrl: '/wp-admin/admin-ajax.php',
+            executeNonce: 'test-nonce',
+            siteUrl: 'http://stop-fallback.example.com',
+            streamUrl: '/stream',
+            streamNonce: 'stream-nonce',
+            pages: [{ id: 1, title: 'Test Page' }]
+        };
+        global.window.ppAiChat = window.ppAiChat;
+
+        // vi.resetModules() alone does not clear Node's own CJS require
+        // cache for a literal require() call — without this, the IIFE only
+        // ever executes once (on the first test in the whole run) and every
+        // later test's require() silently returns that first run's already-
+        // bound DOM references (stale sendBtn/messagesEl/etc. from an
+        // earlier test's now-detached document), so nothing in a later
+        // test's fresh DOM ever actually receives its event listeners.
+        var modulePath = require.resolve('../../assets/js/pp-ai-chat.js');
+        delete require.cache[modulePath];
+        vi.resetModules();
+        require('../../assets/js/pp-ai-chat.js');
+
+        // issue 136: sending is blocked without an explicit page selection —
+        // select one directly rather than relying on localStorage restore
+        // (restoreConversation() only restores state for a non-empty saved
+        // conversation, which these tests intentionally start without).
+        var pageSelect = document.getElementById('pp-ai-page-select');
+        var opt = document.createElement('option');
+        opt.value = '1';
+        pageSelect.appendChild(opt);
+        pageSelect.value = '1';
+        pageSelect.dispatchEvent(new window.Event('change'));
+    });
+
+    afterEach(function () {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        delete global.fetch;
+        delete global.TextDecoder;
+    });
+
+    function send(text) {
+        document.getElementById('pp-ai-input').value = text;
+        document.getElementById('pp-ai-send').click();
+    }
+
+    test('Stop button aborts the request and re-enables input without falling back', async function () {
+        var abortedController = null;
+        streamFetchBehavior = function (opts) {
+            abortedController = opts.signal;
+            return Promise.resolve({
+                ok: true,
+                body: { getReader: function () { return makeReader(['data: {"content":"Partial "}\n\n'], true, opts.signal); } }
+            });
+        };
+
+        send('make the hero bigger');
+        await vi.advanceTimersByTimeAsync(0); // let the fetch + first chunk resolve
+
+        expect(document.getElementById('pp-ai-stop').style.display).not.toBe('none');
+        var assistantBody = document.querySelector('.pp-ai-msg-assistant .pp-ai-msg-body');
+        expect(assistantBody.textContent).toBe('Partial ');
+
+        document.getElementById('pp-ai-stop').click();
+        await flushMicrotasks();
+
+        expect(abortedController.aborted).toBe(true);
+        expect(document.getElementById('pp-ai-send').disabled).toBe(false);
+        expect(document.getElementById('pp-ai-input').disabled).toBe(false);
+        expect(document.getElementById('pp-ai-stop').style.display).toBe('none');
+        expect(ajaxCalls.length).toBe(0); // an intentional stop is not a failure — no fallback
+    });
+
+    test('a stream with no tokens falls back to the AJAX endpoint once the watchdog elapses', async function () {
+        streamFetchBehavior = function (opts) {
+            // Simulated buffered-200: headers resolve, but no data: line ever
+            // arrives — mirrors a proxy holding the whole response.
+            return Promise.resolve({
+                ok: true,
+                body: { getReader: function () { return makeReader([], true, opts.signal); } }
+            });
+        };
+
+        send('make the hero bigger');
+        await flushMicrotasks(); // let the fetch resolve and reader.read() attach its abort listener
+        expect(ajaxCalls.length).toBe(0);
+
+        await vi.advanceTimersByTimeAsync(15000);
+        await flushMicrotasks();
+
+        expect(ajaxCalls.length).toBe(1);
+        expect(document.body.textContent).toContain('compatibility mode');
+    });
+
+    test('happy path with tokens arriving well before the watchdog never falls back', async function () {
+        streamFetchBehavior = function (opts) {
+            return Promise.resolve({
+                ok: true,
+                body: {
+                    getReader: function () {
+                        return makeReader([
+                            'data: {"content":"Hello"}\n\n',
+                            'data: {"done":true}\n\n'
+                        ], false);
+                    }
+                }
+            });
+        };
+
+        send('make the hero bigger');
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Advance well past the watchdog window — since the stream already
+        // finished (reader signalled done), no fallback should ever fire.
+        await vi.advanceTimersByTimeAsync(20000);
+
+        expect(ajaxCalls.length).toBe(0);
+        expect(document.getElementById('pp-ai-stop').style.display).toBe('none');
+        expect(document.getElementById('pp-ai-send').disabled).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
A long, wrong, or runaway chat response had no way to be interrupted, and a proxy/CDN that buffers the whole streaming response (returning HTTP 200 with no usable stream) left the chat in an indefinite "thinking" state despite a working non-streaming fallback already existing.

- Stop button (swapped in for Send while streaming) aborts the request via `AbortController` and finalizes the partial message — an intentional stop, never treated as a failure, never triggers fallback.
- First-token watchdog: no token within 15s aborts the stalled attempt and retries via the existing `wp_ajax_pp_ai_chat` fallback automatically, with a "using compatibility mode" note.
- `currentRequestId` guard prevents an abandoned request's async callbacks from firing into a conversation reset via "New Chat" in the meantime.

## Test plan
- [x] 1159 PHPUnit tests pass
- [x] 338 Vitest tests pass (3 new, covering Stop-mid-stream, watchdog-triggered fallback, and the unaffected happy path — using a controlled fetch/reader mock + fake timers to exercise the exact abort race conditions)
- [x] Verified live on dev.promptingpress.com: Stop button markup renders and toggles correctly across a real streaming round-trip, no console errors
- [x] Redaction scan clean

Closes #139