### PR TITLE
v0.16.71 fix: grid cards layout renders 3 columns for 3-item grids (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.71] — 2026-07-11 — three feature cards, three columns, no orphan (#224)
+
+**A `grid` with `layout: "cards"` and three items rendered two cards on the first row and stranded the third, alone and stretched to half width, on a second row. It did this at every desktop width. The three-across feature row is the most common layout on a marketing page, and PromptingPress could not express it: there is no `columns` prop, and switching to `layout: "steps"` to buy the third column forces number badges and drops images, which changes what the section means. A 3-item cards grid now renders three across at 1024px and up, spanning the container exactly as `steps` already did.**
+
+The markup was never the problem. `grid.php` has been emitting `data-pp-count` on the card list for months, and the desktop cascade already used it to special-case two-item and four-item grids. Three was simply skipped, so three-item grids fell through to the generic two-column rule. The docs had already promised the correct behavior — `components/grid/README.md` claimed three columns at desktop and the site-validation checklist told agents to verify a "3-column layout" — which means the code was the thing that was wrong, and the fix makes two existing documents true instead of asking anyone to accept a new rule. Counts other than three keep the layout they had; the responsive table in the component README now spells out what each count actually does, rather than promising one number for all of them.
+
+### Fixed
+- `grid` `layout: "cards"` with exactly 3 items now renders 3 columns at 1024px and up, instead of 2 columns plus an orphaned third card (`assets/css/components.css`). The row spans the container like `grid--steps`; the 2-item and 4-item layouts are unchanged.
+
+### Docs
+- `components/grid/README.md`: the responsive table now describes desktop layout per item count (2 → 2 up, 3 → 3 across, 4 → 2 x 2, other → 2) instead of claiming 3 columns for every count, and notes that a 4-item `steps` grid lays out 2 x 2.
+- `ai-instructions/validate-site.md`: the desktop checklist item now states the per-count layout an agent should expect.
+
+### Tests
+- `tests/js/css-lint.test.js`: pins that the 3-item rule declares 3 columns inside the desktop media block, carries no narrowing `max-width`, and is declared exactly once, plus scope guards holding the 2-item, 4-item, and `steps` layouts unchanged.
+- `tests/ComponentPropsTest.php`: pins that `grid` emits `data-pp-count`, the attribute the desktop cascade selects on.
+
+---
+
 ## [v0.16.70] — 2026-07-11 — the docs stop counting tests, because the count was always going to be wrong (#250)
 
 **`README.md` advertised "34 E2E specs," "1230 PHP tests," and "350 JS tests." The real numbers were 48, 1479, and 409. `AI_RULES.md`, which an AI agent reads as instructions, carried the same wrong E2E figure. The README also told readers that a broken-media validation check was "currently quarantined (issue #83)" — that issue closed on 2026-07-07 and the test has been running ever since. Every hardcoded count is now gone from the live docs, replaced by the coverage areas they were supposed to be summarizing, and a lint guard keeps them from coming back.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.70-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.71-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/validate-site.md
+++ b/ai-instructions/validate-site.md
@@ -101,7 +101,7 @@ After automated checks pass, verify rendered output:
 - [ ] Component IDs visible in DOM inspector (search for `pp-`)
 - [ ] `data-pp-component` attributes present on all component root elements
 - [ ] Design tokens applied (no raw hex in computed styles)
-- [ ] Grid components show 3-column layout
+- [ ] Grid components lay out by item count (3 items = 3 across; 2 and 4 items = 2 across; `steps` = 3 across, but a 4-item `steps` grid = 2 x 2)
 - [ ] Hero CTA buttons styled correctly (primary solid, secondary outline)
 
 ### Mobile (375px)

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2842,6 +2842,13 @@ main > .grid .grid__item-link::after {
     margin-left: auto;
   }
 
+  main > .grid:not(.grid--steps) .grid__list[data-pp-count="3"] {
+    /* Three-across is the common marketing feature row. No max-width: the row
+       spans the container like grid--steps does, instead of being centered and
+       narrowed the way the 2- and 4-card rules are. */
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   main > .grid:not(.grid--steps) .grid__list[data-pp-count="2"] {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     max-width: 52rem;

--- a/components/grid/README.md
+++ b/components/grid/README.md
@@ -38,7 +38,7 @@ Each item in `items`:
 | Tablet (md 768px+) | 2  |
 | Desktop (lg 1024px+) | depends on item count — see below |
 
-At desktop, a composed grid lays out by item count:
+At desktop, a composed `cards` grid lays out by item count:
 
 | Items | Desktop columns |
 |-------|-----------------|

--- a/components/grid/README.md
+++ b/components/grid/README.md
@@ -36,7 +36,18 @@ Each item in `items`:
 |------------|---------|
 | Mobile     | 1       |
 | Tablet (md 768px+) | 2  |
-| Desktop (lg 1024px+) | 3 |
+| Desktop (lg 1024px+) | depends on item count — see below |
+
+At desktop, a composed grid lays out by item count:
+
+| Items | Desktop columns |
+|-------|-----------------|
+| 2     | 2, centered in a narrower row |
+| 3     | 3 across, spanning the container |
+| 4     | 2 x 2, centered in a narrower row |
+| other | 2 |
+
+The `steps` layout is 3 across at desktop, except for a 4-item steps grid, which lays out 2 x 2.
 
 ## Steps layout
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.70');
+define('PP_VERSION', '0.16.71');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.70",
+  "version": "0.16.71",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.70
+Stable tag: 0.16.71
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.70
+Version:          0.16.71
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1102,6 +1102,27 @@ class ComponentPropsTest extends TestCase
         $this->assertStringNotContainsString('hero__eyebrow', $html);
     }
 
+    /**
+     * Regression pin for #224: the desktop column count is selected in CSS off
+     * data-pp-count, so the attribute is a contract, not a detail. Without this
+     * pin, dropping or renaming it would leave the CSS pins green while 3-item
+     * grids silently fell back to two columns and orphaned the third card.
+     */
+    public function testGridEmitsItemCountAttribute(): void
+    {
+        $items = [
+            ['title' => 'One',   'text' => 'A'],
+            ['title' => 'Two',   'text' => 'B'],
+            ['title' => 'Three', 'text' => 'C'],
+        ];
+
+        $html = $this->render('grid', ['items' => $items]);
+        $this->assertStringContainsString('data-pp-count="3"', $html);
+
+        $html = $this->render('grid', ['items' => array_slice($items, 0, 2)]);
+        $this->assertStringContainsString('data-pp-count="2"', $html);
+    }
+
     public function testGridEyebrowSubheadingAndCenterAlignRender(): void
     {
         $html = $this->render('grid', $this->gridProps([

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -317,6 +317,102 @@ describe('CSS lint: theme variants survive the desktop typography cascade (#222)
     });
 });
 
+/**
+ * Grid desktop column layout (#224).
+ *
+ * The desktop column count is driven by the `data-pp-count` attribute that
+ * grid.php emits on `.grid__list`. Asserting a rule merely *exists* would not
+ * prove it wins the cascade: the generic `@media (min-width: 768px)` rule sets
+ * `repeat(2, 1fr)`, so a count rule only takes effect from inside the
+ * `min-width: 1024px` block that follows it. These pins therefore check
+ * containment in that block, not just presence in the file.
+ */
+describe('CSS lint: grid desktop columns by item count', () => {
+    // Extract the bodies of every `@media (min-width: 1024px)` block by brace matching.
+    function desktopBlocks(css) {
+        const blocks = [];
+        const opener = /@media\s*\(min-width:\s*1024px\)\s*\{/g;
+        let match;
+        while ((match = opener.exec(css)) !== null) {
+            let depth = 1;
+            let i = opener.lastIndex;
+            while (i < css.length && depth > 0) {
+                if (css[i] === '{') depth++;
+                else if (css[i] === '}') depth--;
+                i++;
+            }
+            blocks.push(css.slice(opener.lastIndex, i - 1));
+        }
+        return blocks;
+    }
+
+    const desktop = desktopBlocks(stripComments(COMPONENTS_CSS)).join('\n');
+
+    // Return the LAST grid-template-columns declared for `selector` across the
+    // desktop blocks — the cascade winner, not the first textual match. A rule
+    // added later that re-overrides the same selector must fail the pin rather
+    // than hide behind an earlier one. The selector is anchored to a rule start
+    // (`}` or start-of-input) so it cannot bind to a longer selector that merely
+    // ends with the same text.
+    function rulesFor(selector) {
+        const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const pattern = new RegExp(`(?:^|\\})\\s*${escaped}\\s*\\{([^}]*)\\}`, 'g');
+        const bodies = [];
+        let match;
+        while ((match = pattern.exec(desktop)) !== null) {
+            bodies.push(match[1]);
+            // Re-scan from the rule's own closing brace so back-to-back rules
+            // are not skipped by the leading `}` this pattern consumes.
+            pattern.lastIndex -= 1;
+        }
+        return bodies;
+    }
+
+    function columnsFor(selector) {
+        const bodies = rulesFor(selector);
+        if (bodies.length === 0) return null;
+        const winner = bodies
+            .map(body => /grid-template-columns\s*:\s*([^;]+);/.exec(body))
+            .filter(Boolean)
+            .pop();
+        return winner ? winner[1].trim() : null;
+    }
+
+    test('a 3-item cards grid gets 3 columns at desktop', () => {
+        expect(desktop).not.toEqual('');
+        expect(columnsFor('main > .grid:not(.grid--steps) .grid__list[data-pp-count="3"]'))
+            .toBe('repeat(3, minmax(0, 1fr))');
+    });
+
+    test('a 3-item cards grid spans the container (no narrowing max-width)', () => {
+        const bodies = rulesFor('main > .grid:not(.grid--steps) .grid__list[data-pp-count="3"]');
+        expect(bodies.length).toBeGreaterThan(0);
+        bodies.forEach(body => expect(body).not.toMatch(/max-width\s*:/));
+    });
+
+    test('the 3-item rule is declared exactly once (no later re-override)', () => {
+        expect(rulesFor('main > .grid:not(.grid--steps) .grid__list[data-pp-count="3"]'))
+            .toHaveLength(1);
+    });
+
+    // Scope guards (#224 changed the 3-item case only). If a future change
+    // generalizes the desktop grid, these are the pins that should be revisited
+    // deliberately rather than broken silently.
+    test('a 4-item cards grid still lays out 2 x 2', () => {
+        expect(columnsFor('main > .grid:not(.grid--steps) .grid__list[data-pp-count="4"]'))
+            .toBe('repeat(2, minmax(0, 1fr))');
+    });
+
+    test('a 2-item cards grid still lays out 2 across', () => {
+        expect(columnsFor('main > .grid:not(.grid--steps) .grid__list[data-pp-count="2"]'))
+            .toBe('repeat(2, minmax(0, 1fr))');
+    });
+
+    test('the steps layout keeps its own 3-column rule', () => {
+        expect(columnsFor('.grid--steps .grid__list')).toBe('repeat(3, 1fr)');
+    });
+});
+
 describe('CSS lint: no raw hex in components.css', () => {
     test('components.css has no raw hex color values', () => {
         const stripped = stripComments(COMPONENTS_CSS);


### PR DESCRIPTION
Closes #224

## Scope

A `grid` with `layout: "cards"` and exactly 3 items rendered 2 cards on row 1 and orphaned the third, stretched to half width, on row 2 — at every desktop width. Three-across is the most common marketing feature row, and there was no supported way to get it: no `columns` prop, and `layout: "steps"` buys the third column at the cost of number badges and images.

`grid.php:65` already emits `data-pp-count` on `.grid__list`, and the desktop cascade already special-cased `[data-pp-count="4"]` (2 x 2) and `[data-pp-count="2"]` (2-up). Three was simply skipped, so 3-item grids fell through to the generic 768px `repeat(2, 1fr)`.

The fix is one rule in the existing `@media (min-width: 1024px)` block:

```css
main > .grid:not(.grid--steps) .grid__list[data-pp-count="3"] {
  grid-template-columns: repeat(3, minmax(0, 1fr));
}
```

No `max-width`, so the row spans the container exactly as `.grid--steps` does (still bounded by `.container { max-width: var(--max-width) }` = 72rem).

**Acceptance criteria (from the issue's Expected):** "A 3-item cards grid renders 3 across at desktop, like `layout: steps` does." Met. The alternative the issue floated (expose a `columns` prop) was **not** taken — the recorded approach in the #141 queue is the `data-pp-count="3"` rule.

## Validation

Both suites fully green:

| Suite | Command | Result |
|---|---|---|
| PHP | `./vendor/bin/phpunit --configuration phpunit.xml` | 1480 tests, 5498 assertions, OK |
| JS | `npm test` | 434 tests, 16 files, all passed |

The 3 warnings / 2 PHPUnit deprecations are pre-existing baseline (this diff touches no PHP source; the only PHP file changed is a test).

**Behavioral proof.** Verified in a real headless browser at 1280px against a static fixture loading the actual theme CSS (no server, no environment touched). `getComputedStyle(...).gridTemplateColumns` on a 3-item cards grid:

- **before:** `535.594px 535.609px` — the exact value the issue reported for `#especificaciones`
- **after:** `351.469px 351.469px 351.469px` — the exact value the issue reported for the *working* `steps` grid `#como-funciona`

4-item grids still compute `455.594px 455.609px` (2 x 2) and `steps` is unchanged.

The new CSS pins fail against the unfixed stylesheet (3 failures) and pass with it, so they are real regression tests rather than tautologies.

## Accepted limitations

- **768–1023px still shows 2 + orphan for 3 items.** `grid--steps` behaves identically there, and the issue's Expected is scoped to desktop ("like `layout: steps` does"), so matching steps is the recorded decision. Changing the tablet band would exceed it.
- **Counts 5, 6+ still render 2-up.** Unchanged by design; the README table now says so rather than promising 3 for every count.
- **The featured-first-card treatment** (accent fill, thicker top rule, larger title) is more conspicuous in a symmetric 3-across row, where the three cards read as peers. Pre-existing and already tracked as #226 — not touched here, but this fix raises its priority.

## 7A questions

None. Every review finding resolved to either the issue's recorded decision or a mechanical fix to code written in this PR; nothing extended the accepted behavior, so no maintainer decision was required.

## Reviews

`/plan-eng-review` (with Codex outside voice) and `/review` (testing + maintainability + design specialists, plus Claude and Codex adversarial passes) both ran to completion on this content: 8 findings, 0 critical. Four were fixed — including a false claim I had introduced in the README ("`steps` is always 3 across"; a 4-item steps grid is 2 x 2) and a brittle regex in my own test helper that returned the first matching rule rather than the cascade winner, flagged independently by three reviewers. Three were skipped as pre-existing and out of scope (listed above). One Codex finding (stale built CSS) was refuted: there is no CSS build step, `functions.php:104` enqueues `components.css` directly.
