### PR TITLE
v0.16.74 fix: split the ZIP archive-read failure from a missing style.css and dump the listing (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.74] — 2026-07-11 — the packaging gate says which failure it hit, and shows you the archive (#260)
+
+**A release build that fails on a bad ZIP now tells you which kind of bad. `scripts/package.sh` reported "style.css not found in ZIP" for three different failures — an archive it could not read, an archive genuinely missing the file, and any other hiccup in the check — and printed nothing about what the archive did contain. An unreadable archive and a missing file are now separate messages, and the missing-file case dumps the archive's entry list.**
+
+The conflation was a shell subtlety. The check was `if ! unzip -l "$ZIP" | grep -q 'promptingpress/style.css'`, and the script runs under `set -o pipefail`. A nonzero `unzip` makes the whole pipeline nonzero, `!` inverts that to true, and the missing-file branch fires — so "I could not open this archive" and "this archive has no style.css" printed the same sentence. When an intermittent CI failure hit that line, the message pointed at the wrong cause and the first diagnosis was wrong. Dumping the listing is the part that pays for itself: the next occurrence names itself instead of starting a hypothesis chain.
+
+The check moves to `scripts/validate-zip.sh` so both failure paths can be exercised by tests, which a real `package.sh` build cannot do — it has no way to produce a corrupt archive on demand. Membership is now an exact match on the archive's entry list rather than a substring search, because the old pattern was an unanchored regex: a ZIP carrying only `promptingpress/style.css.map`, or a stray `foo/promptingpress/style.css`, would have satisfied it and passed a build with no theme stylesheet in it. `scripts/` is excluded from the distributed ZIP, so none of this ships to sites; `package.sh` keeps the same usage, the same arguments, and the same output on success.
+
+### Fixed
+- **The ZIP gate distinguishes an unreadable archive from a missing `style.css`** (`scripts/validate-zip.sh`, `scripts/package.sh`). A read failure reports "could not read" and `unzip`'s own error. A missing file reports "style.css missing" and prints the archive's contents. Two guards keep the split honest: a path that is not literally a file is rejected up front, because `unzip` globs its argument and retries it with a `.zip` suffix, so a nonexistent path could otherwise resolve to a different archive and pass; and an empty archive (which `unzip` exits nonzero on) is reported as a missing `style.css`, which is what it is, not as a read failure.
+- **The gate no longer accepts a look-alike path.** Membership is an exact entry match, so `promptingpress/style.css.map` and `foo/promptingpress/style.css` are correctly not `promptingpress/style.css`.
+
+### Tests
+- `tests/js/package.test.js`: every branch of the validator is pinned — a clean archive; an unreadable one, asserting it reports a read failure and *not* a missing file; a nonexistent path; the glob/suffix resolution that could bless a different archive; a missing `style.css`, asserting the entry listing is actually dumped; an empty archive; both look-alike paths; and the usage errors. One test pins that `package.sh` invokes the validator on its real invocation line, so the suite cannot go green while the old inline check quietly persists.
+
+**Known limitation** (tracked in #261): the check reads the archive's central directory, so a ZIP whose payload is corrupt but whose directory is intact still passes. The previous check had the same blind spot; closing it needs an integrity pass, which is its own change.
+
+---
+
 ## [v0.16.73] — 2026-07-11 — the cta eyebrow is a pill above the title, not a band below the button (#255)
 
 **Same defect as v0.16.72, same prop, a different mechanism — and this one moved the eyebrow as well as stretching it. On `#home-cta` at 768px and up, `cta.eyebrow` rendered as a colored band the full width of the title column, sitting underneath the call-to-action button. It now renders where the schema has always said it does: a compact pill, sized to its own text, directly above the headline.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.73-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.74-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.73');
+define('PP_VERSION', '0.16.74');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.73",
+  "version": "0.16.74",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.73
+Stable tag: 0.16.74
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -117,11 +117,9 @@ echo "Integrity manifest: $(grep -c '": "' "$MANIFEST") files hashed"
 (cd "$STAGING" && zip -qr "$THEME_DIR/$ZIP_NAME" promptingpress/)
 
 # ── 5. Validate ──────────────────────────────────────────────────────────
-# style.css must be in the ZIP
-if ! unzip -l "$ZIP_NAME" | grep -q 'promptingpress/style.css'; then
-    echo "ERROR: style.css not found in ZIP" >&2
-    exit 1
-fi
+# style.css must be in the ZIP. Delegated so the archive-read failure and the
+# missing-file failure report distinctly, and so both are testable (#260).
+bash "$THEME_DIR/scripts/validate-zip.sh" "$ZIP_NAME"
 
 # Must have a single top-level directory
 TOP_DIRS=$(unzip -l "$ZIP_NAME" | awk '/\/$/ && NF>=4 {print $4}' | grep -c '^[^/]*/$' || true)

--- a/scripts/validate-zip.sh
+++ b/scripts/validate-zip.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# scripts/validate-zip.sh — Assert a built theme ZIP contains promptingpress/style.css
+#
+# Usage: bash scripts/validate-zip.sh <zip-path>
+#
+# Split out of package.sh so the two failure modes below can be exercised
+# directly by tests/js/package.test.js: a real package.sh build can never be
+# made to emit a corrupt archive or one missing style.css.
+#
+# The single check that lived here previously reported an archive-read failure
+# and a genuinely-missing style.css with the same message, and printed nothing
+# about what the archive did contain. Under `set -o pipefail`, a nonzero
+# `unzip` in `unzip -l "$ZIP" | grep -q ...` made the pipeline nonzero, so `!`
+# took the missing-file branch either way. That conflation produced a wrong
+# root-cause diagnosis on a real CI failure (#260).
+#
+#   unreadable    → "could not read" + unzip's own error + exit 1
+#   missing file  → "style.css missing" + entry listing + exit 1
+#   present       → silent, exit 0
+#
+# Membership is an exact match on the entry list (`unzip -Z1` + `grep -Fxq`),
+# not a substring search of the human-readable `unzip -l` table: an unanchored
+# regex would also accept promptingpress/style.css.map or foo/promptingpress/style.css.
+#
+# Only the style.css check lives here. The single-top-level-directory and size
+# checks stay in package.sh because they feed values into its final report.
+
+set -euo pipefail
+
+ZIP="${1:-}"
+if [[ $# -ne 1 || -z "$ZIP" ]]; then
+    echo "ERROR: usage: validate-zip.sh <zip-path>" >&2
+    exit 1
+fi
+
+# unzip treats its archive argument as a glob and retries it with a .zip/.ZIP
+# suffix, so a path that does not exist can still resolve to some OTHER archive
+# and report success. Reject anything that is not literally this file, and keep
+# a leading dash from being parsed as an option.
+if [[ ! -f "$ZIP" ]]; then
+    echo "ERROR: could not read $ZIP (no such file)" >&2
+    exit 1
+fi
+[[ "$ZIP" == -* ]] && ZIP="./$ZIP"
+
+ERR_FILE=$(mktemp)
+trap 'rm -f "$ERR_FILE"' EXIT
+
+# `unzip -Z1` lists one entry path per line, stdout only. Exit 0 is clean and 1
+# is a warning (an empty archive is rc 1, "Empty zipfile." on stderr) — both
+# mean the archive was READ. Only rc >= 2 is a genuine read failure. An empty
+# archive is a missing-style.css case, not a read failure: routing it here is
+# what the old code got wrong, in the other direction.
+set +e
+ENTRIES=$(unzip -Z1 "$ZIP" 2>"$ERR_FILE")
+RC=$?
+set -e
+
+if [[ "$RC" -ge 2 ]]; then
+    echo "ERROR: could not read $ZIP (unzip failed, exit $RC)" >&2
+    cat "$ERR_FILE" >&2
+    exit 1
+fi
+
+if ! grep -Fxq -- 'promptingpress/style.css' <<<"$ENTRIES"; then
+    echo "ERROR: style.css missing from $ZIP" >&2
+    echo "--- archive contents ---" >&2
+    printf '%s\n' "$ENTRIES" >&2
+    exit 1
+fi

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.73
+Version:          0.16.74
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/package.test.js
+++ b/tests/js/package.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { execSync } from 'child_process';
-import { existsSync, unlinkSync, readFileSync } from 'fs';
-import { resolve } from 'path';
+import { execSync, spawnSync } from 'child_process';
+import { existsSync, unlinkSync, readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 
@@ -138,5 +139,149 @@ describe('package.sh smoke test', () => {
       return parts.slice(1).some(seg => seg.startsWith('.') && seg !== '');
     });
     expect(hidden).toEqual([]);
+  });
+});
+
+// The ZIP-validation step used to report an unreadable archive and a genuinely
+// missing style.css with the same message, and printed nothing about what the
+// archive held — which produced a wrong root-cause diagnosis on a real CI
+// failure (#260). package.sh can't be made to emit either kind of bad archive,
+// so the check lives in scripts/validate-zip.sh and is exercised directly here.
+describe('validate-zip.sh', () => {
+  let workDir;
+
+  const validator = resolve(ROOT, 'scripts/validate-zip.sh');
+
+  const run = (...args) => {
+    const r = spawnSync('bash', [validator, ...args], { encoding: 'utf-8' });
+    return { status: r.status, stderr: r.stderr };
+  };
+
+  // Build a ZIP whose entries are exactly `entries` (path → contents).
+  const makeZip = (name, entries) => {
+    const staging = join(workDir, `${name}-staging`);
+    mkdirSync(staging, { recursive: true });
+    for (const [path, contents] of Object.entries(entries)) {
+      const full = join(staging, path);
+      mkdirSync(resolve(full, '..'), { recursive: true });
+      writeFileSync(full, contents);
+    }
+    const zipPath = join(workDir, `${name}.zip`);
+    const z = spawnSync('zip', ['-qr', zipPath, '.'], { cwd: staging });
+    expect(z.status).toBe(0);
+    return zipPath;
+  };
+
+  beforeAll(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'pp-validate-zip-'));
+  });
+
+  afterAll(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('passes a ZIP containing promptingpress/style.css', () => {
+    const zip = makeZip('good', {
+      'promptingpress/style.css': '/* theme */',
+      'promptingpress/index.php': '<?php',
+    });
+    const { status, stderr } = run(zip);
+    expect(status).toBe(0);
+    expect(stderr).toBe('');
+  });
+
+  it('reports an unreadable archive distinctly from a missing style.css', () => {
+    const corrupt = join(workDir, 'corrupt.zip');
+    writeFileSync(corrupt, 'this is not a zip archive');
+    const { status, stderr } = run(corrupt);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/could not read/);
+    // The whole point of #260: an archive-read failure must NOT masquerade
+    // as a missing file, and there is no listing to show.
+    expect(stderr).not.toMatch(/style\.css missing/);
+    expect(stderr).not.toContain('--- archive contents ---');
+  });
+
+  it('reports a nonexistent archive as unreadable, not as a missing style.css', () => {
+    const { status, stderr } = run(join(workDir, 'does-not-exist.zip'));
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/could not read/);
+    expect(stderr).not.toMatch(/style\.css missing/);
+    expect(stderr).not.toContain('--- archive contents ---');
+  });
+
+  // unzip globs its archive argument and retries it with a .zip suffix, so a
+  // path that does not exist can otherwise resolve to a DIFFERENT archive and
+  // report success on a build nobody examined.
+  it('does not resolve a nonexistent path to another archive by glob or suffix', () => {
+    makeZip('decoy', { 'promptingpress/style.css': '/* decoy */' });
+    for (const arg of ['deco?.zip', 'decoy']) {
+      const r = spawnSync('bash', [validator, arg], { cwd: workDir, encoding: 'utf-8' });
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/could not read/);
+    }
+  });
+
+  it('dumps the archive contents when style.css is genuinely missing', () => {
+    const zip = makeZip('no-style', {
+      'promptingpress/index.php': '<?php',
+      'promptingpress/functions.php': '<?php',
+    });
+    const { status, stderr } = run(zip);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/style\.css missing/);
+    expect(stderr).not.toMatch(/could not read/);
+    // Without the listing, the last occurrence cost hours of guessing.
+    expect(stderr).toContain('promptingpress/index.php');
+    expect(stderr).toContain('promptingpress/functions.php');
+  });
+
+  // An empty archive is readable and has no style.css, so it is a missing-file
+  // failure. unzip exits 1 ("Empty zipfile.") on it, and treating that exit as
+  // a read failure would be #260's conflation running the other way.
+  it('treats an empty archive as a missing style.css, not an unreadable one', () => {
+    const empty = join(workDir, 'empty.zip');
+    // End-of-central-directory record with zero entries: a valid, empty ZIP.
+    writeFileSync(empty, Buffer.from('504b0506' + '00'.repeat(18), 'hex'));
+    const { status, stderr } = run(empty);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/style\.css missing/);
+    expect(stderr).not.toMatch(/could not read/);
+    expect(stderr).toContain('--- archive contents ---');
+  });
+
+  it('does not accept a look-alike suffix (style.css.map) as style.css', () => {
+    const zip = makeZip('suffix', {
+      'promptingpress/style.css.map': '{}',
+    });
+    const { status, stderr } = run(zip);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/style\.css missing/);
+  });
+
+  it('does not accept style.css nested under another top-level directory', () => {
+    const zip = makeZip('nested', {
+      'foo/promptingpress/style.css': '/* wrong place */',
+    });
+    const { status, stderr } = run(zip);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/style\.css missing/);
+  });
+
+  it('fails with usage when the archive path is missing or ambiguous', () => {
+    for (const args of [[], ['a.zip', 'b.zip']]) {
+      const r = spawnSync('bash', [validator, ...args], { encoding: 'utf-8' });
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/usage/);
+    }
+  });
+
+  it('is the check package.sh actually runs', () => {
+    const pkg = readFileSync(resolve(ROOT, 'scripts/package.sh'), 'utf-8');
+    // Pin the real invocation, not a mention: a comment naming the file, or a
+    // deleted validation step, must not satisfy this.
+    expect(pkg).toMatch(/^\s*bash "\$THEME_DIR\/scripts\/validate-zip\.sh" "\$ZIP_NAME"\s*$/m);
+    // The conflated pipeline this replaced must not creep back in.
+    expect(pkg).not.toMatch(/unzip -l .* \| *grep -q .*style\.css/);
   });
 });


### PR DESCRIPTION
Closes #260

## The bug

`scripts/package.sh` validated the built ZIP with a pipeline, under `set -o pipefail`:

```sh
if ! unzip -l "$ZIP_NAME" | grep -q 'promptingpress/style.css'; then
    echo "ERROR: style.css not found in ZIP" >&2
```

A nonzero `unzip` (unreadable or corrupt archive) makes the pipeline nonzero, `!` inverts it, and the missing-file branch fires. So an archive-**read** failure and a genuinely **missing** `style.css` printed the same sentence, and neither said anything about what the archive actually contained. When an intermittent CI failure hit this line, the message pointed at the wrong cause and the first root-cause diagnosis was wrong.

## Scope

The check moves to a new `scripts/validate-zip.sh`, which reports three outcomes distinctly:

| Outcome | Message | Exit |
|---|---|---|
| Unreadable archive | `could not read <zip> (unzip failed, exit N)` + unzip's own error | 1 |
| `style.css` missing | `style.css missing from <zip>` + a dump of the archive's entry listing | 1 |
| Present | (silent) | 0 |

`package.sh` delegates to it. Its usage, arguments, and success output are unchanged, and `scripts/` is excluded from the distributed ZIP by `.distignore`, so nothing here ships to theme users. The single-top-level-directory and size checks are deliberately untouched.

## Scope question — asked and answered

The old matcher was an unanchored **regex substring** search, so it would have reported SUCCESS on a ZIP containing only `promptingpress/style.css.map`, or a stray `foo/promptingpress/style.css` — a packaging gate certifying a build with no theme stylesheet in it. Tightening it changes what the gate accepts, which is beyond #260's recorded decision, so it was put to the maintainer rather than decided unilaterally.

**Answer: tighten it, keep everything else narrow.** Membership is now an exact entry match (`unzip -Z1` + `grep -Fxq`), with tests pinning both false-pass cases. The accompanying direction was "don't chase unrelated package behavior," which is why the limitation below is filed rather than fixed.

## Review findings fixed in this PR

Both were surfaced by the adversarial review pass and verified empirically against real archives before acting:

- **Fail-open.** `unzip` globs its archive argument and retries it with a `.zip` suffix, so a path that does **not exist** could resolve to a *different* archive and exit 0 (`validate-zip.sh 'do?.zip'` → exit 0, having read `dot.zip`). The validator now rejects anything that is not literally a file.
- **Inverted conflation.** An empty archive (zero entries) makes `unzip` exit 1 (`Empty zipfile.`), which the first draft misreported as "could not read" — #260's own bug running the other way. An empty archive is now correctly reported as a missing `style.css`.

## Accepted limitation

Filed as **#261**, not fixed here: the validation reads only the archive's **central directory**, so a ZIP whose payload is corrupt but whose central directory is intact still passes (`unzip -Z1` rc=0 while `unzip -t` rc=2). This is **pre-existing** — the old `unzip -l` check had the identical blind spot, so it is not a regression from this change — and adding an integrity gate is outside #260's recorded decision.

## Tests

10 vitest tests in `tests/js/package.test.js` pin every branch of the validator:

- happy path (clean archive)
- unreadable archive — asserts the distinct message **and** that it does *not* report a missing file, and that no listing is printed
- nonexistent archive
- the glob/suffix fail-open (a nonexistent path must not resolve to another archive)
- missing `style.css` — asserts the archive's entry listing is actually dumped
- empty archive → missing-file, not read-failure
- `promptingpress/style.css.map` is not `style.css`
- `foo/promptingpress/style.css` is not `style.css`
- usage/arity errors
- a static pin that `package.sh` invokes the validator on its real invocation line, so the suite cannot pass while the old inline check quietly persists

## Validation evidence

- `./vendor/bin/phpunit --configuration phpunit.xml` → **1482 tests, OK**. (3 warnings / 2 PHPUnit deprecations, identical to an unmodified tree — verified by stashing the diff and re-running.)
- `npm test` → **463 tests, 16 files, all passing.**
- `bash scripts/package.sh` → builds and validates cleanly; version consistency OK across all five files.