### PR TITLE
v0.16.75 fix: verify the release ZIP payload, not just its central directory (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.75] — 2026-07-11 — the packaging gate now reads the archive's payload, not just its table of contents (#261)
+
+**A release ZIP whose compressed data was damaged used to pass validation and ship. Every check `scripts/package.sh` ran — the style.css membership test, the top-level-directory test, the size test — read only the archive's central directory, which is its table of contents. Corrupt the payload and leave the index intact and the build validated clean, uploaded itself as a release asset, and failed for the first time in someone's WordPress install. `scripts/validate-zip.sh` now inflates and CRC-checks the payload before a build is allowed out.**
+
+Listing a ZIP is not reading it. `unzip -l` and `unzip -Z1` walk the central directory and report what the archive *claims* to contain; neither one touches a single compressed byte. `unzip -t` is the only check that actually decompresses each entry and verifies it against its stored CRC, so it is the only one that can tell a good build from a byte-damaged one. That is the check that was missing, and the class of failure it catches is the one where CI is green, the release asset is published, and the theme is broken on arrival.
+
+The gate fails closed on any nonzero exit, not just on a hard error. `unzip` reports a *skipped* entry — one whose compression method it does not recognize, for instance — as exit 1, a mere "warning". A skipped entry is never inflated and never CRC-checked: flip one byte of style.css's compression-method field and the archive still lists correctly, still passes the membership test, still reports only a warning, and extracts the stylesheet as **zero bytes**. A theme whose style.css is empty is a dead theme. Treating "I could not verify this" as "this is fine" would have left the headline bug alive in a gate written to catch it, so any nonzero result now rejects the build. The membership check moved ahead of the integrity check to make that possible: an empty archive also exits 1, and letting the style.css test reject it first means the integrity gate never has to tell those two apart and needs no exceptions carved into it.
+
+`scripts/` is excluded from the distributed ZIP, so none of this ships to sites. `package.sh` keeps the same usage, arguments, and output on success.
+
+### Fixed
+
+- `scripts/validate-zip.sh` now verifies the ZIP payload with `unzip -tq` and rejects any archive that does not verify, with a distinct message and the failing entry named. Previously an archive with a damaged payload and an intact central directory passed as a good build and was uploaded by `release.yml` (#261).
+- The integrity gate fails closed on any nonzero `unzip -t` exit, so an entry that unzip skips without verifying (and would extract as zero bytes) is rejected rather than waved through as a warning.
+- The style.css membership check now runs before the integrity check, so an empty archive is still reported as a missing style.css rather than as corruption.
+
+### Tests
+
+- Five tests in `tests/js/package.test.js` pin the new gate: a corrupt payload behind an intact index; the failing entry is named in the report; style.css intact but a sibling entry damaged; an entry unzip cannot verify (asserting it extracts as zero bytes *and* is rejected); and a missing style.css reported ahead of corruption, which pins the check order.
+- Two fixture builders construct the bad archives: one corrupts a named entry's payload in place using its own compressed-size field, the other flips that entry's compression method. Both assert the archive is genuinely bad and that its central directory still reads clean, so neither test can pass against a fixture that quietly stopped being corrupt.
+
+---
+
 ## [v0.16.74] — 2026-07-11 — the packaging gate says which failure it hit, and shows you the archive (#260)
 
 **A release build that fails on a bad ZIP now tells you which kind of bad. `scripts/package.sh` reported "style.css not found in ZIP" for three different failures — an archive it could not read, an archive genuinely missing the file, and any other hiccup in the check — and printed nothing about what the archive did contain. An unreadable archive and a missing file are now separate messages, and the missing-file case dumps the archive's entry list.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.74-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.75-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.74');
+define('PP_VERSION', '0.16.75');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.74",
+  "version": "0.16.75",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.74
+Stable tag: 0.16.75
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/scripts/validate-zip.sh
+++ b/scripts/validate-zip.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# scripts/validate-zip.sh — Assert a built theme ZIP contains promptingpress/style.css
+# scripts/validate-zip.sh — Assert a built theme ZIP is intact and contains
+# promptingpress/style.css
 #
 # Usage: bash scripts/validate-zip.sh <zip-path>
 #
-# Split out of package.sh so the two failure modes below can be exercised
-# directly by tests/js/package.test.js: a real package.sh build can never be
-# made to emit a corrupt archive or one missing style.css.
+# Split out of package.sh so the failure modes below can be exercised directly
+# by tests/js/package.test.js: a real package.sh build can never be made to
+# emit a corrupt archive or one missing style.css.
 #
 # The single check that lived here previously reported an archive-read failure
 # and a genuinely-missing style.css with the same message, and printed nothing
@@ -14,16 +15,44 @@
 # took the missing-file branch either way. That conflation produced a wrong
 # root-cause diagnosis on a real CI failure (#260).
 #
-#   unreadable    → "could not read" + unzip's own error + exit 1
-#   missing file  → "style.css missing" + entry listing + exit 1
-#   present       → silent, exit 0
+#   absent/unreadable  → "could not read" + unzip's own error + exit 1
+#   missing file       → "style.css missing" + entry listing + exit 1
+#   unverified payload → "failed its integrity check" + unzip -t's report + exit 1
+#   intact + present   → silent, exit 0
+#
+# The checks run cheapest-and-broadest first, and the order is load bearing
+# (#261):
+#
+#   ┌─ does the file EXIST?                  [[ -f ]]   no    → "could not read"
+#   ├─ can unzip READ the index at all?      unzip -Z1  rc>=2 → "could not read"
+#   ├─ is promptingpress/style.css PRESENT?  grep -Fxq  no    → "style.css missing"
+#   └─ does the PAYLOAD verify?              unzip -t   rc!=0 → "integrity check"
+#
+# (The first two both report "could not read"; only the second has an unzip
+# error to attach, because in the first, unzip never ran.)
+#
+# `unzip -Z1` and `unzip -l` only ever read the archive's CENTRAL DIRECTORY, so
+# a build whose compressed payload is byte-damaged but whose central directory
+# survived listed clean and shipped as a release asset (release.yml uploads
+# whatever package.sh produced). Only `unzip -t` actually decompresses and
+# CRC-checks the payload, so it is the only check that can catch that class.
+#
+# Why integrity runs LAST, not first:
+#   - `unzip -t` returns 9 on a file that is not a ZIP at all, so running it
+#     before the read check would relabel #260's "could not read" case as an
+#     integrity failure and undo that diagnostic split.
+#   - An EMPTY archive returns rc 1 from `unzip -t`, the same rc as an entry
+#     that unzip skipped without verifying. Letting the membership check reject
+#     the empty archive first means integrity never has to tell those apart,
+#     and can therefore fail closed on ANY nonzero rc with no carve-outs. See
+#     the threshold comment at the check itself.
 #
 # Membership is an exact match on the entry list (`unzip -Z1` + `grep -Fxq`),
 # not a substring search of the human-readable `unzip -l` table: an unanchored
 # regex would also accept promptingpress/style.css.map or foo/promptingpress/style.css.
 #
-# Only the style.css check lives here. The single-top-level-directory and size
-# checks stay in package.sh because they feed values into its final report.
+# Only the integrity + style.css checks live here. The single-top-level-directory
+# and size checks stay in package.sh because they feed values into its final report.
 
 set -euo pipefail
 
@@ -46,11 +75,12 @@ fi
 ERR_FILE=$(mktemp)
 trap 'rm -f "$ERR_FILE"' EXIT
 
-# `unzip -Z1` lists one entry path per line, stdout only. Exit 0 is clean and 1
-# is a warning (an empty archive is rc 1, "Empty zipfile." on stderr) — both
-# mean the archive was READ. Only rc >= 2 is a genuine read failure. An empty
-# archive is a missing-style.css case, not a read failure: routing it here is
-# what the old code got wrong, in the other direction.
+# `unzip -Z1` lists one entry path per line, on stdout. Exit 0 is clean and 1
+# is a warning (an empty archive is rc 1, and prints "Empty zipfile." on
+# stdout, so ENTRIES is that notice rather than a path) — both mean the archive
+# was READ. Only rc >= 2 is a genuine read failure. An empty archive is a
+# missing-style.css case, not a read failure: routing it here is what the old
+# code got wrong, in the other direction.
 set +e
 ENTRIES=$(unzip -Z1 "$ZIP" 2>"$ERR_FILE")
 RC=$?
@@ -66,5 +96,44 @@ if ! grep -Fxq -- 'promptingpress/style.css' <<<"$ENTRIES"; then
     echo "ERROR: style.css missing from $ZIP" >&2
     echo "--- archive contents ---" >&2
     printf '%s\n' "$ENTRIES" >&2
+    exit 1
+fi
+
+# The index is sound and names style.css. That still says nothing about the
+# PAYLOAD: zero out an entry's compressed bytes and `unzip -Z1` lists it just
+# as happily. `unzip -t` inflates every entry and checks it against its stored
+# CRC, which is the only way to catch a byte-damaged build before it ships
+# (#261).
+#
+# `-tq` (one q, not two): -qq suppresses the per-entry report on some failures,
+# which would print an error banner with no diagnosis under it — the silent
+# root-cause failure #260 was about. -tq still names the entry that failed.
+#
+# Capture is 2>&1 because unzip writes the per-entry report to STDOUT; folding
+# stderr in too keeps any unzip-level error message with it.
+set +e
+TEST_OUTPUT=$(unzip -tq "$ZIP" 2>&1)
+TRC=$?
+set -e
+
+# Fail closed on ANY nonzero, not just rc >= 2 — and note this check runs LAST
+# precisely so it can afford to. rc 1 is merely a "warning", but unzip SKIPS an
+# entry it cannot handle (unknown compression method, unreadable encryption)
+# with rc 1, and a skipped entry is never inflated and never CRC-checked. So rc
+# 1 can mean "not verified", which is not the same as "verified good". Flip one
+# byte of style.css's compression-method field and you get exactly that: the
+# entry lists fine, membership passes, `unzip -t` returns 1, and the file
+# extracts as ZERO BYTES. A gate that reads "could not verify" as "fine" is the
+# bug, not the fix.
+#
+# The only other archive that returns rc 1 is an empty one, and the membership
+# check above has already rejected it — which is why no rc is carved out here.
+if [[ "$TRC" -ne 0 ]]; then
+    echo "ERROR: $ZIP failed its integrity check (unzip -t, exit $TRC)" >&2
+    echo "The archive index is readable but its payload did not verify — do not ship this build." >&2
+    if [[ -n "$TEST_OUTPUT" ]]; then
+        echo "--- unzip -t report ---" >&2
+        printf '%s\n' "$TEST_OUTPUT" >&2
+    fi
     exit 1
 fi

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.74
+Version:          0.16.75
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/package.test.js
+++ b/tests/js/package.test.js
@@ -268,6 +268,200 @@ describe('validate-zip.sh', () => {
     expect(stderr).toMatch(/style\.css missing/);
   });
 
+  // #261: `unzip -Z1` (and `unzip -l`) only read the archive's CENTRAL
+  // DIRECTORY. A build whose compressed payload is byte-damaged but whose
+  // central directory survived listed clean, passed validation, and would be
+  // uploaded as a release asset by release.yml. Only `unzip -t` inflates the
+  // payload and checks it against its stored CRC.
+  //
+  // Corrupt the payload of a NAMED entry, in place, leaving every header
+  // intact:
+  //
+  //   [PK\x03\x04][hdr 30B][name][extra][>>> payload — flip these <<<] ...
+  //                 ^ compressed size at +18            ^ length from that field
+  //
+  // Locating the entry by name (not "the first local header", which can be the
+  // directory entry) and taking the payload length from the header's own
+  // compressed-size field is what keeps the flip provably inside the payload
+  // rather than running into the next header or the central directory.
+  const makeCorruptPayloadZip = (name, entries, target) => {
+    const zipPath = makeZip(name, entries);
+    const buf = readFileSync(zipPath);
+    const nameBuf = Buffer.from(target, 'utf-8');
+
+    let payloadStart = -1;
+    let payloadLen = 0;
+    for (let i = 0; i + 30 <= buf.length; i++) {
+      if (buf.readUInt32LE(i) !== 0x04034b50) continue; // local file header
+      const compressedSize = buf.readUInt32LE(i + 18);
+      const nameLen = buf.readUInt16LE(i + 26);
+      const extraLen = buf.readUInt16LE(i + 28);
+      const entryName = buf.subarray(i + 30, i + 30 + nameLen);
+      if (!entryName.equals(nameBuf)) continue;
+      payloadStart = i + 30 + nameLen + extraLen;
+      payloadLen = compressedSize;
+      break;
+    }
+
+    // A zero compressed size means the writer streamed this entry and pushed
+    // the size into a trailing data descriptor, so the offsets above would be
+    // corrupting nothing. Fail loudly instead of producing a fixture that
+    // silently isn't corrupt.
+    expect(payloadStart, `no local header for ${target}`).toBeGreaterThan(-1);
+    expect(payloadLen, `${target} has no in-header payload to corrupt`).toBeGreaterThan(0);
+    expect(payloadStart + payloadLen).toBeLessThanOrEqual(buf.length);
+
+    for (let i = payloadStart; i < payloadStart + payloadLen; i++) buf[i] ^= 0xff;
+    writeFileSync(zipPath, buf);
+
+    // Guard the fixture itself: if this archive ever stops being corrupt, the
+    // tests below would pass for the wrong reason. rc >= 2 is a real
+    // integrity failure (rc 1 is only a warning).
+    const probe = spawnSync('unzip', ['-tqq', zipPath], { encoding: 'utf-8' });
+    expect(probe.status, 'fixture is not actually payload-corrupt').toBeGreaterThanOrEqual(2);
+
+    // ...and the central directory must still read clean, or this would be
+    // testing the plain unreadable-archive path that already had coverage.
+    const listing = spawnSync('unzip', ['-Z1', zipPath], { encoding: 'utf-8' });
+    expect(listing.status, 'central directory should still be readable').toBe(0);
+    expect(listing.stdout).toContain(target);
+
+    return zipPath;
+  };
+
+  it('rejects an archive whose payload is corrupt but whose central directory is intact', () => {
+    const zip = makeCorruptPayloadZip(
+      'corrupt-payload',
+      {
+        'promptingpress/style.css': '/* theme */\n'.repeat(64),
+        'promptingpress/index.php': '<?php\n'.repeat(64),
+      },
+      'promptingpress/style.css',
+    );
+    const { status, stderr } = run(zip);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/failed its integrity check/);
+    // The whole point of #261: this must NOT be waved through as a good build.
+    // Before the integrity branch existed, this exact archive exited 0.
+    expect(stderr).not.toMatch(/style\.css missing/);
+    expect(stderr).not.toMatch(/could not read/);
+  });
+
+  it('reports which entry failed the integrity check', () => {
+    const zip = makeCorruptPayloadZip(
+      'corrupt-detail',
+      { 'promptingpress/style.css': '/* theme */\n'.repeat(64) },
+      'promptingpress/style.css',
+    );
+    const { stderr } = run(zip);
+    // The validator must name the damaged entry, not just say "corrupt". A
+    // bare error with no diagnosis attached is the failure #260 was about,
+    // and `unzip -tqq` produces exactly that on some corruptions — which is
+    // why the script uses -tq.
+    expect(stderr).toContain('--- unzip -t report ---');
+    expect(stderr).toContain('promptingpress/style.css');
+  });
+
+  // Corrupt a file's payload while leaving style.css itself intact. This is
+  // the realistic shape of a damaged build: every required entry is present
+  // and style.css reads fine, so every central-directory check passes and
+  // only `unzip -t` can tell that the archive is broken.
+  it('rejects an archive whose style.css is fine but another entry is damaged', () => {
+    const zip = makeCorruptPayloadZip(
+      'corrupt-sibling',
+      {
+        'promptingpress/style.css': '/* theme */\n'.repeat(64),
+        'promptingpress/index.php': '<?php\n'.repeat(64),
+      },
+      'promptingpress/index.php',
+    );
+    const { status, stderr } = run(zip);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/failed its integrity check/);
+    expect(stderr).toContain('promptingpress/index.php');
+  });
+
+  // Regression pin for the fail-closed threshold (#261).
+  //
+  // Flip the compression-method field in an entry's local header and unzip
+  // SKIPS that entry: it is never inflated, never CRC-checked. `unzip -t`
+  // reports rc 1 ("warning"), NOT rc 2 — so a gate keyed on rc >= 2 waves the
+  // build through, and the entry extracts as ZERO BYTES. A theme whose
+  // style.css is empty is a dead theme, shipped as a good release.
+  //
+  // rc 1 here means "could not verify", not "verified good". Anything but a
+  // clean rc 0 on a non-empty archive must fail.
+  const makeUnverifiableZip = (name, entries, target) => {
+    const zipPath = makeZip(name, entries);
+    const buf = readFileSync(zipPath);
+    const nameBuf = Buffer.from(target, 'utf-8');
+
+    let flipped = false;
+    for (let i = 0; i + 30 <= buf.length; i++) {
+      if (buf.readUInt32LE(i) !== 0x04034b50) continue;
+      const nameLen = buf.readUInt16LE(i + 26);
+      if (!buf.subarray(i + 30, i + 30 + nameLen).equals(nameBuf)) continue;
+      buf.writeUInt16LE(20, i + 8); // compression method unzip cannot handle
+      flipped = true;
+      break;
+    }
+    expect(flipped, `no local header for ${target}`).toBe(true);
+    writeFileSync(zipPath, buf);
+
+    // The archive must still LOOK fine to every central-directory check, or
+    // this would be testing some other failure path.
+    const listing = spawnSync('unzip', ['-Z1', zipPath], { encoding: 'utf-8' });
+    expect(listing.status).toBe(0);
+    expect(listing.stdout).toContain(target);
+
+    // And unzip must report it as a skip (rc 1), not a hard error — that is
+    // precisely the case a rc>=2 threshold would let through.
+    const probe = spawnSync('unzip', ['-tq', zipPath], { encoding: 'utf-8' });
+    expect(probe.status, 'fixture should trip the rc-1 skip path').toBe(1);
+
+    return zipPath;
+  };
+
+  it('rejects an archive with an entry unzip cannot verify (skipped, not CRC-checked)', () => {
+    const zip = makeUnverifiableZip(
+      'unverifiable',
+      {
+        'promptingpress/style.css': '/* theme */\n'.repeat(64),
+        'promptingpress/index.php': '<?php\n'.repeat(64),
+      },
+      'promptingpress/style.css',
+    );
+
+    // Prove the stakes: this "valid-looking" archive yields an EMPTY style.css.
+    const extracted = spawnSync('unzip', ['-p', zip, 'promptingpress/style.css'], {
+      encoding: 'buffer',
+    });
+    expect(extracted.stdout.length, 'style.css should extract as 0 bytes').toBe(0);
+
+    const { status, stderr } = run(zip);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/failed its integrity check/);
+    expect(stderr).toContain('promptingpress/style.css');
+  });
+
+  // Ordering is load-bearing (see the diagram in validate-zip.sh). Membership
+  // runs BEFORE integrity, so an archive that is both corrupt and missing
+  // style.css reports the missing file. That ordering is what lets the
+  // integrity check fail closed on any nonzero rc: an empty archive returns
+  // the same rc 1 as an unverified entry, and membership has already rejected
+  // it by then, so integrity never has to tell those two apart.
+  it('reports a missing style.css ahead of payload corruption', () => {
+    const zip = makeCorruptPayloadZip(
+      'corrupt-and-missing',
+      { 'promptingpress/index.php': '<?php\n'.repeat(64) },
+      'promptingpress/index.php',
+    );
+    const { status, stderr } = run(zip);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/style\.css missing/);
+    expect(stderr).not.toMatch(/failed its integrity check/);
+  });
+
   it('fails with usage when the archive path is missing or ambiguous', () => {
     for (const args of [[], ['a.zip', 'b.zip']]) {
       const r = spawnSync('bash', [validator, ...args], { encoding: 'utf-8' });


### PR DESCRIPTION
Closes #261

## Scope

`scripts/package.sh`'s ZIP validation only ever read the archive's **central directory** (`unzip -Z1` / `unzip -l`), never the payload. A build whose compressed data was byte-damaged but whose index survived validated clean and would be uploaded as a release asset by `release.yml` — the corruption would surface at theme-install time in WordPress, not in CI.

`scripts/validate-zip.sh` now inflates and CRC-checks the payload with `unzip -tq`, with a failure message distinct from both existing modes, naming the entry that failed.

Per the issue's recorded decision the fix is narrow: no changes to `package.sh`'s top-level-directory or size checks, no changes to `release.yml`, no release/package refactors.

### The gate fails closed on any nonzero exit, not just >= 2

This is the load-bearing detail, and it came out of the review. `unzip` reports an entry it **skips** — one with a compression method it does not recognize — as exit **1**, a mere "warning". A skipped entry is never inflated and never CRC-checked. Flip one byte of `style.css`'s compression-method field and:

- `unzip -Z1` lists the archive fine (rc 0), so the read check passes
- membership passes — `promptingpress/style.css` is right there in the listing
- `unzip -t` returns **1**, not 2
- `style.css` extracts as **zero bytes**

A first implementation keyed on `rc >= 2` passed that archive as a good build. A theme with an empty `style.css` is a dead theme. Treating "could not verify" as "verified good" would have left the headline bug alive inside the gate written to catch it, so any nonzero result now rejects the build.

### Check order changed (membership before integrity)

Measured exit codes on Info-ZIP UnZip 6.00:

| archive | `unzip -Z1` | `unzip -t` | verdict |
|---|---|---|---|
| good | 0 | 0 | pass |
| corrupt payload (bad CRC) | 0 | 2 | integrity check |
| entry skipped, never verified | 0 | **1** | integrity check |
| empty archive | 1 | **1** | style.css missing |
| not a ZIP at all | 9 | 9 | could not read |

An empty archive returns the same rc 1 as an unverified entry. Letting the membership check reject it first means the integrity gate never has to tell those two apart, and can therefore fail closed with no rc carved out of it. Integrity also cannot run first: `unzip -t` returns 9 on a non-ZIP too, which would relabel #260's "could not read" case and undo that diagnostic split.

## Validation

- `npm test` — **468 passed** (16 files), including 25 in `tests/js/package.test.js`
- `./vendor/bin/phpunit --configuration phpunit.xml` — **1482 passed**. The 3 warnings + 2 deprecations are pre-existing: confirmed identical on a stashed clean tree (this change touches no PHP).
- `bash scripts/package.sh` — five-file version sync validated; the zip it builds as a side effect was deleted (releases are CI-built from tags).
- End to end: the real `package.sh` build, corrupted, now exits 1 with the integrity message and names the damaged entry; the intact build still exits 0 silently.

### Tests added (5)

Corrupt payload behind an intact index; the failing entry is named in the report; `style.css` intact but a sibling entry damaged; an entry unzip cannot verify (asserts it extracts as zero bytes **and** is rejected); a missing `style.css` reported ahead of corruption, pinning the check order.

Two fixture builders construct the bad archives — one corrupts a named entry's payload in place using its own compressed-size field, the other flips that entry's compression method. Both assert the fixture is genuinely bad *and* that its central directory still reads clean, so neither test can pass against a fixture that quietly stopped being corrupt. Reverting the production change fails all of them.

The pre-existing empty-archive and non-ZIP tests are now load-bearing guards for the threshold and the ordering.

## Accepted limitations

Out of scope for #261's recorded decision, and pre-existing (all are membership-check concerns from #260, not payload integrity): a legitimately empty but CRC-valid `style.css`, duplicate `style.css` entries, and symlink entries all still pass. The archive is built by `package.sh` from the repo tree, so entry names are not attacker-controlled.

A benign `unzip -t` warning on an otherwise good archive would now block a release rather than ship it. That is the intended direction, and `package.sh`'s smoke test builds a real ZIP through this validator on every CI run, so such a regression surfaces immediately instead of silently.

## Reviews

`/plan-eng-review`, `/review` (testing + security + maintainability specialists, plus a Codex adversarial pass), and `/document-generate` all ran on this diff. The security specialist found the `rc >= 2` bypass described above; it was fixed and pinned with a regression test. `/document-generate` found no stale doc claims — no doc documents `validate-zip.sh`'s failure modes, and no AI-facing grammar changed.

No 7A question was required: nothing here extends the issue's recorded decision.