### PR TITLE
v0.16.81 ci: run E2E @smoke on pull requests (#82)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,19 +1,26 @@
 name: E2E (WordPress 7.0)
 
-# Scoped Option 4 (D2b): E2E runs in two modes, both NON-blocking.
-#   - push to main  -> @smoke subset (fast, high-signal): action-layer round-trip,
-#                      editor load, publish -> front-end render. A red check here is
-#                      a SIGNAL on the commit, not a merge gate (this repo ships
-#                      direct to main; there is no branch protection to gate on).
-#   - nightly cron  -> full suite.
-#   - manual        -> full suite via workflow_dispatch.
+# E2E runs the @smoke subset (fast, high-signal: action-layer round-trip, editor
+# load, publish -> front-end render) on every pull request and on push to main,
+# and the full suite nightly / on manual dispatch.
+#   - pull_request -> @smoke subset. Reports a check on EVERY PR so it can be a
+#                     required status check (issue 82). Intentionally NO
+#                     paths-ignore here: a required check that is skipped on a
+#                     docs-only PR leaves the PR blocked on a check that never
+#                     reports, so @smoke must always run and report on a PR.
+#   - push to main -> @smoke subset. Post-merge standing watcher on the mainline
+#                     commit (paths-ignore keeps docs-only pushes from re-running).
+#   - nightly cron -> full suite.
+#   - manual       -> full suite via workflow_dispatch.
 #
-# Promotion bar (tracked as a follow-up issue): once the @smoke run holds green on
-# main for 2 weeks with zero flakes, promote it to a required check. That only
-# becomes meaningful if a PR + branch-protection model is adopted; under the
-# current direct-to-main flow, push-smoke + nightly-full is the standing watcher.
+# Making @smoke a REQUIRED check is a manual repo-admin step (branch protection on
+# main requiring "E2E (WordPress 7.0) / e2e" + "ai-ready-check"); the fine-grained
+# PAT cannot set branch protection. See issue 82. Promotion bar: once @smoke holds
+# green for 2 weeks with zero flakes.
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
     paths-ignore:
@@ -50,12 +57,12 @@ jobs:
       - name: Ensure DB matches core
         run: npx wp-env run cli wp core update-db
 
-      - name: Run E2E (@smoke on push, full suite nightly/manual)
+      - name: Run E2E (@smoke on pull_request/push, full suite nightly/manual)
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            npm run test:e2e -- --grep @smoke
-          else
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             npm run test:e2e
+          else
+            npm run test:e2e -- --grep @smoke
           fi
 
       - name: Upload Playwright artifacts on failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.81] — 2026-07-12 — the browser-rendered @smoke E2E check now runs on every pull request (#82)
+
+**The `@smoke` end-to-end subset used to run only after a change landed on `main`, so a pull request could be merged without ever seeing the rendered-browser signal that catches CSS cascade regressions unit tests miss. `@smoke` now runs on every pull request against `main` and reports its own check, so the browser evidence is available before merge instead of after. It still runs on push to `main` as a post-merge watcher and as the full suite nightly and on manual dispatch.**
+
+The E2E workflow triggered on `push` to `main` (the `@smoke` subset) plus a nightly full run. That is a signal on the mainline commit, not a gate on the change that introduced a regression. The workflow now also triggers on `pull_request`, running the same fast `@smoke` subset so a check reports on every PR. The pull-request trigger intentionally carries no `paths-ignore` filter: a check that is required but skipped on a docs-only PR would leave that PR blocked on a status that never reports, so `@smoke` always runs and reports on a PR. Making the check actually required is a separate manual repository-admin step (branch protection on `main` requiring `E2E (WordPress 7.0) / e2e` and `ai-ready-check`), which the automation's token cannot set; until that is enabled the PR check is visible but non-blocking.
+
+### Changed
+
+- The `E2E (WordPress 7.0)` workflow now runs the `@smoke` subset on `pull_request` against `main` in addition to `push`, so every pull request gets a browser-rendered check before merge. Nightly and manual runs still execute the full suite (#82).
+
+### Docs
+
+- The README continuous-integration note now states that `@smoke` runs on every pull request and on push to `main`, non-blocking until branch protection marks it a required check (#82).
+
 ## [v0.16.80] — 2026-07-12 — the featured first grid card now honors a custom card border color (#226)
 
 **Setting `--grid-card-border` on a `grid` with `layout: "cards"` changed every card's border except the first one. The first card gets a "featured" treatment (accent border, accent top bar, tinted fill), and its border color was pinned to the theme accent, so an author's declared border color silently did nothing on that card while the action still reported success. The featured card now respects `--grid-card-border`, falling back to the accent only when no value is set.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.80-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.81-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -411,7 +411,7 @@ npm run test:e2e    # Playwright against http://localhost:8889
 npm run env:stop
 ```
 
-**Continuous integration** — `composer test` + `npm test` run on every push to `main` and gate every release before the ZIP is built, so a failing test can't reach a published theme. End-to-end runs in CI too: a non-blocking `@smoke` subset on push, plus a nightly full suite on WordPress 7.0.
+**Continuous integration** — `composer test` + `npm test` run on every push to `main` and gate every release before the ZIP is built, so a failing test can't reach a published theme. End-to-end runs in CI too: a `@smoke` subset on every pull request and on push to `main` (non-blocking until branch protection marks it a required check), plus a nightly full suite on WordPress 7.0.
 
 ---
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.80');
+define('PP_VERSION', '0.16.81');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.80",
+  "version": "0.16.81",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.80
+Stable tag: 0.16.81
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.80
+Version:          0.16.81
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Closes #82

## Scope
Make the browser-rendered E2E `@smoke` subset run on pull requests so the rendered-cascade signal is available before merge, per #82's recorded decision (the in-repo part).

- `.github/workflows/e2e.yml`: add a `pull_request` trigger (base `main`) that runs the fast `@smoke` subset; the run-step condition now selects the full suite only for `schedule`/`workflow_dispatch`, so both `push` and `pull_request` run `@smoke`. `push` to `main` (with its `paths-ignore`) stays as the post-merge watcher; nightly cron and manual dispatch still run the full suite.
- **No `paths-ignore` on `pull_request`** (deliberate): the acceptance criterion is "reports a check on every PR." A required-but-skipped check would leave a docs-only PR blocked on a status that never reports, so `@smoke` always runs and reports on a PR.
- `README.md`: CI note updated to say `@smoke` runs on every PR and on push to `main`, non-blocking until branch protection marks it required.

## Out of scope / maintainer action required
Making `@smoke` an actually-required check is a manual repo-admin step: enable branch protection on `main` requiring `E2E (WordPress 7.0) / e2e` + `ai-ready-check`. The fine-grained PAT cannot set branch protection (per #82's decision). Until then the PR check is visible but non-blocking. The "promote once green for 2 weeks with zero flakes" bar also stays a maintainer judgment.

## Validation
- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` -> 1482 tests OK (3 warnings / 2 deprecations match an unmodified tree; diff touches no PHP).
- JS: `npm test` -> 484 passed.
- `bash scripts/package.sh` -> version consistency OK across the five synced files at 0.16.81; built zip deleted (releases are CI-built from tags).
- Workflow YAML parsed and validated: triggers are `pull_request`, `push`, `schedule`, `workflow_dispatch`; `@smoke` run-step present.
- This PR self-validates the change: the new `pull_request` trigger runs `@smoke` on this very PR.

## Reviews (this session, on this diff)
- /plan-eng-review: clean, 0 findings (single-file CI change; complexity gate not triggered).
- /review: clean, 0 findings. Shell-injection N/A (`github.event_name` is a GitHub-controlled enum), enum-completeness verified (all four triggering events covered), no duplicate runs (`push` scoped to `main`).
- Adversarial pass: clean (inline; Codex sandbox cannot run git on this container).

## Accepted limitations
- `@smoke` on `pull_request` runs even on docs-only PRs (the cost of always reporting a check); this is the intended tradeoff to keep the future required-check gate from hanging.
