### PR TITLE
v0.16.54 fix: fail preflight closed on a corrupt pp_token_overrides row (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.54] — 2026-07-07 — A corrupt design-token row now fails the pre-apply safety check instead of arming a destructive rollback (#207)
+
+**Before you apply a design change, PromptingPress freezes a snapshot of your current tokens so it can undo the change later. If that stored token row was corrupt or hand-edited into garbage, the snapshot came back empty — and undoing against an empty snapshot doesn't restore your tokens, it deletes them. The safety check now refuses to record an empty snapshot for an unreadable row, so a later undo can't quietly wipe your design tokens.**
+
+`pp_snapshot_token_overrides()` reads the `pp_token_overrides` row under a lock to freeze an atomic rollback baseline. A hardening in #200 made it fail closed when the lock is contended. This closes the sibling gap: a corrupt, truncated, or hand-edited row that doesn't decode to an array was silently treated as "no overrides exist," so the run recorded an empty `[]` baseline. Because `apply restore` reverts every touched token off an empty snapshot by deleting it, that empty baseline turned a later undo into silent token loss. The snapshot now returns `null` for an unreadable row exactly as it does for lock contention, so `wp pp apply preflight` errors and records nothing rather than arming a destructive rollback. A genuinely empty override set (a fresh install) still records a valid `[]` baseline — empty and unreadable are no longer confused.
+
+### Fixed
+- **A corrupt `pp_token_overrides` row fails the preflight closed (#207).** The pre-apply token snapshot now distinguishes an absent row (records `[]`, proceeds) from an unreadable one (corrupt/truncated/non-array → records nothing, errors), so `apply restore` can never delete your touched tokens by rolling back against a baseline that was empty only because the row couldn't be read. The three token writers (`set` / `clear` / `clear-all`) and the revert path keep their existing "start fresh on a missing row" behavior unchanged — only the rollback-baseline snapshot treats an unreadable row as a hard failure. The `wp pp apply preflight` error now names both causes (lock contention or a corrupt row) and points at the fix for each. 6 new PHPUnit tests cover corrupt/truncated rows, serialized scalars, and a valid empty-array row across the snapshot and writer paths.
+
+### Documentation
+- The operating-loop safety explanation, the apply-CLI reference, and the apply/rollback how-to now describe the second fail-closed trigger (an unreadable token row) alongside lock contention, so an operator who hits the preflight error knows a persistent failure means the `pp_token_overrides` option itself needs repair. (#207)
+
 ## [v0.16.53] — 2026-07-07 — Post-apply site validation now flags a missing local image in any URL shape (#83)
 
 **After an apply, the site check that catches broken images used to miss a same-site image whenever its rendered URL didn't byte-match the uploads base URL — an `http` vs `https` or host mismatch. So a page could render an unresolvable image and still report "validation passed." It's caught now, in every URL shape.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1550+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.53-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.54-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/docs/howto-apply-and-rollback.md
+++ b/docs/howto-apply-and-rollback.md
@@ -125,8 +125,8 @@ You didn't pass `--run-id`, or the value isn't a UUID. Re-run `wp pp operate ins
 **`Run token "..." has no completed PREFLIGHT step`**
 You skipped step 3, or the run expired. Run `wp pp apply preflight --run-id=$RUN` (add `--post_id=<id>` for page work). If it still fails, the 2-hour token likely expired — mint a fresh one with `wp pp operate inspect`.
 
-**Preflight errors: `Could not read an atomic pre-apply token baseline ... the token lock is contended`**
-Another process is writing tokens right now. Preflight fails closed on purpose rather than freezing a stale rollback point (issue #200). Wait a moment and re-run the same `preflight` command; it succeeds once the contention clears.
+**Preflight errors: `Could not read an atomic pre-apply token baseline ... the token lock is contended, or the pp_token_overrides row is corrupt/unreadable`**
+Preflight fails closed rather than freezing a rollback point it can't trust. Two causes: another process is writing tokens right now (lock contention, issue #200) — wait a moment and re-run the same `preflight` command, it succeeds once the contention clears; or the stored `pp_token_overrides` option is corrupt/hand-edited into a non-array (issue #207) — re-running won't help because the row stays unreadable, so inspect and repair the `pp_token_overrides` option before retrying. Recording an empty baseline for a corrupt row would make a later `restore` delete the touched tokens instead of restoring them, which is why it refuses.
 
 **`Refusing to apply: run "..." has no usable rollback snapshot`**
 The run has no snapshot to undo to, so `execute`/`reset` won't mutate. Re-run `wp pp operate inspect` then `wp pp apply preflight --run-id=$RUN` to establish a fresh, reversible baseline.

--- a/docs/operating-loop-safety.md
+++ b/docs/operating-loop-safety.md
@@ -97,11 +97,18 @@ post-preflight state or none of it. Any failure leaves both the action gate and
 the apply gate fail-closed: no coverage recorded means no mutation unlocked.
 
 The rollback snapshot itself is read **under the token lock** for an atomic
-baseline. If that lock is contended — another writer is racing, exactly the case
-the baseline protects against — the snapshot fails closed rather than degrading to
-a stale, non-atomic read. `wp pp apply preflight` then **errors and records
-nothing** instead of freezing a baseline that a later `apply restore` would
-silently revert to. Re-run the preflight once the contention clears.
+baseline, and it fails closed on two conditions rather than freezing a baseline a
+later `apply restore` would wrongly revert to. First, if the lock is contended —
+another writer is racing, exactly the case the baseline protects against — it
+refuses to degrade to a stale, non-atomic read. Second, if the stored
+`pp_token_overrides` row is unreadable — corrupt, truncated, or hand-edited into
+something that isn't an array — it refuses to treat that as "no overrides." That
+second case matters because an empty baseline is not harmless: `apply restore`
+reverts every touched token off an empty snapshot by **deleting** it, so recording
+`[]` for a corrupt row would turn a restore into silent token loss. In either case
+`wp pp apply preflight` **errors and records nothing**. Re-run the preflight once
+the contention clears; if the error persists, inspect and repair the
+`pp_token_overrides` option — the row itself is unreadable.
 
 ### Validate first, so errors point at the real problem
 

--- a/docs/reference-apply-cli.md
+++ b/docs/reference-apply-cli.md
@@ -146,13 +146,13 @@ The checks that can run (`pp_preflight`, `lib/operate.php`):
 **Exit codes and errors**
 
 - If any error-grade check fails: prints the JSON, then exits **1** (`WP_CLI::halt(1)`). Nothing is recorded.
-- **Token-lock contention (#200):** the snapshot is read under the token advisory lock for an atomic baseline. If the lock is contended, the snapshot comes back `null` and preflight **records nothing** and errors:
-  > `Could not read an atomic pre-apply token baseline for run token "<uuid>": the token lock is contended. PREFLIGHT was not recorded. Re-run 'wp pp apply preflight' once the contention clears.`
+- **Unreadable baseline (#200 lock contention, #207 corrupt row):** the snapshot is read under the token advisory lock for an atomic baseline. It comes back `null` — and preflight **records nothing** and errors — in two cases: the lock is contended (another writer is racing, #200), or the stored `pp_token_overrides` row is corrupt/truncated/hand-edited into a non-array (#207). Either way:
+  > `Could not read an atomic pre-apply token baseline for run token "<uuid>": the token lock is contended, or the pp_token_overrides row is corrupt/unreadable. PREFLIGHT was not recorded. Re-run 'wp pp apply preflight' once the contention clears; if it persists, inspect and repair the pp_token_overrides option.`
 
-  This is deliberate fail-closed behavior: recording a stale, non-atomic baseline would let a later `restore` revert to a state that never existed. Retry once contention clears.
+  This is deliberate fail-closed behavior. Recording a stale baseline (contention) would let a later `restore` revert to a state that never existed; recording an empty `[]` baseline for a corrupt row is worse — `restore` reverts every touched token off an empty snapshot by **deleting** it, so a corrupt row silently coerced to `[]` would turn a restore into token loss. Retry once contention clears; if the error persists, the row itself is unreadable — inspect and repair `pp_token_overrides`.
 - If the run state can't be written: `Could not record PREFLIGHT state for run token "<uuid>". State file may be missing or expired. Re-run 'wp pp operate inspect'.`
 
-An empty override set is a **valid** baseline: on a fresh install with no overrides the snapshot is `[]` (recorded normally), never `null`. `null` means only "could not read atomically."
+An empty override set is a **valid** baseline: on a fresh install with no overrides the snapshot is `[]` (recorded normally), never `null`. `null` means "could not read an atomic baseline" — either lock contention or an unreadable/corrupt row, never a legitimately empty one.
 
 ---
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.53');
+define('PP_VERSION', '0.16.54');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -645,15 +645,19 @@ class PP_Apply_Command extends WP_CLI_Command {
         // unlocked. First-write-wins inside the recorder keeps the rollback
         // baseline stable across re-runs.
         //
-        // The snapshot is read under the token lock for an atomic baseline. If the
-        // lock is contended it returns null rather than a stale, non-atomic read —
-        // recording that as the rollback baseline would let a later `apply restore`
-        // silently revert to a state that never existed. A null snapshot is a hard
-        // preflight failure: record nothing (leaving both gates fail-closed) and
-        // surface the contention so the operator can retry.
+        // The snapshot is read under the token lock for an atomic baseline. It returns
+        // null on either of two fail-closed conditions rather than a baseline that a
+        // later `apply restore` would wrongly roll back to:
+        //   - lock contended (#200): a stale, non-atomic read, or
+        //   - unreadable overrides row (#207): a corrupt/hand-edited pp_token_overrides
+        //     row that would otherwise be recorded as an empty [] baseline, causing
+        //     restore to DELETE the touched tokens instead of restoring them.
+        // Either way a null snapshot is a hard preflight failure: record nothing
+        // (leaving both gates fail-closed) and surface the cause so the operator can act
+        // (retry once contention clears; repair the corrupt row before re-running).
         $token_snapshot = pp_snapshot_token_overrides();
         if ($token_snapshot === null) {
-            WP_CLI::error('Could not read an atomic pre-apply token baseline for run token "' . $run_id . '": the token lock is contended. PREFLIGHT was not recorded. Re-run `wp pp apply preflight` once the contention clears.');
+            WP_CLI::error('Could not read an atomic pre-apply token baseline for run token "' . $run_id . '": the token lock is contended, or the pp_token_overrides row is corrupt/unreadable. PREFLIGHT was not recorded. Re-run `wp pp apply preflight` once the contention clears; if it persists, inspect and repair the pp_token_overrides option.');
         }
         if (!pp_operate_record_preflight($run_id, $context['post_id'] ?? null, $token_snapshot)) {
             WP_CLI::error('Could not record PREFLIGHT state for run token "' . $run_id . '". State file may be missing or expired. Re-run `wp pp operate inspect`.');

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -1221,15 +1221,26 @@ function _pp_with_token_lock(callable $mutator, $fail_value) {
 }
 
 /**
- * Reads pp_token_overrides authoritatively inside the lock. Reads the single option
- * row straight from the DB (bypassing the options cache) so a concurrent writer's
+ * Reads pp_token_overrides authoritatively inside the lock, distinguishing an ABSENT
+ * row from an UNREADABLE (corrupt/truncated/non-array) one. Reads the single option row
+ * straight from the DB (bypassing the options cache) so a concurrent writer's
  * just-committed value is visible and a stale cached map can't overwrite a newer one
  * inside the critical section. Reads exactly the one row rather than busting the whole
  * `alloptions` autoload cache.
  *
+ * Three distinct outcomes (#207):
+ *   - no row              → []    (legitimately no overrides)
+ *   - row unserializes to an array → that array
+ *   - row exists but does NOT unserialize to an array → null (UNREADABLE)
+ *
+ * Only the snapshot caller (pp_snapshot_token_overrides) needs the unreadable-vs-empty
+ * distinction, so it reads through this strict variant. The writer paths read through
+ * _pp_read_token_overrides_locked(), which coerces null to [] — see that wrapper.
+ *
  * @param object|null $wpdb  The DB handle inside the lock, or null in unit context.
+ * @return array|null  The overrides map, [] if absent, or null if the row is unreadable.
  */
-function _pp_read_token_overrides_locked($wpdb = null): array {
+function _pp_read_token_overrides_locked_strict($wpdb = null): ?array {
     if (is_object($wpdb) && method_exists($wpdb, 'get_var')) {
         $raw = $wpdb->get_var(
             $wpdb->prepare(
@@ -1241,10 +1252,26 @@ function _pp_read_token_overrides_locked($wpdb = null): array {
             return [];
         }
         $value = maybe_unserialize($raw);
-        return is_array($value) ? $value : [];
+        return is_array($value) ? $value : null;
     }
     // No DB handle (unit context): fall back to the cached/stubbed option.
     return pp_get_token_overrides();
+}
+
+/**
+ * Reads pp_token_overrides authoritatively inside the lock for the WRITER paths, where
+ * `[]`-means-"start fresh" is the correct handling of both an absent AND an unreadable
+ * row. Thin wrapper over _pp_read_token_overrides_locked_strict() that coerces the
+ * strict variant's null (unreadable row) back to []. Keeping this coercion here — not in
+ * the strict read — is the Option A boundary from #207: only the rollback-baseline
+ * snapshot treats an unreadable row as a hard failure; set/clear/clear-all/revert keep
+ * their pre-#207 "start fresh on a missing/unreadable row" semantics unchanged.
+ *
+ * @param object|null $wpdb  The DB handle inside the lock, or null in unit context.
+ */
+function _pp_read_token_overrides_locked($wpdb = null): array {
+    $value = _pp_read_token_overrides_locked_strict($wpdb);
+    return $value === null ? [] : $value;
 }
 
 /**
@@ -1371,17 +1398,26 @@ function pp_revert_tokens(array $snapshot, array $touched_keys): bool {
  *
  * Used when freezing a run's pre-apply baseline: taking the read inside the lock means
  * a concurrent apply cannot interleave and produce a baseline that never existed
- * atomically. Fail-closed: if the lock cannot be acquired the read would be non-atomic
- * exactly when contention is happening — the one scenario the lock exists to protect
- * against — so it returns null instead of silently degrading to a plain cached read.
+ * atomically. Fail-closed on TWO distinct failure modes, both surfaced as null:
+ *   1. Lock not acquired (#200): the read would be non-atomic exactly when contention
+ *      is happening — the one scenario the lock exists to protect against — so it
+ *      returns null instead of silently degrading to a plain cached read.
+ *   2. Unreadable row (#207): a corrupt/truncated/hand-edited pp_token_overrides row
+ *      that does not unserialize to an array. Reading through the STRICT locked read
+ *      surfaces this as null rather than coercing it to [] — recording [] as the
+ *      baseline would let a later `apply restore` delete the touched tokens instead of
+ *      restoring them (an [] baseline reverts every touched key via the unset() branch
+ *      of pp_revert_tokens).
  * The caller must treat null as a hard failure (no baseline recorded) rather than
- * freezing a stale snapshot that a later `apply restore` would roll back to.
+ * freezing a snapshot that a later `apply restore` would roll back to. An absent row
+ * still yields [] (a valid, recordable empty baseline), never null.
  *
- * @return array|null  token => value map, or null if the lock could not be acquired.
+ * @return array|null  token => value map, [] if no overrides, or null if the lock could
+ *                     not be acquired OR the overrides row is unreadable.
  */
 function pp_snapshot_token_overrides(): ?array {
     return _pp_with_token_lock( function ( $wpdb ) {
-        return _pp_read_token_overrides_locked( $wpdb );
+        return _pp_read_token_overrides_locked_strict( $wpdb );
     }, null );
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.53",
+  "version": "0.16.54",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.53
+Stable tag: 0.16.54
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.53
+Version:          0.16.54
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/TokenLockTest.php
+++ b/tests/TokenLockTest.php
@@ -32,6 +32,13 @@ class PP_Mock_Wpdb
     public string $options = 'wp_options';
     /** @var array|null The pp_token_overrides row the DB returns (null = no row). */
     public $db_overrides = null;
+    /**
+     * @var string|null Verbatim option_value bytes to return for the pp_token_overrides
+     * read, bypassing serialize(). Set this to simulate a corrupt/truncated/hand-edited
+     * row (anything that does not maybe_unserialize() to an array). Takes precedence over
+     * $db_overrides when non-null.
+     */
+    public $db_overrides_raw = null;
 
     public function prepare(string $query, ...$args): string
     {
@@ -49,6 +56,10 @@ class PP_Mock_Wpdb
         }
         // The in-lock authoritative read of pp_token_overrides (#97).
         if (strpos($sql, 'option_value') !== false && strpos($sql, 'pp_token_overrides') !== false) {
+            // A corrupt/truncated row (#207): return the raw bytes verbatim, unserialized.
+            if ($this->db_overrides_raw !== null) {
+                return $this->db_overrides_raw;
+            }
             return $this->db_overrides === null ? null : serialize($this->db_overrides);
         }
         return null;
@@ -283,6 +294,92 @@ class TokenLockTest extends TestCase
         $this->assertSame([], $snapshot, 'No overrides under a held lock is a recordable empty baseline, not null.');
         $releases = array_filter($wpdb->calls, fn ($c) => strpos($c, 'RELEASE_LOCK') !== false);
         $this->assertNotEmpty($releases, 'A lock that was acquired must be released.');
+    }
+
+    /**
+     * #207: under a HELD lock, a corrupt/unreadable pp_token_overrides row (anything that
+     * does not unserialize to an array) must snapshot as null — NOT [] — so the run's
+     * rollback baseline is never silently recorded as empty. Recording [] would make a
+     * later `apply restore` DELETE every touched token (the unset() branch of
+     * pp_revert_tokens) instead of restoring it. This is the sibling of #200's lock-
+     * failure fail-close, reached through the corrupt-row door.
+     */
+    public function testSnapshotReturnsNullOnCorruptOverridesRowUnderHeldLock(): void
+    {
+        $wpdb = new PP_Mock_Wpdb();
+        $wpdb->get_lock_return = '1';                 // lock acquired
+        $wpdb->db_overrides_raw = 'a:1:{s:3:"--a";'; // truncated serialized row — unreadable
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $snapshot = pp_snapshot_token_overrides();
+
+        $this->assertNull($snapshot,
+            'A corrupt/unreadable overrides row must fail closed (null), not coerce to an [] baseline.');
+        $releases = array_filter($wpdb->calls, fn ($c) => strpos($c, 'RELEASE_LOCK') !== false);
+        $this->assertNotEmpty($releases, 'A lock that was acquired must still be released.');
+    }
+
+    /**
+     * #207 Option A boundary: the fail-closed distinction lives ONLY at the snapshot
+     * caller. The writer paths keep their pre-#207 "[]-means-start-fresh" handling of a
+     * corrupt row — a set on an unreadable row must merge onto [], not abort. This proves
+     * the shared _pp_read_token_overrides_locked() wrapper still coerces the strict null
+     * back to [] for writers.
+     */
+    public function testWriterTreatsCorruptOverridesRowAsStartFresh(): void
+    {
+        $wpdb = new PP_Mock_Wpdb();
+        $wpdb->get_lock_return = '1';                 // lock acquired
+        $wpdb->db_overrides_raw = 'a:1:{s:3:"--a";'; // truncated serialized row — unreadable
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $result = pp_set_token_override('--color-accent', '#abcdef');
+
+        $this->assertTrue($result, 'A writer must still succeed on a corrupt row (start-fresh semantics).');
+        $this->assertSame(
+            ['--color-accent' => '#abcdef'],
+            $GLOBALS['_pp_test_store']['options']['pp_token_overrides'] ?? null,
+            'The write must merge onto a fresh [] baseline, not inherit the unreadable row.'
+        );
+    }
+
+    /**
+     * #207: a legitimately-empty overrides state stored as a serialized empty array
+     * (a:0:{}) must snapshot as [] — a valid recordable baseline — NOT be misclassified
+     * as corrupt (null). The writer paths delete_option() when empty, so a stored []
+     * is rare, but it must never be confused with an unreadable row.
+     */
+    public function testSnapshotReturnsEmptyArrayForSerializedEmptyArrayRow(): void
+    {
+        $wpdb = new PP_Mock_Wpdb();
+        $wpdb->get_lock_return = '1';        // lock acquired
+        $wpdb->db_overrides = [];            // stored empty array → serialize() = 'a:0:{}'
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $snapshot = pp_snapshot_token_overrides();
+
+        $this->assertNotNull($snapshot, 'A serialized empty array is a valid empty baseline, not a corrupt row.');
+        $this->assertSame([], $snapshot, 'a:0:{} must snapshot as [], never null.');
+    }
+
+    /**
+     * #207: a serialized scalar (boolean/null/string) is a non-array row and must fail
+     * closed as null, exactly like truncated bytes. Covers the b:0; (false), N; (null),
+     * and s:5:"hello"; (string) shapes a hand-edit or a wrong writer could leave behind.
+     */
+    public function testSnapshotReturnsNullForSerializedScalarRows(): void
+    {
+        foreach (['b:0;', 'N;', 's:5:"hello";'] as $rawScalar) {
+            $wpdb = new PP_Mock_Wpdb();
+            $wpdb->get_lock_return = '1';           // lock acquired
+            $wpdb->db_overrides_raw = $rawScalar;   // serialized non-array value
+            $GLOBALS['wpdb'] = $wpdb;
+
+            $this->assertNull(
+                pp_snapshot_token_overrides(),
+                "A serialized scalar row ($rawScalar) must fail closed as null, not coerce to []."
+            );
+        }
     }
 
     public function testLockNameVariesByInstall(): void


### PR DESCRIPTION
Closes #207.

## What & why

Before an apply, PromptingPress freezes a snapshot of the current design-token overrides so `apply restore` can undo the change. `pp_snapshot_token_overrides()` reads `pp_token_overrides` under a lock; #200 made it fail closed on lock contention. This closes the sibling gap: a **corrupt/truncated/hand-edited** row that doesn't decode to an array was silently read as "no overrides," so the run recorded an empty `[]` baseline. Because `apply restore` reverts every touched token off an empty snapshot by **deleting** it, that empty baseline turned a later undo into silent token loss.

## Change (Option A — snapshot-only fail-closed, per the recorded decision)

- New strict locked read `_pp_read_token_overrides_locked_strict()` returns `null` for an unreadable row, `[]` for an absent row, the array otherwise.
- `pp_snapshot_token_overrides()` reads through the strict variant and propagates `null`, so `wp pp apply preflight` errors and records nothing instead of arming a destructive rollback.
- The three writers (`set` / `clear` / `clear-all` / `revert`) keep reading through `_pp_read_token_overrides_locked()`, which coerces the strict `null` back to `[]` — only the rollback-baseline path treats an unreadable row as a hard failure. Their "start fresh on a missing row" semantics are unchanged.
- The preflight error message now names both causes (lock contention or a corrupt row) and points at repairing the option when the failure persists.

## Acceptance criteria (all met)

- [x] Corrupt/non-array row → snapshot `null`, preflight fails closed.
- [x] Absent row → `[]`, preflight proceeds.
- [x] Writer semantics unchanged (`set`/`clear` still start fresh on a missing/unreadable row).
- [x] No `apply restore` can delete touched tokens off a silently-empty baseline.

## Tests

6 new PHPUnit tests in `tests/TokenLockTest.php`: corrupt/truncated row → `null`; serialized scalars (`b:0;`, `N;`, `s:5:"hello";`) → `null`; valid empty array `a:0:{}` → `[]` (not misclassified as corrupt); writer still starts fresh on a corrupt row. Full suite green: **1288 PHP** / **350 JS**.

## Docs

Updated `docs/operating-loop-safety.md`, `docs/reference-apply-cli.md`, and `docs/howto-apply-and-rollback.md` to describe the second fail-closed trigger and the repair path.

## Review

`/plan-eng-review` (clean, 1 finding folded), `/review` + Codex adversarial (inline-diff). Codex surfaced a distinct, **pre-existing** door: `$wpdb->get_var()` returning `null` also means a DB read failure, not only an absent row — filed as **#212** (needs-decision) rather than expanding this PR's scope, mirroring how #207 was itself spun out of #200's review.

## Not in scope

- Option B (shared read signals corruption to all callers) — rejected in #207, higher blast radius.
- Writer-hardening on corrupt rows — #207 explicitly defers to a future issue.
- `get_var()` DB-read-failure disambiguation — filed as #212.
