### PR TITLE
Normalize Windows backslash separators in theme file hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.42] — 2026-07-05 — Fix: Theme Integrity Permanently "Unsafe" on Windows Hosting
+
+**On Windows hosting (IIS/XAMPP — fully supported by WordPress), theme file hashing kept backslash path separators instead of stripping them to forward slashes. Since `integrity-manifest.json` is built on Linux CI with forward-slash paths, every nested file mismatched on Windows — reported as both "missing" and "extra" — which permanently flipped theme integrity to "unsafe" and blocked every theme update, with a persistent "files modified locally" admin notice that could never clear.**
+
+### Fixed
+- Both theme-file hashers, and `pp_classify_surface()`'s theme-directory-prefix strip, now normalize backslashes to forward slashes before computing a relative path — regardless of which OS wrote the original absolute path.
+
+### For contributors
+- New pure function `_pp_relative_theme_path($theme_path, $pathname)` in `lib/apply.php` centralizes the normalization; both hashers and `pp_classify_surface()` now call it instead of each doing their own `str_replace()`/`ltrim()`.
+- Being a pure function (no I/O), it's directly testable with synthetic Windows-style backslash inputs on any OS — the test suite doesn't need to actually run on Windows to catch a regression here.
+- 7 new PHPUnit tests, including one asserting `pp_classify_surface()` correctly classifies a Windows-style absolute path end-to-end (theme dir + file path both backslash-separated) and one confirming a real nested file on the filesystem still hashes to a forward-slash key.
+
 ## [v0.16.41] — 2026-07-05 — New: AI Chat Can Build Navigation Menus
 
 **Navigation had zero mutation surface — no action could create a menu, add a link, or assign a location. The only nav-related code was a read-only diagnostic that explicitly told the AI to punt to a human: "Assign one under Appearance → Menus," the exact wp-admin surface the product exists to abstract away. A fresh install had no way to get a working nav menu without leaving the chat.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.41-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.42-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.41');
+define('PP_VERSION', '0.16.42');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/apply.php
+++ b/lib/apply.php
@@ -1373,6 +1373,34 @@ function _pp_save_deployment_manifest(string $theme_path, array $file_hashes): b
 }
 
 /**
+ * Converts an absolute file path within the theme directory into a
+ * normalized, forward-slash-only relative path (issue 127).
+ *
+ * On Windows hosting (IIS/XAMPP — fully supported by WordPress),
+ * RecursiveDirectoryIterator::getPathname() joins path segments with `\`.
+ * A plain `ltrim(str_replace($theme_path, '', $pathname), '/')` never
+ * strips a leading backslash, and nested paths keep `\` separators (e.g.
+ * `\components\hero\hero.php`). Since integrity-manifest.json is built on
+ * Linux CI with `/` paths, every nested file then mismatches on Windows —
+ * reported as both `missing` and `extra` — which flips theme integrity to
+ * "unsafe" and blocks every theme update. Normalizing both sides to `/`
+ * before stripping the prefix fixes this regardless of which OS actually
+ * wrote the file path.
+ *
+ * Pure function — no I/O — so it's testable on any OS regardless of which
+ * platform actually runs the test suite.
+ *
+ * @param  string $theme_path  Absolute theme directory path (either separator).
+ * @param  string $pathname    Absolute file path within the theme (either separator).
+ * @return string              Relative path, forward slashes only, no leading separator.
+ */
+function _pp_relative_theme_path(string $theme_path, string $pathname): string {
+    $base = str_replace('\\', '/', $theme_path);
+    $path = str_replace('\\', '/', $pathname);
+    return ltrim(str_replace($base, '', $path), '/');
+}
+
+/**
  * Hashes all theme files (php, css, js, json) for drift detection.
  * Skips .git/, node_modules/, vendor/, tests/ directories.
  *
@@ -1404,7 +1432,7 @@ function _pp_hash_theme_files(string $theme_path): array {
         if (!in_array($ext, $extensions, true)) {
             continue;
         }
-        $relative = ltrim(str_replace($theme_path, '', $file->getPathname()), '/');
+        $relative = _pp_relative_theme_path($theme_path, $file->getPathname());
         $hashes[$relative] = md5_file($file->getPathname());
     }
 
@@ -1472,7 +1500,7 @@ function _pp_hash_all_theme_files(string $theme_path): array {
             continue;
         }
 
-        $relative = ltrim(str_replace($theme_path, '', $file->getPathname()), '/');
+        $relative = _pp_relative_theme_path($theme_path, $file->getPathname());
 
         // Skip individually excluded files.
         if (in_array($relative, $skip_files, true)) {

--- a/lib/guardrails.php
+++ b/lib/guardrails.php
@@ -139,8 +139,15 @@ function pp_admin_notice_css_conflicts(): void {
  * @return array{classification: string, guidance: string}
  */
 function pp_classify_surface(string $path): array {
+    // Normalize to forward slashes first (issue 127) — on Windows hosting,
+    // get_template_directory() and an absolute $path may both use `\`, and
+    // leaving them unnormalized here produces a `\`-separated relative path
+    // that then fails to match forward-slash `planned_files` entries during
+    // preflight overlap matching, even though the same file is meant.
+    $path      = str_replace('\\', '/', $path);
+    $theme_dir = str_replace('\\', '/', get_template_directory());
+
     // Normalize: strip theme directory prefix if absolute.
-    $theme_dir = get_template_directory();
     if (str_starts_with($path, $theme_dir)) {
         $path = ltrim(substr($path, strlen($theme_dir)), '/');
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.41",
+  "version": "0.16.42",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.41
+Stable tag: 0.16.42
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.41
+Version:          0.16.42
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ApplyTest.php
+++ b/tests/ApplyTest.php
@@ -1732,6 +1732,46 @@ class ApplyTest extends TestCase
         $this->assertSame('media', $apply['target']['type']);
     }
 
+    // ── _pp_relative_theme_path() tests (issue 127) ─────────────────────────
+    //
+    // Pure function — Windows-style backslash inputs are asserted directly
+    // regardless of which OS actually runs this test suite.
+
+    public function testRelativeThemePathNormalizesWindowsSeparators(): void
+    {
+        $result = _pp_relative_theme_path('C:\\wp\\wp-content\\themes\\promptingpress', 'C:\\wp\\wp-content\\themes\\promptingpress\\components\\hero\\hero.php');
+        $this->assertSame('components/hero/hero.php', $result);
+    }
+
+    public function testRelativeThemePathHandlesUnixSeparatorsUnchanged(): void
+    {
+        $result = _pp_relative_theme_path('/var/www/theme', '/var/www/theme/components/hero/hero.php');
+        $this->assertSame('components/hero/hero.php', $result);
+    }
+
+    public function testRelativeThemePathNeverLeavesALeadingSeparator(): void
+    {
+        $result = _pp_relative_theme_path('C:\\wp\\theme', 'C:\\wp\\theme\\functions.php');
+        $this->assertSame('functions.php', $result);
+        $this->assertNotSame('\\functions.php', $result);
+        $this->assertStringStartsNotWith('/', $result);
+        $this->assertStringStartsNotWith('\\', $result);
+    }
+
+    public function testRelativeThemePathHandlesRootLevelFile(): void
+    {
+        $result = _pp_relative_theme_path('C:\\wp\\theme', 'C:\\wp\\theme\\style.css');
+        $this->assertSame('style.css', $result);
+    }
+
+    public function testRelativeThemePathHandlesMixedSeparators(): void
+    {
+        // Defensive: a path assembled from mixed sources (e.g. a manifest
+        // built with '/' loaded into a Windows run) must still normalize.
+        $result = _pp_relative_theme_path('C:/wp/theme', 'C:\\wp\\theme\\assets\\css\\base.css');
+        $this->assertSame('assets/css/base.css', $result);
+    }
+
     // ── _pp_hash_all_theme_files() tests ────────────────────────────────────
 
     public function testHashAllThemeFilesReturnsHashesForAllFileTypes(): void
@@ -1884,6 +1924,23 @@ class ApplyTest extends TestCase
         sort($sorted);
 
         $this->assertSame($sorted, $keys);
+
+        $this->recursiveDelete($dir);
+    }
+
+    public function testHashAllThemeFilesProducesForwardSlashKeysForNestedFiles(): void
+    {
+        // Regression for issue 127: keys for nested files must always use
+        // forward slashes, matching the manifest built on Linux CI —
+        // regardless of which _pp_relative_theme_path() normalization path
+        // ran, on any OS.
+        $dir = sys_get_temp_dir() . '/pp-hash-test-' . getmypid() . '-' . mt_rand();
+        mkdir($dir . '/components/hero', 0755, true);
+        file_put_contents($dir . '/components/hero/hero.php', '<?php');
+
+        $hashes = _pp_hash_all_theme_files($dir);
+
+        $this->assertArrayHasKey('components/hero/hero.php', $hashes);
 
         $this->recursiveDelete($dir);
     }

--- a/tests/GuardrailsTest.php
+++ b/tests/GuardrailsTest.php
@@ -729,6 +729,21 @@ class GuardrailsTest extends TestCase
         $this->assertSame('core', $result['classification']);
     }
 
+    public function testAbsoluteWindowsPathNormalized(): void
+    {
+        // Regression for issue 127: on Windows hosting, get_template_directory()
+        // and an absolute $path may both use backslashes — the theme-prefix
+        // strip must still work, and the resulting relative path must use
+        // forward slashes for planned_files overlap matching to work.
+        $GLOBALS['_pp_test_template_dir'] = 'C:\\wp\\wp-content\\themes\\promptingpress';
+        try {
+            $result = pp_classify_surface('C:\\wp\\wp-content\\themes\\promptingpress\\components\\hero\\hero.php');
+            $this->assertSame('extension', $result['classification']);
+        } finally {
+            unset($GLOBALS['_pp_test_template_dir']);
+        }
+    }
+
     public function testUnknownPathDefaultsToCore(): void
     {
         $result = pp_classify_surface('random-file.txt');


### PR DESCRIPTION
## Summary
On Windows hosting (IIS/XAMPP — fully supported by WordPress), theme file hashing kept backslash path separators. Since `integrity-manifest.json` is built on Linux CI with forward-slash paths, every nested file mismatched on Windows — reported as both "missing" and "extra" — permanently flipping theme integrity to "unsafe" and blocking every theme update.

- New pure function `_pp_relative_theme_path($theme_path, $pathname)` in `lib/apply.php` normalizes both sides to forward slashes before stripping the theme prefix.
- Both hashers (`_pp_hash_theme_files`, `_pp_hash_all_theme_files`) and `pp_classify_surface()`'s theme-directory-prefix strip now use it.
- Drift detection and preflight's `planned_files` overlap matching are fixed transitively — both already call the fixed hashers.

## Test plan
- [x] 1193 PHPUnit tests pass (7 new)
- [x] 338 Vitest tests pass
- [x] New tests exercise the pure function with synthetic Windows-style backslash inputs directly, and confirm `pp_classify_surface()` classifies a fully Windows-style absolute path correctly end-to-end — no need to actually run on Windows to catch a regression
- [x] Redaction scan clean

Closes #127