### PR TITLE
v0.16.80 fix: featured grid card honors --grid-card-border (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.80] — 2026-07-12 — the featured first grid card now honors a custom card border color (#226)
+
+**Setting `--grid-card-border` on a `grid` with `layout: "cards"` changed every card's border except the first one. The first card gets a "featured" treatment (accent border, accent top bar, tinted fill), and its border color was pinned to the theme accent, so an author's declared border color silently did nothing on that card while the action still reported success. The featured card now respects `--grid-card-border`, falling back to the accent only when no value is set.**
+
+The featured first card already routed its background through the `--grid-card-bg` slot so an author could override it, but its border color was hardcoded to the accent token in two cascade rules (the later one is what actually rendered). Setting `--grid-card-border` therefore applied to cards 2..N and no-opped on card 1, which reads as a bug because the neighboring background slot did work. Both rules now route the border through `var(--grid-card-border, <accent>)`, matching how `--grid-card-bg` already behaves on the same card. When the slot is unset the featured accent border is unchanged; the top bar and tinted fill of the featured treatment are also unchanged. This closes the border half of #226; the featured treatment itself remains on by default (opting out of it entirely was the alternative the issue listed but did not require).
+
+### Fixed
+
+- The featured first card of a `grid` with `layout: "cards"` now honors the `--grid-card-border` style slot instead of silently forcing the theme accent, so a declared card border color applies uniformly across all cards. Unset compositions keep the featured accent border (#226).
+
+### Tests
+
+- A CSS lint pin extracts every `main > .grid:not(.grid--steps) .grid__item:first-child` rule that sets `border-color` and asserts each routes through `var(--grid-card-border, ...)` with an accent-token fallback; it fails if either featured-card rule reverts to a bare token. A nonzero-match guard prevents the pin from passing vacuously if the selector ever drifts.
+
 ## [v0.16.79] — 2026-07-11 — a CTA button label with no spaces can no longer scroll the page sideways (#266)
 
 **A `cta` button whose label had no place to break, a long unbroken string like a run-together phrase or a URL slug, grew wider than its column and pushed the page horizontally off screen at 768px. Normal labels, including long ones with spaces, wrap inside the button and were always fine; only a label with zero break opportunities could force the overflow. Any label now wraps inside the button instead of widening its column, so no author-supplied button text can scroll the page.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.79-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.80-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2881,7 +2881,7 @@ main > .grid:not(.grid--steps) .grid__item::before {
 main > .grid:not(.grid--steps) .grid__item:first-child {
   /* Featured-card accent border is the DEFAULT; a per-instance --grid-card-border
      overrides it, mirroring --grid-card-bg below, so a declared style slot never
-     silently no-ops on the first card (#226). */
+     silently no-ops on the first card (issue 226). */
   border-color: var(--grid-card-border, var(--color-border-accent));
   /* Featured-card accent fill is the DEFAULT; a per-instance --grid-card-bg
      overrides it so the first card stays uniform with the rest when an author
@@ -3284,7 +3284,7 @@ main > .grid .grid__item {
 main > .grid:not(.grid--steps) .grid__item:first-child {
   /* Later-cascade winner: this is the border-color that actually applies. Route it
      through --grid-card-border too (matching the earlier rule) or the slot stays
-     ignored on the first card (#226). */
+     ignored on the first card (issue 226). */
   border-color: var(--grid-card-border, var(--color-accent-strong));
 }
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2879,7 +2879,10 @@ main > .grid:not(.grid--steps) .grid__item::before {
 }
 
 main > .grid:not(.grid--steps) .grid__item:first-child {
-  border-color: var(--color-border-accent);
+  /* Featured-card accent border is the DEFAULT; a per-instance --grid-card-border
+     overrides it, mirroring --grid-card-bg below, so a declared style slot never
+     silently no-ops on the first card (#226). */
+  border-color: var(--grid-card-border, var(--color-border-accent));
   /* Featured-card accent fill is the DEFAULT; a per-instance --grid-card-bg
      overrides it so the first card stays uniform with the rest when an author
      sets an explicit card color (e.g. uniform dark cards on a dark band). */
@@ -3279,7 +3282,10 @@ main > .grid .grid__item {
 }
 
 main > .grid:not(.grid--steps) .grid__item:first-child {
-  border-color: var(--color-accent-strong);
+  /* Later-cascade winner: this is the border-color that actually applies. Route it
+     through --grid-card-border too (matching the earlier rule) or the slot stays
+     ignored on the first card (#226). */
+  border-color: var(--grid-card-border, var(--color-accent-strong));
 }
 
 main .btn,

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.79');
+define('PP_VERSION', '0.16.80');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.79",
+  "version": "0.16.80",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.79
+Stable tag: 0.16.80
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.79
+Version:          0.16.80
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -369,6 +369,90 @@ describe('CSS lint: theme variants survive the desktop typography cascade (#222)
 });
 
 /**
+ * Featured grid card honors the --grid-card-border style slot (#226).
+ *
+ * The first card of a `layout: cards` grid gets an unconditional "featured"
+ * treatment. Its sibling slot --grid-card-bg is routed through
+ * `var(--grid-card-bg, <default>)` so an author's declared value wins, but the
+ * border was hardcoded to an accent token — so a declared --grid-card-border
+ * silently no-opped on card 1 while `style_component` reported success.
+ *
+ * TWO rules set border-color on the featured first card and BOTH must route
+ * through the slot: the later one wins the cascade (equal specificity), and the
+ * earlier one is the base featured rule. If either keeps a bare token, the slot
+ * is ignored on that path. The keystone StyleSlotContractTest only proves the
+ * slot is consumed *somewhere* in the grid block (the base `.grid__item` rule
+ * satisfies it), so it cannot catch this first-child-specific gap — hence this
+ * targeted pin.
+ */
+describe('CSS lint: featured grid card honors --grid-card-border (#226)', () => {
+    const SELECTOR = 'main > .grid:not(.grid--steps) .grid__item:first-child';
+
+    // Brace-matched extraction of every rule whose selector is EXACTLY this
+    // (whitespace-normalized). `::before` / descendant rules share the prefix
+    // but have more text before `{`, so `\s*\{` never matches them.
+    function bodiesForExactSelector(selector) {
+        const css = stripComments(COMPONENTS_CSS).replace(/\s+/g, ' ');
+        const re = new RegExp(
+            selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\{',
+            'g'
+        );
+        const bodies = [];
+        let match;
+        while ((match = re.exec(css)) !== null) {
+            let i = re.lastIndex;
+            let depth = 1;
+            const start = i;
+            while (i < css.length && depth > 0) {
+                if (css[i] === '{') depth++;
+                else if (css[i] === '}') depth--;
+                i++;
+            }
+            bodies.push(css.slice(start, i - 1));
+        }
+        return bodies;
+    }
+
+    const bodies = bodiesForExactSelector(SELECTOR);
+    const borderBodies = bodies.filter(b => /border-color\s*:/.test(b));
+
+    // Guard against the selector silently drifting: a zero-match scan would make
+    // every assertion below vacuously pass.
+    test('finds the featured first-card rules that set border-color', () => {
+        expect(borderBodies.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('every border-color on the featured first card routes through --grid-card-border', () => {
+        const offenders = [];
+        borderBodies.forEach(body => {
+            const decls = body.match(/border-color\s*:[^;}]+/g) || [];
+            decls.forEach(d => {
+                if (!/border-color\s*:\s*var\(\s*--grid-card-border\b/.test(d)) {
+                    offenders.push(d.trim());
+                }
+            });
+        });
+        expect(offenders).toEqual([]);
+    });
+
+    // Fallback integrity: the slot must fall back to an accent token, never to a
+    // neutral border, or unset compositions would lose the featured look. Both
+    // accent tokens the two rules historically used are acceptable fallbacks.
+    test('--grid-card-border falls back to an accent token, preserving the default look', () => {
+        const bad = [];
+        borderBodies.forEach(body => {
+            const decls = body.match(/border-color\s*:[^;}]+/g) || [];
+            decls.forEach(d => {
+                if (!/var\(\s*--grid-card-border\s*,\s*var\(\s*--color-(?:border-accent|accent-strong)\s*\)\s*\)/.test(d)) {
+                    bad.push(d.trim());
+                }
+            });
+        });
+        expect(bad).toEqual([]);
+    });
+});
+
+/**
  * Grid desktop column layout (#224).
  *
  * The desktop column count is driven by the `data-pp-count` attribute that


### PR DESCRIPTION
Closes #226

## Summary

The featured first card of a `grid` with `layout: "cards"` gets an accent border/top-bar/tinted-fill treatment. Its border color was pinned to the theme accent token in two cascade rules (the later one wins), so setting the declared `--grid-card-border` style slot applied to cards 2..N and silently no-opped on card 1 while `style_component` still reported success. The neighboring `--grid-card-bg` slot already worked on that card, which made the border omission read as a bug.

**Fix (issue #226 "Expected" Option A):** route both featured-first-card `border-color` rules through `var(--grid-card-border, <accent>)`, mirroring how `--grid-card-bg` is already handled on the same card. When the slot is unset the featured accent border is unchanged; the top bar and tinted fill of the featured treatment are also unchanged.

## Recorded decision

Issue #226 lists two acceptable resolutions: (A) respect `--grid-card-border` on the first card, or (B) add a `featured_first` opt-out prop. I took the surface-preserving Option A (matches the `size:S` label, adds no new prop/schema/AI-doc surface). The featured treatment itself remains on by default; the opt-out prop path (B) was the listed alternative, not required. No 7A question was raised.

## Files changed

- `assets/css/components.css` — two `main > .grid:not(.grid--steps) .grid__item:first-child` `border-color` rules now use `var(--grid-card-border, var(--color-border-accent|accent-strong))`.
- `tests/js/css-lint.test.js` — regression pins: every featured-first-card `border-color` routes through `--grid-card-border` with an accent-token fallback; a nonzero-match guard prevents vacuous passing if the selector drifts.
- Version bump to `v0.16.80` across the five synced files + CHANGELOG entry.

## Validation

- `npm test` (vitest): 484 passed. New `#226` pins negative-verified — reverting either CSS rule turns them red.
- `./vendor/bin/phpunit`: 1482 passed (3 warnings / 2 deprecations are pre-existing; diff touches no PHP).
- `bash scripts/package.sh`: Version consistency OK across all five files (build zip deleted; CI builds the release zip from the tag).

## Reviews (this session, on this exact diff)

- `/plan-eng-review` — clean, scope accepted as-is (Option A).
- `/review` + Codex adversarial — clean; 1 auto-fixed test-robustness item; Codex's "inherited slot erases accent globally" flagged as a false positive (no global `--grid-card-border` setter exists; a per-component slot value winning is the recorded decision).
- `/document-generate` — no doc changes needed (`--grid-card-border` is a declared grid schema slot; the fix makes it behave as documented; no prose doc references the featured card).
