### PR TITLE
v0.16.70 fix: drop hardcoded test counts and the resolved-#83 quarantine claim from the live docs (#250)

### DIFF
--- a/AI_RULES.md
+++ b/AI_RULES.md
@@ -105,7 +105,7 @@ Playwright tests in `tests/e2e/` run against a live WordPress instance via wp-en
 
 ```
 npm run env:start   # boot Docker WordPress on port 8889
-npm run test:e2e    # 34 specs: editor round-trip, serialization gate, CLI actions, post-apply validation, AI chat streaming/apply, token concurrency
+npm run test:e2e    # editor round-trip, serialization gate, CLI actions, post-apply validation, AI chat streaming/apply, token concurrency
 npm run env:stop    # tear down
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.70] — 2026-07-11 — the docs stop counting tests, because the count was always going to be wrong (#250)
+
+**`README.md` advertised "34 E2E specs," "1230 PHP tests," and "350 JS tests." The real numbers were 48, 1479, and 409. `AI_RULES.md`, which an AI agent reads as instructions, carried the same wrong E2E figure. The README also told readers that a broken-media validation check was "currently quarantined (issue #83)" — that issue closed on 2026-07-07 and the test has been running ever since. Every hardcoded count is now gone from the live docs, replaced by the coverage areas they were supposed to be summarizing, and a lint guard keeps them from coming back.**
+
+The counts were not wrong because someone was careless. They were accurate the day they were written and went stale the next time anyone added a test, which is the only thing a hardcoded count can do. The proof arrived mid-fix: while this issue sat in the queue the E2E figure drifted again, from 47 to 48, because the token-concurrency repair landed a new test. Refreshing the numbers would have bought a few days and recreated the same defect, so the docs now describe *what* is covered — the serialization gate, the action-layer CLI, post-apply validation, AI chat streaming, concurrent token writes behind a real MySQL advisory lock — and leave the arithmetic to the test runner, which is the only thing that can count correctly.
+
+The stale quarantine claim was the more dangerous half. It is an instruction, not a statistic: an agent reading `README.md` and hitting a genuine broken-media failure had written permission to dismiss it as a known, expected quarantine. That sentence is deleted.
+
+The `Tests` badge is the deliberate exception. It reads "1936+ passing" — a floor claim, not an exact count, so it stays true as tests are added and only needs attention if the suite shrinks. The new lint strips shields.io badge lines before scanning, so the exemption is explicit rather than accidental.
+
+### Fixed
+- **`README.md` no longer misstates test coverage.** The three suite ledes describe coverage areas and assert no count; the `Tests` badge is refreshed to a `1936+` floor claim.
+- **`README.md` no longer claims a quarantined broken-media check.** #83 closed 2026-07-07 and the test is live (`tests/e2e/validation.spec.ts`).
+- **`AI_RULES.md` no longer feeds a wrong E2E count to agents.** The `npm run test:e2e` comment keeps its coverage-area list and drops the number.
+
+### Docs
+- The E2E coverage list now names AI chat streaming/apply, which the suite has covered for some time without saying so.
+
+### Tests
+- **New: `tests/js/docs-lint.test.js`** — a regression guard, in the same shape as the existing CSS lint. It bans count-shaped claims in `README.md` and `AI_RULES.md`, bans a quarantine claim that names an issue number, and pins that the coverage areas survive, so the count lint cannot be satisfied by gutting the testing docs.
+- **The guard proves it can fail.** It self-tests that its own pattern fires on every historical stale string ("1230 PHP tests", "34 E2E specs", "34 specs:") *and* on the phrasings this change introduces ("1479 PHP unit tests"), while staying silent on legitimate numbers like "20 typed actions" and the real "WordPress 7.0" pin. A lint that cannot fail is decoration.
+- Historical records are deliberately not linted. The `readme.txt` changelog and `CHANGELOG.md` entries state what shipped at a given tag; their counts were true then, and rewriting them would falsify the record.
+
 ## [v0.16.69] — 2026-07-11 — the token-concurrency release gate is green again: a permanently-red E2E test now asserts what it was written to assert (#240)
 
 **The nightly E2E suite carried a deterministically red test — "a writer fails closed while another connection holds the lock" — and it had nothing to do with the behavior under test. The contender died in *setup*, several steps before the contended write it exists to exercise. A release gate that always fails teaches everyone to ignore it, so the signal it was supposed to provide for concurrent token writes was worth nothing. The test now reaches the contended `execute`, and a second test pins the fail-closed preflight behavior that the old test was tripping over by accident.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.69-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.70-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![PHP 8.0+](https://img.shields.io/badge/PHP-8.0+-777BB4?style=flat-square&logo=php&logoColor=white)](https://php.net)
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
-[![Tests](https://img.shields.io/badge/Tests-1550+_passing-22C55E?style=flat-square)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
 [![Version](https://img.shields.io/badge/version-0.16.69-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
@@ -391,19 +391,19 @@ Enforced by `AI_RULES.md` and verified by automated tests:
 
 ## ✅ Tests
 
-**1230 PHP tests, 4556 assertions** — component loader, WP abstraction, schema validation, 20 typed actions, apply layer, batch atomicity/rollback, token family derivation, AI context, proposal parsing, capability model, style slots, cross-component hints, surface classification, font management, media import, SEO metadata, navigation menus, integrity, upgrade-safety guardrails, operating loop, server-driven destructive-action warnings:
+**PHP unit tests** — component loader, WP abstraction, schema validation, 20 typed actions, apply layer, batch atomicity/rollback, token family derivation, AI context, proposal parsing, capability model, style slots, cross-component hints, surface classification, font management, media import, SEO metadata, navigation menus, integrity, upgrade-safety guardrails, operating loop, server-driven destructive-action warnings:
 
 ```bash
 composer install && composer test
 ```
 
-**350 JS tests** — JSON context, composition validator, accordion data, insert position, data-loss guard, DOM selector alignment, serialization invariant (deep diff + round-trip gate), CSS lint, packaging, proposal card, guided error card, page targeting, post-apply validation, shared PHP/JS validation contract, server-driven warning lookup:
+**JS unit tests** — JSON context, composition validator, accordion data, insert position, data-loss guard, DOM selector alignment, serialization invariant (deep diff + round-trip gate), CSS lint, docs lint, packaging, proposal card, guided error card, page targeting, post-apply validation, shared PHP/JS validation contract, server-driven warning lookup:
 
 ```bash
 npm install && npm test
 ```
 
-**34 E2E specs** — composition editor round-trip (including the serialization gate), post-apply validation, the action-layer CLI, and concurrent token-override writes serialized behind a real MySQL advisory lock, run with Playwright against a live **WordPress 7.0** instance (requires Docker). One broken-media validation check is currently quarantined (issue #83):
+**E2E specs** — composition editor round-trip (including the serialization gate), post-apply validation, the action-layer CLI, AI chat streaming/apply, and concurrent token-override writes serialized behind a real MySQL advisory lock, run with Playwright against a live **WordPress 7.0** instance (requires Docker):
 
 ```bash
 npm run env:start   # boot wp-env container (WordPress 7.0)

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.69');
+define('PP_VERSION', '0.16.70');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.69",
+  "version": "0.16.70",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.69
+Stable tag: 0.16.70
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.69
+Version:          0.16.70
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/docs-lint.test.js
+++ b/tests/js/docs-lint.test.js
@@ -1,0 +1,106 @@
+/**
+ * Docs Lint Regression Guards (#250)
+ *
+ * The live doc prose (README.md, AI_RULES.md) must not assert a hardcoded test
+ * count. Any exact number baked into prose re-drifts the moment a test is added:
+ * the "34 E2E specs" claim was accurate when written, then drifted to 47, then
+ * to 48 while #250 sat in the queue. Describe the coverage areas, not the count.
+ *
+ * The shields.io "Tests-N+_passing" badge is deliberately EXEMPT. It is a floor
+ * claim ("at least N"), so adding tests keeps it true; only removing tests below
+ * the floor makes it wrong. Badge lines are stripped before scanning.
+ *
+ * Historical records are deliberately NOT linted. CHANGELOG.md and readme.txt's
+ * "== Changelog ==" entries state what shipped in a given release; their counts
+ * were true at that tag and rewriting them would falsify release history.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const read = (f) => fs.readFileSync(path.resolve(__dirname, '../..', f), 'utf-8');
+
+// Strip shields.io badge lines: the Tests badge is an exempt floor claim.
+const stripBadges = (md) => md.replace(/^.*img\.shields\.io.*$/gm, '');
+
+const README = stripBadges(read('README.md'));
+const AI_RULES = stripBadges(read('AI_RULES.md'));
+
+const LIVE_DOCS = [
+    ['README.md', README],
+    ['AI_RULES.md', AI_RULES],
+];
+
+// A count-shaped claim: a number, then up to three words, then a test noun.
+// Catches "1230 PHP tests", "409 JS unit tests", "48 Playwright E2E specs",
+// "34 specs:", "1479 tests, 5496 assertions". Deliberately does NOT match
+// legitimate prose like "20 typed actions" or "WordPress 7.0" (no test noun).
+// Horizontal whitespace only: \s would span newlines and pair an unrelated
+// number with a test noun on the next line (e.g. port "8889" + "npm run test").
+const COUNT_CLAIM = /\d[\d,]*[ \t]+(?:[A-Za-z0-9.+/-]+[ \t]+){0,3}(?:tests?|specs?|assertions)\b/i;
+
+describe('docs lint: no hardcoded test counts in live docs', () => {
+    test.each(LIVE_DOCS)('%s asserts no hardcoded test count', (name, content) => {
+        const hits = content.match(new RegExp(COUNT_CLAIM, 'gi')) || [];
+        expect(hits).toEqual([]);
+    });
+});
+
+describe('docs lint: no stale #83 quarantine claim', () => {
+    // #83 was resolved 2026-07-07 and the broken-media E2E is de-quarantined.
+    // Scoped to a quarantine claim naming an issue, so a future legitimate
+    // quarantine rule in prose does not trip the guard.
+    test.each(LIVE_DOCS)('%s claims no quarantined test against a closed issue', (name, content) => {
+        const hits = content.match(/quarantin\w*[^.\n]*#\d+/gi) || [];
+        expect(hits).toEqual([]);
+    });
+});
+
+describe('docs lint: coverage areas survive count removal', () => {
+    // Guards against satisfying the count lint by gutting the testing docs:
+    // pin representative coverage areas, not just the headings.
+    test('README.md still documents each suite and its coverage areas', () => {
+        expect(README).toMatch(/PHP unit tests/);
+        expect(README).toMatch(/batch atomicity\/rollback/);
+        expect(README).toMatch(/JS unit tests/);
+        expect(README).toMatch(/serialization invariant/);
+        expect(README).toMatch(/E2E specs/);
+        expect(README).toMatch(/MySQL advisory lock/);
+    });
+
+    test('AI_RULES.md still documents the E2E suite and its coverage areas', () => {
+        expect(AI_RULES).toMatch(/## E2E tests/);
+        expect(AI_RULES).toMatch(/npm run test:e2e/);
+        expect(AI_RULES).toMatch(/serialization gate/);
+        expect(AI_RULES).toMatch(/token concurrency/);
+    });
+});
+
+describe('docs lint: the guard itself is not decoration', () => {
+    // If these ever stop matching, the regex has been loosened into a no-op.
+    const MUST_CATCH = [
+        '1230 PHP tests',           // the original README claim
+        '350 JS tests',             // the original README claim
+        '34 E2E specs',             // the original README claim
+        '34 specs: editor round-trip', // the original AI_RULES claim
+        '1479 tests, 5496 assertions',
+        '1479 PHP unit tests',      // the phrasing this change standardized on
+        '409 JS unit tests',
+        '48 Playwright E2E specs',
+        '48 E2E tests',
+    ];
+    const MUST_NOT_CATCH = [
+        'schema validation, 20 typed actions, apply layer',
+        'against a live **WordPress 7.0** instance (requires Docker)',
+        'boot wp-env container (WordPress 7.0)',
+        '47 CSS custom properties control the entire visual system',
+    ];
+
+    test.each(MUST_CATCH)('catches a hardcoded count: %s', (s) => {
+        expect(COUNT_CLAIM.test(s)).toBe(true);
+    });
+
+    test.each(MUST_NOT_CATCH)('does not false-positive on: %s', (s) => {
+        expect(COUNT_CLAIM.test(s)).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #250

## Scope

`README.md` and `AI_RULES.md` asserted test counts that had drifted, and `README.md` carried a claim that a broken-media E2E check was quarantined under #83 — an issue that closed 2026-07-07 with the test de-quarantined (`tests/e2e/validation.spec.ts:102`).

| Claim | Docs said | Actual |
|---|---|---|
| PHP tests | 1230 (+4556 assertions) | **1479** (5496 assertions) |
| JS tests | 350 | **409** |
| E2E specs | 34 | **48** |
| Broken-media check | "currently quarantined (#83)" | **running** (#83 closed) |

The fix **drops** the numbers rather than refreshing them. That is the issue's own stated preference, and it was confirmed empirically mid-fix: the E2E count re-drifted 47 → 48 between #250 being filed and being picked up, because #240 landed a new test. A refreshed number would have gone stale again within days.

The stale quarantine sentence was the more dangerous half — it is an instruction, not a statistic. An agent reading `README.md` and hitting a genuine broken-media failure had written permission to dismiss it as an expected quarantine.

## Changes

- **`README.md`** — the three suite ledes now describe coverage areas with no hardcoded count; the false #83 quarantine clause is deleted; the `Tests` badge is refreshed to a `1936+` floor claim.
- **`AI_RULES.md`** — the `npm run test:e2e` comment keeps its coverage-area list, drops the `34 specs:` count.
- **`tests/js/docs-lint.test.js` (new)** — regression guard, same shape as the existing CSS lint. Bans count-shaped claims and issue-scoped quarantine claims in both docs, and pins that the coverage areas survive so the count lint cannot be satisfied by gutting the testing docs. It self-tests that its pattern fires on every historical stale string *and* on the phrasings this PR introduces (`1479 PHP unit tests`), while staying silent on `20 typed actions` and the real `WordPress 7.0` pin. A lint that cannot fail is decoration.

## Decisions recorded

1. **Scope of count removal → drop all hardcoded counts** from the live doc prose (applied to `README.md` + `AI_RULES.md`).
2. **The `Tests` badge → refresh to `1936+` rather than drop the number.** Review surfaced this as a 4th hardcoded count (stale by ~390). It is kept as a floor claim, so it stays true as tests are added; the lint strips shields.io badge lines, making the exemption explicit rather than accidental.

## Deliberate non-change

`readme.txt:31` (`1230 PHP tests, 350 JS tests, 34 E2E specs`) is **untouched**. It sits inside `== Changelog ==` under the `= 0.16.48 =` heading and is frozen release history, structurally identical to `CHANGELOG.md` entries. Its counts were true at that tag; rewriting them would falsify the record. Historical records are excluded from the lint for the same reason.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` → **1479 tests, 5496 assertions, OK**. (3 warnings + 2 PHPUnit deprecations — identical to a pre-change baseline run on unmodified `main`, so pre-existing.)
- `npm test` → **428 tests / 16 files passing** (was 409/15; +19 from the new guard).
- `bash scripts/package.sh` → version consistency OK across all five synced files at 0.16.70. Build zip deleted; releases are CI-built from tags.
- E2E not required: this change touches docs and one unit-level lint, with no runtime surface.

## Noticed, not fixed

Review found pre-existing stale **non-test** counts in `README.md` — ai-instructions "13 files" (actually 14) and "47 CSS custom properties" (actually 51). Different claim class, outside this issue's scope. Filed as **#252**.

## Reviews

`/plan-eng-review` and `/review` (specialists + Claude adversarial + Codex outside voice) both ran this session against exactly this content. The review caught a real defect in the guard itself — the original regexes missed `1479 PHP unit tests`, the exact phrasing this PR standardizes on — which is fixed here and now pinned by the self-tests.