### PR TITLE
v0.16.86 fix: restore-composition fails closed on partial restore (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.86] — 2026-07-12 — `restore-composition` fails closed on a partial restore instead of reporting success (#242)
+
+**`wp pp apply restore-composition` printed the run-scoped restore report, warned about any `skipped` posts (a missing pre-run snapshot or a write failure), and then unconditionally ended with `WP_CLI::success` and exit 0. A machine consumer — the documented AI-operator contract — that branches on the exit code therefore read a partial restore as a complete one: if a touched post could not be reverted, the run still reported overall success. The command now fails closed. When any touched post lands in `skipped`, it still prints the JSON report (so you can see which posts were restored versus skipped), but it exits 1 with an explicit `Error: Restore INCOMPLETE` message. Exit 0 now means, and only means, that every touched post was reverted.**
+
+The fix lives entirely in the CLI presentation layer; the report producer `pp_operate_restore_run_compositions()` already reported `reverted` and `skipped` correctly. A new pure verdict helper `pp_operate_restore_run_complete()` in `lib/operate.php` classifies a report as complete only when it has a usable touched-post record (`ok === true`) and an empty `skipped` list. `PP_Apply_Command::restore_composition()` records the APPLY step (the partial revert did run and mutate state), preserves the human-facing skip warning, then branches on the verdict: an incomplete restore errors with a non-zero exit; a complete restore keeps the prior `Success:` messages unchanged. This is the same false-success class already closed for `preflight` (#227) and the token-recording paths (#243/#241): a gate must not report a success it did not achieve.
+
+### Fixed
+
+- `wp pp apply restore-composition` now exits non-zero (`WP_CLI::error`) when the run-scoped restore is incomplete — any touched post skipped for a missing snapshot or a write failure — instead of always exiting 0 with `Success:`. The JSON report (restored vs skipped) and the human skip warning are preserved; exit 0 now guarantees a full restore, so a machine consumer can no longer mistake a partial restore for a complete one (#242).
+
+### Docs
+
+- `docs/reference-apply-cli.md` documents the `restore-composition` exit-code contract: exit 0 only on a full restore, exit 1 with `Error: Restore INCOMPLETE` when any post is skipped, JSON report printed on both paths (#242).
+
+### Tests
+
+- New `OperateTest` cases pin `pp_operate_restore_run_complete()`: a fully-reverted report is complete, a report with any `skipped` entry is incomplete, and an `ok:false` (no usable record) report is incomplete; two end-to-end cases drive the real report producer through a missing-snapshot skip (incomplete) and a clean revert (complete) (#242).
+
 ## [v0.16.85] — 2026-07-12 — run-state readers now take a shared lock so they never observe a half-written file (#274)
 
 **The operating loop's writer (`pp_operate_mutate_state()`) takes an exclusive `flock` for its whole read-modify-write, but `flock` is advisory: a reader that does not itself take a shared lock bypasses it entirely. `pp_operate_read_state()` read the run-state file with a bare `file_get_contents()` and no lock, so while the writer was mid-write (a non-atomic `ftruncate(0)` then `fwrite()`) a concurrent reader — `operate inspect`, a step-completion check, a preflight-coverage query, any snapshot getter — could observe an empty or partially written file, fail to decode it, and treat the run as missing. On the same install this surfaced as a spurious "run not found" or a preflight/step gate transiently reading as unsatisfied while another CLI process recorded state. The read now takes a shared lock (`flock LOCK_SH`) and blocks until the writer releases, so it always sees a complete file.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.85-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.86-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/docs/reference-apply-cli.md
+++ b/docs/reference-apply-cli.md
@@ -369,10 +369,18 @@ The composition counterpart of `wp pp apply restore`. Reverts **every page the r
 wp pp apply restore-composition --run-id=<uuid>
 ```
 
-Fail-closed: if the run's touched-post record is missing / expired / corrupt / from another install, nothing is changed. Per-post snapshot-missing or write failures are reported under `skipped` in the JSON output while the rest proceed. On success:
+Fail-closed: if the run's touched-post record is missing / expired / corrupt / from another install, nothing is changed and it errors (exit **1**). Per-post snapshot-missing or write failures are reported under `skipped` in the JSON output while the reverts that can proceed still proceed.
+
+**Exit codes** — `0` only when **every** touched post was reverted (a full restore). When any post lands in `skipped`, the JSON report is still printed (so you can see which posts were restored vs skipped) but the command **errors and exits 1**: a partial restore is incomplete, not successful, so a machine consumer branching on the exit code never reads it as a full one.
+
+When the restore is complete (empty `skipped`):
 
 - `Success: Reverted N composition(s) to the pre-run state (of M touched).`
 - `Success: Touched compositions already matched the pre-run state; nothing to revert.`
+
+When the restore is incomplete (non-empty `skipped`):
+
+- `Error: Restore INCOMPLETE: reverted N of M touched post(s); K could not be reverted (missing snapshot or write failure). See the report above for which posts were restored vs skipped.` (exit 1)
 
 ### `wp pp operate composition-history <page>` (read-only)
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.85');
+define('PP_VERSION', '0.16.86');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -658,14 +658,25 @@ class PP_Apply_Command extends WP_CLI_Command {
 
         WP_CLI::line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
 
-        if (!empty($report['skipped'])) {
-            WP_CLI::warning(count($report['skipped']) . ' post(s) skipped (missing snapshot or write failure); see the report above.');
+        $skipped  = count($report['skipped']);
+        if ($skipped > 0) {
+            WP_CLI::warning($skipped . ' post(s) skipped (missing snapshot or write failure); see the report above.');
         }
 
         $reverted = count($report['reverted']);
         $changed  = count(array_filter($report['reverted'], static function ($r) { return !empty($r['changed']); }));
 
         pp_operate_record_step($run_id, 'APPLY');
+
+        // issue 242: a partial restore (any skipped touched post) is INCOMPLETE, not
+        // successful. Fail closed with a non-zero exit so a machine consumer branching
+        // on the exit code never reads a partial restore as a full one; the JSON report
+        // above already lists reverted vs skipped explicitly.
+        if (!pp_operate_restore_run_complete($report)) {
+            WP_CLI::error("Restore INCOMPLETE: reverted $reverted of " . ($reverted + $skipped)
+                . " touched post(s); $skipped could not be reverted (missing snapshot or write failure). See the report above for which posts were restored vs skipped.");
+        }
+
         WP_CLI::success($changed > 0
             ? "Reverted $changed composition(s) to the pre-run state (of $reverted touched)."
             : 'Touched compositions already matched the pre-run state; nothing to revert.');

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -1278,6 +1278,21 @@ function pp_operate_restore_run_compositions( string $run_id ): array {
 }
 
 /**
+ * Whether a run-scoped composition restore fully reverted every touched post
+ * (issue 242). A restore is INCOMPLETE when the run had no usable touched-post
+ * record (`ok === false`) OR one or more touched posts could not be reverted
+ * (non-empty `skipped` — missing snapshot or write failure). The CLI uses this
+ * to fail closed: a machine consumer branching on the exit code must never read
+ * a partial restore as a full one.
+ *
+ * @param array $report  A pp_operate_restore_run_compositions() result.
+ * @return bool  True iff the restore reverted all touched posts and none was skipped.
+ */
+function pp_operate_restore_run_complete( array $report ): bool {
+    return ! empty( $report['ok'] ) && empty( $report['skipped'] );
+}
+
+/**
  * True iff the run is currently usable as a rollback source: the state is valid for
  * this install AND a frozen pre-apply snapshot exists. Used as execute()'s pre-mutation
  * gate so a change that could not be rolled back is never applied in the first place.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.85",
+  "version": "0.16.86",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.85
+Stable tag: 0.16.86
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.85
+Version:          0.16.86
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -2222,6 +2222,67 @@ class OperateTest extends TestCase
         pp_operate_cleanup_run($run_id);
     }
 
+    // ── restore-composition completeness verdict (#242) ─────────────────────
+    // The CLI fails closed on an incomplete restore (non-zero exit) so a machine
+    // consumer never reads a partial restore as a full one. The verdict is the
+    // decision seam pp_operate_restore_run_complete() the CLI branches on.
+
+    public function testRestoreRunCompleteTrueWhenAllTouchedPostsReverted(): void
+    {
+        $report = ['ok' => true, 'error' => null,
+            'reverted' => [['post_id' => 1, 'changed' => true]], 'skipped' => []];
+        $this->assertTrue(pp_operate_restore_run_complete($report));
+    }
+
+    public function testRestoreRunCompleteFalseWhenAnyPostSkipped(): void
+    {
+        // A missing snapshot / write failure leaves a touched post in `skipped`:
+        // the restore is INCOMPLETE even though some posts reverted.
+        $report = ['ok' => true, 'error' => null,
+            'reverted' => [['post_id' => 1, 'changed' => true]],
+            'skipped'  => [['post_id' => 2, 'reason' => 'no_snapshot']]];
+        $this->assertFalse(pp_operate_restore_run_complete($report));
+    }
+
+    public function testRestoreRunCompleteFalseWhenNoUsableRecord(): void
+    {
+        // ok:false (no usable touched-post record) is also incomplete.
+        $report = ['ok' => false, 'error' => 'no_touched_post_ids',
+            'reverted' => [], 'skipped' => []];
+        $this->assertFalse(pp_operate_restore_run_complete($report));
+    }
+
+    public function testRestoreRunCompleteVerdictMatchesRealSkipReport(): void
+    {
+        // End-to-end over the real report producer: a touched post with no snapshot
+        // is skipped, so the run-scoped restore is judged incomplete.
+        $GLOBALS['_pp_test_store']['post_meta'] = [];
+        pp_update_composition(821, [['component' => 'hero', 'props' => ['title' => 'Y0']]]);
+        $run_id = pp_operate_create_run();
+        pp_update_composition(821, [['component' => 'hero', 'props' => ['title' => 'Y1']]]);
+        pp_operate_record_touched_post_id($run_id, 821);
+
+        $report = pp_operate_restore_run_compositions($run_id);
+        $this->assertFalse(pp_operate_restore_run_complete($report), 'skipped post → incomplete');
+        pp_operate_cleanup_run($run_id);
+    }
+
+    public function testRestoreRunCompleteVerdictMatchesRealCleanReport(): void
+    {
+        // A run that snapshots its touched post reverts cleanly → complete.
+        $GLOBALS['_pp_test_store']['post_meta'] = [];
+        pp_update_composition(822, [['component' => 'hero', 'props' => ['title' => 'Z0']]]);
+        $run_id = pp_operate_create_run();
+        pp_operate_record_composition_content_snapshot($run_id, 822, pp_get_composition(822));
+        pp_update_composition(822, [['component' => 'hero', 'props' => ['title' => 'Z1']]]);
+        pp_operate_record_touched_post_id($run_id, 822);
+
+        $report = pp_operate_restore_run_compositions($run_id);
+        $this->assertTrue(pp_operate_restore_run_complete($report), 'all reverted → complete');
+        $this->assertSame('Z0', pp_get_composition(822)[0]['props']['title']);
+        pp_operate_cleanup_run($run_id);
+    }
+
     // ── apply reset rollback trail (#122) ──────────────────────────────────
 
     public function testApplyResetRecordsTouchedTokensRestorableViaRevert(): void


### PR DESCRIPTION
Closes #242

## Scope

`wp pp apply restore-composition` fails closed on an incomplete run-scoped restore. Per the recorded v1.0.0 gate decision: skipped restore targets make the CLI restore incomplete, not successful.

Before: the command printed the report, emitted `WP_CLI::warning` for any `skipped` posts (missing pre-run snapshot or write failure), then unconditionally ended with `WP_CLI::success` and exit 0. A machine consumer (the documented AI-operator contract) branching on the exit code read a partial restore as complete.

After: when any touched post is skipped, the command still prints the JSON report and the human skip warning, records the APPLY step (the partial revert ran), then errors with `WP_CLI::error` (exit 1) and `Error: Restore INCOMPLETE: ...`. Exit 0 now means, and only means, every touched post was reverted.

### Against each acceptance criterion
- **Non-zero exit / fail semantics when `skipped` is non-empty** — `restore_composition()` now branches on the new verdict helper and calls `WP_CLI::error` (exit 1) on an incomplete restore.
- **JSON report stays explicit about restored vs skipped** — the `WP_CLI::line(json_encode($report, ...))` print is unchanged and runs on both paths.
- **Preserve warnings for human operators** — the `WP_CLI::warning` skip line is kept before the terminal error.

## Implementation
- `lib/operate.php` — new pure `pp_operate_restore_run_complete(array $report): bool` (complete iff `ok === true` and empty `skipped`).
- `lib/cli.php` — `PP_Apply_Command::restore_composition()` records APPLY, then errors on `!pp_operate_restore_run_complete($report)`; the success branch is unchanged.
- `docs/reference-apply-cli.md` — documents the exit-code contract.

## Validation
- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` — 1512 tests, 5576 assertions, green (was 1507; +5 new). Warning/deprecation counts unchanged vs an unmodified tree (3 warnings / 2 deprecations, pre-existing).
- JS: `npm test` — 484 passed.
- `bash scripts/package.sh` — version consistency OK across the five synced files; built zip deleted (releases are CI-built from tags).

## gstack workflows
- `/plan-eng-review` (plan-stage), `/review` (diff-scoped; one finding — an error-message accuracy bug in the new code — fixed), `/document-generate` (found + fixed one stale exit/success claim in `docs/reference-apply-cli.md`).

## Accepted limitations
- Exit-code behavior is covered by unit-pinning the verdict helper the CLI branches on, not by a new Playwright E2E: forcing a `skipped` through the public CLI requires white-box run-state corruption and a live wp-env, which the repo reserves for genuinely browser-observable changes. The 1-line CLI mapping (verdict -> `WP_CLI::error`) was verified by review.
- Step recording is unchanged: an incomplete restore still records the APPLY step because the partial revert did mutate state; the recorded decision speaks only to exit/reporting semantics.

## 7A question
None. No review finding extended the recorded decision.