### PR TITLE
v0.16.78 fix: shared inline-CTA grid overflow on how/agencies/implementers CTAs (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.78] — 2026-07-11 — the other three inline CTAs no longer scroll the page sideways on a tablet (#265)
+
+**A `cta` with `layout: "inline"` and the id `how-cta`, `agencies-cta`, or `implementers-cta` pushed the page horizontally off screen from 768px to about 912px, exactly as `home-cta` did before v0.16.76. The two-column grid switches on at 768px, but the columns it asked for (32.5rem for the headline, 14rem for the action copy, and a gap of at least 3rem) could not fit in the roughly 40rem the breakpoint actually leaves. Those were floors, not preferences, so the grid could not shrink and the page scrolled. The columns are now allowed to shrink, and pages using any of the three inline CTA ids fit at every width.**
+
+`home-cta` was fixed in v0.16.76 (#258), but its fix lives in an id-specific override that the other three CTAs never reach. They are sized by the shared four-CTA rule, which still carried the same fixed track floors. The fix floors the headline column at zero (fractional, so it absorbs the slack) and floors the action column at the button's own min-width (14.75rem), the one thing in that column that refuses to get narrower, so the button can never overflow its track. `home-cta` re-sets these same tracks in its own override and is unaffected. On desktop nothing moves: the headline and body already cap themselves well before the tracks stop growing, so the two-column composition renders as before.
+
+### Fixed
+
+- A `cta` with `layout: "inline"` and the id `how-cta`, `agencies-cta`, or `implementers-cta` no longer scrolls the page sideways between 768px and ~912px. The shared four-CTA inline grid rule now uses shrinkable track floors (`minmax(0, 2fr) minmax(14.75rem, 1fr)`), mirroring the `home-cta` fix from #258 (#265).
+
+### Tests
+
+- The rendered end-to-end overflow check is now parametrized over all four inline CTA ids (`home-cta`, `how-cta`, `agencies-cta`, `implementers-cta`) across 768–1024px, with one `@smoke` case per id at the worst-overflowing width; reverting the CSS turns the three new ids red.
+- Stylesheet checks assert that the three shared-rule CTAs floor their first column at 0 and their second column at exactly the CTA button's min-width, so the two values cannot silently drift apart.
+
 ## [v0.16.77] — 2026-07-11 — the full-width closing CTA now centers its copy and button instead of splitting them to opposite edges (#257)
 
 **A `cta` with the id `home-cta` in its default `full-width` layout rendered broken on desktop: the body copy was jammed against the right edge and the button against the left, while the eyebrow and headline stayed centered above them. The block read as misassembled rather than composed. It now centers all of its content, as a full-width call-to-action should.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.77-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.78-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1525,7 +1525,19 @@
   #agencies-cta.cta--inline .cta__inner,
   #implementers-cta.cta--inline .cta__inner {
     display: grid;
-    grid-template-columns: minmax(32.5rem, 38rem) minmax(14rem, 1fr);
+    /* Both tracks must be able to SHRINK. This grid turns on at 768px, but the content
+       box it gets there is far narrower than the viewport (the container eats
+       2 * var(--space-lg) and .cta__inner eats 2 * clamp(2rem, 4vw, 2.6rem) padding plus
+       its border), leaving roughly 40rem. Fixed floors (32.5rem + 14rem + a >=3rem gap)
+       could not fit, so #how-cta / #agencies-cta / #implementers-cta scrolled the page
+       sideways from 768px through ~912px (issue 265 — the sibling of home-cta's 258 fix).
+       Column 1 floors at 0 and is fractional so it absorbs the slack; column 2 floors at
+       the button's own min-width (14.75rem, re-declared by the four-CTA button rule below)
+       so the button can never overflow its track. #home-cta re-sets these same tracks in
+       its own override further down and is unaffected. The 0 floor only works because
+       base.css's overflow-wrap:break-word lets a long title word wrap mid-word rather than
+       hold the track open. */
+    grid-template-columns: minmax(0, 2fr) minmax(14.75rem, 1fr);
     column-gap: clamp(3rem, 7vw, 6rem);
     align-items: center;
   }

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.77');
+define('PP_VERSION', '0.16.78');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.77",
+  "version": "0.16.78",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.77
+Stable tag: 0.16.78
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.77
+Version:          0.16.78
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -435,47 +435,57 @@ test.describe('Safe-surface rendered proof', () => {
    */
   const ctaOverflowViewports = [768, 800, 860, 912, 1024];
 
-  for (const width of ctaOverflowViewports) {
-    // One @smoke case at the worst-overflowing width, so the post-merge main run (which
-    // executes only the @smoke subset) still watches for the sideways scroll.
-    const smoke = width === 768 ? ' @smoke' : '';
+  // All four inline CTA ids share the same overflow class. #home-cta is sized by its own
+  // override (#258); #how-cta / #agencies-cta / #implementers-cta are sized by the shared
+  // four-CTA rule, which had the same fixed floors and scrolled the page sideways at
+  // tablet widths (#265). Parametrize over every id so the shared rule is proven too, not
+  // just the home override.
+  const ctaOverflowIds = ['home-cta', 'how-cta', 'agencies-cta', 'implementers-cta'];
 
-    test(`#258 the inline cta does not scroll the page sideways at ${width}px${smoke}`, async ({
-      page,
-    }) => {
-      pageId = createPage(`E2E CTA Overflow ${width}`);
-      setComposition(pageId, [
-        {
-          component: 'cta',
-          props: {
-            // The overflowing track override is scoped to #home-cta.
-            id: 'home-cta',
-            layout: 'inline',
-            title: 'A deliberately long closing headline that widens the title column',
-            text: 'Supporting copy that occupies the right-hand column of the grid.',
-            eyebrow: 'BETA',
-            button_text: 'Get started',
-            button_url: '/start',
+  for (const id of ctaOverflowIds) {
+    for (const width of ctaOverflowViewports) {
+      // One @smoke case per id at the worst-overflowing width, so the post-merge main run
+      // (which executes only the @smoke subset) still watches for the sideways scroll on
+      // every inline CTA, not only #home-cta.
+      const smoke = width === 768 ? ' @smoke' : '';
+
+      test(`#265 the #${id} inline cta does not scroll the page sideways at ${width}px${smoke}`, async ({
+        page,
+      }) => {
+        pageId = createPage(`E2E CTA Overflow ${id} ${width}`);
+        setComposition(pageId, [
+          {
+            component: 'cta',
+            props: {
+              // The overflowing track override / shared rule is scoped to these ids.
+              id,
+              layout: 'inline',
+              title: 'A deliberately long closing headline that widens the title column',
+              text: 'Supporting copy that occupies the right-hand column of the grid.',
+              eyebrow: 'BETA',
+              button_text: 'Get started',
+              button_url: '/start',
+            },
           },
-        },
-      ]);
+        ]);
 
-      await page.setViewportSize({ width, height: 900 });
-      await page.goto(`/?page_id=${pageId}`);
-      await expect(page.locator('.cta__inner')).toBeVisible({ timeout: 10000 });
+        await page.setViewportSize({ width, height: 900 });
+        await page.goto(`/?page_id=${pageId}`);
+        await expect(page.locator('.cta__inner')).toBeVisible({ timeout: 10000 });
 
-      // "No overflow" is also true of a page where the rule under test never applied at
-      // all — if the component stopped emitting id="home-cta", or the media query moved,
-      // the grid would quietly fall back to the flex column and every assertion below
-      // would still pass while guarding nothing. Prove the two-column grid is live first.
-      const tracks = await page.evaluate(
-        () => getComputedStyle(document.querySelector('.cta__inner')!).gridTemplateColumns,
-      );
-      expect(tracks.split(/\s+/).filter(Boolean)).toHaveLength(2);
+        // "No overflow" is also true of a page where the rule under test never applied at
+        // all — if the component stopped emitting the id, or the media query moved, the
+        // grid would quietly fall back to the flex column and every assertion below would
+        // still pass while guarding nothing. Prove the two-column grid is live first.
+        const tracks = await page.evaluate(
+          () => getComputedStyle(document.querySelector('.cta__inner')!).gridTemplateColumns,
+        );
+        expect(tracks.split(/\s+/).filter(Boolean)).toHaveLength(2);
 
-      const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
-      expect(scrollWidth).toBeLessThanOrEqual(width + 1);
-    });
+        const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+        expect(scrollWidth).toBeLessThanOrEqual(width + 1);
+      });
+    }
   }
 
   /*

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -812,6 +812,68 @@ describe('CSS lint: the inline cta grid can shrink to its breakpoint (#258)', ()
 });
 
 /*
+ * #265: the SHARED four-CTA inline grid rule can shrink to its breakpoint.
+ *
+ * #258 fixed only #home-cta, whose tracks are re-set by a #home-cta-specific override.
+ * #how-cta / #agencies-cta / #implementers-cta never reach that override — they are sized
+ * by the shared four-CTA rule, which had the same fixed floors (32.5rem + 14rem + gap) and
+ * scrolled the page sideways at 768..912px. The rendered proof lives in the E2E suite
+ * (scrollWidth <= viewport, now parametrized over all four ids); these pins guard the two
+ * structural properties that proof silently depends on for the shared-rule ids.
+ */
+describe('CSS lint: the shared inline cta grid can shrink to its breakpoint (#265)', () => {
+    const DESKTOP = '(min-width: 768px)';
+    // Every id NOT carrying a later same-selector override — i.e. the three sized only by
+    // the shared rule. #home-cta is excluded: its own override is the cascade winner and is
+    // already pinned by the #258 block above.
+    const SHARED_IDS = ['how-cta', 'agencies-cta', 'implementers-cta'];
+
+    function columnsFor(selector, media) {
+        const decls = rulesMatching('.cta__inner')
+            .filter(r => r.media === media && r.selectors.includes(selector))
+            .map(r => /grid-template-columns\s*:\s*([^;}]+)/.exec(r.body))
+            .filter(Boolean);
+        return decls.length ? decls[decls.length - 1][1].trim() : null;
+    }
+
+    for (const id of SHARED_IDS) {
+        const INNER = `#${id}.cta--inline .cta__inner`;
+        const columns = () => columnsFor(INNER, DESKTOP);
+
+        /*
+         * The whole fix: a fixed track minimum cannot shrink below itself, which is exactly
+         * how the bug worked. Column 1 must floor at 0 so the grid can shrink below its
+         * content at the 768px breakpoint.
+         */
+        test(`#${id} column 1 floors at 0 so the grid can shrink below its content`, () => {
+            expect(columns()).toMatch(/^minmax\(\s*0\s*,/);
+        });
+
+        /*
+         * Column 2's floor is not arbitrary — it is .cta__button's min-width. The button is
+         * the one item in that column that refuses to get narrower, so if the floor drops
+         * below the button min-width the button overflows its own track and the page scrolls
+         * sideways again. Derive both from the stylesheet and compare, so moving either one
+         * without the other fails here instead of in someone's browser.
+         */
+        test(`#${id} column 2 floors at exactly the cta button min-width`, () => {
+            const buttonMinWidth = rulesMatching('.cta__button')
+                .filter(r => (r.media === null || r.media === DESKTOP)
+                    && r.selectors.includes(`#${id} .cta__button`))
+                .map(r => /min-width\s*:\s*([^;}]+)/.exec(r.body))
+                .filter(Boolean)
+                .pop();
+
+            expect(buttonMinWidth).toBeTruthy();
+
+            const floor = /minmax\(\s*([^,]+),[^)]*\)\s*$/.exec(columns());
+            expect(floor).toBeTruthy();
+            expect(floor[1].trim()).toBe(buttonMinWidth[1].trim());
+        });
+    }
+});
+
+/*
  * #257: the full-width cta centers its body and button.
  *
  * `#home-cta .cta__text` is `display: contents` at >=768px, but the grid it feeds is


### PR DESCRIPTION
Closes #265

## Scope

Fixes the shared inline-CTA grid overflow on `#how-cta`, `#agencies-cta`, and `#implementers-cta` (the release-gate sibling of #258, which fixed only `#home-cta`).

- **CSS** (`assets/css/components.css`): the shared four-CTA `@media (min-width: 768px)` inline-grid rule changed from `minmax(32.5rem, 38rem) minmax(14rem, 1fr)` to `minmax(0, 2fr) minmax(14.75rem, 1fr)`. Column 1 floors at 0 and absorbs the slack; column 2 floors at the four-CTA button min-width (14.75rem, `components.css:3047`) so the button never overflows its track. `#home-cta` re-sets these tracks in its own later override and is unaffected. The desktop two-column composition is preserved.

Per each acceptance criterion of the recorded 2026-07-11 gate decision:
- Fix the shared inline-CTA track floors for the three ids — done.
- Preserve the intended desktop two-column composition — unchanged (titles/bodies cap themselves before tracks stop growing).
- No horizontal scroll across the affected activation range — guarded by parametrized E2E + css-lint pins.
- Keep it narrow, no unrelated CTA typography/layout cleanup — respected.

## Recorded-decision note (disclosed)

The issue text literally wrote `minmax(0, 2fr) minmax(14rem, 1fr)`, but its stated intent is "column 2 floored at the button width so the button never overflows its track." The button min-width is **14.75rem**, and the css-lint pin asserts column 2 equals the button min-width. Using the literal `14rem` would leave the button ~12px over its track (the same overflow class). Implemented `14.75rem` to satisfy the decision's own intent and mirror #258 exactly. No 7A question was raised — this is faithful to the recorded decision, not an extension of it.

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` — **1482 passed** (3 warnings / 2 deprecations are the pre-existing baseline; diff touches no PHP).
- JS: `npm test` (vitest) — **481 passed**, including the two new #265 css-lint pins per shared-rule id.
- `bash scripts/package.sh` — version consistency OK across the five synced files; built zip deleted (releases are CI-built from tags).
- Reviews (this session, on this working-tree diff): `/plan-eng-review` APPROVED; `/review` structured pass clean; Claude + Codex adversarial passes clean.

## Accepted limitations

- The rendered proof for the three new ids runs in the post-merge E2E job (wp-env/Docker), not locally; the css-lint pins guard the exact track floors and the button-width coupling in `npm test` without a browser.

Not tagged/released/deployed — those are the maintainer's separate steps.
