### PR TITLE
v0.16.56 fix: distinguish corrupted composition from an empty one (#144)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -230,7 +230,8 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | `pp_render_responsive_image($url, $alt, $class, $loading, $attachment_id)` | Renders `wp_get_attachment_image()` (real srcset/sizes) when `$attachment_id` resolves to an image attachment; plain escaped `<img src="$url">` otherwise |
 | `pp_render_faq_schema($items)` | Returns the FAQPage JSON-LD `<script>` block for faq items (plain-text-stripped), or `''` when no complete items |
 | `pp_default_homepage_composition()` | Default homepage component array (hero, section, cta) — single source of truth for activation seeding and blank-page fallback |
-| `pp_get_composition($post_id)` | Composition array for any page by ID (returns [] if absent) |
+| `pp_get_composition($post_id)` | Composition array for any page by ID (returns [] if absent, corrupt, or non-list) |
+| `pp_get_composition_result($post_id)` | State-classifying read: `['ok'=>bool,'composition'=>array,'error'=>?string,'raw'=>?string]`. Distinguishes absent vs empty `[]` vs `decode_error` (undecodable JSON) vs `unexpected_shape` (valid JSON that isn't a list, e.g. an object). Use this (not `pp_get_composition`) when a check must tell a corrupted page apart from a blank one; `wp pp check page`/`validate site`/`validate page` and `pp_inspect_site()` all surface its error (issue 144) |
 | `pp_composition_pages()`       | All composition pages: [{id, title, status, url}, ...] (static cached) |
 | `pp_get_menus()`               | All navigation menus: [{id, name, location (registered theme location or null), items: [{title, url}, ...]}, ...] (issue 132) |
 | `pp_create_nav_menu($name)`    | Creates a menu. Returns menu (term) ID\|WP_Error |
@@ -419,7 +420,7 @@ Pages using the **Composition** template store their layout in `_pp_composition`
 - Invalid compositions are rejected on save — the DB retains the last valid value
 - AI can write `_pp_composition` directly (via WP CLI or REST) — same format
 
-**To read the composition in PHP:** use `pp_composition()` (no args — reads the current loop post) or `pp_get_composition($post_id)` (any post by ID) from `lib/wp.php`. Both return `[]` when meta is absent or invalid JSON. Off the main loop, always pass an explicit `$post_id` via `pp_get_composition()`.
+**To read the composition in PHP:** use `pp_composition()` (no args — reads the current loop post) or `pp_get_composition($post_id)` (any post by ID) from `lib/wp.php`. Both return `[]` when meta is absent or invalid JSON. Off the main loop, always pass an explicit `$post_id` via `pp_get_composition()`. To tell an *absent* page apart from a *corrupted* one (undecodable JSON or a non-list shape), read through `pp_get_composition_result($post_id)` instead — the render path stays defensive (degrades to empty, never fatal), but inspect/check/validate act on its `error` (issue 144).
 
 **To write a composition as AI (preferred):**
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.56] — 2026-07-07 — A corrupted page composition is now flagged, not silently reported as blank (#144)
+
+**A page whose stored composition is corrupted — truncated JSON, a bad encoding, or a shape that isn't a list — used to look identical to a genuinely empty page in every inspection command. An agent that runs INSPECT before editing a page would see a clean "no smells" report and mutate against corrupt data. Corruption now surfaces as a distinct data-integrity signal in inspect, check, and validate, while page rendering stays defensive and degrades to empty rather than fataling.**
+
+`pp_get_composition()` collapsed four different states — absent meta, an empty `[]`, undecodable JSON, and valid-but-non-list JSON — into the same empty array. Since #119, `pp_inspect_site()` reads through it, so a corrupt page reported a clean INSPECT indistinguishable from a blank one. A new state-classifying accessor, `pp_get_composition_result()`, tells the four apart and becomes the single decode owner: `wp pp operate inspect` now carries a `composition_decode_error` field, and `wp pp check page`, `wp pp validate site`, and `wp pp validate page` report the corruption distinctly instead of "no composition." A JSON object (which decodes to an associative PHP array that a bare `is_array()` check would wrongly accept) is now correctly classified as an unexpected shape via a list check, and the falsy-but-present payload `"0"` is no longer mistaken for an absent page. `pp_get_composition()` becomes a thin wrapper that still degrades any corrupt or non-list row to `[]`, so template and front-page rendering never fatal on a bad row.
+
+### Fixed
+- **A corrupted composition is surfaced distinctly from an empty one (#144).** `pp_get_composition_result($post_id)` returns `['ok'=>bool,'composition'=>array,'error'=>?string,'raw'=>?string]`, distinguishing absent meta, empty `[]`, `decode_error` (undecodable JSON), and `unexpected_shape` (valid JSON that isn't a list). `pp_inspect_site()` exposes the error as `composition_decode_error`; `wp pp check page`, `wp pp validate site`, and `wp pp validate page` (`pp_post_apply_validate()`) all report the integrity error rather than treating a corrupt page as blank. Rendering paths are unchanged and still degrade to an empty page on a bad row. 24 new unit tests cover every state, the `array_is_list` shim (`pp_is_list()`, PHP 8.0 compatible), the `"0"` falsy-payload trap, an already-decoded associative-array fixture, and the front-page no-fatal regression.
+
+### For contributors
+- New `pp_get_composition_result()` and `pp_is_list()` in `lib/wp.php`; `AI_CONTEXT.md` documents the classifying accessor and when to use it over `pp_get_composition()`.
+
 ## [v0.16.55] — 2026-07-07 — AI-chat history is now private to each WordPress user, even on a shared browser (#157)
 
 **Two WordPress admins who share one computer login and browser used to see each other's AI-chat conversation history, because the chat was saved under a key tied only to the site, not the user. It's now saved per site and per user, so your chat history stays yours. If a page ever loads without a valid user id, the chat simply won't persist that session rather than fall back to a shared bucket.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1550+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.55-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.56-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/operating-loop.md
+++ b/ai-instructions/operating-loop.md
@@ -37,7 +37,7 @@ old order let typed edits land before the safety gate; they no longer can.
 
 Run: `wp pp operate inspect` (or `wp pp operate inspect --post_id=<id>` for page-specific smells).
 
-This returns the full operating picture: target environment, composition pages, drift state, preflight status, design tokens, CSS conflicts, and composition smells.
+This returns the full operating picture: target environment, composition pages, drift state, preflight status, design tokens, CSS conflicts, composition smells, and (with `--post_id`) a `composition_decode_error` signal that is set when the page's stored composition is corrupt or not a valid list rather than genuinely empty (issue 144).
 
 **Required output**: `site_state` — the full inspect result. Store it; you'll reference it throughout the loop.
 

--- a/ai-instructions/playbook-inspect-fix.md
+++ b/ai-instructions/playbook-inspect-fix.md
@@ -13,6 +13,7 @@ Diagnose and fix a reported issue. INSPECT includes a screenshot of the current 
 ### 1. INSPECT
 Run `wp pp operate inspect --post_id=<page_id>`. Review:
 - Current composition (look for structural issues)
+- `composition_decode_error` (if set, the stored composition is corrupt/undecodable or not a list — that data-integrity problem is likely the root cause; don't treat the page as blank)
 - Composition smells (may identify the root cause)
 - Design tokens (token issues cause visual bugs)
 - CSS conflicts (custom CSS may be overriding components)

--- a/ai-instructions/validate-site.md
+++ b/ai-instructions/validate-site.md
@@ -21,6 +21,7 @@ wp pp validate site
 This checks:
 1. **Custom CSS conflicts** — selectors in WordPress Custom CSS that target PP component classes (also surfaced via admin notice on composition edit screens)
 2. **Composition styling** — duplicate component types without stable IDs (ambiguous targeting)
+3. **Composition data integrity** — a page whose stored composition is corrupt (undecodable JSON) or not a valid composition list is flagged as a data-integrity error and fails validation, instead of being silently treated as a blank page (issue 144). `wp pp check page` reports the same corruption distinctly from "no composition".
 
 Individual checks:
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.55');
+define('PP_VERSION', '0.16.56');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -710,7 +710,15 @@ class PP_Check_Command extends WP_CLI_Command {
             WP_CLI::error('--post_id is required.');
         }
 
-        $composition = pp_get_composition($post_id);
+        $result = pp_get_composition_result($post_id);
+        if (!$result['ok']) {
+            // Corrupt/undecodable _pp_composition — distinct from a blank page
+            // so a data-integrity problem isn't reported as "no composition"
+            // (issue #144).
+            WP_CLI::warning("Page {$post_id}: composition data integrity error ({$result['error']}). The stored _pp_composition is not a valid composition list — treat as corrupted, not empty.");
+            return;
+        }
+        $composition = $result['composition'];
         if (empty($composition)) {
             WP_CLI::warning('No composition found for page ' . $post_id . '.');
             return;
@@ -823,7 +831,16 @@ class PP_Validate_Command extends WP_CLI_Command {
             foreach ($pages as $page) {
                 $post_id     = $page['id'];
                 $title       = $page['title'] ?? '(untitled)';
-                $composition = pp_get_composition($post_id);
+                $result      = pp_get_composition_result($post_id);
+                if (!$result['ok']) {
+                    // Corrupt row must fail validation, not report clean (issue
+                    // #144). This is the command CI runs, so a silent-clean here
+                    // would hide data corruption from the pipeline.
+                    $pass = false;
+                    WP_CLI::warning("Page {$post_id} ({$title}): composition data integrity error ({$result['error']}) — stored _pp_composition is not a valid composition list.");
+                    continue;
+                }
+                $composition = $result['composition'];
                 $warnings    = pp_validate_composition_styling($composition);
                 $smells      = pp_validate_composition_smells($composition);
 

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -155,25 +155,32 @@ function pp_inspect_site(?int $post_id = null): array {
     $drift = pp_check_drift();
 
     $smells = [];
+    $composition_decode_error = null;
     if ($post_id !== null) {
-        // Read through the canonical accessor: normal storage is a JSON string
+        // Read through the classifying accessor: normal storage is a JSON string
         // (pp_update_composition), so a raw get_post_meta + is_array() check
         // always reports empty for real pages. See lib/operate.php preflight
-        // check 6 for the same pattern.
-        $composition = pp_get_composition($post_id);
-        if (!empty($composition)) {
-            $smells = pp_validate_composition_smells($composition);
+        // check 6 for the same pattern. A corrupt/undecodable row is surfaced as
+        // composition_decode_error rather than masquerading as a clean, blank
+        // page (issue #144) — an agent relying on INSPECT before a mutation must
+        // be warned about data corruption instead of seeing smells: [].
+        $result = pp_get_composition_result($post_id);
+        if (!$result['ok']) {
+            $composition_decode_error = $result['error'];
+        } elseif (!empty($result['composition'])) {
+            $smells = pp_validate_composition_smells($result['composition']);
         }
     }
 
     return [
-        'target'    => pp_get_target(),
-        'pages'     => pp_composition_pages(),
-        'drift'     => $drift,
-        'preflight' => pp_preflight([], $drift),
-        'tokens'    => pp_design_tokens(),
-        'conflicts' => pp_check_custom_css_conflicts(),
-        'smells'    => $smells,
+        'target'                   => pp_get_target(),
+        'pages'                    => pp_composition_pages(),
+        'drift'                    => $drift,
+        'preflight'                => pp_preflight([], $drift),
+        'tokens'                   => pp_design_tokens(),
+        'conflicts'                => pp_check_custom_css_conflicts(),
+        'smells'                   => $smells,
+        'composition_decode_error' => $composition_decode_error,
     ];
 }
 

--- a/lib/post-apply-validate.php
+++ b/lib/post-apply-validate.php
@@ -29,7 +29,18 @@ function pp_post_apply_validate(int $post_id, ?array $target = null): array {
     $warnings = [];
 
     // 1. Composition read-back from DB.
-    $composition = pp_get_composition($post_id);
+    $composition_result = pp_get_composition_result($post_id);
+    if (!$composition_result['ok']) {
+        // Corrupt/undecodable row after apply — surfaced distinctly from a
+        // genuinely-empty read-back so the failure names data corruption
+        // (issue #144), not just "empty".
+        $errors[] = [
+            'check'   => 'composition_decode_error',
+            'message' => "Stored composition is corrupted after apply ({$composition_result['error']}): not a valid composition list.",
+        ];
+        return ['ok' => false, 'warnings' => $warnings, 'errors' => $errors];
+    }
+    $composition = $composition_result['composition'];
     if (empty($composition)) {
         $errors[] = [
             'check'   => 'composition_readback',

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -222,24 +222,102 @@ function pp_composition(): array {
 // ── Site-state read functions (action-layer support) ─────────────────────────
 
 /**
+ * Compatibility shim for array_is_list() (PHP 8.1+); the plugin floor is PHP 8.0.
+ *
+ * A list has sequential integer keys 0..n-1. The empty array is a list. Guard
+ * the empty case first — range(0, count($a) - 1) is range(0, -1) on [], which
+ * yields [0], not [].
+ *
+ * @param array $arr
+ * @return bool
+ */
+function pp_is_list(array $arr): bool {
+    if ($arr === []) {
+        return true;
+    }
+    return array_keys($arr) === range(0, count($arr) - 1);
+}
+
+/**
+ * Reads _pp_composition and classifies its state, so callers can tell a
+ * genuinely blank page apart from a corrupted one (issue #144).
+ *
+ * Return shape: ['ok' => bool, 'composition' => array, 'error' => ?string, 'raw' => ?string].
+ *
+ * State classification, checked in this exact order:
+ *
+ *   absent / blank meta ('' / falsy)   ok=true  composition=[]     error=null               raw=null
+ *   already-decoded list (fixture)     ok=true  composition=$raw   error=null               raw=null
+ *   already-decoded NON-list array     ok=false composition=[]     error='unexpected_shape' raw=null
+ *   non-string scalar meta (int/bool)  ok=false composition=[]     error='unexpected_shape' raw=null
+ *   undecodable JSON string            ok=false composition=[]     error='decode_error'     raw=<raw>
+ *   valid JSON, non-list (obj/scalar)  ok=false composition=[]     error='unexpected_shape' raw=<raw>
+ *   valid JSON list ([] or [ ... ])    ok=true  composition=$items error=null               raw=<raw>
+ *
+ * A JSON object decodes to an associative PHP array that is_array() would accept,
+ * so list-shape is enforced via pp_is_list() to keep objects out of compositions.
+ *
+ * This is the single owner of composition decode + state classification for
+ * consuming callers (inspect / check / validate). Render paths (pp_composition())
+ * keep their own defensive decode by design — issue #144 leaves rendering untouched.
+ *
+ * @param int $post_id  WordPress post ID.
+ * @return array{ok: bool, composition: array, error: ?string, raw: ?string}
+ */
+function pp_get_composition_result(int $post_id): array {
+    $raw = get_post_meta($post_id, '_pp_composition', true);
+
+    // Absent meta: get_post_meta(single=true) returns '' when the key does not
+    // exist. Match only genuine absence here — NOT every falsy value — so a
+    // stored falsy-but-present payload (the JSON string "0", an int 0) still
+    // reaches shape classification below instead of masquerading as a blank page.
+    if ($raw === '' || $raw === null || $raw === false) {
+        return ['ok' => true, 'composition' => [], 'error' => null, 'raw' => null];
+    }
+
+    // Defensive: a caller/fixture may have persisted an already-decoded array.
+    // Enforce the same list-shape as the JSON path so a decoded object (an
+    // associative array) is flagged, not silently accepted.
+    if (is_array($raw)) {
+        if (!pp_is_list($raw)) {
+            return ['ok' => false, 'composition' => [], 'error' => 'unexpected_shape', 'raw' => null];
+        }
+        return ['ok' => true, 'composition' => $raw, 'error' => null, 'raw' => null];
+    }
+
+    // Normal storage is a JSON string. A truthy non-string scalar (int, float,
+    // bool) is neither a composition nor a JSON payload we should decode.
+    if (!is_string($raw)) {
+        return ['ok' => false, 'composition' => [], 'error' => 'unexpected_shape', 'raw' => null];
+    }
+
+    $items = json_decode($raw, true);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        // Truncated write, encoding bug, malformed UTF-8: undecodable.
+        return ['ok' => false, 'composition' => [], 'error' => 'decode_error', 'raw' => $raw];
+    }
+    if (!is_array($items) || !pp_is_list($items)) {
+        // Valid JSON but the wrong shape: object, scalar, or literal null.
+        return ['ok' => false, 'composition' => [], 'error' => 'unexpected_shape', 'raw' => $raw];
+    }
+
+    return ['ok' => true, 'composition' => $items, 'error' => null, 'raw' => $raw];
+}
+
+/**
  * Returns the composition array for a specific page by post ID.
  * Unlike pp_composition(), this works outside the loop.
+ *
+ * Legacy array-only accessor: delegates to pp_get_composition_result() (the
+ * single decode owner) and returns only the items. A corrupt or non-list row
+ * degrades to [] here — callers that need to distinguish corruption from an
+ * empty page use pp_get_composition_result() directly.
  *
  * @param int $post_id  WordPress post ID.
  * @return array  Array of component objects, or [] if absent/invalid.
  */
 function pp_get_composition(int $post_id): array {
-    $raw = get_post_meta($post_id, '_pp_composition', true);
-    if (!$raw) {
-        return [];
-    }
-    // Normal storage is a JSON string (pp_update_composition). Be defensive about
-    // callers/fixtures that persist an already-decoded array.
-    if (is_array($raw)) {
-        return $raw;
-    }
-    $items = json_decode($raw, true);
-    return is_array($items) ? $items : [];
+    return pp_get_composition_result($post_id)['composition'];
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.55",
+  "version": "0.16.56",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.55
+Stable tag: 0.16.56
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.55
+Version:          0.16.56
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/CompositionResultTest.php
+++ b/tests/CompositionResultTest.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * tests/CompositionResultTest.php — pp_get_composition_result() state classifier.
+ *
+ * Issue #144: distinguish absent / empty [] / undecodable / non-list JSON so an
+ * agent relying on INSPECT before a mutation is warned about a corrupted page
+ * instead of seeing it as a clean, blank one. Also pins pp_is_list() (the PHP 8.0
+ * array_is_list() shim) and the pp_get_composition() delegation parity.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class CompositionResultTest extends TestCase
+{
+    private int $postId = 77;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['_pp_test_store']['post_meta'] = [];
+    }
+
+    private function setRawMeta($value): void
+    {
+        // Store the exact raw value (not json_encode) so we can exercise the
+        // undecodable / non-string / already-array branches directly.
+        update_post_meta($this->postId, '_pp_composition', $value);
+    }
+
+    // ── pp_is_list() shim ────────────────────────────────────────────────
+
+    public function testIsListEmptyArrayIsAList(): void
+    {
+        // range(0, -1) would be [0], so [] must be special-cased.
+        $this->assertTrue(pp_is_list([]));
+    }
+
+    public function testIsListSequentialIsAList(): void
+    {
+        $this->assertTrue(pp_is_list(['a', 'b', 'c']));
+    }
+
+    public function testIsListAssociativeIsNotAList(): void
+    {
+        $this->assertFalse(pp_is_list(['component' => 'hero']));
+    }
+
+    public function testIsListGappedKeysIsNotAList(): void
+    {
+        $this->assertFalse(pp_is_list([0 => 'a', 2 => 'b']));
+    }
+
+    // ── pp_get_composition_result(): the four+ states ────────────────────
+
+    public function testAbsentMeta(): void
+    {
+        // No meta row at all.
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['composition']);
+        $this->assertNull($result['error']);
+        $this->assertNull($result['raw'], 'absent meta must have raw=null (distinguishes it from empty [])');
+    }
+
+    public function testStoredEmptyStringTreatedAsAbsent(): void
+    {
+        // A stored empty string is falsy; treated as absent/blank, not corrupt,
+        // matching the pre-existing defensive contract.
+        $this->setRawMeta('');
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['composition']);
+        $this->assertNull($result['error']);
+        $this->assertNull($result['raw']);
+    }
+
+    public function testEmptyJsonArrayIsDistinctFromAbsent(): void
+    {
+        $this->setRawMeta('[]');
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['composition']);
+        $this->assertNull($result['error']);
+        $this->assertSame('[]', $result['raw'], 'empty [] must carry raw so it is distinguishable from absent');
+    }
+
+    public function testValidJsonListDecodes(): void
+    {
+        $composition = [
+            ['component' => 'hero', 'props' => ['id' => 'pp-hero1']],
+            ['component' => 'cta', 'props' => []],
+        ];
+        $this->setRawMeta(json_encode($composition));
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame($composition, $result['composition']);
+        $this->assertNull($result['error']);
+        $this->assertIsString($result['raw']);
+    }
+
+    public function testUndecodableJsonIsDecodeError(): void
+    {
+        $this->setRawMeta('{"component":');
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame([], $result['composition']);
+        $this->assertSame('decode_error', $result['error']);
+        $this->assertSame('{"component":', $result['raw']);
+    }
+
+    public function testMalformedUtf8IsDecodeError(): void
+    {
+        // Invalid UTF-8 byte inside an otherwise well-formed string → json error.
+        $this->setRawMeta("[\"\xB1\x31\x30\"]");
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('decode_error', $result['error']);
+    }
+
+    public function testJsonObjectIsUnexpectedShape(): void
+    {
+        // Decodes to an associative PHP array — is_array() would accept it, so
+        // pp_is_list() must reject it.
+        $this->setRawMeta('{"component":"hero"}');
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame([], $result['composition']);
+        $this->assertSame('unexpected_shape', $result['error']);
+        $this->assertSame('{"component":"hero"}', $result['raw']);
+    }
+
+    public function testJsonScalarIsUnexpectedShape(): void
+    {
+        $this->setRawMeta('42');
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('unexpected_shape', $result['error']);
+    }
+
+    public function testFalsyJsonStringZeroIsUnexpectedShape(): void
+    {
+        // Guard against the PHP-falsy trap: the JSON string "0" is a valid JSON
+        // scalar (decodes to int 0), NOT an absent page, so it must classify as
+        // unexpected_shape rather than being swallowed by an `if (!$raw)` guard.
+        $this->setRawMeta('0');
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame([], $result['composition']);
+        $this->assertSame('unexpected_shape', $result['error']);
+        $this->assertSame('0', $result['raw']);
+    }
+
+    public function testAlreadyDecodedEmptyArray(): void
+    {
+        // A stored empty array [] is a valid (empty) list — the falsy-but-present
+        // case must route through the array branch, not the absent guard.
+        $this->setRawMeta([]);
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['composition']);
+        $this->assertNull($result['error']);
+    }
+
+    public function testJsonNullIsUnexpectedShape(): void
+    {
+        // Valid JSON, no decode error, but not a list.
+        $this->setRawMeta('null');
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('unexpected_shape', $result['error']);
+    }
+
+    public function testAlreadyDecodedListArray(): void
+    {
+        // Defensive: a fixture/caller persisted an already-decoded list.
+        $composition = [['component' => 'hero', 'props' => []]];
+        $this->setRawMeta($composition);
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame($composition, $result['composition']);
+        $this->assertNull($result['error']);
+        $this->assertNull($result['raw']);
+    }
+
+    public function testAlreadyDecodedAssociativeArrayIsUnexpectedShape(): void
+    {
+        // A decoded object (associative array) must be flagged, not accepted.
+        $this->setRawMeta(['component' => 'hero']);
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame([], $result['composition']);
+        $this->assertSame('unexpected_shape', $result['error']);
+        $this->assertNull($result['raw']);
+    }
+
+    public function testNonStringScalarMetaIsUnexpectedShape(): void
+    {
+        // A truthy non-string scalar (e.g. int) is neither a composition nor a
+        // JSON payload we decode; raw must stay ?string (null here).
+        $this->setRawMeta(42);
+        $result = pp_get_composition_result($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame([], $result['composition']);
+        $this->assertSame('unexpected_shape', $result['error']);
+        $this->assertNull($result['raw']);
+    }
+
+    // ── pp_get_composition() delegation parity (render/consumer safety) ───
+
+    public function testGetCompositionReturnsListForValid(): void
+    {
+        $composition = [['component' => 'hero', 'props' => []]];
+        $this->setRawMeta(json_encode($composition));
+
+        $this->assertSame($composition, pp_get_composition($this->postId));
+    }
+
+    public function testGetCompositionDegradesCorruptToEmpty(): void
+    {
+        // Regression (#144): a corrupt/undecodable row must degrade to [] via the
+        // legacy accessor — never fatal — so render paths stay safe.
+        $this->setRawMeta('{"component":');
+
+        $this->assertSame([], pp_get_composition($this->postId));
+    }
+
+    public function testGetCompositionDegradesJsonObjectToEmpty(): void
+    {
+        // A JSON object previously slipped through is_array() as an associative
+        // array; it must now degrade to [] for consumers.
+        $this->setRawMeta('{"component":"hero"}');
+
+        $this->assertSame([], pp_get_composition($this->postId));
+    }
+
+    public function testGetCompositionAbsentIsEmpty(): void
+    {
+        $this->assertSame([], pp_get_composition($this->postId));
+    }
+}

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -272,6 +272,55 @@ class OperateTest extends TestCase
         $this->assertSame([], $result['smells']);
     }
 
+    public function testInspectSiteSurfacesCorruptCompositionDistinctly(): void
+    {
+        // Issue #144: a corrupt/undecodable composition must report a decode
+        // error, NOT a clean smells: [] indistinguishable from a blank page.
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'Corrupt Page', 'post_status' => 'publish']);
+        update_post_meta($post_id, '_pp_composition', '{"component":');
+
+        $result = pp_inspect_site($post_id);
+
+        $this->assertSame([], $result['smells']);
+        $this->assertSame('decode_error', $result['composition_decode_error']);
+    }
+
+    public function testInspectSiteFlagsNonListJsonAsUnexpectedShape(): void
+    {
+        // A JSON object decodes to an associative array; it is a data-integrity
+        // anomaly, not an absent page.
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'Object Page', 'post_status' => 'publish']);
+        update_post_meta($post_id, '_pp_composition', '{"component":"hero"}');
+
+        $result = pp_inspect_site($post_id);
+
+        $this->assertSame([], $result['smells']);
+        $this->assertSame('unexpected_shape', $result['composition_decode_error']);
+    }
+
+    public function testInspectSiteBlankPageHasNoDecodeError(): void
+    {
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'Blank Page', 'post_status' => 'publish']);
+
+        $result = pp_inspect_site($post_id);
+
+        $this->assertSame([], $result['smells']);
+        $this->assertNull($result['composition_decode_error'], 'a genuinely blank page must not report a decode error');
+    }
+
+    public function testInspectSiteValidPageHasNoDecodeError(): void
+    {
+        $post_id = wp_insert_post(['post_type' => 'page', 'post_title' => 'Smelly Page', 'post_status' => 'publish']);
+        update_post_meta($post_id, '_pp_composition', json_encode([
+            ['component' => 'hero', 'props' => ['id' => 'pp-hero1111', 'variant' => 'left']],
+        ]));
+
+        $result = pp_inspect_site($post_id);
+
+        $this->assertNotEmpty($result['smells']);
+        $this->assertNull($result['composition_decode_error']);
+    }
+
     // ── Preflight ──────────────────────────────────────────────────────────
 
     public function testPreflightIncludesDriftCheck(): void

--- a/tests/PostApplyValidateTest.php
+++ b/tests/PostApplyValidateTest.php
@@ -108,6 +108,30 @@ class PostApplyValidateTest extends TestCase
         $this->assertEquals('composition_readback', $result['errors'][0]['check']);
     }
 
+    public function testCorruptCompositionReportsDecodeError(): void
+    {
+        // Issue #144: a corrupt/undecodable row after apply must surface a
+        // distinct composition_decode_error, not the generic empty-readback.
+        update_post_meta($this->postId, '_pp_composition', '{"component":');
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $this->assertCount(1, $result['errors']);
+        $this->assertEquals('composition_decode_error', $result['errors'][0]['check']);
+    }
+
+    public function testNonListJsonReportsDecodeError(): void
+    {
+        // A JSON object (decodes to associative array) is corrupt, not empty.
+        update_post_meta($this->postId, '_pp_composition', '{"component":"hero"}');
+
+        $result = pp_post_apply_validate($this->postId);
+
+        $this->assertFalse($result['ok']);
+        $this->assertEquals('composition_decode_error', $result['errors'][0]['check']);
+    }
+
     public function testValidCompositionPasses(): void
     {
         $this->createTestComponent('hero', '<section class="hero"><h1>Hello</h1></section>');


### PR DESCRIPTION
Closes #144.

## What & why

`pp_get_composition()` collapsed four different states of `_pp_composition` — absent meta, empty `[]`, undecodable JSON, and valid-but-non-list JSON — into the same empty array. Since #119, `pp_inspect_site()` reads through it, so a **corrupt** page reported a clean INSPECT indistinguishable from a **blank** one. An agent running INSPECT before a mutation would never be warned about the data-integrity problem.

Per the recorded ✅ Decision (Option A): add a companion state-classifying accessor, keep rendering defensive.

## Changes

- **`pp_get_composition_result($post_id)`** (`lib/wp.php`) — the single decode owner. Returns `['ok'=>bool,'composition'=>array,'error'=>?string,'raw'=>?string]`, distinguishing:
  - absent meta → `ok=true, raw=null`
  - empty `[]` → `ok=true, raw='[]'` (distinct from absent)
  - undecodable JSON → `ok=false, error='decode_error'`
  - valid JSON that isn't a list (object/scalar/`null`) → `ok=false, error='unexpected_shape'`
- **`pp_is_list()`** — PHP 8.0-compatible `array_is_list()` shim (plugin floor is 8.0). A JSON object decodes to an associative array that a bare `is_array()` would wrongly accept; the list check rejects it.
- **`pp_get_composition()`** now delegates to the result accessor and still degrades any corrupt/non-list row to `[]` — render/template paths are untouched and never fatal.
- **Callers surface the signal:** `pp_inspect_site()` adds a `composition_decode_error` field; `wp pp check page`, `wp pp validate site`, and `wp pp validate page` (`pp_post_apply_validate()`) report the integrity error distinctly instead of "no composition".
- **Docs:** `AI_CONTEXT.md` documents the classifying accessor and when to prefer it.

`wp pp validate site` was added as a 4th caller beyond the issue's enumerated three (maintainer-approved during review) because it's the CI-facing command with the same silent-clean-on-corrupt hole.

## Tests

24 new unit tests (`CompositionResultTest.php`, plus additions to `OperateTest.php` and `PostApplyValidateTest.php`) covering every state, `pp_is_list()`, the falsy-but-present `"0"` trap, an already-decoded associative-array fixture, malformed UTF-8, and the front-page no-fatal regression.

- PHP: **1316 passing** (`vendor/bin/phpunit`)
- JS: **365 passing** (`npm test`)

## Reviews

- `/plan-eng-review` (Option A locked; Fernando caught the `array_is_list` object-vs-list requirement)
- `/review` + Codex adversarial — found and fixed the `"0"` falsy-payload misclassification, added 2 regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)