### PR TITLE
v0.16.76 fix: #home-cta inline grid overflows the viewport between 768px and ~912px (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.76] — 2026-07-11 — the homepage closing CTA no longer scrolls the page sideways on a tablet (#258)
+
+**A `cta` with `layout: "inline"` and the id `home-cta` pushed the page horizontally off screen on every viewport from 768px to about 912px. The two-column grid switches on at 768px, but the columns it asked for could not fit in the space that breakpoint actually leaves: 36rem for the headline, 18rem for the action copy and a gap of at least 3rem, against a content box of roughly 40rem. Those were floors, not preferences, so the grid could not shrink and the page scrolled instead. The columns are now allowed to shrink, and the shipped homepage fits at every width.**
+
+The arithmetic that made this invisible is worth naming, because the same trap is set for any component that turns a grid on at a breakpoint. The viewport is not the space the grid gets. By the time the tracks are laid out, `.container` has taken its padding from both sides (and at 768px that padding widens, from `--space-md` to `--space-lg`), and `.cta__inner` has taken its own `clamp(2rem, 4vw, 2.6rem)` of padding plus a border. What is left at the 768px breakpoint is about 40rem. The old tracks demanded about 57rem. A track whose minimum is a fixed length cannot go below it, so the overflow was not a rounding error, it was the layout doing exactly what it was told.
+
+The fix gives each column a minimum it can actually honor. The action column now floors at the width of the button itself, which is the one thing in that column that refuses to get narrower, so the button can never overflow the track it lives in. The headline column floors at zero and takes what remains. On desktop nothing moves: the headline and the body copy already cap themselves well before the tracks stop growing, so the two-column composition renders as it did before.
+
+Two related defects found while fixing this are filed rather than folded in, because they are separate pre-existing bugs: the shared rule behind `#how-cta`, `#agencies-cta` and `#implementers-cta` overflows the same way (#265), and a CTA button label with no place to break still outgrows its column (#266).
+
+### Fixed
+
+- `#home-cta` with `layout: "inline"` no longer scrolls the page horizontally between 768px and ~912px. Its grid tracks are now `minmax(0, 2fr) minmax(14.75rem, 1fr)` instead of `minmax(36rem, 40rem) minmax(18rem, 1fr)`, so the grid fits the content box the breakpoint provides. The desktop two-column composition is unchanged (#258).
+
+### Tests
+
+- Seven rendered end-to-end cases assert the page does not scroll sideways at 768px, 800px, 860px, 912px and 1024px, and cover a headline whose longest word cannot wrap and a button label long enough to need wrapping. Reverting the CSS turns six of them red.
+- Three stylesheet checks pin the parts the rendered proof silently depends on: the headline column floors at zero, the action column's floor is read from the button's own `min-width` rather than hardcoded, and `base.css` still lets a long word break (without it, a 0-floored column would let the word paint outside the layout and scroll the page anyway).
+
 ## [v0.16.75] — 2026-07-11 — the packaging gate now reads the archive's payload, not just its table of contents (#261)
 
 **A release ZIP whose compressed data was damaged used to pass validation and ship. Every check `scripts/package.sh` ran — the style.css membership test, the top-level-directory test, the size test — read only the archive's central directory, which is its table of contents. Corrupt the payload and leave the index intact and the build validated clean, uploaded itself as a release asset, and failed for the first time in someone's WordPress install. `scripts/validate-zip.sh` now inflates and CRC-checks the payload before a build is allowed out.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.75-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.76-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2184,8 +2184,32 @@
 
 /* Homepage closing CTA headline fix: title-left, action copy-right on desktop. */
 @media (min-width: 768px) {
+  /* Both tracks must be able to SHRINK, because this grid turns on at 768px but the
+     content box it gets there is far narrower than the viewport: the container eats
+     2 * var(--space-lg) (its padding switches to --space-lg at this same 768px
+     breakpoint, utilities.css), and .cta__inner itself eats 2 * clamp(2rem, 4vw, 2.6rem)
+     of padding plus its 1px border (see the .cta__inner rule further down). At 768px that
+     leaves roughly 40rem, so the old fixed floors (36rem + 18rem + a 3rem gap = 57rem)
+     could not fit and the section scrolled the page sideways from 768px through ~912px
+     (issue 258). The E2E cases pin the rendered page width across that band.
+
+     Column 2's floor is the button's own min-width (14.75rem — the four-CTA button rule
+     below re-declares it and wins over the earlier 15.5rem), so the button can never
+     overflow its track. Keep the two in step. Column 1 is 0-floored and fractional, so it
+     absorbs whatever is left. The desktop composition is unchanged in practice because
+     .cta__title and .cta__body already cap themselves (max-width 40rem / 22rem) long
+     before the tracks stop growing.
+
+     Two separate mechanisms, easy to conflate: the `0` min sizing function is what lets
+     the TRACK size below the title's min-content (a `minmax(0, ...)` track's minimum is a
+     fixed 0, so a grid item's `min-width: auto` cannot hold it open). That alone would
+     still leave a long unbreakable headline word PAINTING outside the narrowed column and
+     scrolling the page. What keeps the word inside the column is base.css's
+     `overflow-wrap: break-word` on `p, h1..h6`, which lets it wrap mid-word. Both are
+     load-bearing: at 768px, forcing `overflow-wrap: normal` on the title puts ~97px back
+     outside the viewport. The E2E long-word case guards that cross-file dependency. */
   #home-cta.cta--inline .cta__inner {
-    grid-template-columns: minmax(36rem, 40rem) minmax(18rem, 1fr);
+    grid-template-columns: minmax(0, 2fr) minmax(14.75rem, 1fr);
     column-gap: clamp(3rem, 6vw, 5.5rem);
     row-gap: 0;
     align-items: center;

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.75');
+define('PP_VERSION', '0.16.76');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.75",
+  "version": "0.16.76",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.75
+Stable tag: 0.16.76
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.75
+Version:          0.16.76
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -230,10 +230,10 @@ test.describe('Safe-surface rendered proof', () => {
   // the title.
   //
   // 768px is covered to prove the placement rules take effect the moment the media
-  // query matches, not to prove the section fits there — it does not. The #home-cta
-  // track (minmax(36rem, 40rem) + minmax(18rem, 1fr) + a >=3rem gap) needs ~57rem, so
-  // the grid overflows the viewport between 768px and ~912px. That overflow predates
-  // this fix and is tracked separately; asserting against it here would pin a bug.
+  // query matches. It now also FITS there: #258 replaced the old fixed track floors
+  // (minmax(36rem, 40rem) + minmax(18rem, 1fr), which needed ~57rem the 768px
+  // breakpoint never had) with shrinkable ones. The overflow those floors caused is
+  // asserted against directly by the #258 block below.
   const ctaEyebrowViewports = [
     { label: 'desktop', width: 1280, height: 900 },
     { label: 'breakpoint', width: 768, height: 900 },
@@ -366,5 +366,144 @@ test.describe('Safe-surface rendered proof', () => {
     const eyebrowCenter = eyebrowBox.x + eyebrowBox.width / 2;
     const innerCenter = innerBox.x + innerBox.width / 2;
     expect(Math.abs(eyebrowCenter - innerCenter)).toBeLessThan(2);
+  });
+
+  /*
+   * #258: the inline CTA grid turns on at 768px, but the old track floors
+   * (minmax(36rem, 40rem) + minmax(18rem, 1fr) + a >=3rem gap = ~57rem) could not fit
+   * in the content box that breakpoint actually provides — the container's padding and
+   * .cta__inner's own clamp(2rem, 4vw, 2.6rem) padding + border leave roughly 40rem at
+   * 768px. The grid could not shrink, so it pushed the page sideways.
+   *
+   * Measured on THIS page with the fix reverted (documentElement.scrollWidth): 768px ->
+   * 977, 800px -> 977, 860px -> 983, 912px -> 983, 1024px -> fits. So 768..912 are the
+   * cases that actually catch the regression; 1024 is carried as the clean upper edge, to
+   * fail if a future change ever widens the band into it rather than to prove today's bug.
+   *
+   * A page that scrolls sideways is the whole bug, so assert exactly that, at the widths
+   * that used to fail. scrollWidth is rounded up to an integer, so allow 1px of slack
+   * rather than pinning a fractional layout.
+   */
+  const ctaOverflowViewports = [768, 800, 860, 912, 1024];
+
+  for (const width of ctaOverflowViewports) {
+    // One @smoke case at the worst-overflowing width, so the post-merge main run (which
+    // executes only the @smoke subset) still watches for the sideways scroll.
+    const smoke = width === 768 ? ' @smoke' : '';
+
+    test(`#258 the inline cta does not scroll the page sideways at ${width}px${smoke}`, async ({
+      page,
+    }) => {
+      pageId = createPage(`E2E CTA Overflow ${width}`);
+      setComposition(pageId, [
+        {
+          component: 'cta',
+          props: {
+            // The overflowing track override is scoped to #home-cta.
+            id: 'home-cta',
+            layout: 'inline',
+            title: 'A deliberately long closing headline that widens the title column',
+            text: 'Supporting copy that occupies the right-hand column of the grid.',
+            eyebrow: 'BETA',
+            button_text: 'Get started',
+            button_url: '/start',
+          },
+        },
+      ]);
+
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator('.cta__inner')).toBeVisible({ timeout: 10000 });
+
+      // "No overflow" is also true of a page where the rule under test never applied at
+      // all — if the component stopped emitting id="home-cta", or the media query moved,
+      // the grid would quietly fall back to the flex column and every assertion below
+      // would still pass while guarding nothing. Prove the two-column grid is live first.
+      const tracks = await page.evaluate(
+        () => getComputedStyle(document.querySelector('.cta__inner')!).gridTemplateColumns,
+      );
+      expect(tracks.split(/\s+/).filter(Boolean)).toHaveLength(2);
+
+      const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+      expect(scrollWidth).toBeLessThanOrEqual(width + 1);
+    });
+  }
+
+  /*
+   * The fix floors column 1 at 0 (`minmax(0, 2fr)`), which only lets the track shrink
+   * because base.css declares `overflow-wrap: break-word` — that collapses the title's
+   * min-content size. A grid item's `min-width: auto` otherwise resolves to min-content
+   * and holds the track open regardless of the 0 floor, which would bring the sideways
+   * scroll straight back for any headline containing a long unbreakable word.
+   *
+   * That dependency is invisible in the CTA's own rules, so pin the behavior rather than
+   * the declaration: a headline that cannot wrap at a space must still not scroll the
+   * page. Guards a future edit to base.css, not just to this component.
+   */
+  test('#258 a long unbreakable headline word still does not scroll the page sideways', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E CTA Overflow Long Word');
+    setComposition(pageId, [
+      {
+        component: 'cta',
+        props: {
+          id: 'home-cta',
+          layout: 'inline',
+          title: 'Internationalisierungszusammenarbeitsvereinbarung',
+          text: 'Supporting copy that occupies the right-hand column of the grid.',
+          button_text: 'Get started',
+          button_url: '/start',
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 768, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+    await expect(page.locator('.cta__inner')).toBeVisible({ timeout: 10000 });
+
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(769);
+  });
+
+  /*
+   * Column 2's floor IS the button's min-width, which is the only reason the button can
+   * never overflow its own track. (The exact value is derived from the stylesheet by the
+   * css-lint pin rather than restated here, so the two cannot drift apart.) That holds
+   * because the button wraps its label (`white-space: normal`) instead of growing past
+   * the floor. A `white-space: nowrap` added to .cta__button would make a long label
+   * widen the track and reopen the overflow, with every other pin here still green.
+   */
+  test('#258 a long button label wraps instead of widening the action column', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E CTA Overflow Long Button');
+    setComposition(pageId, [
+      {
+        component: 'cta',
+        props: {
+          id: 'home-cta',
+          layout: 'inline',
+          title: 'A deliberately long closing headline that widens the title column',
+          text: 'Supporting copy that occupies the right-hand column of the grid.',
+          button_text: 'Start your free 30-day trial now, no card required',
+          button_url: '/start',
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 768, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const button = page.locator('.cta__button');
+    await expect(button).toBeVisible({ timeout: 10000 });
+
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(769);
+
+    // The button stayed inside .cta__inner's content box rather than pushing through it.
+    const buttonBox = (await button.boundingBox())!;
+    const innerBox = (await page.locator('.cta__inner').boundingBox())!;
+    expect(buttonBox.x + buttonBox.width).toBeLessThanOrEqual(innerBox.x + innerBox.width + 1);
   });
 });

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -716,6 +716,101 @@ describe('CSS lint: cta eyebrow is a pill above the title (#255)', () => {
     });
 });
 
+/*
+ * #258: the inline CTA grid activates at 768px, but the content box it gets there is
+ * only ~40rem — the container's padding plus .cta__inner's own clamp(2rem, 4vw, 2.6rem)
+ * padding and border come out of the viewport first. The old floors demanded
+ * 36rem + 18rem + a >=3rem gap = ~57rem, so the grid could not shrink and scrolled the
+ * page sideways from 768px to ~1030px.
+ *
+ * The rendered proof lives in the E2E suite (scrollWidth <= viewport). These pins guard
+ * the two structural properties that proof silently depends on, and that a later edit
+ * could break while the CSS still looked reasonable.
+ */
+describe('CSS lint: the inline cta grid can shrink to its breakpoint (#258)', () => {
+    const DESKTOP = '(min-width: 768px)';
+    const INNER = '#home-cta.cta--inline .cta__inner';
+
+    function columnsFor(selector, media) {
+        const decls = rulesMatching('.cta__inner')
+            .filter(r => r.media === media && r.selectors.includes(selector))
+            .map(r => /grid-template-columns\s*:\s*([^;}]+)/.exec(r.body))
+            .filter(Boolean);
+        return decls.length ? decls[decls.length - 1][1].trim() : null;
+    }
+
+    // Read the LAST declaration, i.e. the cascade winner: .cta__inner's tracks are set by
+    // the shared four-CTA block AND re-set by the #home-cta override after it. A pin that
+    // matched the first hit would keep passing while a later rule reintroduced fixed floors.
+    const columns = () => columnsFor(INNER, DESKTOP);
+
+    /*
+     * The whole fix. A track whose MIN is a fixed length cannot shrink below it, which is
+     * precisely how the bug worked. Column 1 must therefore floor at 0, and column 2 may
+     * only floor at the button's min-width (below).
+     */
+    test('column 1 floors at 0 so the grid can shrink below its content', () => {
+        expect(columns()).toMatch(/^minmax\(\s*0\s*,/);
+    });
+
+    /*
+     * Column 2's floor is not an arbitrary number — it is .cta__button's min-width. The
+     * button is the one item in that column that refuses to get narrower, so if the floor
+     * ever drops below the button's min-width the button overflows its own track and the
+     * page scrolls sideways again. Derive both from the stylesheet and compare, so moving
+     * either one without the other fails here instead of in someone's browser.
+     */
+    test('column 2 floors at exactly the cta button min-width', () => {
+        // The cascade winner AT THE BREAKPOINT, which is not simply the last unscoped
+        // rule: #home-cta .cta__button is declared min-width twice outside any media
+        // query, and a `@media (min-width: 768px)` rule for these buttons already exists.
+        // A min-width added to that media rule would beat both base declarations exactly
+        // where this grid is live, so consider unscoped and desktop rules together and
+        // take the last. Reading only the unscoped rules would compare the track floor
+        // against a value the browser no longer uses, and pass while the button overflows.
+        const buttonMinWidth = rulesMatching('.cta__button')
+            .filter(r => (r.media === null || r.media === DESKTOP)
+                && r.selectors.includes('#home-cta .cta__button'))
+            .map(r => /min-width\s*:\s*([^;}]+)/.exec(r.body))
+            .filter(Boolean)
+            .pop();
+
+        expect(buttonMinWidth).toBeTruthy();
+
+        const floor = /minmax\(\s*([^,]+),[^)]*\)\s*$/.exec(columns());
+        expect(floor).toBeTruthy();
+        expect(floor[1].trim()).toBe(buttonMinWidth[1].trim());
+    });
+
+    /*
+     * The 0 floor shrinks the TRACK, but it does not make the title's text fit inside it:
+     * a long unbreakable word would simply paint outside the narrowed column and scroll
+     * the page anyway. base.css's `overflow-wrap: break-word` on `p, h1..h6` is what lets
+     * the word wrap mid-word instead (measured: forcing `overflow-wrap: normal` on the
+     * title at 768px puts ~97px back outside the viewport). Nothing in components.css says
+     * so, so a base.css edit could reopen #258 from a distance. The E2E long-word case
+     * proves the render; this pin names the cross-file dependency.
+     */
+    test('the title can still break a long word (base.css keeps the 0 floor effective)', () => {
+        // Scoped, not a file-wide substring search: `overflow-wrap: break-word` narrowed
+        // to some unrelated selector would leave a bare /break-word/ match green while the
+        // CTA title regained a min-content floor — the exact edit that reopens #258. The
+        // title renders as an <h2> and the body as a <p>, so assert the rule that actually
+        // covers them still carries the declaration.
+        const wrapping = stripComments(BASE_CSS)
+            .split('}')
+            .map(chunk => chunk.split('{'))
+            .filter(([, body]) => body && /overflow-wrap\s*:\s*break-word/.test(body))
+            .map(([selectors]) => selectors.split(',').map(s => s.trim()));
+
+        expect(wrapping.length).toBeGreaterThan(0);
+
+        const covered = wrapping.flat();
+        expect(covered).toContain('h2');
+        expect(covered).toContain('p');
+    });
+});
+
 describe('CSS lint: no raw hex in components.css', () => {
     test('components.css has no raw hex color values', () => {
         const stripped = stripComments(COMPONENTS_CSS);


### PR DESCRIPTION
Closes #258

## The bug

A `cta` with `layout: "inline"` and `id: "home-cta"` (the shipped homepage) scrolled the page horizontally on every viewport from 768px through ~912px.

The two-column grid activates at 768px, but the tracks it declared could not fit the content box that breakpoint actually provides:

```css
/* before */
grid-template-columns: minmax(36rem, 40rem) minmax(18rem, 1fr);
column-gap: clamp(3rem, 6vw, 5.5rem);
```

Minimum demanded: `36rem + 18rem + 3rem` = **~57rem**. Available at 768px: **~40rem**, because `.container` takes its padding from both sides (and that padding *widens* to `--space-lg` at this same 768px breakpoint), and `.cta__inner` takes its own `clamp(2rem, 4vw, 2.6rem)` padding plus a 1px border. Those track values are floors, not preferences, so the grid could not shrink and pushed the page sideways instead.

> Note: the issue estimated the band ended at ~912px from the track arithmetic alone. Measured on the real rendered page, that estimate was right: `documentElement.scrollWidth` was 977 at 768px, 983 at 912px, and clean by 1024px.

## The fix

`assets/css/components.css` — one declaration:

```css
/* after */
grid-template-columns: minmax(0, 2fr) minmax(14.75rem, 1fr);
```

- **Column 2 floors at `14.75rem`** — the button's own `min-width`, and the one thing in that column that refuses to get narrower. Tying the floor to it means the button can never overflow its own track. (`14.75rem` is the cascade winner: `components.css:3026` re-declares it over an earlier `15.5rem`.)
- **Column 1 floors at `0`** and absorbs what is left, so the grid fits.
- **Desktop is unchanged.** `.cta__title` and `.cta__body` already cap themselves (`max-width: 40rem` / `22rem`) long before the tracks stop growing, so the two-column composition renders as before.

A subtlety the tests pin: `minmax(0, …)` shrinks the *track*, but it does not make the text fit inside it. A long unbreakable word would still paint outside the narrowed column and scroll the page. `base.css`'s `overflow-wrap: break-word` on `p, h1..h6` is the load-bearing second half. Measured: forcing `overflow-wrap: normal` on the title at 768px puts ~97px back outside the viewport.

## Validation

| Suite | Result |
|---|---|
| PHP (`./vendor/bin/phpunit --configuration phpunit.xml`) | **1482 passed** |
| JS (`npm test`) | **471 passed** |
| E2E (Playwright + wp-env, WordPress 7.0) | **69 passed** |

Rendered page width equals the viewport at 375, 700, 768, 800, 860, 912, 1024, 1280 and 1440px.

**The tests fail on revert.** Reverting only the CSS declaration turns **6 of the 7** new E2E cases red (`scrollWidth` 977 at a 768px viewport) and 2 of the 3 stylesheet pins. They guard the bug rather than restate the implementation.

### Tests added

- **7 rendered E2E cases** (`tests/e2e/style-render.spec.ts`): no horizontal scroll at 768/800/860/912/1024px, plus a headline whose longest word cannot wrap and a button label long enough to need wrapping. Each also asserts the two-column grid is actually live, so they cannot pass vacuously if the selector stops matching.
- **3 stylesheet pins** (`tests/js/css-lint.test.js`): column 1 floors at 0; column 2's floor is *derived from the button's `min-width` in the stylesheet* rather than hardcoded, so moving one without the other fails CI; and `base.css` still lets a long word break.

## Scope

The issue's recorded gate decision was to keep the fix narrow and browser-verified. No accepted behavior or public surface changed: the `cta` schema, props, layouts and design tokens are untouched (the diff adds and removes zero CSS custom properties), so no AI-facing docs needed updating. No 7A question arose.

## Accepted limitations (filed, not fixed)

Both are pre-existing and out of scope for #258's "keep the fix narrow" decision:

- **#265** — the shared four-CTA rule (`components.css:1523`) overflows the same way for `#how-cta`, `#agencies-cta` and `#implementers-cta` (measured +140px at 768px). Different pages, same bug class.
- **#266** — a CTA button label with no break opportunities still outgrows its column (a 48-char unbreakable token overflows by 46px). Surfaced by the adversarial review pass.

## Reviews

`/plan-eng-review` (clean), `/review` (clean, quality 9.5, testing + maintainability specialists), Codex adversarial pass, and `/document-generate` (no doc claims invalidated) all ran this session against this diff. Codex correctly caught that my original comment misstated *why* the fix works; the mechanism was re-verified in a browser and the comment rewritten.