### PR TITLE
v0.16.53 fix: flag missing local media in any same-site URL shape (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.53] — 2026-07-07 — Post-apply site validation now flags a missing local image in any URL shape (#83)
+
+**After an apply, the site check that catches broken images used to miss a same-site image whenever its rendered URL didn't byte-match the uploads base URL — an `http` vs `https` or host mismatch. So a page could render an unresolvable image and still report "validation passed." It's caught now, in every URL shape.**
+
+`pp_post_apply_validate()` re-renders a page after an apply and flags images that point at missing Media Library files (`missing_local_media`). It only treated a rendered image or `background-image` URL as local to verify when the URL was byte-for-byte prefixed by the resolved uploads base URL. A same-site image whose scheme, host, port, or path shape differed even slightly — the exact situation on some setups where the live base URL comes back `https` while the rendered URL is `http` — was classed "external" and skipped, so an unresolvable image passed silently. This reuses the same-site URL matcher introduced in #153 so the post-apply validator and the action-param validator now agree on what "same-site" means.
+
+### Fixed
+- **A missing local image is flagged in any URL shape (#83).** The two rendered-HTML scan sites (`<img src>` and inline `background-image:url()`) now classify a same-site image via the origin-aware matcher instead of an exact base-URL prefix, so an unresolvable image written as an absolute-under-baseurl, site-relative `/wp-content/uploads/…`, protocol-relative, or `http`/`https`-swapped URL all correctly surface `missing_local_media`. A genuinely external image (a different host) stays skipped, unchanged. The relative-path derivation is percent-encoding safe, so a valid file referenced with an encoded uploads segment still resolves instead of false-flagging, and a `?ver=` cachebuster on a valid image no longer reports it missing.
+
 ## [v0.16.52] — 2026-07-07 — Media-URL validation now catches same-site images in any URL shape, and no longer fails open (#153)
 
 **A same-site image URL that pointed at a non-image attachment used to slip past validation whenever it wasn't written in the one exact canonical form — a relative `/wp-content/uploads/…` path, a CDN/offloaded URL, an `http`/`https` or `:443` variant. Those are all validated now, and a misconfigured uploads path no longer disables the check entirely.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1550+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.52-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.53-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/TODOS.md
+++ b/TODOS.md
@@ -38,11 +38,11 @@
 
 - **Concurrent edit hash check for patch** — `pp_patch_composition()` currently has a TOCTOU gap: the composition can change between preview and apply. Add a content hash to `inspect-composition` output, accept it as an optional `--etag` flag on `patch`, and reject the apply if the composition changed. Single-operator use makes this low-risk for v1 but should be addressed before multi-operator scenarios. Deferred from Semantic Composition Operator v1 sprint (2026-06-12).
 
-- **Investigate broken-media missing_local_media validation on WP 7.0** — The E2E spec `validation.spec.ts › broken media` is quarantined (`test.fixme`): `style_component` succeeds but post-apply validation returns `ok=true` — `missing_local_media` does not fire for an unresolvable local image URL. Determine whether it's a product gap in `pp_post_apply_validate()` or a test-setup mismatch, then re-enable. See #83. Surfaced by /plan-eng-review D2 spike (2026-06-22).
-
 - **Positively track menus created during a batch instead of negative inference** — `_pp_restore_menu_state()` deletes ANY menu absent from the pre-batch snapshot, so a menu another admin creates in Appearance → Menus during the batch window would be destroyed by a rollback (and a menu they edit during the window is rebuilt to pre-batch state with all item ids churned). Track the term_ids the batch's own `create_menu`/`set_menu` steps created (mirroring `created_posts`) and delete only those. Belongs to the concurrency cluster (#13 optimistic locking, #113 preflight freshness) — single-operator run tokens make the window small today. Surfaced by /ship adversarial review, 2026-07-06.
 
 ## Completed
+
+- **Broken-media `missing_local_media` validation on WP 7.0** — Root cause was a product gap: `pp_post_apply_validate()` classified a rendered image as local only on an exact uploads-baseurl byte-prefix, so a scheme/host-mismatched same-site URL was skipped on WP 7.0. Fixed by reusing #153's same-site matcher; the quarantined E2E was re-enabled (its seed also needed `image`→`image_url` + a rendering variant to actually render the broken image). **Completed:** v0.16.53 (#83, 2026-07-07)
 
 - **`wp pp validate page` CLI command** — Shipped as `wp pp validate page --post_id=N [--component-index=N]` reusing `pp_post_apply_validate()` (issue #77 / PR #196), and documented in ai-instructions/validate-site.md. **Completed:** v0.16.46 (#196), documented v0.16.48 (2026-07-06)
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.52');
+define('PP_VERSION', '0.16.53');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/post-apply-validate.php
+++ b/lib/post-apply-validate.php
@@ -135,15 +135,24 @@ function pp_post_apply_validate(int $post_id, ?array $target = null): array {
                 continue;
             }
 
-            // Check if local URL.
-            if (strpos($src, $uploads_baseurl) === 0) {
+            // Classify as same-site media to verify. An exact byte-prefix match
+            // against the uploads baseurl is too brittle: a same-site URL whose
+            // scheme/host/port differs byte-for-byte (http vs https, :443, a
+            // site-relative or protocol-relative path) gets misclassified as
+            // external and skipped, so missing_local_media never fires for it
+            // (#83 — same defect class as #153 in the action-param validator).
+            // Reuse #153's origin-aware classifier (lib/actions.php) to derive
+            // the stored _wp_attached_file relative path; null => genuinely
+            // external (CDN/offloaded) and skipped.
+            $relative = _pp_uploads_relative_path($src, $uploads_baseurl);
+            if ($relative !== null) {
                 $local_urls_to_verify[$src] = [
                     'component_index' => $index,
                     'component_name'  => $name,
                     'element'         => 'img',
+                    'relative'        => $relative,
                 ];
             }
-            // External/CDN URLs skipped for MVP.
         }
 
         // 3b. Inline CSS background-image:url(...) references.
@@ -165,11 +174,14 @@ function pp_post_apply_validate(int $post_id, ?array $target = null): array {
                         continue;
                     }
 
-                    if (strpos($bg_url, $uploads_baseurl) === 0) {
+                    // Same origin-aware classification as the img src scan (#83).
+                    $relative = _pp_uploads_relative_path($bg_url, $uploads_baseurl);
+                    if ($relative !== null) {
                         $local_urls_to_verify[$bg_url] = [
                             'component_index' => $index,
                             'component_name'  => $name,
                             'element'         => 'background-image',
+                            'relative'        => $relative,
                         ];
                     }
                 }
@@ -222,10 +234,12 @@ function pp_post_apply_validate(int $post_id, ?array $target = null): array {
     // 5. Batch media library verification for local URLs.
     if (!empty($local_urls_to_verify)) {
         $relative_paths = [];
-        foreach (array_keys($local_urls_to_verify) as $url) {
-            // _wp_attached_file stores relative paths, strip uploads baseurl prefix.
-            $relative = str_replace($uploads_baseurl . '/', '', $url);
-            $relative_paths[$relative] = $url;
+        foreach ($local_urls_to_verify as $url => $info) {
+            // _pp_uploads_relative_path() already resolved the stored
+            // _wp_attached_file-relative form during classification (origin +
+            // uploads-path aware, query/fragment dropped), so we no longer
+            // re-derive it by byte-stripping the raw URL (#83).
+            $relative_paths[$info['relative']] = $url;
         }
 
         // Single batch query: find which relative paths exist in Media Library.
@@ -286,4 +300,65 @@ function pp_post_apply_validate(int $post_id, ?array $target = null): array {
         'warnings' => $warnings,
         'errors'   => $errors,
     ];
+}
+
+/**
+ * Resolves a rendered image/background URL to the `_wp_attached_file`-relative
+ * path used by the batch Media Library lookup, or null when the URL is
+ * genuinely external and should be skipped.
+ *
+ * Reuses #153's origin-aware classifier from lib/actions.php
+ * (_pp_canonicalize_same_site_url, always loaded before this file via both
+ * functions.php and tests/bootstrap.php) so the two media validators agree on
+ * what "same-site" means:
+ *
+ *   same-site (absolute-under-baseurl, site-relative, protocol-relative,
+ *     scheme- or default-port-mismatched)  → stored relative path (verify it)
+ *   same-origin but OUTSIDE the uploads path (/wp-content/themes/…, /about.jpg)
+ *                                            → null (canonicalizer rejects it)
+ *   different origin (CDN/offloaded/external) → null (skip; out of #83 scope)
+ *
+ * Only classification changed here (#83). Verification stays the exact
+ * `_wp_attached_file` batch query, so its pre-existing limits are unchanged and
+ * inherited, not introduced: size derivatives (image-1024x768.jpg vs the stored
+ * image.jpg) and CDN/offloaded resolution are still out of scope — the
+ * action-param validator (#153) owns those via attachment_url_to_postid().
+ *
+ * Query strings and fragments are dropped (the canonical path is used), which
+ * also removes the old str_replace path's `?ver=` false-missing class for free.
+ */
+function _pp_uploads_relative_path(string $url, string $uploads_baseurl): ?string {
+    // Same-site absolute/relative under the real uploads baseurl. The
+    // canonicalizer returns null unless the path sits under the uploads path,
+    // so a same-origin URL elsewhere on the site can't produce a bogus lookup.
+    if ($uploads_baseurl !== '') {
+        $canonical = _pp_canonicalize_same_site_url($url, $uploads_baseurl);
+        if ($canonical !== null) {
+            $base_path  = rtrim((string) parse_url($uploads_baseurl, PHP_URL_PATH), '/');
+            $canon_path = (string) parse_url($canonical, PHP_URL_PATH);
+            // The classifier guarantees `rawurldecode(url path)` sits under the
+            // (raw) $base_path — that is exactly the boundary it checks via
+            // _pp_path_is_under(). Strip on the SAME decoded path so a
+            // percent-encoded uploads segment (…/%75ploads/…) yields the real
+            // relative path (`foo.jpg`) instead of a length-shifted garbage
+            // slice. For an unencoded URL rawurldecode is a no-op, so this is
+            // identical to a plain strip; a DOM-decoded multibyte filename
+            // (café.jpg) has no `%` and stays byte-for-byte matched against
+            // _wp_attached_file.
+            return ltrim(substr(rawurldecode($canon_path), strlen($base_path)), '/');
+        }
+        return null;
+    }
+
+    // Fail-open parity with #153: when the uploads baseurl is empty/filtered we
+    // can't derive the real path, but a conventional site-relative uploads path
+    // is still verifiable rather than silently skipped.
+    if (_pp_url_is_relative_uploads_path($url)) {
+        // Decode first, mirroring _pp_url_is_relative_uploads_path()'s own
+        // decoded prefix test, so an encoded uploads segment strips cleanly.
+        $path = rawurldecode((string) parse_url(trim($url), PHP_URL_PATH));
+        return ltrim(substr($path, strlen('/wp-content/uploads')), '/');
+    }
+
+    return null;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.52",
+  "version": "0.16.53",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.52
+Stable tag: 0.16.53
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.52
+Version:          0.16.53
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/PostApplyValidateTest.php
+++ b/tests/PostApplyValidateTest.php
@@ -303,6 +303,150 @@ class PostApplyValidateTest extends TestCase
         $this->assertEmpty($result['errors']);
     }
 
+    // ── #83: same-site media classification (any URL shape) ──────────────
+    // Default test uploads baseurl is https://example.com/wp-content/uploads.
+
+    private function registerAttachment(int $id, string $relative): void
+    {
+        $GLOBALS['_pp_test_store']['posts'][$id] = [
+            'post_type'   => 'attachment',
+            'post_status' => 'inherit',
+        ];
+        $GLOBALS['_pp_test_store']['post_meta'][$id] = ['_wp_attached_file' => $relative];
+    }
+
+    /** WP 7.0 regression: http URL vs https baseurl no longer misclassified as external. */
+    public function testSchemeMismatchedSameSiteImgMissingIsError(): void
+    {
+        $imgUrl = 'http://example.com/wp-content/uploads/2026/06/nope.jpg'; // http, baseurl is https
+        $this->createTestComponent('card', '<div><img src="' . $imgUrl . '" alt="x"></div>');
+        $this->setComposition([['component' => 'card', 'props' => [], 'style' => []]]);
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $errors = array_filter($result['errors'], fn($e) => $e['check'] === 'missing_local_media');
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('2026/06/nope.jpg', $errors[array_key_first($errors)]['message']);
+    }
+
+    /** Scheme-mismatched URL that IS in the library still passes (relative resolves). */
+    public function testSchemeMismatchedSameSiteImgInLibraryPasses(): void
+    {
+        $imgUrl = 'http://example.com/wp-content/uploads/2026/06/ok.jpg';
+        $this->createTestComponent('card', '<div><img src="' . $imgUrl . '" alt="x"></div>');
+        $this->setComposition([['component' => 'card', 'props' => [], 'style' => []]]);
+        $this->registerAttachment(210, '2026/06/ok.jpg');
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertEmpty($result['errors']);
+    }
+
+    /** Site-relative uploads path is same-site and gets verified. */
+    public function testSiteRelativeSameSiteImgMissingIsError(): void
+    {
+        $imgUrl = '/wp-content/uploads/2026/06/rel.jpg';
+        $this->createTestComponent('card', '<div><img src="' . $imgUrl . '" alt="x"></div>');
+        $this->setComposition([['component' => 'card', 'props' => [], 'style' => []]]);
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $errors = array_filter($result['errors'], fn($e) => $e['check'] === 'missing_local_media');
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('2026/06/rel.jpg', $errors[array_key_first($errors)]['message']);
+    }
+
+    /** Protocol-relative same-site URL is verified. */
+    public function testProtocolRelativeSameSiteImgMissingIsError(): void
+    {
+        $imgUrl = '//example.com/wp-content/uploads/2026/06/proto.jpg';
+        $this->createTestComponent('card', '<div><img src="' . $imgUrl . '" alt="x"></div>');
+        $this->setComposition([['component' => 'card', 'props' => [], 'style' => []]]);
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $errors = array_filter($result['errors'], fn($e) => $e['check'] === 'missing_local_media');
+        $this->assertCount(1, $errors);
+    }
+
+    /** The background-image scan uses the same classifier (both scan sites fixed). */
+    public function testSchemeMismatchedSameSiteBackgroundMissingIsError(): void
+    {
+        $bgUrl = 'http://example.com/wp-content/uploads/2026/06/bgnope.jpg';
+        $this->createTestComponent('hero', '<section style="background-image:url(' . $bgUrl . ')"><h1>Hi</h1></section>');
+        $this->setComposition([['component' => 'hero', 'props' => [], 'style' => []]]);
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $errors = array_filter($result['errors'], fn($e) => $e['check'] === 'missing_local_media');
+        $this->assertCount(1, $errors);
+    }
+
+    /** A ?ver= cachebuster on a valid local image no longer reports it missing. */
+    public function testSameSiteImgWithQueryStringResolves(): void
+    {
+        $imgUrl = 'https://example.com/wp-content/uploads/2026/06/qs.jpg?ver=5';
+        $this->createTestComponent('card', '<div><img src="' . $imgUrl . '" alt="x"></div>');
+        $this->setComposition([['component' => 'card', 'props' => [], 'style' => []]]);
+        $this->registerAttachment(211, '2026/06/qs.jpg');
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertEmpty($result['errors']);
+    }
+
+    /** Hostile near-match host (example.com.evil) is a different origin → skipped, not flagged. */
+    public function testHostileExternalNearMatchIsSkipped(): void
+    {
+        $imgUrl = 'https://example.com.evil/wp-content/uploads/2026/06/evil.jpg';
+        $this->createTestComponent('card', '<div><img src="' . $imgUrl . '" alt="x"></div>');
+        $this->setComposition([['component' => 'card', 'props' => [], 'style' => []]]);
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertEmpty($result['errors']);
+    }
+
+    /** Same origin but OUTSIDE the uploads path (theme asset) is not a media lookup. */
+    public function testSameOriginOutsideUploadsIsSkipped(): void
+    {
+        $imgUrl = 'https://example.com/wp-content/themes/pp/assets/logo.png';
+        $this->createTestComponent('card', '<div><img src="' . $imgUrl . '" alt="x"></div>');
+        $this->setComposition([['component' => 'card', 'props' => [], 'style' => []]]);
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertEmpty($result['errors']);
+    }
+
+    /**
+     * Regression (#83 codex adversarial): the classifier boundary-checks the
+     * decoded path but returns the encoded one, so deriving the relative path
+     * by byte-stripping the encoded form corrupted a percent-encoded uploads
+     * segment. A `%75ploads` (= "uploads") URL for a real file must still
+     * resolve to the stored relative path and PASS, not false-flag as missing.
+     */
+    public function testEncodedUploadsSegmentResolvesToStoredPath(): void
+    {
+        $imgUrl = 'https://example.com/wp-content/%75ploads/2026/06/enc.jpg';
+        $this->createTestComponent('card', '<div><img src="' . $imgUrl . '" alt="x"></div>');
+        $this->setComposition([['component' => 'card', 'props' => [], 'style' => []]]);
+        $this->registerAttachment(212, '2026/06/enc.jpg');
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertEmpty($result['errors']);
+    }
+
     // ── DOM inspection: background-image:url() ───────────────────────────
 
     public function testEmptyBackgroundImageUrlIsError(): void

--- a/tests/e2e/validation.spec.ts
+++ b/tests/e2e/validation.spec.ts
@@ -99,25 +99,25 @@ test.describe('Post-Apply Validation', () => {
     expect(result.data.validation.errors).toHaveLength(0);
   });
 
-  // QUARANTINED (D2 spike, 2026-06-22): on WP 7.0 the style_component action now
-  // succeeds (result.success === true after fixing the test's stale param name
-  // `styles`→`style` and invalid slot `--hero-padding`→`--hero-padding-top`), but
-  // post-apply validation returns validation.ok === true — the `missing_local_media`
-  // check does NOT fire for an unresolvable local image URL. Unclear yet whether
-  // that's a product gap in pp_post_apply_validate() or a test-setup mismatch in how
-  // the broken image is attached. Tracked in #83. Re-enable once resolved.
-  // All other E2E specs pass on WP 7.0.
-  test.fixme('broken media: missing image triggers validation error', async ({
+  // #83 (resolved 2026-07-07): the earlier quarantine had two causes. The product
+  // gap — pp_post_apply_validate() only treated a URL as local media on an exact
+  // uploads-baseurl byte-prefix, so a scheme/host-mismatched same-site URL was
+  // skipped on WP 7.0 — is fixed by reusing #153's same-site classifier. The test
+  // itself also never rendered an image: hero only renders a URL when the prop is
+  // `image_url` AND the variant is `cover`/`split` (the seed used `image` +
+  // default `centered`). Both are fixed below so the check genuinely fires.
+  test('broken media: missing image triggers validation error', async ({
     page,
   }) => {
-    // 1. Create page with a hero that has a fake local image URL.
+    // 1. Create page with a cover hero whose background image URL is unresolvable.
     pageId = createPage('E2E Validation Broken Media');
     setComposition(pageId, [
       {
         component: 'hero',
         props: {
           title: 'Hero With Bad Image',
-          image: 'http://localhost:8889/wp-content/uploads/2026/06/nonexistent-image.jpg',
+          variant: 'cover',
+          image_url: 'http://localhost:8889/wp-content/uploads/2026/06/nonexistent-image.jpg',
         },
       },
     ]);


### PR DESCRIPTION
## Summary

Fixes #83. On WP 7.0, `pp_post_apply_validate()` silently missed a broken/unresolvable local image because it classified a rendered `<img src>` / `background-image:url()` as "local media to verify" only when the URL byte-prefix-matched the resolved uploads base URL. When the live base URL comes back `https` while the rendered URL is `http` (or the URL is site-relative / protocol-relative), the same-site image was treated as external and skipped, so `missing_local_media` never fired and validation reported `ok`.

This is the same defect class as #153 (fixed in the action-param validator). The fix reuses #153's origin-aware `_pp_canonicalize_same_site_url()` at both scan sites.

## Changes

- **`lib/post-apply-validate.php`** — both scan sites (`<img src>` and inline `background-image:url()`) now classify same-site media via `_pp_canonicalize_same_site_url()` instead of an exact base-URL prefix. New `_pp_uploads_relative_path()` helper derives the stored `_wp_attached_file` relative path (encoding-safe: strips on the decoded path). The existing single batch `_wp_attached_file` existence query is unchanged.
- **`tests/PostApplyValidateTest.php`** — +9 unit tests: scheme-mismatch, site-relative, protocol-relative, in-library scheme-mismatch, background-image scheme-mismatch, `?ver=` query string, percent-encoded uploads segment, hostile external near-match (`example.com.evil`), and same-origin-outside-uploads (theme asset).
- **`tests/e2e/validation.spec.ts`** — de-quarantined the broken-media test (`test.fixme` removed). Its seed also needed fixing: it used prop `image` (hero renders only `image_url`) with the default `centered` variant (which renders no image), so it could never have fired the check — changed to `image_url` + `cover` variant.

## Acceptance criteria (from #83)

- ✅ Unresolvable same-site image URL (absolute-under-baseurl, site-relative, scheme-mismatched) flags `missing_local_media` on WP 7.0.
- ✅ Genuinely external URL still skipped (not falsely flagged).
- ✅ Previously-quarantined E2E re-enabled and green.

## Validation

- PHPUnit: 1284 passed (9 new).
- Vitest: 350 passed.
- Playwright `validation.spec.ts`: 5 passed on live wp-env (WP 7.0), including the de-quarantined broken-media test.

## Not in scope

- CDN/offloaded URL resolution via `attachment_url_to_postid()` offload hooks and size-derivative (`image-1024x768.jpg`) resolution — pre-existing limitations inherent to the post-apply batch `_wp_attached_file` query; the action-param validator (#153) is the primary gate for image URLs at apply time.

Closes #83.