### PR TITLE
Fix sticky header covering section headings on anchor jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.44] — 2026-07-05 — Fix: Sticky Header Covering Section Headings on Anchor Jump
+
+**A direct link or scripted jump to a section anchor (every content component supports an `id` prop for this) scrolled the target to the very top of the viewport — landing it under the sticky header instead of below it. Worst on mobile, where the header is proportionally taller, this covered the section heading entirely: a page could pass clean overflow/metric checks while still rendering a broken first impression for anyone landing directly on a section.**
+
+### Fixed
+- Anchor jumps to any content section (hero, section, cta, grid, faq, stats, logos, embed, testimonials, table) now land with the heading fully visible below the sticky header, confirmed at both 1280px and 375px viewports.
+- The mobile menu now closes when a nav link is clicked, so an in-page anchor link tapped while the menu is still open scrolls against the header's real (collapsed) height, not its taller expanded-menu state.
+
+### For contributors
+- New `--header-height` CSS custom property (`components.css`), consumed via `scroll-margin-top` on every anchor-able component's root class. Static CSS fallback (65px); `main.js` measures the real rendered `.site-header` height on load, resize, and menu toggle/close, since header height varies with content, breakpoint, and font loading — a hardcoded value would drift.
+- Not a design token: computed/measured, not AI-editable via `update_design_token`.
+- 5 new Vitest tests. Verified live at both breakpoints on the dev site: a direct anchor jump and pricing screenshots confirm the heading sits fully below the header, not covered by it.
+
 ## [v0.16.43] — 2026-07-05 — New: `wp pp validate page` — Rendered-HTML Validation From the CLI
 
 **The rendered-HTML validator that gates the AI chat's success message (render failures, broken images, missing local media, empty links) was wired into the chat's apply flow only. An operator or deployment workflow needed the same check outside the chat — for manual debugging, or a reusable validation hook in Claude Code / CI — but the only CLI validator (`wp pp check page`) checks raw composition data (styling/smells), not the actual rendered output.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.43-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.44-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -87,6 +87,19 @@
    Site header, logo, nav links, hamburger toggle.
    ========================================================================== */
 
+:root {
+  /* Static fallback for the sticky header's real height (issue 63) — JS
+     (main.js) measures the actual rendered .site-header height on load and
+     resize and overrides this, since header height varies with content,
+     breakpoint, and font loading. Without this, an anchor jump to a
+     component's id (hero, section, cta, etc. all support one) lands with
+     the sticky header covering the heading, worst on mobile where the
+     header is proportionally taller. Not a design token: computed, not
+     AI-editable via update_design_token.
+  */
+  --header-height: 65px;
+}
+
 .site-header {
   position: sticky;
   top: 0;
@@ -217,6 +230,28 @@
   .nav__menu ul li a {
     padding: var(--space-xs) var(--space-sm);
   }
+}
+
+/* ==========================================================================
+   SHARED: Anchor scroll offset (issue 63)
+   Every content component supports an `id` prop, rendering it as a direct-
+   link/deep-link anchor target. Without this, jumping to #section-id lands
+   the target at the very top of the viewport, under the sticky header
+   (worst on mobile, where the header is proportionally taller) — covering
+   the heading instead of revealing it.
+   ========================================================================== */
+
+.hero,
+.section,
+.cta,
+.grid,
+.faq,
+.stats,
+.logos,
+.embed,
+.testimonials,
+.table-section {
+  scroll-margin-top: var(--header-height);
 }
 
 /* ==========================================================================

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -7,6 +7,9 @@
  *   1. Hamburger nav toggle (mobile) — progressive enhancement:
  *      the menu is visible without JS; JS hides it and owns the toggle.
  *   2. Escape key closes the nav menu
+ *   3. Closes the mobile menu when a nav link is clicked
+ *   4. Sticky header anchor offset (issue 63) — keeps --header-height
+ *      (components.css) in sync with the real rendered header height
  *
  * Active nav link: handled server-side by WordPress (current-menu-item CSS class).
  * No JS needed — see .nav__menu li.current-menu-item > a in components.css.
@@ -30,6 +33,7 @@
       var expanded = toggle.getAttribute('aria-expanded') === 'true';
       toggle.setAttribute('aria-expanded', String(!expanded));
       menu.hidden = expanded;
+      setHeaderHeightVar();
     });
 
     // ── 2. Escape key closes the menu ──────────────────────────────────────
@@ -38,9 +42,47 @@
         menu.hidden = true;
         toggle.setAttribute('aria-expanded', 'false');
         toggle.focus();
+        setHeaderHeightVar();
       }
     });
 
+    // ── 3. Close the menu on link click ────────────────────────────────────
+    // Without this, an in-page anchor link clicked while the mobile menu is
+    // expanded would scroll while the sticky header is still in its taller,
+    // menu-open state — the exact scenario --header-height can't correct
+    // for after the fact (issue 63). Runs before the browser's default
+    // anchor-scroll for the same click, so --header-height is already
+    // updated to the collapsed height by the time the scroll happens.
+    menu.addEventListener('click', function (e) {
+      if (e.target.tagName === 'A') {
+        menu.hidden = true;
+        toggle.setAttribute('aria-expanded', 'false');
+        setHeaderHeightVar();
+      }
+    });
+
+  }
+
+  // ── 4. Sticky header anchor offset ─────────────────────────────────────────
+  //
+  // A jump to any #section-id (every content component's `id` prop renders
+  // as one) must land with the target heading below the sticky header, not
+  // covered by it (issue 63). components.css's --header-height CSS variable
+  // (consumed via scroll-margin-top) has a static fallback; this measures
+  // the REAL rendered .site-header height — which varies by content, nav
+  // menu open/closed state, breakpoint, and font loading — and keeps it
+  // current on load and resize.
+
+  var header = document.querySelector('.site-header');
+
+  function setHeaderHeightVar() {
+    if (!header) return;
+    document.documentElement.style.setProperty('--header-height', header.offsetHeight + 'px');
+  }
+
+  if (header) {
+    setHeaderHeightVar();
+    window.addEventListener('resize', setHeaderHeightVar);
   }
 
 })();

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.43');
+define('PP_VERSION', '0.16.44');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.43",
+  "version": "0.16.44",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.43
+Stable tag: 0.16.44
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.43
+Version:          0.16.44
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/main-header-offset.test.js
+++ b/tests/js/main-header-offset.test.js
@@ -1,0 +1,108 @@
+/**
+ * Tests for assets/js/main.js's sticky-header anchor-offset behavior
+ * (issue 63) and the mobile-menu-closes-on-link-click behavior that
+ * prevents the header's taller expanded-menu state from persisting into
+ * an anchor scroll.
+ *
+ * jsdom has no real layout engine, so offsetHeight always reads 0 unless
+ * explicitly stubbed — each test defines it on the header element to
+ * simulate a real rendered height.
+ */
+
+const { JSDOM } = require('jsdom');
+
+function setup(headerHeight) {
+    const dom = new JSDOM('<!DOCTYPE html><html><body>' +
+        '<header class="site-header">' +
+        '  <div class="nav__container">' +
+        '    <button class="nav__toggle" aria-expanded="false"></button>' +
+        '    <nav id="pp-nav-menu"><ul><li><a href="#pricing">Pricing</a></li></ul></nav>' +
+        '  </div>' +
+        '</header>' +
+        '</body></html>', { url: 'http://localhost', runScripts: 'outside-only' });
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+
+    const header = dom.window.document.querySelector('.site-header');
+    Object.defineProperty(header, 'offsetHeight', { value: headerHeight, configurable: true });
+
+    delete require.cache[require.resolve('../../assets/js/main.js')];
+    const script = require('fs').readFileSync(require.resolve('../../assets/js/main.js'), 'utf8');
+    dom.window.eval(script);
+
+    return dom;
+}
+
+describe('sticky header anchor offset (issue 63)', function () {
+    afterEach(function () {
+        delete global.window;
+        delete global.document;
+    });
+
+    test('sets --header-height to the real rendered header height on load', function () {
+        const dom = setup(72);
+        const value = dom.window.document.documentElement.style.getPropertyValue('--header-height');
+        expect(value).toBe('72px');
+    });
+
+    test('updates --header-height on window resize', function () {
+        const dom = setup(72);
+        const header = dom.window.document.querySelector('.site-header');
+        Object.defineProperty(header, 'offsetHeight', { value: 120, configurable: true });
+
+        dom.window.dispatchEvent(new dom.window.Event('resize'));
+
+        const value = dom.window.document.documentElement.style.getPropertyValue('--header-height');
+        expect(value).toBe('120px');
+    });
+
+    test('clicking the hamburger toggle re-measures the header height', function () {
+        const dom = setup(65);
+        const header = dom.window.document.querySelector('.site-header');
+        const toggle = dom.window.document.querySelector('.nav__toggle');
+
+        // Simulate the menu expanding and growing the header's total height.
+        Object.defineProperty(header, 'offsetHeight', { value: 240, configurable: true });
+        toggle.click();
+
+        const value = dom.window.document.documentElement.style.getPropertyValue('--header-height');
+        expect(value).toBe('240px');
+    });
+
+    test('clicking a link inside the mobile menu closes it', function () {
+        const dom = setup(65);
+        const toggle = dom.window.document.querySelector('.nav__toggle');
+        const menu = dom.window.document.getElementById('pp-nav-menu');
+        const link = menu.querySelector('a');
+
+        // Open the menu first.
+        toggle.click();
+        expect(menu.hidden).toBe(false);
+
+        link.click();
+
+        expect(menu.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('clicking a link re-measures the header height back to its collapsed size', function () {
+        const dom = setup(65);
+        const header = dom.window.document.querySelector('.site-header');
+        const toggle = dom.window.document.querySelector('.nav__toggle');
+        const menu = dom.window.document.getElementById('pp-nav-menu');
+        const link = menu.querySelector('a');
+
+        // Open the menu (header grows) then click a link — the header
+        // should be re-measured at its now-collapsed height, not left at
+        // the taller expanded-menu measurement.
+        Object.defineProperty(header, 'offsetHeight', { value: 240, configurable: true });
+        toggle.click();
+
+        Object.defineProperty(header, 'offsetHeight', { value: 65, configurable: true });
+        link.click();
+
+        const value = dom.window.document.documentElement.style.getPropertyValue('--header-height');
+        expect(value).toBe('65px');
+    });
+});


### PR DESCRIPTION
## Summary
A direct link or scripted jump to a section anchor scrolled the target to the very top of the viewport, landing it under the sticky header — worst on mobile where the header is proportionally taller, covering the section heading entirely.

- New `--header-height` CSS custom property, consumed via `scroll-margin-top` on every anchor-able component's root class (hero, section, cta, grid, faq, stats, logos, embed, testimonials, table).
- `main.js` measures the real rendered `.site-header` height on load, resize, and menu toggle/close — a hardcoded value would drift since header height varies with content, breakpoint, and font loading.
- The mobile menu now closes on nav-link click, so an in-page anchor tapped while the menu is open scrolls against the header's real collapsed height, not its taller expanded-menu state.

## Test plan
- [x] 1193 PHPUnit tests pass (unchanged — pure CSS/JS)
- [x] 343 Vitest tests pass (5 new)
- [x] Verified live on dev.promptingpress.com at both 1280px and 375px viewports: anchor target lands exactly at the header height (65px), heading fully visible below it — confirmed via computed position and viewport screenshots
- [x] Redaction scan clean

Closes #63