### PR TITLE
v0.16.66 fix: preflight verifies uploads writability for media-target applies (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.66] — 2026-07-11 — preflight stops claiming "no filesystem writes" for `import_media` — it checks the uploads directory instead (#229)
+
+**`wp pp apply preflight --apply=import_media` reported `theme_writable: pass` with "Skipped: planned applies are database-backed (no filesystem writes)" — about the one apply in the set that writes to the filesystem. `import_media` sideloads into `wp-content/uploads/YYYY/MM/`, and on a host where uploads isn't writable by the CLI user the apply then failed at execute with a raw WordPress error. Preflight exists to tell an operator "it is safe to proceed"; here it made a specific, false claim. Media-target applies now get a real `uploads_writable` check, error-grade, fail-closed.**
+
+The check mirrors execute-time `wp_mkdir_p()` semantics instead of naively testing one directory: it walks from the dated `YYYY/MM` path to the deepest existing ancestor and requires a writable directory there. That makes it right in all four states that a single `is_writable(basedir)` gets wrong: a fresh site whose `uploads/` doesn't exist yet passes (WordPress creates the tree), an existing dated dir is checked directly, an unwritable intermediate (`uploads/2026` rsync'd `0555` under a writable `uploads/`) fails, and a regular file squatting on a path segment fails instead of green-lighting a doomed apply off the writable grandparent. The `theme_writable` skip message no longer asserts "no filesystem writes" when a media apply is planned — it points at `uploads_writable`.
+
+### Fixed
+- **Preflight asserted "no filesystem writes" for a filesystem-writing apply (#229).** `pp_preflight()` (`lib/operate.php`) resolves the planned apply's target type once; `media`-target applies route to the new `uploads_writable` check (deepest-existing-ancestor walk, non-directory path-segment detection, `wp_upload_dir()` error propagation, empty-path fail-closed) while `file`-target routing is unchanged.
+- **Stale `preflight` command docblock** (`lib/cli.php`) still listed the removed backup-directory check and omitted the surface check; the check list is now accurate and names both writability checks.
+
+### Docs
+- `docs/reference-apply-cli.md`: `uploads_writable` row in the preflight checks table, updated `--apply` option description, and a new "Uploads writability (#229)" section documenting the ancestor-walk semantics.
+
+### Tests
+- 10 new PHPUnit tests (`tests/OperateTest.php`): writable/unwritable basedir, dated-path precedence (writable and unwritable), unwritable intermediate ancestor, fresh-site missing uploads tree, blocking regular file on a path segment, `wp_upload_dir()` error propagation, unresolved empty path, absence of the check for option-backed/no-apply preflights, and the corrected `theme_writable` message — every failure arm also pins `ok: false` (error-grade).
+
+---
+
 ## [v0.16.65] — 2026-07-11 — `apply preflight` stops printing `{"ok": true}` for a preflight that never recorded itself (#227)
 
 **The preflight gate's JSON — the machine-readable contract an AI operator branches on — could report success for a preflight that did not happen. Pass an unminted run token and the command printed `{"ok": true, "checks": [...]}` to stdout, then died with `Error: Could not record PREFLIGHT state`; a consumer parsing the JSON concluded the gate was open and hit a contradictory refusal on the very next command. The success payload is now emitted only after every recording step has succeeded, so `ok: true` means the gate is genuinely unlocked.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1550+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.65-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.66-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -137,8 +137,10 @@ Every `image_url` field on hero, section, and logos items has a companion `image
 Get an attachment id (and its canonical local URL) via the `import_media` apply — sideloads an external image URL into the media library:
 
 ```bash
-# Like every mutating apply, needs a run token + site-scoped preflight first
-# (wp pp operate inspect → wp pp apply preflight --run-id=<uuid>):
+# Like every mutating apply, needs a run token + site-scoped preflight first.
+# Pass --apply=import_media so preflight verifies the uploads directory is
+# writable (#229) instead of assuming a database-only apply:
+# (wp pp operate inspect → wp pp apply preflight --run-id=<uuid> --apply=import_media):
 wp pp apply execute import_media --run-id=<uuid> --params='{"url":"https://example.com/logo.png","alt":"Client logo"}'
 # => {"attachment_id": 123, "url": "https://yoursite.com/wp-content/uploads/2026/07/logo.png"}
 ```

--- a/docs/reference-apply-cli.md
+++ b/docs/reference-apply-cli.md
@@ -112,7 +112,7 @@ wp pp apply preflight --run-id=<uuid> --post_id=42
 - `--run-id=<uuid>` — **required.** Run token from `wp pp operate inspect`.
 - `--planned-files=<json>` — JSON array of file paths the agent intends to modify. Enables drift-overlap detection. Without it, drift is a warning only.
 - `--post_id=<id>` — target page post ID. Adds the `target_page` check and scopes coverage to that post.
-- `--apply=<name>` — named apply. Auto-populates `planned_files` from a file-based apply's target.
+- `--apply=<name>` — named apply. Auto-populates `planned_files` from a file-based apply's target; a media-target apply (`import_media`) enables the `uploads_writable` check (#229).
 
 **Coverage grain.** A preflight with `--post_id=N` covers mutations on post N; a preflight with no post covers **site-grain** changes. They don't substitute for each other — a page mutation needs a page preflight, a site mutation needs a site preflight. This is what `execute`/`action execute`/`operate patch` check.
 
@@ -156,13 +156,16 @@ The checks that can run (`pp_preflight`, `lib/operate.php`):
 | `target` | always | yes |
 | `capability` | always | yes |
 | `drift` | always | only if drifted files overlap `planned_files` |
-| `theme_writable` | file-targeting applies only | yes (skipped for DB-backed token applies) |
+| `theme_writable` | file-targeting applies only | yes (skipped for DB-backed token applies and for media applies, whose writes are covered by `uploads_writable`) |
+| `uploads_writable` | media-target applies only (`--apply=import_media`, #229) | yes |
 | `target_page` | `--post_id` given | yes |
 | `surface` | `planned_files` given | yes if a `core` file is planned |
 | `nav_readiness` | always (site chrome is not page-scoped, #223) | no (`severity: warning`) |
 | `screenshot_readiness` | always | no (`severity: warning`) |
 
 `ok` is `true` only when no **error-grade** check failed. Rows with `severity: warning` (nav readiness, screenshot readiness, non-overlapping drift) surface a problem without blocking.
+
+**Uploads writability (#229).** `import_media` sideloads a file into `wp-content/uploads/YYYY/MM/`, so a preflight with `--apply=import_media` runs `uploads_writable` instead of asserting "no filesystem writes." The check mirrors execute-time `wp_mkdir_p()` semantics: it walks from the dated path to the **deepest existing ancestor** and requires it to be a writable directory — so a fresh site whose `uploads/` doesn't exist yet passes (WordPress creates it), while an unwritable intermediate directory (`uploads/2026` rsync'd `0555`) or a regular file occupying a path segment fails closed even when `uploads/` itself is writable. The `theme_writable` row still passes for media applies (the theme directory is untouched) with a message pointing at `uploads_writable`.
 
 **Exit codes and errors**
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.65');
+define('PP_VERSION', '0.16.66');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -739,8 +739,9 @@ class PP_Apply_Command extends WP_CLI_Command {
     /**
      * Validates the execution surface before any mutation.
      *
-     * Checks: target resolved, capability OK, backup directory writable,
-     * drift state, theme writability, and target page (if applicable).
+     * Checks: target resolved, capability OK, drift state, theme writability
+     * (file-targeting applies), uploads writability (media-target applies),
+     * target page (if applicable), and surface classification.
      * Records PREFLIGHT step in the run state file.
      *
      * ## OPTIONS
@@ -757,6 +758,7 @@ class PP_Apply_Command extends WP_CLI_Command {
      *
      * [--apply=<name>]
      * : Named apply definition. Auto-populates planned_files from the apply's target (file-based applies only).
+     *   Media-target applies (import_media) enable the uploads_writable check.
      *
      * ## EXAMPLES
      *

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -219,16 +219,16 @@ function pp_preflight(array $context = [], ?array $drift = null): array {
         $drift = pp_check_drift();
     }
 
-    // Auto-populate planned_files from apply definition if apply_name given
+    // Resolve the planned apply's target type once — it routes the
+    // planned_files auto-population and the filesystem checks below.
+    $apply_def         = !empty($context['apply_name']) ? pp_get_apply($context['apply_name']) : null;
+    $apply_target_type = $apply_def !== null && isset($apply_def['target']['type']) ? $apply_def['target']['type'] : null;
+
+    // Auto-populate planned_files from apply definition if apply_name given.
+    // Option-based targets don't produce planned_files (no file drift concern).
     $planned_files = $context['planned_files'] ?? [];
-    if (empty($planned_files) && !empty($context['apply_name'])) {
-        $apply_def = pp_get_apply($context['apply_name']);
-        if ($apply_def !== null && isset($apply_def['target']['type'])) {
-            if ($apply_def['target']['type'] === 'file' && isset($apply_def['target']['path'])) {
-                $planned_files = [$apply_def['target']['path']];
-            }
-            // Option-based targets don't produce planned_files (no file drift concern)
-        }
+    if (empty($planned_files) && $apply_target_type === 'file' && isset($apply_def['target']['path'])) {
+        $planned_files = [$apply_def['target']['path']];
     }
 
     if (!$drift['has_drift']) {
@@ -255,21 +255,77 @@ function pp_preflight(array $context = [], ?array $drift = null): array {
     }
 
     // Check 5: Theme writable (only required when planned applies target files)
-    $needs_filesystem = !empty($planned_files);
-    if (!$needs_filesystem && !empty($context['apply_name'])) {
-        $apply_def = pp_get_apply($context['apply_name']);
-        $needs_filesystem = $apply_def !== null && isset($apply_def['target']['type']) && $apply_def['target']['type'] === 'file';
-    }
+    // Media-target applies (import_media) write to wp-content/uploads, not the
+    // theme dir — they are routed to the uploads_writable check below (#229)
+    // instead of being lumped in with database-backed applies.
+    $needs_filesystem = !empty($planned_files) || $apply_target_type === 'file';
+    $needs_uploads    = $apply_target_type === 'media';
 
     $theme_path = $target['theme_path'];
     if (!$needs_filesystem) {
-        $checks[] = ['check' => 'theme_writable', 'pass' => true, 'message' => 'Skipped: planned applies are database-backed (no filesystem writes).'];
+        $checks[] = [
+            'check'   => 'theme_writable',
+            'pass'    => true,
+            'message' => $needs_uploads
+                ? 'Skipped: planned applies do not write to the theme directory (uploads writes covered by uploads_writable).'
+                : 'Skipped: planned applies are database-backed (no filesystem writes).',
+        ];
     } elseif ($theme_path !== null && is_dir($theme_path) && is_writable($theme_path)) {
         $checks[] = ['check' => 'theme_writable', 'pass' => true, 'message' => 'Theme directory is writable.'];
     } elseif ($theme_path === null) {
         $checks[] = ['check' => 'theme_writable', 'pass' => false, 'message' => 'Cannot resolve theme path.'];
     } else {
         $checks[] = ['check' => 'theme_writable', 'pass' => false, 'message' => 'Theme directory is not writable: ' . $theme_path];
+    }
+
+    // Check 5b: Uploads writable (only when a media-target apply is planned, #229).
+    // import_media sideloads into wp-content/uploads; preflight must verify that
+    // write can succeed instead of asserting "no filesystem writes" and letting
+    // execute fail with a raw WP error. Execute-time wp_mkdir_p() creates any
+    // missing segments of the dated YYYY/MM path, so the write succeeds exactly
+    // when the DEEPEST EXISTING ancestor of the target path is writable — a
+    // writable basedir is neither necessary (fresh site: uploads/ itself doesn't
+    // exist yet but wp-content is writable) nor sufficient (uploads/2026 rsync'd
+    // 0555 blocks creation of 2026/07 while uploads/ stays writable).
+    if ($needs_uploads) {
+        $uploads       = wp_get_upload_dir();
+        $uploads_error = is_array($uploads) ? ($uploads['error'] ?? false) : false;
+        $dated_path    = is_array($uploads) ? (string) ($uploads['path'] ?? '') : '';
+        $basedir       = is_array($uploads) ? (string) ($uploads['basedir'] ?? '') : '';
+        $target_dir    = $dated_path !== '' ? $dated_path : $basedir;
+
+        if (!empty($uploads_error)) {
+            $checks[] = ['check' => 'uploads_writable', 'pass' => false, 'message' => 'Uploads directory cannot be resolved: ' . $uploads_error];
+        } elseif ($target_dir === '') {
+            $checks[] = ['check' => 'uploads_writable', 'pass' => false, 'message' => 'Uploads directory cannot be resolved: (empty path)'];
+        } else {
+            $probe    = $target_dir;
+            $blocking = null; // an existing NON-directory occupying a path segment
+            while (!is_dir($probe)) {
+                if (file_exists($probe)) {
+                    // e.g. a regular file at uploads/2026 — wp_mkdir_p() can
+                    // never create children under it, and a writable ancestor
+                    // above it would be a deterministic false pass.
+                    $blocking = $probe;
+                    break;
+                }
+                $parent = dirname($probe);
+                if ($parent === $probe) {
+                    break; // filesystem root
+                }
+                $probe = $parent;
+            }
+
+            if ($blocking !== null) {
+                $checks[] = ['check' => 'uploads_writable', 'pass' => false, 'message' => 'Uploads path is blocked by a non-directory: ' . $blocking];
+            } elseif (!is_dir($probe) || !is_writable($probe)) {
+                $checks[] = ['check' => 'uploads_writable', 'pass' => false, 'message' => 'Uploads directory is not writable: ' . $probe . ($probe !== $target_dir ? ' (deepest existing ancestor of ' . $target_dir . ')' : '')];
+            } elseif ($probe === $target_dir) {
+                $checks[] = ['check' => 'uploads_writable', 'pass' => true, 'message' => 'Uploads directory is writable: ' . $target_dir];
+            } else {
+                $checks[] = ['check' => 'uploads_writable', 'pass' => true, 'message' => 'Uploads directory ' . $target_dir . ' does not exist yet; its deepest existing ancestor is writable: ' . $probe . ' (WordPress creates the rest).'];
+            }
+        }
     }
 
     // Check 6: Target page (only for page operations)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.65",
+  "version": "0.16.66",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.65
+Stable tag: 0.16.66
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.65
+Version:          0.16.66
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -71,6 +71,7 @@ class OperateTest extends TestCase
         }
         unset($GLOBALS['_pp_test_template_dir']);
         unset($GLOBALS['_pp_test_store']['options']['siteurl']);
+        unset($GLOBALS['_pp_test_store']['upload_dir']);
         pp_invalidate_design_tokens_cache();
         parent::tearDown();
     }
@@ -480,6 +481,230 @@ class OperateTest extends TestCase
 
         $this->assertNotNull($check);
         $this->assertTrue($check['pass'], 'No planned files means no filesystem requirement');
+    }
+
+    // ── Uploads writable (#229) ────────────────────────────────────────────
+
+    private function findCheck(array $result, string $name): ?array
+    {
+        foreach ($result['checks'] as $c) {
+            if ($c['check'] === $name) {
+                return $c;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Seeds the wp_get_upload_dir() stub. Pass 'path' for a dated subdir;
+     * override with empty strings to test unresolved shapes.
+     */
+    private function setUploadDir(array $overrides = []): void
+    {
+        $GLOBALS['_pp_test_store']['upload_dir'] = array_merge([
+            'baseurl' => 'https://example.com/wp-content/uploads',
+            'basedir' => $this->tempDir . '/uploads',
+        ], $overrides);
+    }
+
+    public function testPreflightUploadsWritablePassesForMediaApplyWhenWritable(): void
+    {
+        $uploads = $this->tempDir . '/uploads';
+        mkdir($uploads, 0755, true);
+        $this->setUploadDir();
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'uploads_writable');
+
+        $this->assertNotNull($check, 'Media apply must emit an uploads_writable check');
+        $this->assertTrue($check['pass']);
+        $this->assertStringContainsString($uploads, $check['message']);
+    }
+
+    public function testPreflightUploadsWritableFailsForMediaApplyWhenNotWritable(): void
+    {
+        $uploads = $this->tempDir . '/uploads';
+        mkdir($uploads, 0555, true);
+        $this->setUploadDir();
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'uploads_writable');
+
+        // Restore permissions before assertions (so tearDown cleanup works)
+        chmod($uploads, 0755);
+
+        $this->assertNotNull($check);
+        $this->assertFalse($check['pass'], 'Unwritable uploads dir must fail preflight for import_media');
+        $this->assertFalse($result['ok'], 'uploads_writable is error-grade: preflight ok must be false');
+    }
+
+    public function testPreflightUploadsWritableFailsWhenDatedPathExistsUnwritable(): void
+    {
+        $uploads = $this->tempDir . '/uploads';
+        $dated   = $uploads . '/2026/07';
+        mkdir($dated, 0755, true);
+        chmod($dated, 0555);
+        $this->setUploadDir(['path' => $dated]);
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'uploads_writable');
+
+        chmod($dated, 0755);
+
+        $this->assertNotNull($check);
+        $this->assertFalse($check['pass'], 'Existing but unwritable dated subdir must fail even when basedir is writable');
+        $this->assertFalse($result['ok']);
+    }
+
+    public function testPreflightUploadsWritablePassesWhenDatedPathExistsWritable(): void
+    {
+        $uploads = $this->tempDir . '/uploads';
+        $dated   = $uploads . '/2026/07';
+        mkdir($dated, 0755, true);
+        $this->setUploadDir(['path' => $dated]);
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'uploads_writable');
+
+        $this->assertNotNull($check);
+        $this->assertTrue($check['pass']);
+        $this->assertStringContainsString($dated, $check['message'], 'Dated path takes precedence over basedir as the checked target');
+    }
+
+    public function testPreflightUploadsWritableFailsWhenIntermediateAncestorUnwritable(): void
+    {
+        // uploads/ is writable but uploads/2026 is 0555 (e.g. rsync'd with the
+        // wrong perms): execute's wp_mkdir_p cannot create 2026/07, so preflight
+        // must fail on the deepest existing ancestor, not pass on basedir.
+        $uploads = $this->tempDir . '/uploads';
+        $year    = $uploads . '/2026';
+        mkdir($year, 0755, true);
+        chmod($year, 0555);
+        $this->setUploadDir(['path' => $year . '/07']);
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'uploads_writable');
+
+        chmod($year, 0755);
+
+        $this->assertNotNull($check);
+        $this->assertFalse($check['pass'], 'Unwritable intermediate ancestor must fail even when basedir is writable');
+        $this->assertStringContainsString($year, $check['message']);
+        $this->assertFalse($result['ok']);
+    }
+
+    public function testPreflightUploadsWritablePassesWhenDatedPathMissingButBasedirWritable(): void
+    {
+        // WordPress creates the dated YYYY/MM subdir when the parent is
+        // writable, so a missing dated path must not fail the check.
+        $uploads = $this->tempDir . '/uploads';
+        mkdir($uploads, 0755, true);
+        $this->setUploadDir(['path' => $uploads . '/2026/07']);
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'uploads_writable');
+
+        $this->assertNotNull($check);
+        $this->assertTrue($check['pass']);
+    }
+
+    public function testPreflightUploadsWritablePassesOnFreshSiteWithNoUploadsDir(): void
+    {
+        // Fresh install: wp-content/uploads does not exist yet, but its parent
+        // is writable — wp_mkdir_p at execute time creates the whole tree, so
+        // preflight must not block the first-ever media import.
+        $this->setUploadDir(); // basedir = tempDir/uploads, never created
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'uploads_writable');
+
+        $this->assertNotNull($check);
+        $this->assertTrue($check['pass'], 'Missing uploads dir with a writable parent must pass (WP creates it)');
+        $this->assertStringContainsString($this->tempDir, $check['message']);
+    }
+
+    public function testPreflightUploadsWritableFailsOnUploadDirError(): void
+    {
+        $this->setUploadDir([
+            'baseurl' => '',
+            'basedir' => '',
+            'error'   => 'Unable to create directory. Is its parent directory writable by the server?',
+        ]);
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'uploads_writable');
+
+        $this->assertNotNull($check);
+        $this->assertFalse($check['pass']);
+        $this->assertStringContainsString('Unable to create directory', $check['message']);
+        $this->assertFalse($result['ok']);
+    }
+
+    public function testPreflightUploadsWritableFailsWhenFileBlocksPathSegment(): void
+    {
+        // A regular FILE at uploads/2026 makes wp_mkdir_p unable to create
+        // 2026/07 even though uploads/ itself is writable — the walk must
+        // fail on the blocking file, not pass on the writable ancestor.
+        $uploads = $this->tempDir . '/uploads';
+        mkdir($uploads, 0755, true);
+        file_put_contents($uploads . '/2026', 'not a directory');
+        $this->setUploadDir(['path' => $uploads . '/2026/07']);
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'uploads_writable');
+
+        $this->assertNotNull($check);
+        $this->assertFalse($check['pass'], 'A file occupying an intermediate path segment must fail closed');
+        $this->assertStringContainsString($uploads . '/2026', $check['message']);
+        $this->assertFalse($result['ok']);
+    }
+
+    public function testPreflightUploadsWritableFailsWhenPathUnresolved(): void
+    {
+        $this->setUploadDir(['baseurl' => '', 'basedir' => '']);
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'uploads_writable');
+
+        $this->assertNotNull($check);
+        $this->assertFalse($check['pass'], 'Empty basedir with no error key must fail closed');
+        $this->assertFalse($result['ok']);
+    }
+
+    public function testPreflightNoUploadsCheckForOptionBackedApply(): void
+    {
+        $result = pp_preflight(['apply_name' => 'update_design_token']);
+        $this->assertNull(
+            $this->findCheck($result, 'uploads_writable'),
+            'Option-backed applies must not emit an uploads_writable check'
+        );
+    }
+
+    public function testPreflightNoUploadsCheckWithNoApplyName(): void
+    {
+        $result = pp_preflight();
+        $this->assertNull(
+            $this->findCheck($result, 'uploads_writable'),
+            'Preflight without a planned apply must not emit an uploads_writable check'
+        );
+    }
+
+    public function testPreflightThemeWritableMessageDoesNotClaimNoFilesystemWritesForMediaApply(): void
+    {
+        $uploads = $this->tempDir . '/uploads';
+        mkdir($uploads, 0755, true);
+        $GLOBALS['_pp_test_store']['upload_dir'] = [
+            'baseurl' => 'https://example.com/wp-content/uploads',
+            'basedir' => $uploads,
+        ];
+
+        $result = pp_preflight(['apply_name' => 'import_media']);
+        $check  = $this->findCheck($result, 'theme_writable');
+
+        $this->assertNotNull($check);
+        $this->assertTrue($check['pass'], 'import_media does not touch the theme dir; theme check stays skipped-pass');
+        $this->assertStringNotContainsString('no filesystem writes', $check['message']);
+        $this->assertStringContainsString('uploads_writable', $check['message']);
     }
 
     public function testPreflightTargetPagePassesForValidPost(): void


### PR DESCRIPTION
Closes #229

## What

`wp pp apply preflight --apply=import_media` reported `theme_writable: pass` with *"Skipped: planned applies are database-backed (no filesystem writes)"* — a specific, false claim about the one apply that writes to the filesystem. `import_media` then failed at execute with a raw WP error when `wp-content/uploads` wasn't writable by the CLI user.

Media-target applies now get an error-grade, fail-closed `uploads_writable` check, and the `theme_writable` skip message no longer claims "no filesystem writes" when a media apply is planned.

## How

`pp_preflight()` (lib/operate.php) resolves the planned apply's target type once (also DRY-ing the previous double `pp_get_apply()` lookup) and routes `media`-target applies to the new check. The check mirrors execute-time `wp_mkdir_p()` semantics — walk from the dated `YYYY/MM` path to the **deepest existing ancestor** and require a writable directory there:

| Filesystem state | Naive `is_writable(basedir)` | This check |
|---|---|---|
| Fresh site, `uploads/` missing, `wp-content` writable | ❌ false fail | ✅ pass (WP creates the tree) |
| Dated dir exists, unwritable | ❌ false pass | ✅ fail |
| `uploads/2026` rsync'd `0555` under writable `uploads/` | ❌ false pass | ✅ fail on the ancestor |
| Regular **file** at `uploads/2026` | ❌ false pass | ✅ fail (blocked by non-directory) |
| `wp_upload_dir()` error / empty path | — | ✅ fail closed |

`file`-target routing and non-media preflight output are unchanged (pinned by tests). Execute parity holds: `import_media` sideloads with `media_handle_sideload($file_array, 0)` — no post attachment, so preflight and execute always resolve the same dated path.

## Review trail

- `/plan-eng-review` (scope gate = issue body, per standing preference) + Codex outside voice — ancestor-walk and fresh-site cases folded in from adversarial findings.
- `/review`: testing + maintainability specialists, Claude adversarial, Codex adversarial (inline-diff mode). All FIXABLE findings applied; the pre-existing unknown-`--apply` false pass was filed as #245 (out of scope here).
- Accepted/inherited (not changed): preflight coverage-unlock doesn't bind the apply name (same trust model as `theme_writable`, adjacent to #114); month-rollover TOCTOU (same acceptance class as perms drift between preflight and execute); `error`-key branch is unreachable through `wp_get_upload_dir()` in current core but kept as cheap defense.

## Validation

- PHPUnit: **1452 tests, 5278 assertions** green (10 new in `tests/OperateTest.php`; 3 warnings + 2 deprecations are pre-existing on main).
- `npm test` (vitest): **385 tests** green.
- No browser-observable surface — CLI/PHP only.

## Docs

- `docs/reference-apply-cli.md`: new `uploads_writable` checks-table row, `--apply` option description, and an "Uploads writability (#229)" section.
- `lib/cli.php` preflight docblock check list corrected (dropped the removed backup-dir check, added both writability checks + surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)