### PR TITLE
v0.16.85 fix: shared-lock pp_operate_read_state so readers never observe a half-written run-state file (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.85] — 2026-07-12 — run-state readers now take a shared lock so they never observe a half-written file (#274)
+
+**The operating loop's writer (`pp_operate_mutate_state()`) takes an exclusive `flock` for its whole read-modify-write, but `flock` is advisory: a reader that does not itself take a shared lock bypasses it entirely. `pp_operate_read_state()` read the run-state file with a bare `file_get_contents()` and no lock, so while the writer was mid-write (a non-atomic `ftruncate(0)` then `fwrite()`) a concurrent reader — `operate inspect`, a step-completion check, a preflight-coverage query, any snapshot getter — could observe an empty or partially written file, fail to decode it, and treat the run as missing. On the same install this surfaced as a spurious "run not found" or a preflight/step gate transiently reading as unsatisfied while another CLI process recorded state. The read now takes a shared lock (`flock LOCK_SH`) and blocks until the writer releases, so it always sees a complete file.**
+
+`pp_operate_read_state()` is the single choke point every run-state getter routes through, so hardening it fixes all readers at once. It now opens the file with `fopen('r')`, acquires `LOCK_SH`, reads the full contents, releases the lock, and closes the handle before decoding — coordinating with the writer's `LOCK_EX` on the same file. A missing file (`fopen 'r'` fails) returns `null`, matching the prior `file_exists()` guard; a transient lock-acquire failure returns `null` in the fail-closed direction (a valid run momentarily reads as unusable, never the reverse), matching the writer's own lock-failure handling. Replacing the `file_exists()` + `file_get_contents()` two-step with a single opened handle also removes a time-of-check/time-of-use window against the TTL `@unlink` path. This is the reader-side counterpart of the fail-closed writer hardening in the #200/#207/#212/#241/#243 concurrency cluster: the writer was already correct, but readers did not participate in the lock.
+
+### Fixed
+
+- `pp_operate_read_state()` now reads the run-state file under a shared lock (`flock LOCK_SH`), so a reader can no longer observe an empty or half-written file while `pp_operate_mutate_state()` holds the exclusive lock during its non-atomic truncate-then-write — eliminating the spurious "run not found" / transiently-unsatisfied-gate class for every getter built on it (`operate inspect`, step checks, preflight-coverage, snapshot getters) (#274).
+
+### Tests
+
+- New `OperateTest` cases pin the #274 behavior: a valid state file still reads correctly under the shared lock, a missing file returns `null` via the `fopen` guard, a corrupt payload returns `null` without truncating or recreating the file, and the shared lock is released after the read so a subsequent `mutate_state` proceeds (no lock leak) (#274).
+
 ## [v0.16.84] — 2026-07-12 — the preflight gate can no longer unlock without its composition restore baseline (#241)
 
 **A page-scoped `wp pp apply preflight` used to record its unlock (PREFLIGHT coverage, freshness marker, token snapshot) in one state write and the pre-run composition content snapshot — the baseline `restore-composition` reverts to — in a separate second write. If that second write failed, the run was left fully unlocked with no restore baseline: a parallel agent or an operator reading `operate inspect` could execute a page mutation through the open gate, and the change could never be rolled back. The composition snapshot is now folded into the same locked state write as the PREFLIGHT step, so coverage and its restore baseline are all-or-nothing. A corrupt stored composition now fails the preflight closed instead of freezing an empty baseline that a later restore would replay to blank the page.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.84-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.85-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.84');
+define('PP_VERSION', '0.16.85');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -652,6 +652,10 @@ function pp_operate_site_id(): string {
  * an older build (no site_id) is treated as a mismatch — fail-closed, drains within
  * the TTL. Corrupt JSON returns null WITHOUT truncating or recreating the file.
  *
+ * The read is taken under a shared lock (flock LOCK_SH) so it cannot observe a file
+ * mid-write while pp_operate_mutate_state() holds LOCK_EX for its non-atomic
+ * truncate+write; readers block until the writer releases and always see a complete file.
+ *
  * @param string $run_id  The run token UUID.
  * @return array|null  The decoded state array, or null if the run is unusable.
  */
@@ -661,11 +665,29 @@ function pp_operate_read_state( string $run_id ): ?array {
     }
 
     $path = pp_operate_run_path( $run_id );
-    if ( ! file_exists( $path ) ) {
+
+    // Shared-lock the read. flock() is advisory: pp_operate_mutate_state() holds
+    // LOCK_EX for its non-atomic ftruncate()+fwrite() read-modify-write, so a
+    // reader that does not take LOCK_SH can observe an empty or half-written file
+    // mid-mutation. json_decode() would then fail and the run would read as
+    // missing / step-not-completed (a spurious "run not found" or a transiently
+    // unsatisfied gate). Taking LOCK_SH blocks until the writer releases, so the
+    // read always sees a complete file. A missing file → fopen 'r' fails → null,
+    // matching the prior file_exists() guard. Reader-side counterpart of the
+    // #200/#207/#212/#241/#243 writer fail-closed hardening.
+    $fh = @fopen( $path, 'r' );
+    if ( ! $fh ) {
         return null;
     }
+    if ( ! flock( $fh, LOCK_SH ) ) {
+        fclose( $fh );
+        return null;
+    }
+    $raw = stream_get_contents( $fh );
+    flock( $fh, LOCK_UN );
+    fclose( $fh );
 
-    $data = json_decode( (string) file_get_contents( $path ), true );
+    $data = json_decode( (string) $raw, true );
     if ( ! is_array( $data ) || ! isset( $data['steps_completed'] ) || ! isset( $data['created_at'] ) ) {
         return null;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.84",
+  "version": "0.16.85",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.84
+Stable tag: 0.16.85
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.84
+Version:          0.16.85
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -2604,4 +2604,58 @@ class OperateTest extends TestCase
 
         pp_operate_cleanup_run($run_id);
     }
+
+    // ── Shared-lock reads (issue 274) ─────────────────────────────────────
+
+    public function testReadStateReturnsStateForValidFileUnderSharedLock(): void
+    {
+        // A complete, valid state file still reads correctly now that the read
+        // path takes flock(LOCK_SH).
+        $run_id = pp_operate_create_run();
+        pp_operate_record_step($run_id, 'PREFLIGHT');
+
+        $data = pp_operate_read_state($run_id);
+        $this->assertIsArray($data);
+        $this->assertContains('INSPECT', $data['steps_completed']);
+        $this->assertContains('PREFLIGHT', $data['steps_completed']);
+
+        pp_operate_cleanup_run($run_id);
+    }
+
+    public function testReadStateReturnsNullForMissingFile(): void
+    {
+        // fopen('r') on a non-existent file fails → null, matching the prior
+        // file_exists() guard. Valid UUID, no file written.
+        $this->assertNull(pp_operate_read_state('00000000-0000-4000-8000-000000000274'));
+    }
+
+    public function testReadStateReturnsNullForCorruptJson(): void
+    {
+        // A torn/corrupt payload decodes to null under the shared lock without
+        // truncating or recreating the file.
+        $fake_id = wp_generate_uuid4();
+        $path    = pp_operate_run_path($fake_id);
+        file_put_contents($path, 'NOT VALID JSON {{{', LOCK_EX);
+
+        $this->assertNull(pp_operate_read_state($fake_id));
+        // File is untouched by the failed read.
+        $this->assertSame('NOT VALID JSON {{{', file_get_contents($path));
+        @unlink($path);
+    }
+
+    public function testReadStateReleasesSharedLockSoWriterCanProceed(): void
+    {
+        // The shared lock must be released (LOCK_UN + fclose) after the read, or
+        // a subsequent mutate would deadlock/fail. Proving read → mutate → read
+        // round-trips confirms no lock leak.
+        $run_id = pp_operate_create_run();
+
+        $this->assertIsArray(pp_operate_read_state($run_id));
+        $this->assertTrue(pp_operate_record_step($run_id, 'PREFLIGHT'));
+        $after = pp_operate_read_state($run_id);
+        $this->assertIsArray($after);
+        $this->assertContains('PREFLIGHT', $after['steps_completed']);
+
+        pp_operate_cleanup_run($run_id);
+    }
 }


### PR DESCRIPTION
Closes #274

## What

`pp_operate_read_state()` — the single choke point every run-state getter routes through — read the run-state file with a bare `file_get_contents()` and **no lock**. `pp_operate_mutate_state()` holds an exclusive `flock` (`LOCK_EX`) for its non-atomic `ftruncate(0)` + `fwrite()`, but `flock` is advisory: a reader that does not itself take a shared lock bypasses it and can observe an empty or partially written file mid-mutation, fail to `json_decode` it, and treat the run as missing. On the same install this surfaced as a spurious "run not found" or a preflight/step gate transiently reading as unsatisfied while another CLI process recorded state.

The read now opens with `fopen('r')`, acquires `LOCK_SH`, reads the full contents, releases the lock (`LOCK_UN`), and closes the handle before decoding — coordinating with the writer's `LOCK_EX` on the same file so a read always sees a complete file.

This is the **reader-side counterpart** of the fail-closed writer hardening in the #200 / #207 / #212 / #241 / #243 concurrency cluster.

## Approach (recorded decision — issue #274 body)

The issue's Expected section recommended the shared-lock read (`open 'r'`, `flock LOCK_SH`, read, `LOCK_UN`) and explicitly ruled out temp-file + `rename()` (it breaks the same-`$fh` `flock` mutual-exclusion model). Implemented exactly that.

- Missing file: `fopen('r')` fails → `null`, matching the prior `file_exists()` guard.
- Transient `flock` acquire failure: `fclose` + `null`, in the fail-closed direction (a valid run momentarily reads unusable, never the reverse) — matching the writer's own lock-failure handling.
- Replacing the `file_exists()` + `file_get_contents()` two-step with one opened handle also removes a TOCTOU window against the TTL `@unlink` path.

## Scope

- `lib/operate.php` — `pp_operate_read_state()` reads under `LOCK_SH`; docblock updated.
- `tests/OperateTest.php` — 4 new cases: valid file reads under the shared lock, missing file → `null` via the `fopen` guard, corrupt payload → `null` without truncating/recreating the file, and lock-release verified (a subsequent `mutate_state` proceeds — no leak).

No AI-facing docs (`docs/`, `ai-instructions/`, `AI_RULES.md`, `AI_CONTEXT.md`, `README.md`, `lib/ai-context.php`) reference `read_state` or run-state locking — the read contract (state-or-null) is unchanged, so nothing there needed updating.

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → **1507 tests, 5570 assertions, all pass** (was 1503 on base; +4 new). Warning/deprecation counts (3 warnings / 2 deprecations) identical to a clean-tree baseline (`git stash` compare), so not introduced by this change.
- JS: `npm test` → **484 tests pass**.
- `bash scripts/package.sh` → version consistency OK across all five files; build zip deleted (releases are CI-built from tags).

## Accepted limitation (noted for maintainer)

The shared-lock read **blocks** under writer contention (no `LOCK_NB`/timeout), exactly as the recorded decision specifies and matching the writer, which also blocks on `LOCK_EX`. Both outside voices (Codex + Claude adversarial subagent) converged on suggesting a bounded-wait / non-blocking variant. That would **extend** the recorded decision (change accepted behavior under contention, and make the reader asymmetric with the writer), so per the pipeline's arbitration rule it was **not** implemented here — surfaced as a candidate follow-up. Consumers are CLI-only and the writer's critical section is small, so real contention is low. The self-deadlock both voices hedged is unreachable: every `read_state` caller invokes it top-level, and `mutate_state` never calls `read_state` (verified).

## Reviews (this session, on this exact diff)

- `/plan-eng-review` — approved the shared-lock approach; single-function change, Layer-1 built-in, all getters covered by one choke point.
- `/review` — critical pass (Race Conditions & Concurrency) + Claude adversarial subagent + Codex adversarial (`codex exec`, diff inlined). Verdict: MERGE. No lock leak, valid `LOCK_SH`/`LOCK_EX` coordination, unlink race improved. One convergent finding (blocking read) handled as the accepted limitation above.

Version: v0.16.85 (PATCH). Do not tag/release/deploy — maintainer does that separately.
