### PR TITLE
Add wp pp validate page CLI command for rendered-HTML validation

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -249,7 +249,7 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | `pp_token_families()` | Returns token family definitions: base token to derived tokens with mix ratios |
 | `pp_derive_family_tokens($base_token, $value)` | Derives related tokens from a base token value (e.g., accent to hover/strong/border/surface) |
 | `pp_check_token_coherence($base_token, $value)` | Returns stale warnings for existing derived overrides whose hue drifts >30 degrees from the new base |
-| `pp_post_apply_validate($post_id, $target)` | Validates rendered page after apply: DOM inspection for broken images, empty content, missing components |
+| `pp_post_apply_validate($post_id, $target)` | Validates rendered page after apply: DOM inspection for broken images, empty content, missing components. Also reachable outside the chat via `wp pp validate page --post_id=N` (issue 77) |
 | `pp_get_font_urls()` | Returns array of custom font URLs from `pp_font_urls` option |
 | `pp_set_font_urls($urls)` | Writes font URL array to `pp_font_urls` option |
 
@@ -494,9 +494,10 @@ wp pp action list                                    # all actions with scope an
 wp pp action preview <name> --params='{"key":"val"}'  # validate + diff, never writes (no run-id)
 wp pp action execute <name> --run-id=<uuid> --params='{"key":"val"}'  # mutates: needs INSPECT + a covering PREFLIGHT
 wp pp check conflicts                                 # Custom CSS conflict detection
-wp pp check page --post_id=42                         # composition styling validation
+wp pp check page --post_id=42                         # composition styling validation (raw composition data, not rendered HTML)
 wp pp check surface lib/wp.php                        # surface classification (safe/extension/core)
 wp pp validate site                                   # full site validation battery
+wp pp validate page --post_id=42                      # rendered-HTML validation (issue 77) — same service that gates the AI chat's success message; optional --component-index=N; exits non-zero on failure
 
 # Semantic composition operator
 wp pp operate inspect-composition <page>              # editable targets with selectors and current values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.43] — 2026-07-05 — New: `wp pp validate page` — Rendered-HTML Validation From the CLI
+
+**The rendered-HTML validator that gates the AI chat's success message (render failures, broken images, missing local media, empty links) was wired into the chat's apply flow only. An operator or deployment workflow needed the same check outside the chat — for manual debugging, or a reusable validation hook in Claude Code / CI — but the only CLI validator (`wp pp check page`) checks raw composition data (styling/smells), not the actual rendered output.**
+
+### Added
+- `wp pp validate page --post_id=N` (optionally `--component-index=N` to validate a single component) runs the exact same `pp_post_apply_validate()` service the AI chat uses. Human-readable output, exits non-zero on any validation error.
+
+### For contributors
+- Thin CLI wrapper — no new validation logic, just a second entry point onto the existing #75 service. Distinct name from `wp pp check page` (raw composition data) since the two check genuinely different things.
+- Verified live against a real page on the dev site: passing page reports success; a hero component with a nonexistent local image reports `missing_local_media` with the exact filename and exits 1.
+
 ## [v0.16.42] — 2026-07-05 — Fix: Theme Integrity Permanently "Unsafe" on Windows Hosting
 
 **On Windows hosting (IIS/XAMPP — fully supported by WordPress), theme file hashing kept backslash path separators instead of stripping them to forward slashes. Since `integrity-manifest.json` is built on Linux CI with forward-slash paths, every nested file mismatched on Windows — reported as both "missing" and "extra" — which permanently flipped theme integrity to "unsafe" and blocked every theme update, with a persistent "files modified locally" admin notice that could never clear.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.42-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.43-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.42');
+define('PP_VERSION', '0.16.43');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -839,6 +839,64 @@ class PP_Validate_Command extends WP_CLI_Command {
             WP_CLI::halt(1);
         }
     }
+
+    /**
+     * Runs the rendered-HTML post-apply validation used to gate the AI
+     * chat's success message, outside the chat flow (issue 77).
+     *
+     * Re-renders the page's composition and inspects the HTML: render
+     * failures, empty rendered output, broken/empty image sources, missing
+     * local media references, invalid inline background-image URLs, empty
+     * links, and component-count mismatches. Distinct from `wp pp check
+     * page`, which validates composition styling/smells against the raw
+     * composition data, not the rendered HTML.
+     *
+     * ## OPTIONS
+     *
+     * --post_id=<id>
+     * : WordPress page post ID.
+     *
+     * [--component-index=<index>]
+     * : Validate only this component (0-based index) instead of the whole page.
+     *
+     * ## EXAMPLES
+     *
+     *     wp pp validate page --post_id=42
+     *     wp pp validate page --post_id=42 --component-index=2
+     *
+     */
+    public function page($args, $assoc_args) {
+        $post_id = (int) ($assoc_args['post_id'] ?? 0);
+        if (!$post_id) {
+            WP_CLI::error('--post_id is required.');
+        }
+
+        $target = null;
+        if (isset($assoc_args['component-index'])) {
+            $target = ['component_index' => (int) $assoc_args['component-index']];
+        }
+
+        $result = pp_post_apply_validate($post_id, $target);
+
+        if (!empty($result['warnings'])) {
+            WP_CLI::line(count($result['warnings']) . ' warning(s):');
+            foreach ($result['warnings'] as $w) {
+                WP_CLI::line('  - [' . $w['check'] . '] ' . $w['message']);
+            }
+        }
+
+        if ($result['ok']) {
+            WP_CLI::success("Page {$post_id}: rendered validation passed.");
+            return;
+        }
+
+        WP_CLI::line(count($result['errors']) . ' error(s):');
+        foreach ($result['errors'] as $e) {
+            WP_CLI::line('  - [' . $e['check'] . '] ' . $e['message']);
+        }
+        WP_CLI::warning("Page {$post_id}: rendered validation failed.");
+        WP_CLI::halt(1);
+    }
 }
 
 WP_CLI::add_command('pp validate', 'PP_Validate_Command');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.42",
+  "version": "0.16.43",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.42
+Stable tag: 0.16.43
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.42
+Version:          0.16.43
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
## Summary
The rendered-HTML validator that gates the AI chat's success message was wired into the chat's apply flow only. An operator or deployment workflow had no way to run the same check outside the chat — the only CLI validator (`wp pp check page`) checks raw composition data (styling/smells), not the actual rendered output.

- `wp pp validate page --post_id=N` (optionally `--component-index=N`) runs the exact same `pp_post_apply_validate()` service the AI chat uses.
- Human-readable output, exits non-zero on any validation error.
- Distinct name from `wp pp check page` since the two genuinely check different things.

## Test plan
- [x] 1193 PHPUnit tests pass (unchanged — `lib/cli.php` self-guards on the `WP_CLI` class and isn't loaded in PHPUnit, matching every other command in this file, none of which have unit coverage)
- [x] 338 Vitest tests pass
- [x] Verified live against dev.promptingpress.com: a passing page reports success; a hero component pointed at a nonexistent local image reports `missing_local_media` with the exact filename and exits 1
- [x] Redaction scan clean

Closes #77