### PR TITLE
v0.16.72 fix: render the hero eyebrow as a pill, not a full-width band (#225)

### DIFF
--- a/AI_RULES.md
+++ b/AI_RULES.md
@@ -105,11 +105,11 @@ Playwright tests in `tests/e2e/` run against a live WordPress instance via wp-en
 
 ```
 npm run env:start   # boot Docker WordPress on port 8889
-npm run test:e2e    # editor round-trip, serialization gate, CLI actions, post-apply validation, AI chat streaming/apply, token concurrency
+npm run test:e2e    # editor round-trip, serialization gate, CLI actions, post-apply validation, AI chat streaming/apply, token concurrency, rendered-layout proof
 npm run env:stop    # tear down
 ```
 
-Requires Docker. Tests cover workspace init, preview updates, save rejection, autosave skip, front-end rendering, accordion round-trip, and the serialization gate (blocked state, save/publish restore, copy-as-issue).
+Requires Docker. Tests cover workspace init, preview updates, save rejection, autosave skip, front-end rendering, accordion round-trip, the serialization gate (blocked state, save/publish restore, copy-as-issue), and rendered-layout proof — geometry and style slots measured in the browser, because a static check on the CSS text cannot prove what the cascade actually renders.
 
 ## File responsibilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.72] — 2026-07-11 — the hero eyebrow is a pill again, not a colored band (#225)
+
+**`hero.eyebrow` is documented as a pill: a short kicker sized to its own text, sitting above the headline. It rendered as a full-width colored band spanning the entire hero content column. The CSS said `display: inline-block` and meant it, but `.hero__eyebrow` is a direct child of `.hero__content`, which is a flex column, and a flex container blockifies its children — `inline-block` computes to `block`, then the default `stretch` alignment pulls the box across the full width. The eyebrow now shrinks to its text in all four hero layouts, flush with the leading edge on `left` and `split`, centered on `centered` and `cover`.**
+
+Nothing about the fix is new to this codebase. `.hero__cta-group` sits in the same flex column and hit the same wall, and the file already solved it: `align-self: flex-start` on the base rule, `align-self: center` in the two center-aligned layout blocks. The eyebrow now gets the identical treatment a few lines away. `grid.eyebrow` was never affected, because its parent is a plain block container — which is why the same prop rendered as a pill in one component and a band in another.
+
+It stayed invisible for a long time because it is invisible by default. `--hero-eyebrow-bg` falls back to a pale surface tint on a light hero, so the band blends into the page; set a saturated brand color, or use a dark hero, and it is the first thing you see. No page on the shipped site sets `hero.eyebrow`, so nothing ever rendered it. That is the gap this release closes twice: once in the CSS, and once in the tests, which now measure the rendered box in a real browser instead of trusting that a declaration in a stylesheet is what the cascade actually produces.
+
+### Fixed
+- **`hero.eyebrow` renders as a pill, not a full-width band** (`assets/css/components.css`). `align-self: flex-start` on `.hero__eyebrow` opts the pill out of the flex stretch that was blockifying it; `.hero--centered` and `.hero--cover` re-center it, matching the alignment their CTA groups already carry. `left` and `split` inherit the leading-edge default.
+
+### Docs
+- `README.md` and `AI_RULES.md`: the E2E coverage lists now name rendered-layout proof — geometry and style slots measured in the browser — alongside the editor round-trip, CLI actions, post-apply validation, chat streaming, and token concurrency.
+
+### Tests
+- `tests/e2e/style-render.spec.ts`: rendered-box proof for the eyebrow across all four layouts at desktop and mobile. Each asserts the pill is under half the content width and lands on the edge or the center that its layout calls for. A static check on CSS text cannot prove what the cascade renders; these fail with the eyebrow measured at the full content width when the fix is reverted.
+- `tests/js/css-lint.test.js`: pins the three alignment declarations and, more usefully, guards the ways the band could come back without touching them — a width on the pill, a duplicate rule later in the cascade, a media-scoped override, or a parent that stops being a flex column. The rule scanner tracks enclosing at-rules, so a rule nested inside `@supports` inside `@media` is still read as media-scoped.
+- `tests/ComponentPropsTest.php`: pins the eyebrow as a direct child of `.hero__content` in every layout. The alignment fix depends on that parent-child relationship, so a wrapper element of any kind would quietly kill the pill while every CSS pin stayed green.
+
+---
+
 ## [v0.16.71] — 2026-07-11 — three feature cards, three columns, no orphan (#224)
 
 **A `grid` with `layout: "cards"` and three items rendered two cards on the first row and stranded the third, alone and stretched to half width, on a second row. It did this at every desktop width. The three-across feature row is the most common layout on a marketing page, and PromptingPress could not express it: there is no `columns` prop, and switching to `layout: "steps"` to buy the third column forces number badges and drops images, which changes what the section means. A 3-item cards grid now renders three across at 1024px and up, spanning the container exactly as `steps` already did.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.71-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.72-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -403,7 +403,7 @@ composer install && composer test
 npm install && npm test
 ```
 
-**E2E specs** — composition editor round-trip (including the serialization gate), post-apply validation, the action-layer CLI, AI chat streaming/apply, and concurrent token-override writes serialized behind a real MySQL advisory lock, run with Playwright against a live **WordPress 7.0** instance (requires Docker):
+**E2E specs** — composition editor round-trip (including the serialization gate), post-apply validation, the action-layer CLI, AI chat streaming/apply, concurrent token-override writes serialized behind a real MySQL advisory lock, and rendered-layout proof (style slots and component geometry measured in the browser, where the full cascade decides the outcome), run with Playwright against a live **WordPress 7.0** instance (requires Docker):
 
 ```bash
 npm run env:start   # boot wp-env container (WordPress 7.0)

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -288,8 +288,12 @@
   max-width: var(--hero-content-width, var(--measure-centered));
 }
 
+/* align-self keeps the pill sized to its text: .hero__content is a flex column,
+   which blockifies inline-block and would otherwise stretch the eyebrow to the
+   full content width. Centered/cover re-center it alongside their CTA overrides. */
 .hero__eyebrow {
   display: inline-block;
+  align-self: flex-start;
   padding: 0.35rem 0.85rem;
   margin-bottom: var(--space-sm);
   border-radius: 3px;
@@ -350,6 +354,10 @@
 
 .hero--centered .hero__subtitle {
   max-width: none;
+}
+
+.hero--centered .hero__eyebrow {
+  align-self: center;
 }
 
 .hero--centered .hero__cta-group {
@@ -425,6 +433,10 @@
   color: var(--hero-subtitle-color, var(--color-bg));
   opacity: 0.85;
   max-width: none;
+}
+
+.hero--cover .hero__eyebrow {
+  align-self: center;
 }
 
 .hero--cover .hero__cta-group {

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.71');
+define('PP_VERSION', '0.16.72');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.71",
+  "version": "0.16.72",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.71
+Stable tag: 0.16.72
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.71
+Version:          0.16.72
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1103,6 +1103,32 @@ class ComponentPropsTest extends TestCase
     }
 
     /**
+     * Regression pin for #225: the pill only holds because the eyebrow is a direct
+     * flex item of .hero__content and the CSS gives it align-self. Wrapping it in
+     * any intermediate element would leave the CSS pins green while the eyebrow
+     * silently went back to stretching across the full hero content width.
+     */
+    public function testHeroEyebrowIsDirectChildOfHeroContent(): void
+    {
+        foreach (['left', 'centered', 'split', 'cover'] as $layout) {
+            $html = $this->render('hero', [
+                'title'   => 'T',
+                'eyebrow' => 'NEW',
+                'layout'  => $layout,
+            ]);
+            // No element of ANY kind may open between the two tags — a <span> or <p>
+            // wrapper destroys the flex-item relationship just as surely as a <div>,
+            // and would leave every CSS pin green. Position within hero__content, and
+            // any attributes it grows, stay free: direct childhood is the whole contract.
+            $this->assertMatchesRegularExpression(
+                '/<div class="hero__content"[^>]*>(?:(?!<[a-zA-Z])[\s\S])*?<span class="hero__eyebrow"/',
+                $html,
+                "hero__eyebrow must be a direct child of hero__content (layout: {$layout})"
+            );
+        }
+    }
+
+    /**
      * Regression pin for #224: the desktop column count is selected in CSS off
      * data-pp-count, so the attribute is a contract, not a detail. Without this
      * pin, dropping or renaming it would leave the CSS pins green while 3-item

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -13,6 +13,11 @@ import { execSync } from 'child_process';
  *         rule used to clobber it (mobile always passed).
  *   #24 — a per-instance `--hero-surface-*` slot must reach the rendered `.hero__surface`
  *         shell (previously hardcoded, uncontrollable through safe surfaces).
+ *   #225 — the hero eyebrow must render as a pill sized to its text. It is a direct flex
+ *          item of the flex-column `.hero__content`, which blockifies its declared
+ *          `inline-block` and stretched it across the full content width. The CSS-text
+ *          pins in tests/js/css-lint.test.js can only prove the declaration is present;
+ *          only a rendered box can prove the pill is not a band.
  */
 
 // ── Helpers (mirrors validation.spec.ts) ────────────────────────────────────
@@ -144,4 +149,70 @@ test.describe('Safe-surface rendered proof', () => {
     const borderWidth = await surface.evaluate((el) => getComputedStyle(el).borderTopWidth);
     expect(borderWidth).toBe('7px');
   });
+
+  // #225: the eyebrow is a pill, not a band. Each layout is its own test so a failure
+  // names the layout that regressed. `left`/`split` flush the pill to the content's
+  // leading edge; `centered`/`cover` center it, matching how those layouts already
+  // treat the CTA group.
+  //
+  // Both viewports matter. A band restored by a `max-width: 767px` rule is invisible at
+  // desktop, and #86's docblock above records that "mobile always passed" is exactly how
+  // the last cascade bug in this file hid.
+  const eyebrowLayouts: { layout: string; align: 'start' | 'center' }[] = [
+    { layout: 'left', align: 'start' },
+    { layout: 'split', align: 'start' },
+    { layout: 'centered', align: 'center' },
+    { layout: 'cover', align: 'center' },
+  ];
+  const eyebrowViewports = [
+    { label: 'desktop', width: 1280, height: 900 },
+    { label: 'mobile', width: 375, height: 800 },
+  ];
+
+  for (const { layout, align } of eyebrowLayouts) {
+    for (const viewport of eyebrowViewports) {
+      // One @smoke case, so the post-merge main run (which executes only the @smoke
+      // subset) still watches the pill. The rest run nightly.
+      const smoke = layout === 'left' && viewport.label === 'desktop' ? ' @smoke' : '';
+
+      test(`#225 hero eyebrow renders as a pill, not a full-width band (${layout}, ${viewport.label})${smoke}`, async ({
+        page,
+      }) => {
+        pageId = createPage(`E2E Hero Eyebrow Pill ${layout} ${viewport.label}`);
+        setComposition(pageId, [
+          {
+            component: 'hero',
+            props: {
+              id: 'pp-hero01',
+              layout,
+              // A long title widens .hero__content, so a stretched eyebrow is unmistakable.
+              title: 'A deliberately long hero headline that widens the content column',
+              eyebrow: 'BETA',
+            },
+          },
+        ]);
+
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await page.goto(`/?page_id=${pageId}`);
+
+        const eyebrow = page.locator('.hero__eyebrow');
+        await expect(eyebrow).toBeVisible({ timeout: 10000 });
+
+        const eyebrowBox = (await eyebrow.boundingBox())!;
+        const contentBox = (await page.locator('.hero__content').boundingBox())!;
+
+        // The bug: the eyebrow spanned the full content width. "BETA" in a padded pill is
+        // nowhere near half the column, so this fails loudly on any return of the band.
+        expect(eyebrowBox.width).toBeLessThan(contentBox.width * 0.5);
+
+        if (align === 'start') {
+          expect(Math.abs(eyebrowBox.x - contentBox.x)).toBeLessThan(2);
+        } else {
+          const eyebrowCenter = eyebrowBox.x + eyebrowBox.width / 2;
+          const contentCenter = contentBox.x + contentBox.width / 2;
+          expect(Math.abs(eyebrowCenter - contentCenter)).toBeLessThan(2);
+        }
+      });
+    }
+  }
 });

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -413,6 +413,148 @@ describe('CSS lint: grid desktop columns by item count', () => {
     });
 });
 
+/**
+ * Hero eyebrow stays a pill (#225).
+ *
+ * `.hero__eyebrow` declares `display: inline-block`, but it is a direct child of
+ * `.hero__content`, which is a flex column. Flex items are blockified, so the
+ * declared inline-block computes to block and the default `stretch` alignment
+ * spans the eyebrow across the full content width — a band, not a pill. The only
+ * thing holding the pill together is the cross-axis alignment, so that is what
+ * these pins assert.
+ *
+ * Asserting `align-self` merely *appears* somewhere would not prove the pill
+ * survives: the four benchmark pages carry an ID-specificity `.hero__eyebrow`
+ * block that outranks every class rule here. It does not set `align-self` today,
+ * and the pin below is what keeps it that way.
+ */
+describe('CSS lint: hero eyebrow is a pill, not a full-width band', () => {
+    // Every rule targeting `needle` as a whole class, in source order, each tagged with
+    // the @media condition wrapping it (null at top level). Media context is part of the
+    // identity of a rule: `.hero__eyebrow` inside `@media (max-width: 767px)` is a
+    // DIFFERENT rule from the base one, and a stretch declared there would restore the
+    // band at mobile while a media-blind scan reported green. components.css already
+    // redeclares `.hero__content` inside a max-width block, so this is a live pattern.
+    function rulesMatching(needle) {
+        const css = stripComments(COMPONENTS_CSS);
+        // Class-boundary match, so `.hero__eyebrow` never swallows `.hero__eyebrow--lg`.
+        const boundary = new RegExp(
+            needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w-])'
+        );
+        const rules = [];
+        // A stack, not a depth counter: components.css already nests at-rules (@keyframes
+        // at :909), and any nested block — @supports, @keyframes, an inner @media — emits
+        // a closing brace of its own. A counter mistakes that brace for the media block's
+        // and reports every following rule as top-level, which is exactly how a
+        // mobile-scoped regression would hide from a media-aware-looking scan.
+        const pattern = /@([\w-]+)([^{;]*)\{|([^{}]+)\{([^{}]*)\}|\}|;/g;
+        const stack = [];
+        let match;
+        while ((match = pattern.exec(css)) !== null) {
+            if (match[1] !== undefined) {
+                stack.push(match[1] === 'media' ? match[2].trim() : null);
+            } else if (match[3] !== undefined) {
+                const selectors = match[3].split(',').map(s => s.trim().replace(/\s+/g, ' '));
+                if (selectors.some(s => boundary.test(s))) {
+                    // Nearest enclosing @media, looking outward past non-media at-rules.
+                    const media = [...stack].reverse().find(m => m !== null) ?? null;
+                    rules.push({ selectors, body: match[4], media });
+                }
+            } else if (match[0] === '}') {
+                stack.pop();
+            }
+        }
+        return rules;
+    }
+
+    // Declarations that can restore the band even with align-self intact: an explicit
+    // width/min-width, a flex shorthand that sets a basis, or place-self overriding the
+    // cross-axis alignment. Guarding align-self alone is not enough — `width: 100%` in a
+    // mobile media block reintroduces #225 with every alignment pin still green.
+    const BAND_RESTORING = /(?:^|[;{\s])(?:min-)?width\s*:|(?:^|[;\s])flex\s*:|place-self\s*:|align-self\s*:/;
+
+    // The cascade winner among equal-specificity rules is the LAST one, not the first.
+    // Taking the first match would let a duplicate appended later silently shadow the
+    // pin while it stayed green.
+    function alignSelfFor(selector, media = null) {
+        const decls = rulesMatching('.hero__eyebrow')
+            .filter(r => r.media === media && r.selectors.includes(selector))
+            .map(r => /align-self\s*:\s*([^;}]+)/.exec(r.body))
+            .filter(Boolean);
+        return decls.length ? decls[decls.length - 1][1].trim() : null;
+    }
+
+    const BASE = '.hero__eyebrow';
+    const CENTERED = '.hero--centered .hero__eyebrow';
+    const COVER = '.hero--cover .hero__eyebrow';
+
+    test('the eyebrow opts out of the flex stretch that would blockify it', () => {
+        expect(alignSelfFor(BASE)).toBe('flex-start');
+    });
+
+    // The pill is padding + background, not `display`. Pinning `inline-block` would be
+    // vacuous — the flex parent blockifies it regardless, which is the whole bug.
+    test('the eyebrow keeps its pill styling', () => {
+        const rule = rulesMatching(BASE).find(r => r.selectors.includes(BASE) && !r.media);
+        expect(rule.body).toMatch(/padding\s*:/);
+        expect(rule.body).toMatch(/background\s*:/);
+    });
+
+    // The pill must be sized by its text. A width on the base rule would defeat
+    // align-self without touching it.
+    test('the base rule sizes the pill by its content, not a width', () => {
+        const rule = rulesMatching(BASE).find(r => r.selectors.includes(BASE) && !r.media);
+        expect(rule.body).not.toMatch(/(?:^|[;\s])(?:min-)?width\s*:/);
+    });
+
+    // The two center-aligned layouts re-center the pill, matching the treatment their
+    // CTA groups already get. Both outrank the base rule on specificity (0,2,0 vs
+    // 0,1,0), so source order cannot flip these.
+    test('the centered layout centers the pill', () => {
+        expect(alignSelfFor(CENTERED)).toBe('center');
+    });
+
+    test('the cover layout centers the pill', () => {
+        expect(alignSelfFor(COVER)).toBe('center');
+    });
+
+    // Scope guard: left/split are left-aligned layouts and inherit the base flex-start.
+    // An override here would be a silent behavior change.
+    test('the left and split layouts inherit the base flex-start (no override)', () => {
+        expect(alignSelfFor('.hero--left .hero__eyebrow')).toBeNull();
+        expect(alignSelfFor('.hero--split .hero__eyebrow')).toBeNull();
+    });
+
+    // The cascade risks that would restore the band while every pin above stayed green:
+    // the benchmark pages' ID-specificity block (which outranks all four class rules),
+    // and any media-scoped or duplicate rule. Only the three known rules may size or
+    // align the eyebrow — everything else must leave it alone, in every media context.
+    test('no other eyebrow rule anywhere sizes or re-aligns the pill', () => {
+        const owners = [BASE, CENTERED, COVER];
+        rulesMatching(BASE)
+            .filter(r => r.media || !r.selectors.every(s => owners.includes(s)))
+            .forEach(r => expect(r.body).not.toMatch(BAND_RESTORING));
+    });
+
+    // The fix only matters while the parent is a flex column. If any rule, in any media
+    // context, makes it a row or a non-flex box (a grid parent re-points align-self at
+    // the block axis and lets justify-self stretch the item), align-self stops
+    // controlling the eyebrow's width and every pin above becomes dead code. Matching
+    // any selector ending in .hero__content catches layout-scoped overrides too.
+    test('the eyebrow parent is a flex column in every media context', () => {
+        const contentRules = rulesMatching('.hero__content');
+        const base = contentRules.find(r => r.selectors.includes('.hero__content') && !r.media);
+        expect(base.body).toMatch(/display\s*:\s*flex\s*;/);
+        expect(base.body).toMatch(/flex-direction\s*:\s*column\s*;/);
+        contentRules
+            .filter(r => r !== base)
+            .forEach(r => {
+                expect(r.body).not.toMatch(/display\s*:(?!\s*flex\s*;)/);
+                expect(r.body).not.toMatch(/flex-direction\s*:(?!\s*column\s*;)/);
+            });
+    });
+});
+
 describe('CSS lint: no raw hex in components.css', () => {
     test('components.css has no raw hex color values', () => {
         const stripped = stripComments(COMPONENTS_CSS);


### PR DESCRIPTION
Closes #225

## Scope

`hero.eyebrow` is documented as a pill (`components/hero/README.md:12`: "Short kicker/label rendered as a pill above the title"). It rendered as a full-width colored band spanning the whole hero content column.

`.hero__eyebrow` declares `display: inline-block`, but it is a **direct child of `.hero__content`**, which is `display: flex; flex-direction: column`. Flex containers blockify their children, so the declared `inline-block` computes to `block`, and the default `align-items: normal` → `stretch` pulls the box across the full content width. The declaration was never wrong; it was simply overridden by the formatting context.

**Fix** (`assets/css/components.css`): `align-self: flex-start` on `.hero__eyebrow`, plus `align-self: center` on `.hero--centered .hero__eyebrow` and `.hero--cover .hero__eyebrow`. This mirrors the existing, identical treatment of `.hero__cta-group`, which sits in the same flex column and already carries exactly this base/centered/cover trio a few lines away in the same file.

`grid.eyebrow` was never affected (its parent is a plain block container), which is why the same prop rendered as a pill in one component and a band in another.

## Acceptance criteria

| Criterion (from #225) | Status |
|---|---|
| Hero eyebrow renders as a compact pill sized to its text, matching `.grid__eyebrow` | ✅ verified in-browser, all 4 layouts |
| `align-self: flex-start` on `.hero__eyebrow` | ✅ |
| `align-self: center` for the centered layout | ✅ (and `cover` — see disclosure) |

## Decision beyond the recorded fix direction — flagging for review

The issue's recorded fix direction names only `centered` for the center override. **I also applied it to `cover`.**

Rationale: `cover` is a center-aligned layout (`.hero--cover .hero__inner { align-items: center; text-align: center }`) and already carries its own `align-self: center` override for its CTA group. Once the base `flex-start` rule lands, `cover` necessarily gets *some* treatment — leaving it at `flex-start` would left-orphan the pill above centered text. So this was a forced choice, not an expansion. The repo's own CTA precedent, the design specialist in `/review`, and Codex (outside voice) each independently endorsed centering it.

Easy to revert in isolation if you disagree: it is one three-line rule.

## Validation

| Suite | Command | Result |
|---|---|---|
| PHP | `./vendor/bin/phpunit --configuration phpunit.xml` | **1481 passed** (baseline on clean main: 1480; the 3 warnings + 2 deprecations are pre-existing, verified against an unmodified tree) |
| JS | `npm test` | **442 passed**, 16 files |
| E2E | `npm run test:e2e -- style-render.spec.ts` | **11 passed** (8 new eyebrow pins: 4 layouts × desktop/mobile) |

**The tests were verified to actually catch the bug.** With the CSS fix reverted, the Playwright pins fail with the eyebrow measured at **414.39px — exactly the full content width**, i.e. the band itself. The CSS-text pins were likewise mutation-tested against four ways the band could return (a `width: 100%`, a later duplicate rule, a media-scoped override, and a parent that stops being a flex column); all four are caught.

## Accepted limitations

- **E2E does not gate this PR.** `e2e.yml` triggers on push-to-main, nightly, and manual only — the PR gate is `ai-ready` + `tests` (PHPUnit + vitest). One new eyebrow pin is tagged `@smoke` so the post-merge main run watches it. Promoting `@smoke` to a required check is already tracked in #82.
- Because the PR gate is static, the CSS-text pins were hardened to guard *width*, *duplicate rules*, *media-scoped overrides*, and *the flex-column parent* — not just the `align-self` declarations, which alone would let a `@media (max-width: 767px) { .hero__eyebrow { width: 100% } }` restore the band with the suite green.

## Noticed, not fixed

Filed **#255**: `.cta__eyebrow` has the same band failure on `#home-cta` at ≥768px, via a different mechanism — `#home-cta .cta__text { display: contents }` dissolves the block box and promotes the eyebrow into a stretched grid cell. Out of scope here; kept this PR to the hero.

## Review trail

`/plan-eng-review` (issue body as plan doc, scope accepted) → `/review` (testing + maintainability + design specialists, Claude adversarial, Codex adversarial) → `/document-generate` → `/ship`. The CSS fix was confirmed correct by every reviewer; the reviews' real yield was **five defects in the tests**, all fixed and mutation-verified before this PR was opened.
