### PR TITLE
v0.16.87 fix: preflight fails closed on unknown --apply name (#245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.87] — 2026-07-12 — `apply preflight` fails closed on an unknown `--apply` name instead of passing clean (#245)
+
+**`wp pp apply preflight --apply=<name>` never validated `<name>` against the apply registry. A typo (`--apply=import_medai`) resolved `pp_get_apply()` to `null` and was treated exactly like "no apply planned": the apply-routed filesystem checks were skipped, preflight passed clean, and a `PREFLIGHT` state was recorded — a green gate asserting a precondition ("no filesystem writes") the operator never earned. That is the same false-pass class as the fail-closed preflight cluster (#200/#207/#212/#227/#229), one level up: a gate must not certify a claim it did not verify. Preflight now emits an error-grade `apply_known` check for any provided-but-unregistered name, so `ok` is `false`, the CLI reports the checks and exits non-zero, and no `PREFLIGHT` is recorded. `wp pp apply execute` already rejected unknown action names; preflight now matches that posture for apply names.**
+
+The guard lives at the single apply-name resolution point in `pp_preflight()` (`lib/operate.php`): when a supplied apply name resolves to no registered definition, an error-grade `apply_known` check is appended (`pass:false`, `Unknown apply: <name>`), which drives the existing `ok = no error-grade failure` logic to `false` and the existing CLI path to report-and-halt without recording state. Presence is tested as a non-empty string (`!== ''`), not `empty()`: PHP's `empty('0')` is `true`, so an `!empty()` gate would let the literal apply name `0` (and a bare `--apply` that WP-CLI coerces to boolean) slip through as "no apply planned" — no registered apply is named `0`, so any provided value that fails the registry lookup fails closed. The CLI boundary in `PP_Apply_Command::preflight()` (`lib/cli.php`) matches: it now routes any non-empty `--apply` value into the preflight context (previously `!empty()` dropped `--apply=0` before it could be validated). An empty `--apply=` remains "no apply planned," identical to omitting the flag.
+
+### Fixed
+
+- `wp pp apply preflight --apply=<name>` now fails closed with an error-grade `apply_known` check when `<name>` is not a registered apply, instead of silently treating an unknown/typo'd name as "no apply planned," skipping the apply-routed filesystem checks, and recording a successful `PREFLIGHT`. Presence is tested as a non-empty string so the falsy literal `--apply=0` is validated (and rejected) rather than dropped by `empty()` (#245).
+
+### Docs
+
+- `docs/reference-apply-cli.md` documents the `apply_known` check (checks table + `--apply` option + a worked "Unknown apply name" note): a provided non-empty apply name that matches no registered apply fails preflight closed; an empty `--apply=` is "no apply planned" (#245).
+
+### Tests
+
+- New `OperateTest` cases pin `pp_preflight()` apply-name validation: an unknown name emits a failing `apply_known` check and makes `ok` false; an unknown name still skips the apply-routed `uploads_writable` check while the overall preflight fails; a registered name and an absent flag emit no `apply_known` check; and the falsy literal `0` is validated and rejected while an empty string is treated as no-apply (#245).
+
 ## [v0.16.86] — 2026-07-12 — `restore-composition` fails closed on a partial restore instead of reporting success (#242)
 
 **`wp pp apply restore-composition` printed the run-scoped restore report, warned about any `skipped` posts (a missing pre-run snapshot or a write failure), and then unconditionally ended with `WP_CLI::success` and exit 0. A machine consumer — the documented AI-operator contract — that branches on the exit code therefore read a partial restore as a complete one: if a touched post could not be reverted, the run still reported overall success. The command now fails closed. When any touched post lands in `skipped`, it still prints the JSON report (so you can see which posts were restored versus skipped), but it exits 1 with an explicit `Error: Restore INCOMPLETE` message. Exit 0 now means, and only means, that every touched post was reverted.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.86-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.87-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/docs/reference-apply-cli.md
+++ b/docs/reference-apply-cli.md
@@ -112,7 +112,7 @@ wp pp apply preflight --run-id=<uuid> --post_id=42
 - `--run-id=<uuid>` — **required.** Run token from `wp pp operate inspect`.
 - `--planned-files=<json>` — JSON array of file paths the agent intends to modify. Enables drift-overlap detection. Without it, drift is a warning only.
 - `--post_id=<id>` — target page post ID. Adds the `target_page` check and scopes coverage to that post.
-- `--apply=<name>` — named apply. Auto-populates `planned_files` from a file-based apply's target; a media-target apply (`import_media`) enables the `uploads_writable` check (#229).
+- `--apply=<name>` — named apply. Auto-populates `planned_files` from a file-based apply's target; a media-target apply (`import_media`) enables the `uploads_writable` check (#229). A name that matches no registered apply **fails preflight closed** via the `apply_known` check (issue 245) — a typo is never treated as "no apply planned."
 
 **Coverage grain.** A preflight with `--post_id=N` covers mutations on post N; a preflight with no post covers **site-grain** changes. They don't substitute for each other — a page mutation needs a page preflight, a site mutation needs a site preflight. This is what `execute`/`action execute`/`operate patch` check.
 
@@ -161,6 +161,7 @@ The checks that can run (`pp_preflight`, `lib/operate.php`):
 |---|---|---|
 | `target` | always | yes |
 | `capability` | always | yes |
+| `apply_known` | `--apply=<name>` given and unregistered | yes |
 | `drift` | always | only if drifted files overlap `planned_files` |
 | `theme_writable` | file-targeting applies only | yes (skipped for DB-backed token applies and for media applies, whose writes are covered by `uploads_writable`) |
 | `uploads_writable` | media-target applies only (`--apply=import_media`, #229) | yes |
@@ -172,6 +173,12 @@ The checks that can run (`pp_preflight`, `lib/operate.php`):
 `ok` is `true` only when no **error-grade** check failed. Rows with `severity: warning` (nav readiness, screenshot readiness, non-overlapping drift) surface a problem without blocking.
 
 **Uploads writability (#229).** `import_media` sideloads a file into `wp-content/uploads/YYYY/MM/`, so a preflight with `--apply=import_media` runs `uploads_writable` instead of asserting "no filesystem writes." The check mirrors execute-time `wp_mkdir_p()` semantics: it walks from the dated path to the **deepest existing ancestor** and requires it to be a writable directory — so a fresh site whose `uploads/` doesn't exist yet passes (WordPress creates it), while an unwritable intermediate directory (`uploads/2026` rsync'd `0555`) or a regular file occupying a path segment fails closed even when `uploads/` itself is writable. The `theme_writable` row still passes for media applies (the theme directory is untouched) with a message pointing at `uploads_writable`.
+
+**Unknown apply name (issue 245).** The `--apply` flag exists so preflight can verify the named apply's preconditions, so a name that matches no registered apply is a hard error, not a no-op. Without the guard, `--apply=import_medai` (a typo) would resolve to "no apply planned," skip the apply-routed filesystem checks, pass clean, and record a `PREFLIGHT` state asserting "no filesystem writes" the operator never earned — the same false-pass class as #227/#229, one level up. Any **provided** non-empty apply value is validated (including the falsy literal `--apply=0`, which is never a registered name); an empty `--apply=` is treated as "no apply planned," same as omitting the flag. The `apply_known` check is error-grade, so an unknown name makes `ok` false and no `PREFLIGHT` is recorded:
+
+```json
+{ "check": "apply_known", "pass": false, "message": "Unknown apply: import_medai. Preflight cannot verify preconditions for an unregistered apply; check the name against the apply registry." }
+```
 
 **Exit codes and errors**
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.86');
+define('PP_VERSION', '0.16.87');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -795,7 +795,12 @@ class PP_Apply_Command extends WP_CLI_Command {
             $context['post_id'] = (int) $assoc_args['post_id'];
         }
 
-        if (!empty($assoc_args['apply'])) {
+        // Route any provided --apply value (non-empty string) into the context so an
+        // unregistered name fails the apply_known preflight check (issue 245). Guard
+        // on `!== ''` rather than !empty(): PHP's empty('0') is true, so an !empty()
+        // gate would drop the literal apply name "0" here and let pp_preflight() treat
+        // it as "no apply planned" — the exact false-pass the apply_known check closes.
+        if (isset($assoc_args['apply']) && $assoc_args['apply'] !== '') {
             $context['apply_name'] = $assoc_args['apply'];
         }
 

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -220,9 +220,34 @@ function pp_preflight(array $context = [], ?array $drift = null): array {
     }
 
     // Resolve the planned apply's target type once — it routes the
-    // planned_files auto-population and the filesystem checks below.
-    $apply_def         = !empty($context['apply_name']) ? pp_get_apply($context['apply_name']) : null;
+    // planned_files auto-population and the filesystem checks below. Normalize the
+    // supplied name to a string and treat "provided" as any non-empty string, NOT
+    // empty() — PHP's empty('0') is true, so an !empty() gate would silently let the
+    // literal apply name "0" (and a bare --apply that WP-CLI coerces to bool true)
+    // slip past the apply_known guard below as "no apply planned." No registered
+    // apply is named "0", so any provided value that fails the registry lookup must
+    // fail closed (issue 245).
+    $apply_name        = isset($context['apply_name']) ? (string) $context['apply_name'] : '';
+    $apply_def         = $apply_name !== '' ? pp_get_apply($apply_name) : null;
     $apply_target_type = $apply_def !== null && isset($apply_def['target']['type']) ? $apply_def['target']['type'] : null;
+
+    // Apply name known (issue 245): a provided --apply that names no registered
+    // apply must FAIL preflight closed. Left unguarded, an unknown/typo'd name
+    // (e.g. import_medai) resolves $apply_def to null and is treated exactly like
+    // "no apply planned": the apply-routed filesystem checks are skipped, preflight
+    // passes, and PREFLIGHT is recorded — a green gate asserting a precondition
+    // ("no filesystem writes") the operator never earned. This is the same
+    // false-pass class as the fail-closed preflight trilogy (#200/#207/#212) and
+    // #227/#229, one level up. Error-grade (no 'severity') so ok=false and the CLI
+    // reports the checks and halts without recording PREFLIGHT. Mirrors action
+    // execute's unknown-name rejection in lib/cli.php.
+    if ($apply_name !== '' && $apply_def === null) {
+        $checks[] = [
+            'check'   => 'apply_known',
+            'pass'    => false,
+            'message' => 'Unknown apply: ' . $apply_name . '. Preflight cannot verify preconditions for an unregistered apply; check the name against the apply registry.',
+        ];
+    }
 
     // Auto-populate planned_files from apply definition if apply_name given.
     // Option-based targets don't produce planned_files (no file drift concern).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.86",
+  "version": "0.16.87",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.86
+Stable tag: 0.16.87
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.86
+Version:          0.16.87
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -689,6 +689,82 @@ class OperateTest extends TestCase
         );
     }
 
+    // ── Apply name known (issue 245) ───────────────────────────────────────
+
+    public function testPreflightFailsForUnknownApplyName(): void
+    {
+        // A typo'd / unregistered --apply name must fail preflight closed
+        // instead of being treated as "no apply planned".
+        $result = pp_preflight(['apply_name' => 'import_medai']);
+        $check  = $this->findCheck($result, 'apply_known');
+
+        $this->assertNotNull($check, 'Unknown apply must emit an apply_known check');
+        $this->assertFalse($check['pass'], 'Unknown apply name must fail the apply_known check');
+        $this->assertStringContainsString('Unknown apply: import_medai', $check['message']);
+        $this->assertFalse($result['ok'], 'apply_known is error-grade: an unknown apply makes preflight ok false');
+    }
+
+    public function testPreflightUnknownApplySkipsApplyRoutedFilesystemChecks(): void
+    {
+        // Guards the false-pass path: with an unknown name, $apply_target_type is
+        // null, so the theme/uploads checks fall to the "no filesystem writes"
+        // skip. apply_known is what keeps the overall preflight failing.
+        $result = pp_preflight(['apply_name' => 'import_medai']);
+
+        $this->assertNull(
+            $this->findCheck($result, 'uploads_writable'),
+            'Unknown apply resolves no target type, so no uploads_writable check is emitted'
+        );
+        $this->assertFalse($result['ok'], 'Overall preflight must still fail via apply_known');
+    }
+
+    public function testPreflightFailsForFalsyStringApplyName(): void
+    {
+        // Regression guard: the presence test must be `!== ''`, not empty().
+        // PHP's empty('0') is true, so an !empty() gate would let the literal
+        // apply name "0" slip through as "no apply planned" — a provided-but-
+        // unregistered value must still fail closed (Codex adversarial finding
+        // on issue 245). No registered apply is named "0".
+        $result = pp_preflight(['apply_name' => '0']);
+        $check  = $this->findCheck($result, 'apply_known');
+
+        $this->assertNotNull($check, 'A provided falsy-string apply name must still be validated');
+        $this->assertFalse($check['pass'], 'apply name "0" is unregistered and must fail the apply_known check');
+        $this->assertStringContainsString('Unknown apply: 0', $check['message']);
+        $this->assertFalse($result['ok'], 'Overall preflight must fail for the unregistered name "0"');
+    }
+
+    public function testPreflightNoApplyKnownCheckForEmptyStringApplyName(): void
+    {
+        // An empty-string apply name is "no apply planned" (equivalent to omitting
+        // the flag), NOT an unknown apply — it must not emit an apply_known failure.
+        $result = pp_preflight(['apply_name' => '']);
+        $this->assertNull(
+            $this->findCheck($result, 'apply_known'),
+            'An empty apply name is no-apply-planned, not an unknown apply'
+        );
+    }
+
+    public function testPreflightNoApplyKnownCheckForRegisteredApply(): void
+    {
+        // A known apply name must NOT emit a failing apply_known check.
+        $result = pp_preflight(['apply_name' => 'update_design_token']);
+        $this->assertNull(
+            $this->findCheck($result, 'apply_known'),
+            'A registered apply must not emit an apply_known check'
+        );
+    }
+
+    public function testPreflightNoApplyKnownCheckWithNoApplyName(): void
+    {
+        // No --apply at all is "no apply planned", not an unknown apply.
+        $result = pp_preflight();
+        $this->assertNull(
+            $this->findCheck($result, 'apply_known'),
+            'Preflight without a planned apply must not emit an apply_known check'
+        );
+    }
+
     public function testPreflightThemeWritableMessageDoesNotClaimNoFilesystemWritesForMediaApply(): void
     {
         $uploads = $this->tempDir . '/uploads';


### PR DESCRIPTION
Closes #245

## Summary

`wp pp apply preflight --apply=<name>` never validated `<name>` against the apply registry. A typo like `--apply=import_medai` resolved `pp_get_apply()` to `null` and was treated exactly like "no apply planned": the apply-routed filesystem checks were skipped, preflight passed clean, and a `PREFLIGHT` state was recorded — a green gate asserting a precondition ("no filesystem writes") the operator never earned. Same false-pass class as the fail-closed preflight cluster (#200/#207/#212/#227/#229), one level up.

Preflight now emits an error-grade `apply_known` check for any provided-but-unregistered apply name, so `ok` is `false`, the CLI reports the checks and exits non-zero, and no `PREFLIGHT` is recorded. This matches `wp pp apply execute`, which already rejects unknown action names.

## Recorded decision applied

Per #245's 2026-07-11 v1.0.0 gate decision: "unknown `--apply` names fail preflight closed." Acceptance — validate the supplied apply name against the registry before apply-routed checks are skipped; report a failing `apply_known` check; do not record a successful preflight for unknown applies. All three met.

## Scope / acceptance criteria

- **Validate before skipping apply-routed checks** — the `apply_known` guard sits at the single apply-name resolution point in `pp_preflight()` (`lib/operate.php`), before the theme/uploads routing.
- **Report an explicit failing check** — `{check:"apply_known", pass:false, message:"Unknown apply: <name>. ..."}`, error-grade (no `severity`), so it drives `ok` to `false`.
- **No successful PREFLIGHT for unknown applies** — `ok:false` makes the existing CLI path report the checks and `halt(1)` without recording state.
- **Falsy-name edge (from /review)** — presence is tested as `!== ''`, not `empty()` (PHP's `empty('0')` is `true`), so the literal `--apply=0` and a bare `--apply` are validated and rejected instead of dropped. `PP_Apply_Command::preflight()` (`lib/cli.php`) now routes any non-empty `--apply` value into context to match. An empty `--apply=` stays "no apply planned."

## Files changed

- Code: `lib/operate.php` (apply_known guard + `!== ''` presence), `lib/cli.php` (CLI routes non-empty `--apply` into context)
- Tests: `tests/OperateTest.php` (6 new cases: unknown name fails / skips uploads check but overall fails / registered name and absent flag emit no check / falsy `0` rejected / empty string is no-apply)
- Docs: `docs/reference-apply-cli.md` (checks table row, `--apply` option, "Unknown apply name" note)
- Version + changelog: five synced files to 0.16.87, CHANGELOG entry

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — 1518 passing (was 1512 on main; +6), 3 warnings / 2 deprecations (unchanged from base tree)
- `npm test` (vitest) — 484 passing
- `bash scripts/package.sh` — version consistency OK across all five files; built zip deleted (releases are CI-built)

## Review

- `/plan-eng-review` (plan stage) and `/review` (working-tree diff) ran this session on this diff. `/review`'s Codex adversarial pass surfaced the `empty('0')` gap, verified against source, and fixed within the recorded decision (no 7A escalation needed — rejecting `0` is faithful to "validate the supplied apply name," not an extension of accepted behavior).

## Accepted limitations

None. No 7A question was raised.

## Not done deliberately

No tag, release, or deploy — per repo policy, releases are CI-built from tags by the maintainer.