### PR TITLE
v0.16.77 fix: home-cta full-width layout centers body/button (#257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.77] — 2026-07-11 — the full-width closing CTA now centers its copy and button instead of splitting them to opposite edges (#257)
+
+**A `cta` with the id `home-cta` in its default `full-width` layout rendered broken on desktop: the body copy was jammed against the right edge and the button against the left, while the eyebrow and headline stayed centered above them. The block read as misassembled rather than composed. It now centers all of its content, as a full-width call-to-action should.**
+
+The cause was a set of alignment rules that were only ever meant for the other CTA layout. At 768px and up, `home-cta` in `inline` layout becomes a two-column grid, and its body and button carry `align-self` values that place them within that grid. Those declarations were written without the `inline` scope, so they also reached the default `full-width` layout, where the same block is a centered vertical stack, not a grid. In a vertical stack `align-self` controls the horizontal axis, so "place at the grid's end" became "shove to the right edge" and "place at the grid's start" became "shove to the left edge". The fix scopes those two declarations to the inline layout. In `full-width` the body and button now fall back to the stack's own centering, matching the eyebrow and title.
+
+Every shipped page uses the inline layout, where these rules were always correct, so no live page changed. The bug only appeared for an author who set `id: home-cta` with the default layout, which is now what the release gate guards against.
+
+### Fixed
+
+- A `full-width` `cta` with `id: home-cta` now centers its body copy and button at 768px and up, instead of flushing the body to the right edge and the button to the left. The `align-self` declarations that position those elements in the `inline` grid are now scoped to the inline layout and no longer leak into the default full-width stack (#257).
+
+### Tests
+
+- A rendered end-to-end case pins the full-width `home-cta` body and button centered within the block at 1280px; reverting the CSS pushes them back to opposite edges and turns it red.
+- Stylesheet checks assert the leaking `align-self` values (`start`/`end`, and the `flex-end` synonym) never sit on a bare `#home-cta` selector, that the inline layout keeps its intended placement, and that the two-column grid the inline rules describe is still present.
+
 ## [v0.16.76] — 2026-07-11 — the homepage closing CTA no longer scrolls the page sideways on a tablet (#258)
 
 **A `cta` with `layout: "inline"` and the id `home-cta` pushed the page horizontally off screen on every viewport from 768px to about 912px. The two-column grid switches on at 768px, but the columns it asked for could not fit in the space that breakpoint actually leaves: 36rem for the headline, 18rem for the action copy and a gap of at least 3rem, against a content box of roughly 40rem. Those were floors, not preferences, so the grid could not shrink and the page scrolled instead. The columns are now allowed to shrink, and the shipped homepage fits at every width.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.76-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.77-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2236,10 +2236,12 @@
      row 1 is exactly the eyebrow's height, so there is no free space to align within
      — and is kept to state the intent for a row that ever grows taller.
 
-     Do NOT "tidy" this selector to match the bare #home-cta siblings below. They are
-     bare only because grid-row is safely inert in the full-width flex column; their
-     own align-self declarations DO leak into it, which is a separate pre-existing
-     bug, not a pattern to copy. */
+     The bare #home-cta siblings below keep their grid-column/grid-row/justify-self
+     bare: those three are safely inert on a flex item, so they describe the inline
+     grid without disturbing the full-width flex column. Their align-self, which is
+     NOT inert on a flex item, is scoped to .cta--inline for the same reason this
+     selector is (issue 257) — a bare align-self:end/start leaked into the full-width
+     column and shoved the body and button to opposite edges. */
   #home-cta.cta--inline .cta__eyebrow {
     grid-column: 1;
     grid-row: 1;
@@ -2261,13 +2263,26 @@
     grid-row: 2;
     max-width: 22rem;
     margin: 0 0 1.15rem;
-    align-self: end;
   }
 
   #home-cta .cta__button {
     grid-column: 2;
     grid-row: 3;
     justify-self: start;
+  }
+
+  /* align-self is the one placement declaration that is NOT inert on a flex item,
+     so it is scoped to the inline grid. In the default full-width layout .cta__inner
+     stays a flex COLUMN whose cross axis is horizontal; a bare align-self:end/start
+     here shoved the body to the right edge and the button to the left while the
+     eyebrow and title stayed centered (issue 257). Left bare, they leak; scoped, the
+     full-width body falls back to .cta--full-width .cta__inner's align-items:center and
+     the button to the shared four-CTA rule's align-self:center just above. */
+  #home-cta.cta--inline .cta__body {
+    align-self: end;
+  }
+
+  #home-cta.cta--inline .cta__button {
     align-self: start;
   }
 }

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.76');
+define('PP_VERSION', '0.16.77');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.76",
+  "version": "0.16.77",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.76
+Stable tag: 0.16.77
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.76
+Version:          0.16.77
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -368,6 +368,55 @@ test.describe('Safe-surface rendered proof', () => {
     expect(Math.abs(eyebrowCenter - innerCenter)).toBeLessThan(2);
   });
 
+  // Same scope failure as #255, one row down. `#home-cta .cta__body { align-self: end }`
+  // and `#home-cta .cta__button { align-self: start }` are grid-cross-axis placement for
+  // the inline layout, but they were declared bare. `.cta__inner` is a flex COLUMN in the
+  // default full-width layout, where the cross axis is horizontal — so align-self:end
+  // shoved the body to the right edge and align-self:start shoved the button to the left,
+  // while the eyebrow and title stayed centered. The fix scopes both to `.cta--inline`; in
+  // full-width the body falls back to `.cta--full-width .cta__inner`'s align-items:center
+  // and the button to the shared four-CTA rule's align-self:center. Both end up centered.
+  test('#257 the full-width cta centers its body and button (fix stays scoped) @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E CTA Full Width Centering');
+    setComposition(pageId, [
+      {
+        component: 'cta',
+        props: {
+          id: 'home-cta',
+          layout: 'full-width',
+          title: 'A deliberately long closing headline for the full width layout',
+          text: 'Supporting copy that sits below the headline in the full-width layout.',
+          button_text: 'Get started',
+          button_url: '/start',
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const body = page.locator('.cta__body');
+    const button = page.locator('.cta__button');
+    await expect(body).toBeVisible({ timeout: 10000 });
+    await expect(button).toBeVisible();
+
+    const bodyBox = (await body.boundingBox())!;
+    const buttonBox = (await button.boundingBox())!;
+    const innerBox = (await page.locator('.cta__inner').boundingBox())!;
+    const innerCenter = innerBox.x + innerBox.width / 2;
+
+    // Both boxes are narrower than .cta__inner (body caps at 22rem, the button at its
+    // fit-content width), so "centered" is a real constraint: the regression renders the
+    // body hard against the right edge (x+width ~ inner right) and the button hard against
+    // the left (x ~ inner left). Assert the centers line up instead.
+    const bodyCenter = bodyBox.x + bodyBox.width / 2;
+    const buttonCenter = buttonBox.x + buttonBox.width / 2;
+    expect(Math.abs(bodyCenter - innerCenter)).toBeLessThan(2);
+    expect(Math.abs(buttonCenter - innerCenter)).toBeLessThan(2);
+  });
+
   /*
    * #258: the inline CTA grid turns on at 768px, but the old track floors
    * (minmax(36rem, 40rem) + minmax(18rem, 1fr) + a >=3rem gap = ~57rem) could not fit

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -811,6 +811,83 @@ describe('CSS lint: the inline cta grid can shrink to its breakpoint (#258)', ()
     });
 });
 
+/*
+ * #257: the full-width cta centers its body and button.
+ *
+ * `#home-cta .cta__text` is `display: contents` at >=768px, but the grid it feeds is
+ * `.cta--inline` only. `layout` defaults to 'full-width', where `.cta__inner` stays a
+ * flex COLUMN (align-items: center). grid-column/grid-row/justify-self are all inert on
+ * a flex item, so they are safe to declare bare — but `align-self` is NOT. A bare
+ * `#home-cta .cta__body { align-self: end }` and `#home-cta .cta__button { align-self:
+ * start }` therefore leaked into the full-width column and shoved the body to the right
+ * edge and the button to the left, while the eyebrow and title stayed centered.
+ *
+ * The fix scopes those two `align-self` declarations to `#home-cta.cta--inline`. The
+ * rendered proof (both boxes centered within .cta__inner) lives in the E2E suite; these
+ * pins guard the scope, which a later edit could quietly widen back to bare #home-cta.
+ */
+describe('CSS lint: the full-width cta centers its body and button (#257)', () => {
+    const DESKTOP = '(min-width: 768px)';
+
+    // The cross-axis values a flex column reads as horizontal placement. The shared
+    // four-CTA block legitimately sets `align-self: center` / `flex-start` on these same
+    // classes (centered / left in BOTH layouts), so a blanket "no align-self bare" pin
+    // would be wrong. `start` / `end` — the grid-cross-axis values that break the
+    // full-width column — must never sit on a bare #home-cta selector, and neither may
+    // `flex-end` (its column-axis synonym for `end`, which nothing here uses legitimately).
+    // `flex-start` is deliberately NOT in this set: the shared block declares it bare at
+    // the base breakpoint, so banning it would flag correct, pre-existing CSS.
+    const LEAK = /align-self\s*:\s*(?:start|end|flex-end)\b/;
+
+    test('no bare #home-cta body/button rule sets align-self:start or :end', () => {
+        ['.cta__body', '.cta__button'].forEach(cls =>
+            rulesMatching(cls)
+                .filter(r => LEAK.test(r.body))
+                .forEach(r =>
+                    r.selectors
+                        .filter(s => s.includes('#home-cta') && s.includes(cls))
+                        .forEach(s => expect(s).toContain('.cta--inline'))
+                )
+        );
+    });
+
+    // The positive half: the inline grid still gets its intended placement. Deleting the
+    // scoped rule would center the inline body/button too, silently undoing the grid
+    // layout while the leak guard above stayed green (nothing bare, nothing to catch).
+    function scopedAlignSelf(cls) {
+        const decls = rulesMatching(cls)
+            .filter(r => r.media === DESKTOP
+                && r.selectors.includes(`#home-cta.cta--inline ${cls}`))
+            .map(r => /align-self\s*:\s*([^;}]+)/.exec(r.body))
+            .filter(Boolean);
+        return decls.length ? decls[decls.length - 1][1].trim() : null;
+    }
+
+    test('the inline body keeps align-self:end, scoped to .cta--inline', () => {
+        expect(scopedAlignSelf('.cta__body')).toBe('end');
+    });
+
+    test('the inline button keeps align-self:start, scoped to .cta--inline', () => {
+        expect(scopedAlignSelf('.cta__button')).toBe('start');
+    });
+
+    // The bare rules still describe the inline grid (grid-column:2). If the grid
+    // placement is gone, the scoped align-self pins above still pass while describing a
+    // layout that no longer exists.
+    function bareDecl(cls, prop) {
+        const decls = rulesMatching(cls)
+            .filter(r => r.media === DESKTOP && r.selectors.includes(`#home-cta ${cls}`))
+            .map(r => new RegExp(prop + '\\s*:\\s*([^;}]+)').exec(r.body))
+            .filter(Boolean);
+        return decls.length ? decls[decls.length - 1][1].trim() : null;
+    }
+
+    test('the bare desktop body/button rules keep their grid column', () => {
+        expect(bareDecl('.cta__body', 'grid-column')).toBe('2');
+        expect(bareDecl('.cta__button', 'grid-column')).toBe('2');
+    });
+});
+
 describe('CSS lint: no raw hex in components.css', () => {
     test('components.css has no raw hex color values', () => {
         const stripped = stripComments(COMPONENTS_CSS);


### PR DESCRIPTION
Closes #257

## Scope

Fixes the default `full-width` layout of `cta` with `id: home-cta`. At >=768px the body copy was flushed to the right edge and the button to the left, while the eyebrow and title stayed centered, so the block read as broken.

Root cause: two `align-self` declarations that place the body/button inside the `inline` layout's two-column grid (`#home-cta .cta__body { align-self: end }`, `#home-cta .cta__button { align-self: start }`) were declared bare inside a `@media (min-width: 768px)` block. In the default `full-width` layout `.cta__inner` stays a flex COLUMN (`.cta--full-width .cta__inner { align-items: center }`), where the cross axis is horizontal, so those values leaked in and shoved the two elements to opposite edges.

Fix (per the recorded gate decision, kept narrow): scope only the two `align-self` declarations to `#home-cta.cta--inline`. `grid-column`/`grid-row`/`justify-self`/`max-width`/`margin` stay on the bare selectors (the first three are inert on a flex item; `max-width`/`margin` are load-bearing in full-width). In full-width the body now falls back to `.cta--full-width .cta__inner`'s `align-items: center` and the button to the shared four-CTA rule's `align-self: center`.

## Files

- `assets/css/components.css` — split the two rules; scope `align-self` to `.cta--inline`; comment updated.
- `tests/e2e/style-render.spec.ts` — `@smoke` E2E pin: full-width `home-cta` body + button centered within `.cta__inner` at 1280px.
- `tests/js/css-lint.test.js` — stylesheet pins: leaking `start`/`end`/`flex-end` never bare on `#home-cta`; inline layout keeps scoped `align-self`; bare rules keep the two-column grid.

## Validation

- `npm test` (vitest): 475 passed (16 files), including 4 new #257 css-lint pins.
- `./vendor/bin/phpunit`: 1482 passed (3 warnings / 2 deprecations are the pre-existing baseline).
- `bash scripts/package.sh`: version consistency OK across the five synced files at 0.16.77; built zip deleted (CI builds releases from tags).
- E2E (Playwright/wp-env) not run locally; the new case is `@smoke`, so it runs in the post-merge WordPress 7.0 E2E job.

## Reviews

- `/plan-eng-review`: clean (1 code-quality finding folded).
- `/review` + adversarial (Claude subagent) + Codex outside voice: cascade fix verified correct; 2 within-decision findings applied (comment accuracy; broadened the css-lint leak regex to include `flex-end`).
- No rule-4 / 7A questions arose; the fix matches the recorded decision exactly and expands no accepted behavior or public surface.

## Accepted limitations

- The css-lint leak pin deliberately does not ban bare `align-self: flex-start` on `#home-cta` selectors, because the shared four-CTA block uses it legitimately at the base breakpoint.
