### PR TITLE
v0.16.79 fix: CTA button label no longer overflows the page (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.79] — 2026-07-11 — a CTA button label with no spaces can no longer scroll the page sideways (#266)
+
+**A `cta` button whose label had no place to break, a long unbroken string like a run-together phrase or a URL slug, grew wider than its column and pushed the page horizontally off screen at 768px. Normal labels, including long ones with spaces, wrap inside the button and were always fine; only a label with zero break opportunities could force the overflow. Any label now wraps inside the button instead of widening its column, so no author-supplied button text can scroll the page.**
+
+The button on the four inline CTAs (`home-cta`, `how-cta`, `agencies-cta`, `implementers-cta`) sizes itself to its content with a min-width floor and a 20rem cap. A label with spaces wraps at a space and stays inside the button; a label with no spaces cannot wrap, so the button grew toward its 20rem cap, past the grid track it sits in, and the page scrolled. The fix gives the button a last-resort break with `overflow-wrap: anywhere`. Unlike the `break-word` behavior already applied site-wide, `anywhere` lets the browser count a mid-word break as a width the button can shrink to, so the button collapses back to its min-width and the label wraps onto a second line inside it. Short and spaced labels are unchanged: they still size the button to its min-width floor and never trigger the break.
+
+### Fixed
+
+- A `cta` button label with no break opportunities (an unbroken string with no spaces) no longer widens the action column past its grid track and scrolls the page sideways at 768px. The four inline CTA buttons now carry `overflow-wrap: anywhere`, so any label wraps inside the button instead of growing it; short and spaced-label rendering is unchanged (#266).
+
+### Tests
+
+- A rendered end-to-end case sets an unbreakable ~48-character button label on `home-cta` at 768px and asserts the page does not scroll sideways and the button stays inside its container; reverting the CSS turns it red.
+
 ## [v0.16.78] — 2026-07-11 — the other three inline CTAs no longer scroll the page sideways on a tablet (#265)
 
 **A `cta` with `layout: "inline"` and the id `how-cta`, `agencies-cta`, or `implementers-cta` pushed the page horizontally off screen from 768px to about 912px, exactly as `home-cta` did before v0.16.76. The two-column grid switches on at 768px, but the columns it asked for (32.5rem for the headline, 14rem for the action copy, and a gap of at least 3rem) could not fit in the roughly 40rem the breakpoint actually leaves. Those were floors, not preferences, so the grid could not shrink and the page scrolled. The columns are now allowed to shrink, and pages using any of the three inline CTA ids fit at every width.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.78-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.79-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -3060,6 +3060,13 @@ main .btn--ghost {
   max-width: 20rem;
   padding-right: 1.35rem;
   padding-left: 1.35rem;
+  /* Last-resort break for an unbreakable author-supplied button_text label
+     (issue 266): `anywhere` (unlike the global `break-word`) feeds soft-wrap
+     opportunities into the intrinsic min-content size, so `fit-content`
+     collapses to the available track and the label wraps inside the button
+     instead of widening the column past its grid track and scrolling the
+     page. Short and spaced labels are unaffected (they still hit min-width). */
+  overflow-wrap: anywhere;
 }
 
 #home-cta .cta__button::before,

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.78');
+define('PP_VERSION', '0.16.79');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.78",
+  "version": "0.16.79",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.78
+Stable tag: 0.16.79
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.78
+Version:          0.16.79
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -565,4 +565,39 @@ test.describe('Safe-surface rendered proof', () => {
     const innerBox = (await page.locator('.cta__inner').boundingBox())!;
     expect(buttonBox.x + buttonBox.width).toBeLessThanOrEqual(innerBox.x + innerBox.width + 1);
   });
+
+  test('#266 an unbreakable button label wraps instead of scrolling the page', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E CTA Overflow Unbreakable Button');
+    setComposition(pageId, [
+      {
+        component: 'cta',
+        props: {
+          id: 'home-cta',
+          layout: 'inline',
+          title: 'A deliberately long closing headline that widens the title column',
+          text: 'Supporting copy that occupies the right-hand column of the grid.',
+          // No spaces: the label cannot wrap at a word boundary, so without a
+          // last-resort break it grows past its grid track and scrolls the page.
+          button_text: 'StartYourFreeThirtyDayTrialNowNoCardRequiredToday',
+          button_url: '/start',
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 768, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const button = page.locator('.cta__button');
+    await expect(button).toBeVisible({ timeout: 10000 });
+
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(769);
+
+    // The button wrapped inside .cta__inner's content box rather than widening past it.
+    const buttonBox = (await button.boundingBox())!;
+    const innerBox = (await page.locator('.cta__inner').boundingBox())!;
+    expect(buttonBox.x + buttonBox.width).toBeLessThanOrEqual(innerBox.x + innerBox.width + 1);
+  });
 });


### PR DESCRIPTION
Closes #266

## Scope

A `cta` button whose `button_text` label has no break opportunities (an unbroken string with no spaces) grew wider than its grid track on the four inline CTAs (`home-cta`, `how-cta`, `agencies-cta`, `implementers-cta`) and scrolled the page sideways at 768px. `button_text` is an author/AI-supplied composition prop, so this was reachable from a valid composition without touching CSS.

Per the recorded 2026-07-11 gate decision: add a last-resort break for CTA button labels, preserve short and spaced-label rendering, and pin the unbreakable-label case in rendered E2E coverage. Kept narrow — no validation, copy-policy, or typography work.

**Change:** one declaration, `overflow-wrap: anywhere`, on the shared inline-CTA button rule (`assets/css/components.css`). Unlike the site-wide `break-word`, `anywhere` feeds a mid-word break into the intrinsic min-content size, so `fit-content` collapses back to the track and the label wraps inside the button. Short and spaced labels still hit the `min-width: 14.75rem` floor unchanged.

## Validation

- Browser-verified in headless Chromium against the actual stylesheets at 768px:
  - **Without fix:** `document.scrollWidth` 874px (page scrolls), button 320px (hits `max-width: 20rem`), extends past `.cta__inner`.
  - **With fix:** `scrollWidth` 768px (no scroll), button collapses to 236px (= the 14.75rem min-width floor, short-label rendering preserved) and the label wraps to a second line inside it.
- `./vendor/bin/phpunit --configuration phpunit.xml` — 1482 passed (3 warnings + 2 deprecations, pre-existing; no PHP touched).
- `npm test` — 481 passed.
- `bash scripts/package.sh` — version consistency OK across the five files; zip built and deleted (releases are CI-built).
- New rendered E2E case (`tests/e2e/style-render.spec.ts`) sets an unbreakable ~48-char label on `home-cta` at 768px and asserts no horizontal scroll and the button stays inside `.cta__inner`; it runs in the post-merge E2E (WordPress 7.0) job.

## Reviews (this session)

- `/plan-eng-review` — clean, 0 issues, 0 critical gaps.
- `/review` — clean, 0 findings; adversarial reasoning performed inline (CSS + test diff, 42 lines, no executable-logic surface).
- `/document-generate` — no doc updates needed (no accepted-grammar change; `button_text` was already a documented prop).

## Accepted limitations

- No 7A question was raised: the fix stays strictly within the recorded decision (a last-resort visual wrap), so accepted grammar/behavior is unchanged.
