### PR TITLE
v0.16.83 fix: run-state write fails closed instead of reporting success (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.83] — 2026-07-12 — a failed run-state write can no longer report success (#243)
+
+**Every recorder behind the operating loop's run token — PREFLIGHT, step completion, token and composition snapshots — persists through one locked write to a JSON state file. That write truncated the file first and then wrote, never checking that the encode or the write actually succeeded, so a full disk or an unencodable payload could leave the state file empty or torn while the recorder still reported success. The write is now fail-closed: it encodes before touching the file, refuses to write if the file cannot be truncated, verifies the whole payload landed, restores the prior bytes if it did not, and returns failure so the caller surfaces the error instead of trusting a destroyed baseline.**
+
+`pp_operate_mutate_state()` did `ftruncate` then `fwrite( wp_json_encode(...) )` and returned `true` unconditionally. `wp_json_encode()` can return `false` (for example on malformed UTF-8), and `fwrite` can short-write on `ENOSPC` — either way the prior state (the INSPECT baseline and any recorded snapshots) was already discarded, yet callers like `wp pp apply preflight` printed `{"ok":true}` for a run whose state file was now empty or partial. The persist now encodes the new state first and aborts untouched on an encode failure; it checks the `ftruncate` result and aborts without writing rather than leaving stale trailing bytes from a longer prior state behind a shorter new one; and after writing it verifies the byte count and flush, restoring the captured prior bytes on a best-effort basis and returning `false` on any seek, write, or flush failure. A failed persistence can no longer truncate the state file yet report a confirmed write.
+
+### Fixed
+
+- `pp_operate_mutate_state()` now fails closed: it encodes the new run state before truncating the file, verifies the full payload was written and flushed, checks the truncate result, restores the prior bytes on a short or failed write, and returns `false` on any encode/truncate/seek/write/flush failure — so a failed write can no longer destroy the run-state baseline while reporting success (#243).
+
+### Tests
+
+- New `OperateTest` cases pin the fail-closed behavior: an encode failure (malformed UTF-8 payload) returns `false` and leaves the prior state file byte-for-byte intact; a shorter payload written after a longer one leaves no stale trailing bytes; and a valid multibyte payload persists in full (guarding the byte-count check against a `strlen`/`mb_strlen` mixup) (#243).
+
 ## [v0.16.82] — 2026-07-12 — two components can no longer share the same id (#238)
 
 **A composition could carry two components with the same `id` and still save without complaint, and every id-based action (`update_component`, `remove_component`, `style_component`) then silently targeted whichever one sorted first, reporting success while it changed or deleted the wrong component. Duplicate component ids are now rejected at write time, so the ambiguous state is never persisted. If a duplicate ever reaches a page through a raw write, targeting it fails closed with a clear error instead of guessing.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.82-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.83-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.82');
+define('PP_VERSION', '0.16.83');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -694,6 +694,14 @@ function pp_operate_read_state( string $run_id ): ?array {
  * invalid run-id, unopenable/unlockable file, structurally-invalid or expired state,
  * site-identity mismatch, or mutator abort.
  *
+ * Persistence is fail-closed: the new state is encoded BEFORE the file is truncated,
+ * and the write is verified to cover the full payload (byte count + flush). On any
+ * encode, truncate, seek, write, or flush failure, false is returned so callers never
+ * trust a torn state file. Prior state fully survives an encode or truncate failure
+ * (the file is untouched); after truncation a short/failed write restores the captured
+ * prior bytes on a best-effort basis. A failed persistence can never truncate the
+ * state file yet report true.
+ *
  * @param string   $run_id
  * @param callable $mutator  fn(array $data): array|false
  * @return bool  True only on a confirmed write.
@@ -714,7 +722,8 @@ function pp_operate_mutate_state( string $run_id, callable $mutator ): bool {
         return false;
     }
 
-    $data = json_decode( stream_get_contents( $fh ), true );
+    $raw  = stream_get_contents( $fh );
+    $data = json_decode( $raw, true );
 
     $abort = static function ( $fh ) {
         flock( $fh, LOCK_UN );
@@ -740,10 +749,45 @@ function pp_operate_mutate_state( string $run_id, callable $mutator ): bool {
         return $abort( $fh );
     }
 
-    ftruncate( $fh, 0 );
-    rewind( $fh );
-    fwrite( $fh, wp_json_encode( $new ) );
-    fflush( $fh );
+    // Fail closed: encode BEFORE touching the file. wp_json_encode() can return
+    // false (e.g. malformed UTF-8). If we truncated first and then discovered the
+    // encode failed, the prior state (INSPECT baseline, recorded snapshots) would
+    // already be destroyed while we returned true. Encoding first means an encode
+    // failure leaves the existing valid state file untouched.
+    $json = wp_json_encode( $new );
+    if ( ! is_string( $json ) ) {
+        return $abort( $fh );
+    }
+
+    // A failed truncate leaves the prior state fully intact, so abort without
+    // writing. Writing over a file we could not truncate would leave stale trailing
+    // bytes from the (longer) prior state after the new payload — corrupt JSON that
+    // still passes the byte-count check below and looks like a confirmed write.
+    if ( ! ftruncate( $fh, 0 ) ) {
+        return $abort( $fh );
+    }
+
+    // The file is now empty: the prior state MUST be rewritten. Any failure from here
+    // (seek, short/failed write, or flush) means the new payload did not fully land.
+    // Restore the captured prior bytes on a best-effort basis (they previously fit,
+    // so the space just freed by the truncate is available) and fail closed so the
+    // caller surfaces the error instead of trusting a torn or partial state file.
+    $seeked  = rewind( $fh );
+    $written = $seeked ? fwrite( $fh, $json ) : false;
+    $flushed = ( false !== $written ) ? fflush( $fh ) : false;
+
+    if ( ! $seeked || false === $written || strlen( $json ) !== $written || false === $flushed ) {
+        if ( rewind( $fh ) ) {
+            ftruncate( $fh, 0 );
+            rewind( $fh );
+            fwrite( $fh, $raw );
+            fflush( $fh );
+        }
+        flock( $fh, LOCK_UN );
+        fclose( $fh );
+        return false;
+    }
+
     flock( $fh, LOCK_UN );
     fclose( $fh );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.82",
+  "version": "0.16.83",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.82
+Stable tag: 0.16.83
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.82
+Version:          0.16.83
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -998,6 +998,94 @@ class OperateTest extends TestCase
         $this->assertTrue(true);
     }
 
+    // ── Fail-closed persistence (issue 243) ───────────────────────────────
+
+    public function testMutateStateEncodeFailureFailsClosedAndPreservesPriorState(): void
+    {
+        $run_id = pp_operate_create_run();
+        $path   = pp_operate_run_path($run_id);
+
+        // Establish a known prior state so we can prove it survives a failed persist.
+        $this->assertTrue(pp_operate_record_step($run_id, 'INSPECT'));
+        $before = file_get_contents($path);
+        $before_decoded = json_decode($before, true);
+        $this->assertContains('INSPECT', $before_decoded['steps_completed']);
+
+        // Mutator returns a structurally-valid array whose payload cannot be
+        // JSON-encoded: a lone malformed UTF-8 byte makes wp_json_encode() return
+        // false. Pre-fix, the file was truncated first and the function still
+        // returned true — destroying the prior state.
+        $result = pp_operate_mutate_state($run_id, static function (array $data) {
+            $data['bad'] = "\xB1\x31"; // invalid UTF-8 -> json_encode() === false
+            return $data;
+        });
+
+        // Fail closed: the write is refused...
+        $this->assertFalse($result);
+
+        // ...and the prior state file is byte-for-byte intact (not truncated/torn).
+        $after = file_get_contents($path);
+        $this->assertSame($before, $after);
+        $after_decoded = json_decode($after, true);
+        $this->assertIsArray($after_decoded);
+        $this->assertContains('INSPECT', $after_decoded['steps_completed']);
+
+        pp_operate_cleanup_run($run_id);
+    }
+
+    public function testMutateStatePersistsFullMultibytePayload(): void
+    {
+        // Guards the full-payload byte-count check: a valid write of multibyte
+        // content (where byte length != character length) must still be accepted
+        // and persisted completely. If the check used mb_strlen instead of strlen,
+        // a correct write would be wrongly rejected as short.
+        $run_id = pp_operate_create_run();
+        $path   = pp_operate_run_path($run_id);
+
+        $result = pp_operate_mutate_state($run_id, static function (array $data) {
+            $data['note'] = 'café ☕ 日本語 déjà';
+            return $data;
+        });
+
+        $this->assertTrue($result);
+        $decoded = json_decode(file_get_contents($path), true);
+        $this->assertSame('café ☕ 日本語 déjà', $decoded['note']);
+
+        pp_operate_cleanup_run($run_id);
+    }
+
+    public function testMutateStateShorterPayloadLeavesNoTrailingBytes(): void
+    {
+        // Guards truncate-correctness: writing a shorter state after a longer one
+        // must not leave stale trailing bytes from the prior payload (which would
+        // pass the byte-count check yet corrupt the JSON on disk).
+        $run_id = pp_operate_create_run();
+        $path   = pp_operate_run_path($run_id);
+
+        // Grow the file first with a large filler value.
+        $this->assertTrue(pp_operate_mutate_state($run_id, static function (array $data) {
+            $data['filler'] = str_repeat('x', 500);
+            return $data;
+        }));
+        $this->assertGreaterThan(400, strlen(file_get_contents($path)));
+
+        // Now persist a much shorter state.
+        $result = pp_operate_mutate_state($run_id, static function (array $data) {
+            unset($data['filler']);
+            return $data;
+        });
+        $this->assertTrue($result);
+
+        // The file must be exactly the new JSON — no leftover filler bytes.
+        $raw     = file_get_contents($path);
+        $decoded = json_decode($raw, true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayNotHasKey('filler', $decoded);
+        $this->assertSame(wp_json_encode($decoded), $raw);
+
+        pp_operate_cleanup_run($run_id);
+    }
+
     // ── Validation Hardening Tests ────────────────────────────────────────
 
     public function testValidateLoopRunRejectsRetryCountAbove2(): void


### PR DESCRIPTION
Closes #243

## Scope

`pp_operate_mutate_state()` (the single locked writer behind every operating-loop recorder: PREFLIGHT, step completion, token/composition snapshots) truncated the run-state file and wrote without checking either the encode or the write result, then returned `true` unconditionally. A `wp_json_encode()` failure (e.g. malformed UTF-8) or a short write (ENOSPC) could leave the state file empty or torn while callers reported success — the destructive `#227` fail-open inversion one layer down.

Per the recorded v1.0.0 gate decision (fail closed before destroying existing run state):

- **Encode before truncation** — `wp_json_encode()` runs before the file is touched; a non-string result aborts with the prior state fully intact.
- **Check the truncate** — a failed `ftruncate` aborts without writing, so stale trailing bytes from a longer prior state can't be left behind a shorter new payload.
- **Verify the full write** — byte count (`strlen($json) === fwrite`) plus `fflush`; any seek/write/flush failure restores the captured prior bytes on a best-effort basis and returns `false`.

A failed persistence can no longer truncate the state file yet report a confirmed write.

## Approach / decision

Kept the existing same-`$fh` `flock(LOCK_EX)` model. A temp-file + atomic `rename()` was considered and rejected: `rename` swaps the inode and breaks the advisory-lock mutual exclusion the recorders rely on, so in-place fail-closed with best-effort restore is the fit. Accepted limitation: under persistent ENOSPC the best-effort restore may itself short-write; the function still returns `false` so callers surface the error (never a false success). No public surface or AI grammar changed, so `lib/ai-context.php` and `ai-instructions/` are untouched; `/document-generate` found no invalidated doc claims.

No 7A question was raised — the review findings were mechanical hardening within the recorded decision.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — 1498 tests OK (3 new `OperateTest` cases); warnings/deprecations unchanged from base (3/2, verified via stash).
- `npm test` — 484 passed.
- `bash scripts/package.sh` — version consistency OK across the five files; built zip deleted (CI builds releases from tags).

## Reviews

- `/plan-eng-review` — plan confirmed, 0 findings.
- `/review` + adversarial pass (Codex `exec` with inlined diff + Claude adversarial subagent) — converged on the unchecked `ftruncate` (torn-file-reported-as-true) and a docstring overstatement; both fixed in this branch. Multibyte `strlen`/`fwrite`, empty-`$raw`, and lock/handle-leak suspicions were verified as non-issues.

## Noticed, not touched

Filed #274 — `pp_operate_read_state()` reads the state file without a shared lock, so a concurrent reader can observe a mid-write file and get `null`. Pre-existing, out of #243 scope.