### PR TITLE
v0.16.88 fix: run-scoped restore-composition reports current-rule findings (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.88] — 2026-07-12 — run-scoped `restore-composition` reports current-rule findings instead of a bare success (#236)
+
+**`wp pp apply restore-composition --run-id=<uuid>` reverts every page a run touched back to its PREFLIGHT-frozen composition through `pp_update_composition()`, the deliberately non-validating writer. A snapshot that violates a validation rule which landed after it was frozen (site chrome in the composition, a dangling `var(--token)`, any future rule) was restored verbatim and the command reported an unqualified success with no indication the restored page would not pass current validation. That is the same false-pass class as the per-page `restore_composition` action (#233) and the chrome validators (#223), on the run-scoped CLI surface. The rollback stays permissive — an undo must never be refused by a rule that landed after the snapshot — but each reverted post now carries a `findings` array, and the command warns when any restored composition violates current rules. A clean restore reports `findings: []` and prints no warning; exit codes are unchanged (a partial restore still fails per #242).**
+
+The findings reuse the shared engine `restore_composition` already uses (`_pp_composition_findings()`, which runs `pp_validate_composition_errors()` + `pp_validate_composition_smells()`); no third validator is introduced. `pp_operate_restore_run_compositions()` (`lib/operate.php`) attaches `findings` to each `reverted` entry, computed from the composition re-read via `pp_get_composition()` — the read-path migration shim makes that the canonical shape the validators expect, so the report matches the stored page. A pure predicate `pp_operate_restore_run_finding_count()` counts reverted posts (not total findings, and never skipped posts) so the CLI branch is unit-testable; `PP_Apply_Command::restore_composition()` (`lib/cli.php`) emits a `WP_CLI::warning` naming that count before the #242 completeness gate, to STDERR so the STDOUT JSON stays machine-clean. The revert is never blocked and the exit code never changes because of findings.
+
+### Fixed
+
+- `wp pp apply restore-composition` now attaches a `findings` array to every reverted post and warns (`WP_CLI::warning`) when any restored composition violates current validation rules, instead of reporting a bare `Success:` for a rollback that reintroduces rule-violating state. The rollback is still never blocked by rules that landed after the snapshot, and the exit code is unaffected by findings (a partial restore still fails per #242). Reuses the `restore_composition` action's findings helper; no second validator (#236).
+
+### Docs
+
+- `docs/reference-apply-cli.md` documents the run-scoped `restore-composition` `findings` contract: each reverted post carries `findings` (`[]` when clean), a `Warning:` names how many reverted posts have findings, and findings are advisory (they never change the exit code); skipped posts carry no `findings` key (#236).
+
+### Tests
+
+- New `OperateTest` cases pin the run-scoped findings: a rule-violating snapshot (chrome) is restored verbatim and its reverted entry reports a `template_owned_component` finding; a clean snapshot reports `findings: []`; a mixed run (clean + dirty + a skipped post with no snapshot) reports findings per reverted post, no `findings` key on the skipped post, and a `pp_operate_restore_run_finding_count()` of 1. Unit cases pin the predicate directly: it counts posts not total findings, ignores skipped entries, and returns 0 for a fail-closed report with no `reverted` key (#236).
+
 ## [v0.16.87] — 2026-07-12 — `apply preflight` fails closed on an unknown `--apply` name instead of passing clean (#245)
 
 **`wp pp apply preflight --apply=<name>` never validated `<name>` against the apply registry. A typo (`--apply=import_medai`) resolved `pp_get_apply()` to `null` and was treated exactly like "no apply planned": the apply-routed filesystem checks were skipped, preflight passed clean, and a `PREFLIGHT` state was recorded — a green gate asserting a precondition ("no filesystem writes") the operator never earned. That is the same false-pass class as the fail-closed preflight cluster (#200/#207/#212/#227/#229), one level up: a gate must not certify a claim it did not verify. Preflight now emits an error-grade `apply_known` check for any provided-but-unregistered name, so `ok` is `false`, the CLI reports the checks and exits non-zero, and no `PREFLIGHT` is recorded. `wp pp apply execute` already rejected unknown action names; preflight now matches that posture for apply names.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.87-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.88-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/docs/reference-apply-cli.md
+++ b/docs/reference-apply-cli.md
@@ -389,6 +389,8 @@ When the restore is incomplete (non-empty `skipped`):
 
 - `Error: Restore INCOMPLETE: reverted N of M touched post(s); K could not be reverted (missing snapshot or write failure). See the report above for which posts were restored vs skipped.` (exit 1)
 
+**Each reverted post carries a `findings` array (#236).** Like the `restore_composition` action, the run-scoped restore never blocks a rollback just because a rule that landed *after* the snapshot would reject it — but it must not report a clean success when a restored composition violates current rules. Every entry under `reverted` therefore includes `findings` (`[]` when the restored composition is clean under current rules; otherwise the shared `pp_validate_composition_*` errors and smells). When any reverted post reports findings, the command prints a `Warning:` naming how many, alongside the JSON report. The findings are advisory: the revert still succeeds and the exit code is unaffected (a partial restore still exits 1 per the completeness rule above; findings alone never change the exit code). Skipped posts were never rewritten and carry no `findings` key.
+
 ### `wp pp operate composition-history <page>` (read-only)
 
 Lists a page's history ring so you know which `steps_back` / `history_index` to restore. Needs no run token.

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.87');
+define('PP_VERSION', '0.16.88');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -663,6 +663,17 @@ class PP_Apply_Command extends WP_CLI_Command {
             WP_CLI::warning($skipped . ' post(s) skipped (missing snapshot or write failure); see the report above.');
         }
 
+        // issue 236: a run-scoped restore is never blocked by validation rules that
+        // landed after the snapshot, so it must not report a bare success when a
+        // restored composition violates current rules. Warn (never fail) so the operator
+        // sees the gap; the per-post `findings` in the JSON report above name the detail.
+        // Emitted before the completeness gate below (which can exit) so it always shows,
+        // and to STDERR (WP_CLI::warning) so the STDOUT JSON stays machine-clean.
+        $with_findings = pp_operate_restore_run_finding_count($report);
+        if ($with_findings > 0) {
+            WP_CLI::warning($with_findings . ' reverted post(s) have composition findings under current validation rules (see "findings" in the report above). The rollback was applied as-is; a restore is never blocked by rules that landed after the snapshot.');
+        }
+
         $reverted = count($report['reverted']);
         $changed  = count(array_filter($report['reverted'], static function ($r) { return !empty($r['changed']); }));
 

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -1296,7 +1296,18 @@ function pp_operate_restore_run_compositions( string $run_id ): array {
             continue;
         }
         $after      = pp_get_composition( $post_id );
-        $reverted[] = [ 'post_id' => $post_id, 'changed' => ( $before !== $after ) ];
+        // issue 236: report current-rule findings on the restored composition without
+        // ever blocking the rollback (parity with the restore_composition action, issue
+        // 233 — a rollback must never be refused by a rule that landed after the
+        // snapshot). Reuses the shared findings helper (pp_validate_composition_errors +
+        // _smells); no second validator. pp_get_composition() runs the read-path
+        // migration shim, so $after is already the canonical shape the validators expect
+        // — the same findings the action reports for the equivalent normalized snapshot.
+        $reverted[] = [
+            'post_id'  => $post_id,
+            'changed'  => ( $before !== $after ),
+            'findings' => _pp_composition_findings( $after ),
+        ];
     }
 
     return [ 'ok' => true, 'error' => null, 'reverted' => $reverted, 'skipped' => $skipped ];
@@ -1315,6 +1326,29 @@ function pp_operate_restore_run_compositions( string $run_id ): array {
  */
 function pp_operate_restore_run_complete( array $report ): bool {
     return ! empty( $report['ok'] ) && empty( $report['skipped'] );
+}
+
+/**
+ * Number of reverted posts whose restored composition carries current-rule
+ * findings (issue 236). The run-scoped restore never blocks on newer validation
+ * rules, so the CLI uses this to WARN (not fail) when a restored composition
+ * would not pass current validation. Counts POSTS with a non-empty findings
+ * array, not total findings, and only over `reverted` entries — `skipped` posts
+ * were never rewritten and carry no findings key. The decision seam the CLI
+ * branches on, mirroring pp_operate_restore_run_complete().
+ *
+ * @param array $report  A pp_operate_restore_run_compositions() result.
+ * @return int  Count of reverted posts reporting at least one finding.
+ */
+function pp_operate_restore_run_finding_count( array $report ): int {
+    $reverted = isset( $report['reverted'] ) && is_array( $report['reverted'] ) ? $report['reverted'] : [];
+    $count = 0;
+    foreach ( $reverted as $entry ) {
+        if ( ! empty( $entry['findings'] ) ) {
+            $count++;
+        }
+    }
+    return $count;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.87",
+  "version": "0.16.88",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.87
+Stable tag: 0.16.88
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.87
+Version:          0.16.88
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -2298,6 +2298,137 @@ class OperateTest extends TestCase
         pp_operate_cleanup_run($run_id);
     }
 
+    // ── run-scoped restore reports current-rule findings (#236) ─────────────
+    // Parity with the restore_composition action (#233): the run-scoped CLI restore
+    // never blocks a rollback on a rule that landed after the snapshot, but each
+    // reverted post must carry current-rule findings so the CLI can warn instead of
+    // reporting a bare success. Snapshots are seeded through pp_update_composition (the
+    // non-validating writer) — the only way a rule-violating composition reaches a
+    // preflight snapshot, exactly as a legacy row would have.
+
+    public function testRunScopedRestoreReportsFindingsForRuleViolatingSnapshot(): void
+    {
+        $GLOBALS['_pp_test_store']['post_meta'] = [];
+        // Chrome in the composition is legal before #223; freeze it as the pre-run baseline.
+        pp_update_composition(831, [
+            ['component' => 'nav', 'props' => []],
+            ['component' => 'hero', 'props' => ['title' => 'H0']],
+        ]);
+        $run_id = pp_operate_create_run();
+        pp_operate_record_composition_content_snapshot($run_id, 831, pp_get_composition(831));
+        // The run mutates it to a clean, chrome-free composition.
+        pp_update_composition(831, [['component' => 'hero', 'props' => ['title' => 'H1']]]);
+        pp_operate_record_touched_post_id($run_id, 831);
+
+        $report = pp_operate_restore_run_compositions($run_id);
+        $this->assertTrue($report['ok']);
+        $this->assertCount(1, $report['reverted']);
+        // The chrome snapshot is restored verbatim (never stripped)...
+        $this->assertSame('nav', pp_get_composition(831)[0]['component'], 'chrome survives the revert');
+        // ...and the reverted entry carries the current-rule finding rather than a bare ok.
+        $this->assertArrayHasKey('findings', $report['reverted'][0]);
+        $this->assertContains('template_owned_component', array_column($report['reverted'][0]['findings'], 'type'));
+        // The decision seam the CLI warns on counts this post.
+        $this->assertSame(1, pp_operate_restore_run_finding_count($report));
+        pp_operate_cleanup_run($run_id);
+    }
+
+    public function testRunScopedRestoreReportsEmptyFindingsForCleanSnapshot(): void
+    {
+        $GLOBALS['_pp_test_store']['post_meta'] = [];
+        pp_update_composition(832, [['component' => 'hero', 'props' => ['title' => 'C0']]]);
+        $run_id = pp_operate_create_run();
+        pp_operate_record_composition_content_snapshot($run_id, 832, pp_get_composition(832));
+        pp_update_composition(832, [['component' => 'hero', 'props' => ['title' => 'C1']]]);
+        pp_operate_record_touched_post_id($run_id, 832);
+
+        $report = pp_operate_restore_run_compositions($run_id);
+        $this->assertTrue($report['ok']);
+        $this->assertCount(1, $report['reverted']);
+        $this->assertArrayHasKey('findings', $report['reverted'][0]);
+        $this->assertSame([], $report['reverted'][0]['findings'], 'a clean snapshot reports no findings');
+        $this->assertSame(0, pp_operate_restore_run_finding_count($report), 'clean restore → CLI does not warn');
+        pp_operate_cleanup_run($run_id);
+    }
+
+    public function testRunScopedRestoreFindingsMixedCleanDirtyAndSkipped(): void
+    {
+        // One dirty (chrome) snapshot, one clean snapshot, one touched post with no
+        // snapshot (skipped). Verifies findings are per-post, skipped posts carry no
+        // findings key, and the CLI count ignores skipped entries.
+        $GLOBALS['_pp_test_store']['post_meta'] = [];
+        pp_update_composition(841, [
+            ['component' => 'footer', 'props' => []],
+            ['component' => 'hero', 'props' => ['title' => 'D0']],
+        ]);
+        pp_update_composition(842, [['component' => 'hero', 'props' => ['title' => 'E0']]]);
+        $run_id = pp_operate_create_run();
+        pp_operate_record_composition_content_snapshot($run_id, 841, pp_get_composition(841));
+        pp_operate_record_composition_content_snapshot($run_id, 842, pp_get_composition(842));
+        // Mutate + touch all three; 843 has no snapshot so it will be skipped.
+        pp_update_composition(841, [['component' => 'hero', 'props' => ['title' => 'D1']]]);
+        pp_operate_record_touched_post_id($run_id, 841);
+        pp_update_composition(842, [['component' => 'hero', 'props' => ['title' => 'E1']]]);
+        pp_operate_record_touched_post_id($run_id, 842);
+        pp_update_composition(843, [['component' => 'hero', 'props' => ['title' => 'F1']]]);
+        pp_operate_record_touched_post_id($run_id, 843);
+
+        $report = pp_operate_restore_run_compositions($run_id);
+        $this->assertCount(2, $report['reverted']);
+        $this->assertCount(1, $report['skipped']);
+        $this->assertSame(843, $report['skipped'][0]['post_id']);
+        $this->assertArrayNotHasKey('findings', $report['skipped'][0], 'skipped posts carry no findings');
+
+        $byPost = [];
+        foreach ($report['reverted'] as $entry) {
+            $byPost[$entry['post_id']] = $entry;
+        }
+        $this->assertContains('template_owned_component', array_column($byPost[841]['findings'], 'type'));
+        $this->assertSame([], $byPost[842]['findings'], 'clean post reports no findings');
+        // Only the dirty reverted post is counted — clean and skipped are excluded.
+        $this->assertSame(1, pp_operate_restore_run_finding_count($report));
+        pp_operate_cleanup_run($run_id);
+    }
+
+    // ── pp_operate_restore_run_finding_count() unit seam (#236) ─────────────
+    // The CLI warns iff this count > 0. Pure over the report shape so the warn
+    // decision is testable without a WP-CLI harness (mirrors _restore_run_complete).
+
+    public function testFindingCountZeroWhenNoRevertedPostHasFindings(): void
+    {
+        $report = ['ok' => true, 'error' => null, 'skipped' => [], 'reverted' => [
+            ['post_id' => 1, 'changed' => true, 'findings' => []],
+            ['post_id' => 2, 'changed' => false, 'findings' => []],
+        ]];
+        $this->assertSame(0, pp_operate_restore_run_finding_count($report));
+    }
+
+    public function testFindingCountCountsPostsNotTotalFindings(): void
+    {
+        // Two posts with findings (one carries two findings) → count is 2 POSTS, not 3.
+        $report = ['ok' => true, 'error' => null, 'skipped' => [], 'reverted' => [
+            ['post_id' => 1, 'changed' => true, 'findings' => [
+                ['type' => 'template_owned_component', 'severity' => 'warning'],
+                ['type' => 'invalid_style_value', 'severity' => 'error'],
+            ]],
+            ['post_id' => 2, 'changed' => true, 'findings' => []],
+            ['post_id' => 3, 'changed' => true, 'findings' => [
+                ['type' => 'template_owned_component', 'severity' => 'warning'],
+            ]],
+        ]];
+        $this->assertSame(2, pp_operate_restore_run_finding_count($report));
+    }
+
+    public function testFindingCountIgnoresSkippedAndMissingRevertedKey(): void
+    {
+        // A report with no reverted key (fail-closed shape) counts zero, and skipped
+        // entries are never inspected for findings.
+        $this->assertSame(0, pp_operate_restore_run_finding_count(
+            ['ok' => false, 'error' => 'no_touched_post_ids', 'reverted' => [], 'skipped' => []]
+        ));
+        $this->assertSame(0, pp_operate_restore_run_finding_count(['ok' => true]));
+    }
+
     // ── restore-composition completeness verdict (#242) ─────────────────────
     // The CLI fails closed on an incomplete restore (non-zero exit) so a machine
     // consumer never reads a partial restore as a full one. The verdict is the


### PR DESCRIPTION
Closes #236

## Scope

Run-scoped `wp pp apply restore-composition --run-id=<uuid>` reverts every page a run touched back to its PREFLIGHT-frozen composition through `pp_update_composition()` (the non-validating writer). A snapshot that violates a rule which landed after it was frozen was restored verbatim and the command reported a bare success. Per the recorded 2026-07-11 decision, the rollback stays permissive but must report current-rule findings.

Against the acceptance criteria:
- **Reuse the existing #233 helper, no third validator** — `pp_operate_restore_run_compositions()` calls `_pp_composition_findings()` (errors + smells) on each reverted post.
- **Attach findings per reverted post** — each `reverted[]` entry gains a `findings` array, computed from the migrated `pp_get_composition()` re-read (canonical shape the validators expect).
- **Warn when findings exist, never block** — new pure predicate `pp_operate_restore_run_finding_count()` (counts reverted posts with findings, ignores skipped); `PP_Apply_Command::restore_composition()` emits `WP_CLI::warning` before the #242 completeness gate, to STDERR so STDOUT JSON stays clean. The revert is never blocked and findings never change the exit code.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — **1524 passed** (5 new `OperateTest` cases; 3 warnings / 2 deprecations are pre-existing, unrelated to this change).
- `npm test` — **484 passed**.
- `bash scripts/package.sh` — version sync validated across the five files (v0.16.88); build zip deleted (CI builds releases).

## Files

- `lib/operate.php` — attach `findings` per reverted post + `pp_operate_restore_run_finding_count()` predicate.
- `lib/cli.php` — `WP_CLI::warning` when any reverted post has findings.
- `docs/reference-apply-cli.md` — run-scoped `findings` contract.
- `tests/OperateTest.php` — 5 new cases (chrome/clean/mixed report + predicate units).

## Accepted limitations

Findings are advisory: a restore is never refused, and the exit code is unaffected by findings (a partial restore still fails per #242). Findings describe the re-read persisted composition; since `pp_get_composition()` applies the read-path migration shim, this matches #233's normalized-findings semantics.

## 7A questions

None — the change stays strictly within the recorded decision.

## gstack workflows

/plan-eng-review (clean, no unresolved decisions), /review (clean, no findings after adversarial + codex passes), /document-generate (no additional docs needed beyond the reference update).