### PR TITLE
Add Playwright E2E coverage for AI chat streaming/apply flow (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.46] — 2026-07-05 — Test Coverage: AI Chat Streaming & Apply E2E Flow (Mock SSE)
+
+**The AI chat's streaming/proposal/apply state machine (`assets/js/pp-ai-chat.js`) had no end-to-end coverage — only its pure helper functions were unit-tested. The SSE transport, the AJAX fallback path, and the atomic batch-apply flow were only ever exercised manually.**
+
+### For contributors
+- New `tests/e2e/ai-chat.spec.ts`: 9 Playwright specs driving the real chat UI (type → send → observe) against a deterministic mocked `ai-stream.php`, matching its exact wire format (`data: {"content"|"error"|"done"...}\n\n` frames, `data: [DONE]\n\n`) — no real AI provider is ever called.
+- Covers: streamed content rendering and a single-step proposal; a multi-step proposal's "Apply All" going through the one atomic `pp_ai_execute_batch` request (#137) rather than N sequential calls; Cancel discarding a previewed proposal; a non-configured provider (plain-text HTTP 400) driving the AJAX fallback; three distinct mid-stream SSE error events (invalid key, rate limit, quota-exhausted) and the Connectors-link suppression rule tied to "no remaining credits"; a genuine dropped connection falling back to the non-streaming `pp_ai_chat` AJAX endpoint; and a truncated response (no proposal) surfacing its retry hint.
+- Scoped deliberately to this flow per the issue's own diagnostic recommendation — provider/model selection, page-switch suggestions, composition diff rendering, and localStorage restore are exercised elsewhere and were left out to avoid scope creep into full UI coverage.
+
 ## [v0.16.45] — 2026-07-05 — Test Coverage: AI Chat Trust-Boundary Gaps From v0.2.0 Review
 
 **A v0.2.0 code review identified several unit test coverage gaps in the AI chat PHP layer, deferred as non-blocking since live QA had already verified the functional paths end-to-end. Re-auditing against current code found most of the original gaps closed by later work (#131's capability-model tests are a strict superset of what was originally asked); five genuine gaps remained.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-970+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.45-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.46-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.45');
+define('PP_VERSION', '0.16.46');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.45",
+  "version": "0.16.46",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.45
+Stable tag: 0.16.46
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.45
+Version:          0.16.46
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/ai-chat.spec.ts
+++ b/tests/e2e/ai-chat.spec.ts
@@ -1,0 +1,358 @@
+import { test, expect, Page } from '@playwright/test';
+import { execSync } from 'child_process';
+
+/**
+ * AI Chat streaming/apply E2E coverage (#14).
+ *
+ * Scoped to the SSE streaming + proposal/apply state machine in
+ * assets/js/pp-ai-chat.js, using a deterministic mocked `ai-stream.php`
+ * (and the `admin-ajax.php` actions it falls back to / depends on for
+ * proposal previews and batch apply) — no real AI provider is ever called.
+ *
+ * Wire formats mocked here mirror ai-stream.php exactly:
+ *   - success: `data: {"content": "..."}\n\n` chunks, then
+ *     `data: {"done": true, "proposal"?: {...}, "truncated"?: true}\n\n`,
+ *     then `data: [DONE]\n\n`.
+ *   - mid-stream error: `data: {"error": "..."}\n\n` (still followed by a
+ *     `done` + `[DONE]` event, matching the real transport).
+ *   - not-configured: plain-text HTTP 400 (no SSE framing at all) — this is
+ *     what actually drives the client into ajaxFallback(), not a mocked
+ *     SSE error event.
+ *
+ * Not covered here (out of scope per the issue's own diagnostic comment,
+ * to avoid "scope creep into full UI coverage"): provider/model selection,
+ * page-switch suggestions, composition diff rendering, localStorage restore.
+ * Those are exercised elsewhere (unit tests) or are follow-up issues.
+ */
+
+function wpCli(cmd: string): string {
+  return execSync(`npx wp-env run cli ${cmd}`, {
+    cwd: process.cwd(),
+    encoding: 'utf-8',
+  }).trim();
+}
+
+function createPage(title: string): number {
+  const cmd = `npx wp-env run cli wp post create --post_type=page --post_status=publish --post_author=1 --post_title="${title}" --porcelain`;
+  const id = parseInt(
+    execSync(cmd, { cwd: process.cwd(), encoding: 'utf-8' }).trim(),
+    10,
+  );
+  execSync(
+    `npx wp-env run cli wp post meta update ${id} _wp_page_template composition.php`,
+    { cwd: process.cwd() },
+  );
+  wpCli(`wp post meta update ${id} _pp_composition '[{"component":"hero","props":{"title":"Chat E2E"}}]'`);
+  return id;
+}
+
+function deletePage(id: number): void {
+  execSync(`npx wp-env run cli wp post delete ${id} --force`, {
+    cwd: process.cwd(),
+  });
+}
+
+type SseEvent = Record<string, unknown>;
+
+function sseBody(events: SseEvent[]): string {
+  const frames = events.map((e) => `data: ${JSON.stringify(e)}\n\n`);
+  frames.push('data: [DONE]\n\n');
+  return frames.join('');
+}
+
+async function mockStream(page: Page, events: SseEvent[]): Promise<void> {
+  await page.route('**/ai-stream.php', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: sseBody(events),
+    });
+  });
+}
+
+async function mockStreamNotConfigured(page: Page): Promise<void> {
+  await page.route('**/ai-stream.php', async (route) => {
+    await route.fulfill({
+      status: 400,
+      contentType: 'text/plain',
+      body: 'AI provider not configured. Check Settings > Connectors.',
+    });
+  });
+}
+
+async function mockStreamDropped(page: Page): Promise<void> {
+  await page.route('**/ai-stream.php', async (route) => {
+    await route.abort('failed');
+  });
+}
+
+/** One handler covers every admin-ajax.php action this suite mocks. */
+async function mockAjax(
+  page: Page,
+  handlers: Record<string, (postData: string) => Record<string, unknown>>,
+): Promise<void> {
+  await page.route('**/admin-ajax.php', async (route, request) => {
+    const postData = request.postData() || '';
+    const actionName = Object.keys(handlers).find((name) =>
+      postData.includes(name),
+    );
+    if (!actionName) {
+      return route.continue();
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(handlers[actionName](postData)),
+    });
+  });
+}
+
+function previewOkResponse() {
+  return {
+    success: true,
+    data: { changes: [{ path: 'props.title', from: 'Chat E2E', to: 'Updated Title' }] },
+  };
+}
+
+async function gotoChat(page: Page, pageId: number): Promise<void> {
+  await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+  await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+  await page.selectOption('#pp-ai-page-select', String(pageId));
+}
+
+test.describe('AI Chat — streaming & apply (mock SSE)', () => {
+  let pageId: number;
+
+  test.afterEach(async () => {
+    if (pageId) {
+      try {
+        deletePage(pageId);
+      } catch {
+        /* already cleaned */
+      }
+      pageId = 0;
+    }
+  });
+
+  test('streams content and renders a single-step proposal', async ({ page }) => {
+    pageId = createPage('E2E Chat Single Step');
+    await gotoChat(page, pageId);
+    await mockStream(page, [
+      { content: 'Sure, ' },
+      { content: 'here is the change.' },
+      {
+        done: true,
+        proposal: {
+          steps: [
+            { type: 'action', name: 'update_component', description: 'Update hero title', params: { post_id: pageId, component_index: 0, props: { title: 'Updated Title' } } },
+          ],
+        },
+      },
+    ]);
+    await mockAjax(page, { pp_ai_preview: previewOkResponse });
+
+    await page.fill('#pp-ai-input', 'Update the hero title');
+    await page.click('#pp-ai-send');
+
+    await expect(page.locator('.pp-ai-msg-user .pp-ai-msg-body').last()).toHaveText('Update the hero title');
+    await expect(page.locator('.pp-ai-msg-assistant .pp-ai-msg-body').last()).toHaveText(
+      'Sure, here is the change.',
+      { timeout: 10000 },
+    );
+    await expect(page.locator('.pp-ai-msg-assistant .pp-ai-msg-streaming')).toHaveCount(0);
+
+    await expect(page.locator('.pp-ai-proposal-step-label')).toHaveText('1. Update hero title');
+    const applyBtn = page.locator('.pp-ai-proposal-apply');
+    await expect(applyBtn).toBeVisible({ timeout: 10000 });
+    await expect(applyBtn).toHaveText('Apply');
+  });
+
+  test('renders Apply All for a multi-step proposal and applies via one atomic batch request', async ({ page }) => {
+    pageId = createPage('E2E Chat Multi Step');
+    await gotoChat(page, pageId);
+    await mockStream(page, [
+      {
+        done: true,
+        proposal: {
+          steps: [
+            { type: 'action', name: 'update_component', description: 'Update hero title', params: { post_id: pageId, component_index: 0, props: { title: 'A' } } },
+            { type: 'action', name: 'style_component', description: 'Add hero shadow', params: { post_id: pageId, component_index: 0, style: { '--hero-shadow': 'var(--shadow-md)' } } },
+          ],
+        },
+      },
+    ]);
+
+    let executeBody = '';
+    await mockAjax(page, {
+      pp_ai_preview: previewOkResponse,
+      pp_ai_execute_batch: (postData) => {
+        executeBody = postData;
+        return {
+          success: true,
+          data: {
+            ok: true,
+            steps: [
+              { ok: true, validation: { ok: true, warnings: [], errors: [] }, stale_warnings: null },
+              { ok: true, validation: { ok: true, warnings: [], errors: [] }, stale_warnings: null },
+            ],
+            failed_at: null,
+            rolled_back: false,
+          },
+        };
+      },
+    });
+
+    await page.fill('#pp-ai-input', 'Update the title and add a shadow');
+    await page.click('#pp-ai-send');
+
+    const applyBtn = page.locator('.pp-ai-proposal-apply');
+    await expect(applyBtn).toBeVisible({ timeout: 10000 });
+    await expect(applyBtn).toHaveText('Apply All');
+
+    await applyBtn.click();
+
+    // On success the proposal card is replaced wholesale with a post-apply
+    // summary (buildPostApplyCard) — the per-step "executing" elements are
+    // gone, not just re-classed, so assert on that summary rather than on
+    // transient per-step classes.
+    await expect(
+      page.locator('.pp-ai-proposal-card .pp-ai-step-done', { hasText: 'All changes applied successfully.' }),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.pp-ai-proposal-card .pp-ai-status', { hasText: 'Applied: Update hero title' })).toBeVisible();
+    await expect(page.locator('.pp-ai-proposal-card .pp-ai-status', { hasText: 'Applied: Add hero shadow' })).toBeVisible();
+
+    // #137: one atomic batch call carrying both steps, not two sequential
+    // pp_ai_execute calls — the "steps" field is valid JSON with both entries.
+    const stepsField = /name="steps"\r?\n\r?\n(\[.*?\])\r?\n/s.exec(executeBody);
+    expect(stepsField).not.toBeNull();
+    expect(JSON.parse(stepsField![1])).toHaveLength(2);
+  });
+
+  test('Cancel discards a previewed proposal without applying', async ({ page }) => {
+    pageId = createPage('E2E Chat Cancel');
+    await gotoChat(page, pageId);
+    await mockStream(page, [
+      {
+        done: true,
+        proposal: {
+          steps: [
+            { type: 'action', name: 'update_component', description: 'Update hero title', params: { post_id: pageId, component_index: 0, props: { title: 'A' } } },
+          ],
+        },
+      },
+    ]);
+    await mockAjax(page, { pp_ai_preview: previewOkResponse });
+
+    await page.fill('#pp-ai-input', 'Update the hero title');
+    await page.click('#pp-ai-send');
+
+    const cancelBtn = page.locator('.pp-ai-proposal-cancel');
+    await expect(cancelBtn).toBeVisible({ timeout: 10000 });
+    await cancelBtn.click();
+
+    await expect(page.locator('.pp-ai-proposal-card.pp-ai-proposal-cancelled')).toBeVisible();
+    await expect(page.locator('.pp-ai-status', { hasText: 'Proposal cancelled.' })).toBeVisible();
+    await expect(page.locator('.pp-ai-proposal-apply')).toBeDisabled();
+  });
+
+  test('no API key configured: stream 400s and the AJAX fallback surfaces a Connectors error', async ({ page }) => {
+    pageId = createPage('E2E Chat No Key');
+    await gotoChat(page, pageId);
+    await mockStreamNotConfigured(page);
+    await mockAjax(page, {
+      pp_ai_chat: () => ({
+        success: false,
+        data: 'AI provider not configured. Check Settings > Connectors.',
+      }),
+    });
+
+    await page.fill('#pp-ai-input', 'Hello');
+    await page.click('#pp-ai-send');
+
+    await expect(page.locator('.pp-ai-status', { hasText: 'Streaming unavailable' })).toBeVisible({ timeout: 10000 });
+    const errBody = page.locator('.pp-ai-msg-assistant .pp-ai-msg-error');
+    await expect(errBody).toContainText('AI provider not configured.');
+    await expect(errBody.locator('a')).toHaveText('Settings > Connectors');
+  });
+
+  test('invalid API key mid-stream: SSE error event shows a Connectors link', async ({ page }) => {
+    pageId = createPage('E2E Chat Invalid Key');
+    await gotoChat(page, pageId);
+    await mockStream(page, [
+      { error: 'AI provider rejected the API key. Check Settings > Connectors.' },
+    ]);
+
+    await page.fill('#pp-ai-input', 'Hello');
+    await page.click('#pp-ai-send');
+
+    const errBody = page.locator('.pp-ai-msg-assistant .pp-ai-msg-error');
+    await expect(errBody).toContainText('rejected the API key', { timeout: 10000 });
+    await expect(errBody.locator('a')).toHaveText('Settings > Connectors');
+  });
+
+  test('rate limited mid-stream: SSE error event shows no Connectors link', async ({ page }) => {
+    pageId = createPage('E2E Chat Rate Limited');
+    await gotoChat(page, pageId);
+    await mockStream(page, [
+      { error: 'Rate limited. Try again in a moment.' },
+    ]);
+
+    await page.fill('#pp-ai-input', 'Hello');
+    await page.click('#pp-ai-send');
+
+    const errBody = page.locator('.pp-ai-msg-assistant .pp-ai-msg-error');
+    await expect(errBody).toContainText('Rate limited', { timeout: 10000 });
+    await expect(errBody.locator('a')).toHaveCount(0);
+  });
+
+  test('quota exhausted mid-stream: mentions API key but still suppresses the Connectors link', async ({ page }) => {
+    pageId = createPage('E2E Chat Quota');
+    await gotoChat(page, pageId);
+    await mockStream(page, [
+      { error: 'Your API key has no remaining credits. Add billing at your provider, or switch to a different provider above.' },
+    ]);
+
+    await page.fill('#pp-ai-input', 'Hello');
+    await page.click('#pp-ai-send');
+
+    const errBody = page.locator('.pp-ai-msg-assistant .pp-ai-msg-error');
+    await expect(errBody).toContainText('no remaining credits', { timeout: 10000 });
+    await expect(errBody.locator('a')).toHaveCount(0);
+  });
+
+  test('genuine network failure during streaming falls back to the AJAX chat endpoint', async ({ page }) => {
+    pageId = createPage('E2E Chat Connection Drop');
+    await gotoChat(page, pageId);
+    await mockStreamDropped(page);
+    await mockAjax(page, {
+      pp_ai_chat: () => ({
+        success: true,
+        data: { content: 'Here is my reply via the fallback endpoint.' },
+      }),
+    });
+
+    await page.fill('#pp-ai-input', 'Hello');
+    await page.click('#pp-ai-send');
+
+    await expect(page.locator('.pp-ai-status', { hasText: 'Streaming unavailable' })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.pp-ai-msg-assistant .pp-ai-msg-body').last()).toHaveText(
+      'Here is my reply via the fallback endpoint.',
+    );
+  });
+
+  test('truncated response without a proposal surfaces a retry hint', async ({ page }) => {
+    pageId = createPage('E2E Chat Truncated');
+    await gotoChat(page, pageId);
+    await mockStream(page, [
+      { content: 'Sure, let me think about this.' },
+      { done: true, truncated: true },
+    ]);
+
+    await page.fill('#pp-ai-input', 'Make a change');
+    await page.click('#pp-ai-send');
+
+    await expect(
+      page.locator('.pp-ai-status', { hasText: 'was cut short before the proposal could be generated' }),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `tests/e2e/ai-chat.spec.ts`: 9 Playwright specs driving the real chat UI against a deterministic mocked `ai-stream.php` (SSE), matching the real wire format exactly — no AI provider is ever called.
- Covers: streamed content + single-step proposal; multi-step "Apply All" via the one atomic `pp_ai_execute_batch` call (#137); Cancel; not-configured (400) → AJAX fallback; three mid-stream SSE error variants (invalid key, rate limit, quota — including the "no remaining credits" link-suppression rule); genuine dropped connection → AJAX fallback; truncated response retry hint.
- Scoped deliberately per the issue's diagnostic comment to avoid "scope creep into full UI coverage" — provider/model selection, page-switch suggestions, composition diffs, and localStorage restore are out of scope here (covered elsewhere).
- v0.16.46 version bump (5 synced files) + CHANGELOG entry.

## Test plan
- [x] `npx playwright test --config tests/e2e/playwright.config.ts` — full suite (32 passed, 1 pre-existing quarantined skip from #83)
- [x] `./vendor/bin/phpunit` — 1207/1207 passed
- [x] `npx vitest run` — 343/343 passed
- [x] `gstack-redact --diff` — clean

Closes #14.