### PR TITLE
v0.16.73 fix: render the cta eyebrow as a pill above the title (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.73] — 2026-07-11 — the cta eyebrow is a pill above the title, not a band below the button (#255)
+
+**Same defect as v0.16.72, same prop, a different mechanism — and this one moved the eyebrow as well as stretching it. On `#home-cta` at 768px and up, `cta.eyebrow` rendered as a colored band the full width of the title column, sitting underneath the call-to-action button. It now renders where the schema has always said it does: a compact pill, sized to its own text, directly above the headline.**
+
+The hero's band came from a flex column blockifying an `inline-block`. The CTA's came from a grid. At the desktop breakpoint `#home-cta .cta__text` is `display: contents`, which dissolves that wrapper and promotes the eyebrow, title and body into `.cta__inner` — which is a two-column grid. Grid blockifies its items exactly as flex does, so the pill stretched. But the eyebrow was also the only child with no placement of its own, and its three siblings are all explicitly placed: title in column 1 across both rows, body and button stacked in column 2. Auto-placement therefore walked past every occupied cell and dropped the eyebrow into the first free one — row 3, column 1 — which is why a label whose entire job is to sit above the headline was rendering below the button. Sizing it correctly without placing it would have produced a tidy pill in the wrong place, so the fix does both: the eyebrow takes row 1 of the title column, and title, body and button each shift down one row.
+
+Nothing about the authoring surface changes. `cta.eyebrow` already existed, and `components/cta/schema.json` already described it as "a short kicker/label rendered as a pill above the title" — the render simply did not match the contract. This was invisible on the live site for the same reason #225 was: no shipped page sets `cta.eyebrow`, so nothing ever drew the band. The new empty row costs those pages nothing, because the row gap is zero and an empty grid row collapses to nothing — a claim the tests now measure in a browser rather than assume.
+
+### Fixed
+- **`cta.eyebrow` renders as a pill above the title on `#home-cta`, not a band below the button** (`assets/css/components.css`). The eyebrow takes `grid-column: 1` / `grid-row: 1` with `justify-self: start`; title, body and button shift to rows 2, 2 and 3. The rule is scoped to `#home-cta.cta--inline` on purpose: `.cta__inner` is a flex column in the default `full-width` layout, where `align-self` controls the horizontal axis and an unscoped rule would flush the pill against the right edge instead.
+
+### Tests
+- `tests/e2e/style-render.spec.ts`: rendered-box proof that the pill sits above the title at 1280px, at the 768px breakpoint, and at mobile — position, not just width, because a width-only assertion passes happily while the eyebrow renders under the button. One case pins the state every shipped page is actually in (no eyebrow set) and proves the empty row still collapses; another renders the `full-width` layout and proves the fix stayed scoped to `inline`.
+- `tests/js/css-lint.test.js`: pins both halves of the bug — the pill is sized to its content, and it is placed in row 1 — plus the ways either could return while the other pins stayed green: a `gap` shorthand quietly resetting the zero row gap, a width added to any eyebrow rule, an alignment declared outside the two rules allowed to carry one, or the title reclaiming row 1. The rule scanner and the band-restoring guard are now shared with the hero pins rather than duplicated.
+- `tests/ComponentPropsTest.php`: pins the eyebrow as a direct child of `.cta__text`. `display: contents` dissolves exactly one box, so wrapping the eyebrow in anything would leave it inside a box that still exists, silently stop it being a grid item, and take the placement rules out of the cascade with every CSS pin still passing.
+
+---
+
 ## [v0.16.72] — 2026-07-11 — the hero eyebrow is a pill again, not a colored band (#225)
 
 **`hero.eyebrow` is documented as a pill: a short kicker sized to its own text, sitting above the headline. It rendered as a full-width colored band spanning the entire hero content column. The CSS said `display: inline-block` and meant it, but `.hero__eyebrow` is a direct child of `.hero__content`, which is a flex column, and a flex container blockifies its children — `inline-block` computes to `block`, then the default `stretch` alignment pulls the box across the full width. The eyebrow now shrinks to its text in all four hero layouts, flush with the leading edge on `left` and `split`, centered on `centered` and `cover`.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.72-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.73-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2196,9 +2196,36 @@
     max-width: none;
   }
 
+  /* display:contents above dissolves .cta__text, so the eyebrow becomes a grid item
+     of .cta__inner. Grid blockifies its inline-block and, with no placement of its
+     own, auto-flows it past every explicitly-placed sibling into the first free cell
+     — row 3, column 1 — and stretches it there: a band the full width of the TITLE
+     COLUMN, rendered below the button. Placing it in row 1 of the title column
+     restores the pill above the title. Row 1 collapses when no eyebrow is set
+     (row-gap is 0), so a CTA without one renders exactly as it did before.
+
+     Only .cta--inline carries this placement, because align-self is the one
+     declaration here that is NOT inert outside the grid: grid-column, grid-row and
+     justify-self are all ignored on a flex item, but .cta__inner stays a flex COLUMN
+     in the full-width layout, where the cross axis is horizontal and align-self:end
+     would shove the pill to the right edge. align-self:end is itself inert today —
+     row 1 is exactly the eyebrow's height, so there is no free space to align within
+     — and is kept to state the intent for a row that ever grows taller.
+
+     Do NOT "tidy" this selector to match the bare #home-cta siblings below. They are
+     bare only because grid-row is safely inert in the full-width flex column; their
+     own align-self declarations DO leak into it, which is a separate pre-existing
+     bug, not a pattern to copy. */
+  #home-cta.cta--inline .cta__eyebrow {
+    grid-column: 1;
+    grid-row: 1;
+    justify-self: start;
+    align-self: end;
+  }
+
   #home-cta .cta__title {
     grid-column: 1;
-    grid-row: 1 / span 2;
+    grid-row: 2 / span 2;
     max-width: 40rem;
     margin: 0;
     font-size: clamp(2.35rem, 3.05vw, 2.65rem);
@@ -2207,7 +2234,7 @@
 
   #home-cta .cta__body {
     grid-column: 2;
-    grid-row: 1;
+    grid-row: 2;
     max-width: 22rem;
     margin: 0 0 1.15rem;
     align-self: end;
@@ -2215,7 +2242,7 @@
 
   #home-cta .cta__button {
     grid-column: 2;
-    grid-row: 2;
+    grid-row: 3;
     justify-self: start;
     align-self: start;
   }

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.72');
+define('PP_VERSION', '0.16.73');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.72",
+  "version": "0.16.73",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.72
+Stable tag: 0.16.73
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.72
+Version:          0.16.73
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1220,6 +1220,31 @@ class ComponentPropsTest extends TestCase
         $this->assertStringNotContainsString('cta__eyebrow', $html);
     }
 
+    /**
+     * Regression pin for #255: the pill only holds because `display: contents` on
+     * .cta__text dissolves that box and promotes the eyebrow into the .cta__inner
+     * grid, where the CSS places it in row 1. display:contents only dissolves the ONE
+     * box it is set on — wrapping the eyebrow in any intermediate element leaves it
+     * inside a box that is still there, so it stops being a grid item, the placement
+     * rules stop applying, and every CSS pin stays green while the render changes.
+     */
+    public function testCtaEyebrowIsDirectChildOfCtaText(): void
+    {
+        foreach (['full-width', 'inline'] as $layout) {
+            $html = $this->render('cta', $this->ctaProps([
+                'eyebrow' => 'NEW',
+                'layout'  => $layout,
+            ]));
+            // No element of ANY kind may open between the two tags. Attributes and
+            // whitespace stay free: direct childhood is the whole contract.
+            $this->assertMatchesRegularExpression(
+                '/<div class="cta__text"[^>]*>(?:(?!<[a-zA-Z])[\s\S])*?<span class="cta__eyebrow"/',
+                $html,
+                "cta__eyebrow must be a direct child of cta__text (layout: {$layout})"
+            );
+        }
+    }
+
     public function testHeroSchemaDeclaresEyebrowSlots(): void
     {
         $schema = json_decode(file_get_contents(dirname(__DIR__) . '/components/hero/schema.json'), true);

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -18,6 +18,11 @@ import { execSync } from 'child_process';
  *          `inline-block` and stretched it across the full content width. The CSS-text
  *          pins in tests/js/css-lint.test.js can only prove the declaration is present;
  *          only a rendered box can prove the pill is not a band.
+ *   #255 — the cta eyebrow must render as a pill ABOVE the title. `display: contents` on
+ *          `#home-cta .cta__text` promotes it into a grid, which blockified it AND
+ *          auto-placed it into row 3, column 1 — a band the full width of the title
+ *          column, below the button. Position, not just width, is what a rendered box
+ *          proves here.
  */
 
 // ── Helpers (mirrors validation.spec.ts) ────────────────────────────────────
@@ -215,4 +220,151 @@ test.describe('Safe-surface rendered proof', () => {
       });
     }
   }
+
+  // #255: the same visual failure as #225 on the CTA, but reached through the grid.
+  // `#home-cta .cta__text` is `display: contents` at >=768px, so the eyebrow is promoted
+  // into the `.cta__inner` GRID, blockified, and — with no placement of its own —
+  // auto-flowed past every explicitly-placed sibling into a stretched row-3 cell. The
+  // rendered bug was a band the full width of the title column, BELOW the button, so
+  // width alone does not prove the fix: these assert the box is a pill AND sits above
+  // the title.
+  //
+  // 768px is covered to prove the placement rules take effect the moment the media
+  // query matches, not to prove the section fits there — it does not. The #home-cta
+  // track (minmax(36rem, 40rem) + minmax(18rem, 1fr) + a >=3rem gap) needs ~57rem, so
+  // the grid overflows the viewport between 768px and ~912px. That overflow predates
+  // this fix and is tracked separately; asserting against it here would pin a bug.
+  const ctaEyebrowViewports = [
+    { label: 'desktop', width: 1280, height: 900 },
+    { label: 'breakpoint', width: 768, height: 900 },
+    { label: 'mobile', width: 375, height: 800 },
+  ];
+
+  for (const viewport of ctaEyebrowViewports) {
+    // One @smoke case, so the post-merge main run (which executes only the @smoke
+    // subset) still watches the pill.
+    const smoke = viewport.label === 'desktop' ? ' @smoke' : '';
+
+    test(`#255 cta eyebrow renders as a pill above the title (${viewport.label})${smoke}`, async ({
+      page,
+    }) => {
+      pageId = createPage(`E2E CTA Eyebrow Pill ${viewport.label}`);
+      setComposition(pageId, [
+        {
+          component: 'cta',
+          props: {
+            // The bug is ID-scoped: only #home-cta gets `display: contents`.
+            id: 'home-cta',
+            layout: 'inline',
+            title: 'A deliberately long closing headline that widens the title column',
+            text: 'Supporting copy that occupies the right-hand column of the grid.',
+            eyebrow: 'BETA',
+            button_text: 'Get started',
+            button_url: '/start',
+          },
+        },
+      ]);
+
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto(`/?page_id=${pageId}`);
+
+      const eyebrow = page.locator('.cta__eyebrow');
+      await expect(eyebrow).toBeVisible({ timeout: 10000 });
+
+      const eyebrowBox = (await eyebrow.boundingBox())!;
+      const titleBox = (await page.locator('.cta__title').boundingBox())!;
+
+      // The band spanned the whole title column. "BETA" in a padded pill is nowhere near
+      // half of it, so this fails loudly on any return of the stretch.
+      expect(eyebrowBox.width).toBeLessThan(titleBox.width * 0.5);
+
+      // The half a width-only assertion would miss: auto-placement put the pill in row 3,
+      // under the button. An eyebrow that renders below its own headline is not an eyebrow.
+      expect(eyebrowBox.y + eyebrowBox.height).toBeLessThanOrEqual(titleBox.y + 1);
+
+      // Same column as the title, flush to its leading edge.
+      expect(Math.abs(eyebrowBox.x - titleBox.x)).toBeLessThan(2);
+    });
+  }
+
+  // The state every shipped page is actually in: #home-cta with NO eyebrow. The fix moved
+  // the title off row 1, so an empty row now sits above it on every live CTA. That row
+  // collapses only while the row gap is 0 — a `gap` shorthand added to the desktop block
+  // would silently open a band of dead space above every homepage headline. The CSS-text
+  // pins guard the declarations; only a rendered box proves the row actually collapsed.
+  test('#255 a cta with no eyebrow keeps its title flush to the top (empty row collapses) @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E CTA No Eyebrow Row Collapse');
+    setComposition(pageId, [
+      {
+        component: 'cta',
+        props: {
+          id: 'home-cta',
+          layout: 'inline',
+          title: 'A deliberately long closing headline that widens the title column',
+          text: 'Supporting copy that occupies the right-hand column of the grid.',
+          button_text: 'Get started',
+          button_url: '/start',
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const title = page.locator('.cta__title');
+    await expect(title).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.cta__eyebrow')).toHaveCount(0);
+
+    const titleBox = (await title.boundingBox())!;
+    const innerBox = (await page.locator('.cta__inner').boundingBox())!;
+
+    // The title's inset from the top of .cta__inner is what a phantom row 1 inflates.
+    // Measured in chromium at 1280px: 71px with the row collapsed (correct), 107px once
+    // a `gap: 1.5rem` shorthand resets row-gap and the empty row takes up space. 90px
+    // sits clear of both, so this fails on the regression without pinning exact metrics.
+    expect(titleBox.y - innerBox.y).toBeLessThan(90);
+  });
+
+  // The placement rules are deliberately scoped to `.cta--inline`, because `.cta__inner`
+  // is a flex COLUMN in the default full-width layout — where the cross axis is
+  // horizontal and `align-self: end` would push the pill to the right edge instead of
+  // leaving it centered. An unscoped `#home-cta .cta__eyebrow` selector would fix the
+  // inline layout by breaking the default one, and no inline-only test would notice.
+  test('#255 the full-width cta keeps its centered pill (fix stays scoped) @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E CTA Eyebrow Full Width');
+    setComposition(pageId, [
+      {
+        component: 'cta',
+        props: {
+          id: 'home-cta',
+          layout: 'full-width',
+          title: 'A deliberately long closing headline for the full width layout',
+          eyebrow: 'BETA',
+          button_text: 'Get started',
+          button_url: '/start',
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const eyebrow = page.locator('.cta__eyebrow');
+    await expect(eyebrow).toBeVisible({ timeout: 10000 });
+
+    const eyebrowBox = (await eyebrow.boundingBox())!;
+    const innerBox = (await page.locator('.cta__inner').boundingBox())!;
+
+    expect(eyebrowBox.width).toBeLessThan(innerBox.width * 0.5);
+
+    // Centered, not flushed to either edge. The regression this guards renders the pill
+    // hard against the right edge of .cta__inner.
+    const eyebrowCenter = eyebrowBox.x + eyebrowBox.width / 2;
+    const innerCenter = innerBox.x + innerBox.width / 2;
+    expect(Math.abs(eyebrowCenter - innerCenter)).toBeLessThan(2);
+  });
 });

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -25,6 +25,57 @@ function stripComments(css) {
     return css.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
+// Declarations that can restore an eyebrow band even with the alignment intact: an
+// explicit width/min-width, a flex shorthand that sets a basis, or place-self/align-self
+// overriding the cross-axis. Guarding the alignment alone is not enough — `width: 100%`
+// in a media block reintroduces the band with every alignment pin still green.
+//
+// Shared by the #225 (hero, flex) and #255 (cta, grid) guards: the ways a pill can be
+// re-stretched do not depend on which layout mode promoted it.
+const BAND_RESTORING = /(?:^|[;{\s])(?:min-)?width\s*:|(?:^|[;\s])flex\s*:|place-self\s*:|align-self\s*:/;
+
+// Every rule targeting `needle` as a whole class, in source order, each tagged with
+// the @media condition wrapping it (null at top level). Media context is part of the
+// identity of a rule: `.hero__eyebrow` inside `@media (max-width: 767px)` is a
+// DIFFERENT rule from the base one, and a stretch declared there would restore the
+// band at mobile while a media-blind scan reported green. components.css already
+// redeclares `.hero__content` inside a max-width block, so this is a live pattern.
+//
+// Shared by the #225 (hero) and #255 (cta) eyebrow guards below — both need to reason
+// about "every rule touching this class, in every media context", and a second copy of
+// this parser would be a place for the two to silently drift apart.
+function rulesMatching(needle) {
+    const css = stripComments(COMPONENTS_CSS);
+    // Class-boundary match, so `.hero__eyebrow` never swallows `.hero__eyebrow--lg`.
+    const boundary = new RegExp(
+        needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w-])'
+    );
+    const rules = [];
+    // A stack, not a depth counter: components.css already nests at-rules (@keyframes
+    // at :909), and any nested block — @supports, @keyframes, an inner @media — emits
+    // a closing brace of its own. A counter mistakes that brace for the media block's
+    // and reports every following rule as top-level, which is exactly how a
+    // mobile-scoped regression would hide from a media-aware-looking scan.
+    const pattern = /@([\w-]+)([^{;]*)\{|([^{}]+)\{([^{}]*)\}|\}|;/g;
+    const stack = [];
+    let match;
+    while ((match = pattern.exec(css)) !== null) {
+        if (match[1] !== undefined) {
+            stack.push(match[1] === 'media' ? match[2].trim() : null);
+        } else if (match[3] !== undefined) {
+            const selectors = match[3].split(',').map(s => s.trim().replace(/\s+/g, ' '));
+            if (selectors.some(s => boundary.test(s))) {
+                // Nearest enclosing @media, looking outward past non-media at-rules.
+                const media = [...stack].reverse().find(m => m !== null) ?? null;
+                rules.push({ selectors, body: match[4], media });
+            }
+        } else if (match[0] === '}') {
+            stack.pop();
+        }
+    }
+    return rules;
+}
+
 describe('CSS lint: positional selectors', () => {
     test('components.css has no nth-of-type selectors', () => {
         const matches = stripComments(COMPONENTS_CSS).match(/nth-of-type/g);
@@ -429,50 +480,6 @@ describe('CSS lint: grid desktop columns by item count', () => {
  * and the pin below is what keeps it that way.
  */
 describe('CSS lint: hero eyebrow is a pill, not a full-width band', () => {
-    // Every rule targeting `needle` as a whole class, in source order, each tagged with
-    // the @media condition wrapping it (null at top level). Media context is part of the
-    // identity of a rule: `.hero__eyebrow` inside `@media (max-width: 767px)` is a
-    // DIFFERENT rule from the base one, and a stretch declared there would restore the
-    // band at mobile while a media-blind scan reported green. components.css already
-    // redeclares `.hero__content` inside a max-width block, so this is a live pattern.
-    function rulesMatching(needle) {
-        const css = stripComments(COMPONENTS_CSS);
-        // Class-boundary match, so `.hero__eyebrow` never swallows `.hero__eyebrow--lg`.
-        const boundary = new RegExp(
-            needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w-])'
-        );
-        const rules = [];
-        // A stack, not a depth counter: components.css already nests at-rules (@keyframes
-        // at :909), and any nested block — @supports, @keyframes, an inner @media — emits
-        // a closing brace of its own. A counter mistakes that brace for the media block's
-        // and reports every following rule as top-level, which is exactly how a
-        // mobile-scoped regression would hide from a media-aware-looking scan.
-        const pattern = /@([\w-]+)([^{;]*)\{|([^{}]+)\{([^{}]*)\}|\}|;/g;
-        const stack = [];
-        let match;
-        while ((match = pattern.exec(css)) !== null) {
-            if (match[1] !== undefined) {
-                stack.push(match[1] === 'media' ? match[2].trim() : null);
-            } else if (match[3] !== undefined) {
-                const selectors = match[3].split(',').map(s => s.trim().replace(/\s+/g, ' '));
-                if (selectors.some(s => boundary.test(s))) {
-                    // Nearest enclosing @media, looking outward past non-media at-rules.
-                    const media = [...stack].reverse().find(m => m !== null) ?? null;
-                    rules.push({ selectors, body: match[4], media });
-                }
-            } else if (match[0] === '}') {
-                stack.pop();
-            }
-        }
-        return rules;
-    }
-
-    // Declarations that can restore the band even with align-self intact: an explicit
-    // width/min-width, a flex shorthand that sets a basis, or place-self overriding the
-    // cross-axis alignment. Guarding align-self alone is not enough — `width: 100%` in a
-    // mobile media block reintroduces #225 with every alignment pin still green.
-    const BAND_RESTORING = /(?:^|[;{\s])(?:min-)?width\s*:|(?:^|[;\s])flex\s*:|place-self\s*:|align-self\s*:/;
-
     // The cascade winner among equal-specificity rules is the LAST one, not the first.
     // Taking the first match would let a duplicate appended later silently shadow the
     // pin while it stayed green.
@@ -552,6 +559,160 @@ describe('CSS lint: hero eyebrow is a pill, not a full-width band', () => {
                 expect(r.body).not.toMatch(/display\s*:(?!\s*flex\s*;)/);
                 expect(r.body).not.toMatch(/flex-direction\s*:(?!\s*column\s*;)/);
             });
+    });
+});
+
+/**
+ * CTA eyebrow stays a pill, above the title (#255).
+ *
+ * Same visual failure as #225, different mechanism. `#home-cta .cta__text` is
+ * `display: contents` at >=768px, which dissolves its box and promotes the eyebrow
+ * into `#home-cta.cta--inline .cta__inner` — a GRID. Grid blockifies the eyebrow's
+ * inline-block, and with no placement of its own it auto-flows past every
+ * explicitly-placed sibling (title col1/rows1-2, body col2/row1, button col2/row2)
+ * into the first free cell — row 3, column 1 — and stretches it there: a band the
+ * full width of the title column, rendered BELOW the button.
+ *
+ * So the fix has two halves, and both need pinning: `justify-self: start` sizes the
+ * pill to its text, and `grid-row: 1` puts it back above the title. A pin on the
+ * width alone would stay green while the eyebrow rendered under the button.
+ */
+describe('CSS lint: cta eyebrow is a pill above the title (#255)', () => {
+    const DESKTOP = '(min-width: 768px)';
+    const BASE = '.cta__eyebrow';
+    const PLACED = '#home-cta.cta--inline .cta__eyebrow';
+
+    // The cascade winner among equal-specificity rules is the LAST declaration, not the
+    // first — and these selectors really are declared more than once: `.cta__inner` is
+    // styled by the shared four-CTA block AND by a #home-cta-specific override further
+    // down, both at >=768px. Taking the first match reads the wrong rule, and a
+    // duplicate appended later would shadow a pin while it stayed green.
+    function declFor(needle, selector, prop, media) {
+        const decls = rulesMatching(needle)
+            .filter(r => r.media === media && r.selectors.includes(selector))
+            .map(r => new RegExp(prop + '\\s*:\\s*([^;}]+)').exec(r.body))
+            .filter(Boolean);
+        return decls.length ? decls[decls.length - 1][1].trim() : null;
+    }
+
+    // The pill is padding + background, not `display` — pinning `inline-block` would be
+    // vacuous, since the grid parent blockifies it regardless. That is the whole bug.
+    test('the base rule keeps its pill styling', () => {
+        const rule = rulesMatching(BASE).find(r => r.selectors.includes(BASE) && !r.media);
+        expect(rule.body).toMatch(/padding\s*:/);
+        expect(rule.body).toMatch(/background\s*:/);
+    });
+
+    // A width on the base rule would defeat justify-self without touching it.
+    test('the base rule sizes the pill by its content, not a width', () => {
+        const rule = rulesMatching(BASE).find(r => r.selectors.includes(BASE) && !r.media);
+        expect(rule.body).not.toMatch(/(?:^|[;\s])(?:min-)?width\s*:/);
+    });
+
+    // Half one of the fix: the pill is sized to its text instead of stretching across
+    // the 36-40rem title column.
+    test('the promoted eyebrow opts out of the grid stretch', () => {
+        expect(declFor(BASE, PLACED, 'justify-self', DESKTOP)).toBe('start');
+    });
+
+    // Half two: without an explicit row it auto-places into row 3, i.e. below the
+    // button. This is the pin that a width-only guard would miss.
+    test('the promoted eyebrow is placed in row 1 of the title column', () => {
+        expect(declFor(BASE, PLACED, 'grid-column', DESKTOP)).toBe('1');
+        expect(declFor(BASE, PLACED, 'grid-row', DESKTOP)).toBe('1');
+    });
+
+    // Row 1 belongs to the eyebrow. If the title ever reclaims it, the two collide in
+    // the same cell and the eyebrow renders on top of the headline.
+    test('the title starts at row 2, leaving row 1 to the eyebrow', () => {
+        expect(declFor('.cta__title', '#home-cta .cta__title', 'grid-row', DESKTOP))
+            .toBe('2 / span 2');
+    });
+
+    /*
+     * Scope guard — the reason the placement rule carries `.cta--inline`.
+     *
+     * `layout` accepts 'full-width' (the DEFAULT) and 'inline'. The grid only exists
+     * for `.cta--inline`; in the full-width layout `.cta__inner` stays a flex COLUMN,
+     * where the cross axis is horizontal and `align-self: end` pushes the pill to the
+     * right edge (measured: x=1110 vs 611 in a 1280px viewport). Grid placement only
+     * means "grid", so a bare `#home-cta .cta__eyebrow` selector would fix the inline
+     * layout by breaking the default one.
+     */
+    test('the placement rule is scoped to the inline layout, never bare #home-cta', () => {
+        const placement = /grid-(?:row|column)\s*:|justify-self\s*:|align-self\s*:/;
+        rulesMatching(BASE)
+            .filter(r => placement.test(r.body))
+            .forEach(r =>
+                r.selectors
+                    .filter(s => s.includes('.cta__eyebrow'))
+                    .forEach(s => expect(s).toContain('.cta--inline'))
+            );
+    });
+
+    // The placement rules are dead code unless the parent is still a grid and
+    // .cta__text still dissolves into it. If either stops being true, the eyebrow is no
+    // longer a grid item and every pin above silently stops describing the render.
+    const INNER = '#home-cta.cta--inline .cta__inner';
+
+    test('the eyebrow is only a grid item because .cta__text dissolves into a grid', () => {
+        expect(declFor('.cta__inner', INNER, 'display', DESKTOP)).toBe('grid');
+        // Two tracks, not merely "some template". `grid-column: 1` on the eyebrow and
+        // `grid-column: 2` on the body/button only mean anything against a two-column
+        // track; a collapse to one column would leave every placement pin green while
+        // describing a layout that no longer exists.
+        expect(declFor('.cta__inner', INNER, 'grid-template-columns', DESKTOP))
+            .toMatch(/minmax\(.+\)\s+minmax\(.+\)/);
+        expect(declFor('.cta__text', '#home-cta .cta__text', 'display', DESKTOP))
+            .toBe('contents');
+    });
+
+    /*
+     * The empty row 1 collapses only while the row gap is 0 — and EVERY shipped page is
+     * in that state, because none of them sets an eyebrow. This is the highest-blast-
+     * radius way the fix can regress: a gap above the title on every live CTA.
+     *
+     * Reading the last `row-gap` declaration is not enough. `.cta__inner`'s base rule
+     * declares the `gap` SHORTHAND (`gap: var(--cta-inner-gap, ...)`), and a shorthand
+     * re-declared inside the desktop block would reset row-gap back to a non-zero value
+     * while a `row-gap`-only scan still reported 0. So pin both: row-gap is 0, and no
+     * shorthand reintroduces one. (`column-gap` is fine — the hyphen means the
+     * word-boundary below never matches it.)
+     */
+    test('row-gap stays 0 so the empty row collapses when no eyebrow is set', () => {
+        expect(declFor('.cta__inner', INNER, 'row-gap', DESKTOP)).toBe('0');
+    });
+
+    test('no gap shorthand in the desktop block can reset that row-gap', () => {
+        rulesMatching('.cta__inner')
+            .filter(r => r.media === DESKTOP && r.selectors.includes(INNER))
+            .forEach(r => expect(r.body).not.toMatch(/(?:^|[;{\s])gap\s*:/));
+    });
+
+    /*
+     * Half (a) of the bug — the stretch — can return without touching the placement at
+     * all. Two distinct guards, because the two declaration families have different
+     * legitimacy:
+     *
+     * Sizing (width / min-width / flex basis / place-self) is NEVER legitimate on the
+     * pill, in ANY rule, including the two owners. `width: 100%` added to the placement
+     * rule itself restores the band, and a guard that skipped the owners would sail
+     * straight past it.
+     */
+    const SIZE_RESTORING = /(?:^|[;{\s])(?:min-)?width\s*:|(?:^|[;\s])flex\s*:|place-self\s*:/;
+
+    test('no eyebrow rule anywhere gives the pill a width', () => {
+        rulesMatching(BASE).forEach(r => expect(r.body).not.toMatch(SIZE_RESTORING));
+    });
+
+    // Alignment IS legitimate — but only on the two owner rules. Anywhere else (a
+    // media-scoped override, a duplicate appended later, a new ID-specificity block) it
+    // can re-stretch the pill or drag it out of column 1 while every pin above stays green.
+    test('only the two owner rules may align the pill', () => {
+        const owners = [BASE, PLACED];
+        rulesMatching(BASE)
+            .filter(r => !r.selectors.every(s => owners.includes(s)))
+            .forEach(r => expect(r.body).not.toMatch(BAND_RESTORING));
     });
 });
 


### PR DESCRIPTION
Closes #255

## What was wrong

At >=768px, `#home-cta .cta__text` is `display: contents` (`assets/css/components.css:2194`). That dissolves the wrapper and promotes `.cta__eyebrow` into `#home-cta.cta--inline .cta__inner` — a two-column **grid**. Two things then went wrong at once:

1. Grid blockifies the eyebrow's declared `inline-block`, so with no `justify-self` it **stretched** across the title column.
2. The eyebrow was the only item with **no placement**, while title (col 1, rows 1-2), body (col 2, row 1) and button (col 2, row 2) are all explicit. Auto-placement therefore walked past every occupied cell into the first free one — **row 3, column 1**.

Net rendered result: a band the full width of the title column, **below the button**. A label whose entire job is to sit above the headline.

Measured in headless Chromium at 1280px, before the fix:

| element | x | y | width |
|---|---|---|---|
| `.cta__eyebrow` | 155 | **278** | **606** (= full title column) |
| `.cta__title` | 155 | 163 | 606 |
| `.cta__body` | 837 | 135 | 288 |
| `.cta__button` | 837 | 230 | 236 |

## The fix

Place the eyebrow at `grid-column: 1` / `grid-row: 1` with `justify-self: start`, and shift the siblings down: title `grid-row: 2 / span 2`, body `grid-row: 2`, button `grid-row: 3`.

After (same conditions): eyebrow **y=135, width=58** — a pill above the title (y=203). Holds at 768px and 1280px.

## Scope decision (asked and answered)

The issue's recorded **Fix direction** was `justify-self: start` alone. Browser measurement showed that fixes only the *stretch* — the pill still rendered at y=278, under the button. The maintainer was asked and chose **explicit grid placement**, treating the placement as part of #255. `components/cta/schema.json` already documents `eyebrow` as "a short kicker/label rendered as a pill **above the title**", so this makes the render match a contract that already existed rather than introducing a new one.

**No authoring surface changed**: no new prop, no new accepted value, no validation or grammar change. AI-facing docs (`lib/ai-context.php`, `ai-instructions/`) needed no update — `ai-instructions/composition.md:131` already claims the eyebrow is "a pill above the title" on all five components, and this diff makes that claim true for `cta`.

## Why the rule is scoped to `.cta--inline`

`layout` accepts `full-width` (the **default**) and `inline`. The grid only exists for `.cta--inline`, but the `display: contents` rule is not so scoped. In the full-width layout `.cta__inner` stays a flex **column**, where the cross axis is horizontal — an unscoped `align-self: end` shoves the pill to the **right edge** (measured x=1110 vs 611). `grid-*` and `justify-self` are inert on flex items; `align-self` is not. Hence the asymmetry, which is documented in a code comment so it does not get "tidied" away.

`align-self: end` is a **no-op today** (row 1 is exactly the eyebrow's height, so there is no free space to align within). It is retained deliberately, at the maintainer's instruction, to state intent for a row that ever grows taller.

## No regression for shipped pages

No page sets `cta.eyebrow` today. With no eyebrow, the new empty row 1 collapses (`row-gap: 0`) and the rendered boxes are **byte-identical** to before the fix: title y=163, body y=135, button y=230, `.cta__inner` height 228. The `full-width` layout is likewise unchanged (pill stays centered, x=611).

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — **1482 tests OK** (baseline 1481; +1 is the new structural pin. Warning/deprecation counts identical to an unmodified tree.)
- `npm test` — **453 passed** (baseline 450; +3 new pins).
- `bash scripts/package.sh` — version consistency OK across all five files. The side-effect zip was deleted; releases are CI-built from tags.
- E2E requires wp-env/Docker and runs in CI.

### Tests are mutation-verified

Reverting the fix turns the pins red — they are load-bearing, not decorative:

- Restoring the buggy CSS fails **3** css-lint pins, one per half of the bug (`justify-self`, `grid-row: 1`, and the title's row 2).
- Adding a `gap: 1.5rem` shorthand (which resets `row-gap`) fails the shorthand guard. Without it, all pins stayed green while the title shifted down 36px on every shipped page.
- Adding `width: 100%` to the placement rule fails the width guard.
- Wrapping the eyebrow in an element fails the PHPUnit structural pin.

## Reviews

`/plan-eng-review` and `/review` both ran to completion on this exact diff (plus a Codex outside-voice pass and testing/maintainability specialists). Findings were applied: the shorthand + width guards and the no-eyebrow E2E case all came out of that review, as did three comment corrections.

## Noticed, not fixed (filed separately)

- **#257** — in the `full-width` layout, `#home-cta` flushes the body hard right and the button hard left, because those rules carry bare `align-self` declarations that leak into the flex column. Pre-existing; unchanged by this diff.
- **#258** — the `#home-cta` grid needs ~912px (36rem + 18rem + gap) but activates at 768px, so it overflows the viewport between 768px and ~912px (`scrollWidth` 977 at a 768px viewport). Present on unmodified `main`. The new 768px E2E case documents this explicitly so it does not accidentally pin the bug as correct.