### PR TITLE
v0.16.89 fix: add pp_footer_show_logo site option to reach the footer logo (#234)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -158,7 +158,7 @@ If adding background-image support to another component, follow this exact patte
 
 **Hero:** `layout` = `left`, `centered`, `split` (inline image), `cover` (fullscreen background-image with overlay). Supports dual CTA buttons (`cta_text` + `cta2_text`), each with an independent `cta_variant`/`cta2_variant` (`primary`/`secondary`/`outline`/`ghost`; secondary defaults to `outline` — these are button-style props, unrelated to the layout `layout`). Composition props: `spacing` (compact/default/spacious), `width` (narrow/default/full), `split_ratio` (50-50/60-40/40-60, split layout only), `vertical_align` (top/center/bottom, cover and split only), `proof` (HTML string for trust signals like logos/ratings, rendered after CTA group). Hero content uses `--measure-centered` (56rem) as default max-width.
 
-**Nav/Footer:** Supports image logos via `logo_id` (Media Library attachment ID, not a URL) + `logo_alt`. Both the `logo_id` component prop and the `pp_logo_id` site option must be an **image** attachment; a non-image or non-existent ID is rejected when the action is validated (`update_component`/`add_component`/`update_composition` for the prop, `update_site_option` for the option). Resolution: `logo_id` prop → `pp_logo_id` site option → WP `custom_logo` theme-mod → `logo_text` (text) wordmark. Footer logo is opt-in via `show_logo` (default off). Set the site-wide logo through the `update_site_option` action with key `pp_logo_id`.
+**Nav/Footer:** Supports image logos via `logo_id` (Media Library attachment ID, not a URL) + `logo_alt`. Both the `logo_id` component prop and the `pp_logo_id` site option must be an **image** attachment; a non-image or non-existent ID is rejected when the action is validated (`update_component`/`add_component`/`update_composition` for the prop, `update_site_option` for the option). Resolution: `logo_id` prop → `pp_logo_id` site option → WP `custom_logo` theme-mod → `logo_text` (text) wordmark. Footer logo is off by default; turn it on with the `pp_footer_show_logo` site option (a boolean `1`/`0`/`true`/`false`) via `update_site_option` — composing a `footer` to pass `show_logo` is rejected (#223). Set the site-wide logo through the `update_site_option` action with key `pp_logo_id`.
 
 **Grid:** `layout` = `cards` (card grid), `steps` (numbered process cards — filled circular number badge, subtle connector line between badges at desktop). `theme` controls background color independently of `layout`. Card items accept `bullets` — a checklist of plain-text lines rendered below `text`, each prefixed with a check mark.
 
@@ -259,7 +259,7 @@ All functions are prefixed `pp_`. Templates and components use only these wrappe
 | `pp_set_token_override($token, $value)` | Writes a single token override to the database. |
 | `pp_clear_token_override($token)` | Removes a single token override (reverts to default). |
 | `pp_clear_all_token_overrides()` | Removes all overrides (reverts site to shipped defaults). |
-| `pp_site_option($key)`         | Whitelisted option value (blogname, blogdescription, pp_logo_id, pp_logo_alt) or WP_Error |
+| `pp_site_option($key)`         | Whitelisted option value (blogname, blogdescription, pp_logo_id, pp_logo_alt, pp_footer_show_logo) or WP_Error |
 | `pp_update_composition($post_id, $composition, $expected_version = null)` | Writes composition array to post meta (handles JSON serialization) and bumps the freshness marker under a per-post lock. Optional `$expected_version` (#13) does a write-time compare-and-swap: if the current version differs it returns a `composition_conflict` WP_Error and writes nothing. Null skips the CAS. Returns true\|WP_Error |
 | `pp_update_page_title($post_id, $title)` | Updates page title. Returns true\|WP_Error |
 | `pp_update_page_slug($post_id, $slug)` | Updates page slug/permalink (#134). Sanitizes via sanitize_title(); WordPress de-duplicates on collision. Returns the actual resulting slug\|WP_Error |
@@ -494,7 +494,7 @@ These are the keys every action returns, not the complete set for every action. 
 | Action | Scope | Params | Semantics |
 |---|---|---|---|
 | `create_page` | site | title (req), composition, status, slug | Create. Defaults to draft with empty composition. Optional `slug` sets the canonical route up front — omit to let WordPress derive one from the title |
-| `update_site_option` | site | key (req), value (req) | Replace. Whitelisted: blogname, blogdescription, pp_logo_id (attachment ID), pp_logo_alt |
+| `update_site_option` | site | key (req), value (req) | Replace. Whitelisted: blogname, blogdescription, pp_logo_id (attachment ID), pp_logo_alt, pp_footer_show_logo (bool) |
 | `update_page_title` | page | post_id (req), title (req) | Replace |
 | `update_page_slug` | page | post_id (req), slug (req) | Replace. Sanitized via `sanitize_title()`; WordPress de-duplicates on collision (suffixing `-2`, `-3`, ...) — `changes` always reports the actual resulting slug and permalink, which may differ from what was requested |
 | `update_seo_meta` | page | post_id (req), meta (req) | **Patch.** `meta` is a map of `meta_description`/`seo_title`/`canonical_url` → value, shallow-merged into existing SEO metadata. `seo_title` overrides the rendered `<title>` tag; `canonical_url` overrides the `<link rel="canonical">` tag. Set a key to `""` to clear it |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.89] — 2026-07-12 — `pp_footer_show_logo` site option makes the footer logo reachable again (#234)
+
+**#223 made `nav`/`footer` template-owned chrome, so composing a `footer` to pass `show_logo: true` is now rejected — which left the footer logo with no supported surface to turn it on (`footer.show_logo` defaults off, and nothing else set it). This adds `pp_footer_show_logo`, a boolean site option on the same safe `update_site_option` surface as `pp_logo_id`. `templates/base.php` reads it and passes `show_logo` into the footer; when on, the footer resolves the same logo as the header (`pp_logo_id` → `custom_logo` theme-mod → text wordmark). The header logo (`pp_logo_id`) is unchanged and independent.**
+
+The site-option whitelist (`pp_allowed_site_options()`) gains a third value type, `bool`, alongside `string` and `attachment_id`. `pp_validate_site_option_value()` accepts `1`/`0`/`true`/`false` (case-insensitive) and rejects anything else with a clear error — a typo like `flase` fails closed rather than silently coercing to on. The canonical stored form is `'1'` (on) / `'0'` (off), not `''`: both are themselves valid bool inputs, so a stored value survives the round-trip through the validating writer that the snapshot/rollback path (`_pp_restore_snapshot()`) uses to re-apply captured site options. Validation stays in the shared engine — no surface-specific second validator — and every AI-facing doc that described the footer logo as unreachable is corrected in the same change.
+
+### Added
+
+- `pp_footer_show_logo` boolean site option (whitelisted for `update_site_option`) turns the footer logo on/off; `templates/base.php` passes it into the footer component. New `bool` type in `pp_allowed_site_options()` with validation (`1`/`0`/`true`/`false`, case-insensitive) and canonical `'1'`/`'0'` storage via `pp_normalize_bool_option()` (#234).
+
+### Docs
+
+- `ai-instructions/set-logo.md`, `ai-instructions/website-building.md`, `components/footer/README.md`, `AI_CONTEXT.md`, and the `update_site_option` action description now document `pp_footer_show_logo` as the supported footer-logo surface, replacing the "footer logo is currently unreachable / no supported surface" notes left by #223 (#234).
+
+### Tests
+
+- New `LogoTest` cases pin the `bool` site option: the whitelist entry and its type; `pp_validate_site_option_value()` accepts `1`/`0`/`true`/`false` (incl. case + surrounding whitespace) and rejects non-bool values (`maybe`, `flase`, `2`, `''`, `yes`, `on`); `pp_update_site_option()` normalizes true-forms to `'1'` and false-forms to `'0'` and refuses to write a non-bool; the `update_site_option` action path accepts a valid bool and rejects an invalid one; the footer renders the logo when `show_logo` is true and a logo resolves, and omits it when false; and a round-trip guard confirms both stored forms (`'1'`/`'0'`) re-validate through the writer (regression guard for the rejected `''` OFF form) (#234).
+
 ## [v0.16.88] — 2026-07-12 — run-scoped `restore-composition` reports current-rule findings instead of a bare success (#236)
 
 **`wp pp apply restore-composition --run-id=<uuid>` reverts every page a run touched back to its PREFLIGHT-frozen composition through `pp_update_composition()`, the deliberately non-validating writer. A snapshot that violates a validation rule which landed after it was frozen (site chrome in the composition, a dangling `var(--token)`, any future rule) was restored verbatim and the command reported an unqualified success with no indication the restored page would not pass current validation. That is the same false-pass class as the per-page `restore_composition` action (#233) and the chrome validators (#223), on the run-scoped CLI surface. The rollback stays permissive — an undo must never be refused by a rule that landed after the snapshot — but each reverted post now carries a `findings` array, and the command warns when any restored composition violates current rules. A clean restore reports `findings: []` and prints no warning; exit codes are unchanged (a partial restore still fails per #242).**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.88-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.89-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/set-logo.md
+++ b/ai-instructions/set-logo.md
@@ -80,11 +80,15 @@ So if you never set `pp_logo_id`, a logo set through the WordPress Customizer st
 
 ## Footer logo
 
-The footer does **not** show the logo, and there is currently **no supported surface to turn it on**.
+The footer logo is **off by default**. Turn it on with the `pp_footer_show_logo` site option (`update_site_option`), the same safe surface used for `pp_logo_id`:
 
-`footer.show_logo` gates it, and the only way to pass that prop was to put a `footer` component into a page composition. Since #223 that is rejected: `nav` and `footer` are site chrome rendered by the base template, and composing one renders the chrome twice. `templates/base.php` invokes the footer with `location` only.
+```bash
+wp pp action execute update_site_option --run-id=<uuid> --params='{"key":"pp_footer_show_logo","value":"true"}'
+```
 
-`pp_logo_id` therefore sets the **header** logo. The footer keeps its copyright line. Tracked in #234. Do not work around this by composing a `footer` component — the write is rejected with `template_owned_component`, and every validator flags the page.
+The value is a boolean — `1`, `0`, `true`, or `false`. When on, the footer resolves the same logo as the header (`pp_logo_id` → `custom_logo` theme-mod → text wordmark). When off, the footer shows only its copyright line.
+
+`footer.show_logo` is a prop of the template-owned `footer` component; since #223 you cannot pass it by composing a `footer` (the write is rejected with `template_owned_component`, and every validator flags the page). The site option is the only supported surface. `pp_logo_id` still sets the **header** logo independently.
 
 ---
 
@@ -94,6 +98,7 @@ The footer does **not** show the logo, and there is currently **no supported sur
 |-----|-------|-------|
 | `pp_logo_id` | Media Library attachment ID (integer) | Must be an image. Never a URL. |
 | `pp_logo_alt` | string | Optional. Defaults to the attachment's alt metadata, then the site title. |
+| `pp_footer_show_logo` | boolean (`1`/`0`/`true`/`false`) | Optional, default off. Turns the footer logo on/off. Uses the same resolved logo as the header. |
 
 ---
 
@@ -102,4 +107,4 @@ The footer does **not** show the logo, and there is currently **no supported sur
 - **"requires a Media Library image attachment ID"** — the value isn't an image attachment. Confirm the ID with Step 1; a PDF/video attachment or a plain number that isn't an attachment is rejected. Never pass a URL.
 - **Logo shows as text, not an image** — no source resolved to an image. Check that `pp_logo_id` is set (or a `custom_logo` theme-mod exists) and that the attachment still exists.
 - **Action refused with a preflight error** — you skipped the run token flow. Run `wp pp operate inspect` for a `run_id`, then `wp pp apply preflight --run-id=<uuid>` before executing.
-- **Footer logo not appearing** — that's expected; the footer logo is opt-in via `show_logo`.
+- **Footer logo not appearing** — it is off by default. Turn it on by setting the `pp_footer_show_logo` site option to `true` via `update_site_option`, and make sure a logo resolves (a `pp_logo_id` image or a `custom_logo` theme-mod). Do not compose a `footer` component to set `show_logo`; that write is rejected (#223).

--- a/ai-instructions/website-building.md
+++ b/ai-instructions/website-building.md
@@ -13,6 +13,7 @@ Every visual change maps to exactly one mutation surface. Writing to the wrong s
 | Component-specific CSS (spacing, layout) | `assets/css/components.css` | Direct file edit (BEM classes, token values only) |
 | Site name, tagline | WordPress options | `update_site_option` action |
 | Site logo (header) | WordPress option (Media Library attachment) | `update_site_option` action (key `pp_logo_id`, an attachment ID) |
+| Footer logo (on/off) | WordPress option (boolean) | `update_site_option` action (key `pp_footer_show_logo`, `1`/`0`/`true`/`false`; uses the same resolved logo as the header) |
 | Bringing an external image onto the site as a locally-owned asset | Media Library (new attachment) | `import_media` apply (returns `{attachment_id, url}` — pass `url` to `image_url`/`background_image`/`logo_url`; on hero/section/logos also pass `attachment_id` as `image_id` for responsive srcset output) |
 | Page-specific SEO metadata (meta description, `<title>` override, canonical URL) | `_pp_seo_meta` post meta | `update_seo_meta` action (patch; set a key to `""` to clear it) |
 | Page slug / URL (post_name) | WordPress core (`post_name`) | `update_page_slug` action (post_id + slug), or the `slug` param on `create_page` to set the route up front. Always check the URL in the page inventory above before proposing a change — never guess or construct one |

--- a/components/footer/README.md
+++ b/components/footer/README.md
@@ -16,17 +16,19 @@ so in practice only `location` is ever set.
 | Prop        | Type   | Required | Default    | Description |
 |-------------|--------|----------|------------|-------------|
 | `location`  | string | No       | `'footer'` | WP theme location slug |
-| `show_logo` | bool   | No       | `false`    | Whether to render the site logo in the footer. **No supported surface sets this today** — see below |
+| `show_logo` | bool   | No       | `false`    | Whether to render the site logo in the footer. Not set by composing a `footer` (rejected since #223) — set the `pp_footer_show_logo` site option instead; the base template passes it in |
 | `logo_text` | string | No       | —          | Logo text (falls back to site title). Not reachable from a page |
 | `logo_id`   | int    | No       | —          | Media Library attachment ID for an image logo (takes priority over `logo_text`). Must be an image attachment. Not reachable from a page; use the `pp_logo_id` option |
 | `logo_alt`  | string | No       | —          | Alt text for the image logo. Not reachable from a page |
 
-### The footer logo is currently unreachable
+### Turning the footer logo on
 
-`show_logo` defaults to `false`, and the only way to pass `true` was to compose a `footer`
-component — which is now rejected. So the footer logo cannot be turned on through any
-supported surface. `pp_logo_id` sets the **header** logo; the footer keeps its copyright
-line. Tracked in #234. Do not work around it by composing a `footer`.
+`show_logo` defaults to `false`. Composing a `footer` to pass `true` is rejected since #223
+(the base template already renders the footer as site chrome). The supported surface is the
+`pp_footer_show_logo` site option (a boolean, set via `update_site_option`); `templates/base.php`
+reads it and passes `show_logo` into the footer. When on, the footer resolves the same logo as
+the header (`pp_logo_id` → `custom_logo` theme-mod → text wordmark). `pp_logo_id` still sets the
+**header** logo independently.
 
 ## Usage
 
@@ -41,6 +43,7 @@ pp_get_component('footer', ['location' => 'footer']);
 |------|---------|
 | Build the footer menu | The menu actions: `create_menu` / `set_menu` / `add_menu_item` |
 | Attach a menu to the footer | `assign_menu_location` with location `footer` |
+| Show/hide the footer logo | `update_site_option` with key `pp_footer_show_logo` (boolean) |
 
 `wp pp apply preflight` reports a `nav_readiness` warning when the `footer` location has no
 menu assigned, or its menu is empty.

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.88');
+define('PP_VERSION', '0.16.89');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -1186,8 +1186,8 @@ pp_register_action('create_page', [
 
 pp_register_action('update_site_option', [
     'scope'       => 'site',
-    'description' => 'Updates a whitelisted WordPress site option (blogname, blogdescription, pp_logo_id, pp_logo_alt). pp_logo_id takes a Media Library attachment ID (not a URL) to set the site logo.',
-    'semantics'   => 'Replace. Key must be whitelisted. Value replaces entirely and is validated against the key type (pp_logo_id must be an attachment ID).',
+    'description' => 'Updates a whitelisted WordPress site option (blogname, blogdescription, pp_logo_id, pp_logo_alt, pp_footer_show_logo). pp_logo_id takes a Media Library attachment ID (not a URL) to set the site logo. pp_footer_show_logo is a boolean (1/0/true/false) that turns the footer logo on/off.',
+    'semantics'   => 'Replace. Key must be whitelisted. Value replaces entirely and is validated against the key type (pp_logo_id must be an attachment ID; pp_footer_show_logo must be a boolean).',
     'params'      => [
         'key'   => ['type' => 'string', 'required' => true],
         'value' => ['type' => 'string', 'required' => true],

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -2012,18 +2012,33 @@ function pp_set_font_urls(array $urls): bool {
  * key to its value type, used for server-side validation on write.
  *
  * Types: 'string' (free text) | 'attachment_id' (a positive int that resolves
- * to a Media Library attachment — never a raw URL).
+ * to a Media Library attachment — never a raw URL) | 'bool' (a canonical
+ * on/off flag: accepts 1/0/true/false, stored as '1' or '0'). '0' (not '')
+ * is the canonical OFF form so a stored value always re-validates — the
+ * snapshot/rollback path re-applies it through the validating writer.
  *
  * @return array<string,string>  key => type
  */
 function pp_allowed_site_options(): array {
     return [
-        'blogname'        => 'string',
-        'blogdescription' => 'string',
-        'pp_logo_id'      => 'attachment_id',
-        'pp_logo_alt'     => 'string',
+        'blogname'            => 'string',
+        'blogdescription'     => 'string',
+        'pp_logo_id'          => 'attachment_id',
+        'pp_logo_alt'         => 'string',
+        // Site-option surface for the footer logo. The footer is template-owned
+        // chrome (issue 223), so it cannot be composed to pass show_logo; this
+        // option is the only supported way to turn the footer logo on (issue 234).
+        'pp_footer_show_logo' => 'bool',
     ];
 }
+
+/**
+ * Canonical string forms accepted for a 'bool' site option, lower-cased.
+ * A strict allowlist (not "any non-empty string is true") so a typo like
+ * "flase" is rejected instead of silently coercing to on.
+ */
+const PP_BOOL_OPTION_TRUE  = ['1', 'true'];
+const PP_BOOL_OPTION_FALSE = ['0', 'false'];
 
 /**
  * Single source of truth for "is $id a Media Library image attachment?".
@@ -2061,7 +2076,29 @@ function pp_validate_site_option_value(string $key, string $value) {
             ));
         }
     }
+    if ($type === 'bool') {
+        $norm = strtolower(trim($value));
+        if (!in_array($norm, PP_BOOL_OPTION_TRUE, true) && !in_array($norm, PP_BOOL_OPTION_FALSE, true)) {
+            return new WP_Error('invalid_option_value', sprintf(
+                'Option "%s" requires a boolean (1/0/true/false), got "%s".',
+                $key, $value
+            ));
+        }
+    }
     return true;
+}
+
+/**
+ * Normalizes a validated 'bool' site-option value to its canonical stored form:
+ * '1' (on) or '0' (off). Caller must have validated the value first. Both forms
+ * are themselves valid bool inputs, so a stored value survives a round-trip
+ * through pp_update_site_option (as the snapshot/rollback path requires).
+ *
+ * @param string $value  A value already accepted by pp_validate_site_option_value.
+ * @return string        '1' or '0'.
+ */
+function pp_normalize_bool_option(string $value): string {
+    return in_array(strtolower(trim($value)), PP_BOOL_OPTION_TRUE, true) ? '1' : '0';
 }
 
 /**
@@ -2531,9 +2568,12 @@ function pp_update_site_option(string $key, string $value) {
     if (is_wp_error($valid)) {
         return $valid;
     }
-    // Normalize attachment IDs to a canonical integer string on store.
-    if ((pp_allowed_site_options()[$key] ?? null) === 'attachment_id') {
+    // Normalize to each type's canonical stored form.
+    $type = pp_allowed_site_options()[$key] ?? null;
+    if ($type === 'attachment_id') {
         $value = (string) (int) $value;
+    } elseif ($type === 'bool') {
+        $value = pp_normalize_bool_option($value);
     }
     update_option($key, $value);
     return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.88",
+  "version": "0.16.89",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.88
+Stable tag: 0.16.89
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.88
+Version:          0.16.89
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/templates/base.php
+++ b/templates/base.php
@@ -46,7 +46,12 @@ if (!function_exists('pp_base_template')) {
 <!-- PP WARNING: Custom CSS conflicts detected: <?php echo esc_html(implode(', ', $pp_conflict_selectors)); ?> -->
 <?php endif; endif; ?>
 
-<?php pp_get_component('footer', ['location' => 'footer']); ?>
+<?php pp_get_component('footer', [
+    'location'  => 'footer',
+    // Footer logo is site chrome, set via the pp_footer_show_logo site option
+    // (issue 234) — the footer can no longer be composed to pass show_logo (issue 223).
+    'show_logo' => get_option('pp_footer_show_logo', '') === '1',
+]); ?>
 
 <?php wp_footer(); ?>
 </body>

--- a/tests/LogoTest.php
+++ b/tests/LogoTest.php
@@ -142,6 +142,110 @@ class LogoTest extends TestCase
         $this->assertSame('88', get_option('pp_logo_id'));
     }
 
+    // ── Footer show-logo site option (issue 234) ────────────────────────────
+
+    public function testAllowedSiteOptionsIncludesFooterShowLogoAsBool(): void
+    {
+        $allowed = pp_allowed_site_options();
+        $this->assertArrayHasKey('pp_footer_show_logo', $allowed);
+        $this->assertSame('bool', $allowed['pp_footer_show_logo']);
+    }
+
+    public function testValidateBoolAcceptsCanonicalForms(): void
+    {
+        foreach (['1', '0', 'true', 'false', 'TRUE', 'False', ' true '] as $val) {
+            $this->assertTrue(
+                pp_validate_site_option_value('pp_footer_show_logo', $val),
+                "Expected '{$val}' to be accepted as a boolean"
+            );
+        }
+    }
+
+    public function testValidateBoolRejectsNonBool(): void
+    {
+        foreach (['maybe', 'flase', '2', '', 'yes', 'on'] as $val) {
+            $result = pp_validate_site_option_value('pp_footer_show_logo', $val);
+            $this->assertInstanceOf(\WP_Error::class, $result, "Expected '{$val}' to be rejected");
+            $this->assertStringContainsString('boolean', $result->get_error_message());
+        }
+    }
+
+    public function testUpdateBoolNormalizesTrueFormsToCanonicalOne(): void
+    {
+        foreach (['1', 'true', 'TRUE', ' true '] as $val) {
+            $this->assertTrue(pp_update_site_option('pp_footer_show_logo', $val));
+            $this->assertSame('1', get_option('pp_footer_show_logo'), "'{$val}' should store as '1'");
+        }
+    }
+
+    public function testUpdateBoolNormalizesFalseFormsToCanonicalZero(): void
+    {
+        foreach (['0', 'false', 'False'] as $val) {
+            $this->assertTrue(pp_update_site_option('pp_footer_show_logo', $val));
+            $this->assertSame('0', get_option('pp_footer_show_logo'), "'{$val}' should store as '0'");
+        }
+    }
+
+    public function testStoredBoolValuesRoundTripThroughValidatingWriter(): void
+    {
+        // The snapshot/rollback path (lib/actions.php) re-applies the stored
+        // value through pp_update_site_option — the canonical stored form must
+        // itself pass validation. Regression guard for the '' OFF form (which
+        // the validator rejects) that an earlier draft of issue 234 shipped.
+        foreach (['1', '0'] as $stored) {
+            $this->assertTrue(pp_validate_site_option_value('pp_footer_show_logo', $stored));
+            $this->assertTrue(pp_update_site_option('pp_footer_show_logo', $stored));
+            $this->assertSame($stored, get_option('pp_footer_show_logo'));
+        }
+    }
+
+    public function testUpdateBoolRejectsNonBoolAndDoesNotWrite(): void
+    {
+        $result = pp_update_site_option('pp_footer_show_logo', 'maybe');
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertArrayNotHasKey('pp_footer_show_logo', $GLOBALS['_pp_test_store']['options']);
+    }
+
+    public function testActionSetsFooterShowLogo(): void
+    {
+        $result = pp_execute_action('update_site_option', ['key' => 'pp_footer_show_logo', 'value' => 'true']);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('1', get_option('pp_footer_show_logo'));
+    }
+
+    public function testActionRejectsNonBoolFooterShowLogoWithClearMessage(): void
+    {
+        $result = pp_execute_action('update_site_option', ['key' => 'pp_footer_show_logo', 'value' => 'nope']);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('boolean', $result['error']);
+    }
+
+    // ── Footer render honors show_logo prop (base.php passes the option) ─────
+
+    private function renderFooter(array $props): string
+    {
+        ob_start();
+        pp_get_component('footer', $props);
+        return ob_get_clean();
+    }
+
+    public function testFooterRendersLogoWhenShowLogoTrueAndLogoResolves(): void
+    {
+        $this->seedAttachment(70, 'https://example.com/footer-logo.png', 'Brand');
+        update_option('pp_logo_id', '70');
+        $html = $this->renderFooter(['location' => 'footer', 'show_logo' => true]);
+        $this->assertStringContainsString('site-footer__logo', $html);
+        $this->assertStringContainsString('https://example.com/footer-logo.png', $html);
+    }
+
+    public function testFooterOmitsLogoWhenShowLogoFalse(): void
+    {
+        $this->seedAttachment(71, 'https://example.com/footer-logo.png', 'Brand');
+        update_option('pp_logo_id', '71');
+        $html = $this->renderFooter(['location' => 'footer', 'show_logo' => false]);
+        $this->assertStringNotContainsString('site-footer__logo', $html);
+    }
+
     // ── pp_resolve_logo ─────────────────────────────────────────────────────
 
     public function testResolveLogoFromPropId(): void


### PR DESCRIPTION
Closes #234

## Summary

#223 made `nav`/`footer` template-owned chrome, so composing a `footer` to pass `show_logo: true` is now rejected — which left the footer logo with **no supported surface to turn it on**. This adds `pp_footer_show_logo`, a boolean site option on the same `update_site_option` safe surface as `pp_logo_id`, per the issue's recorded decision (Option 1).

- `pp_allowed_site_options()` gains a `bool` value type alongside `string` and `attachment_id`.
- `pp_validate_site_option_value()` accepts `1`/`0`/`true`/`false` (case-insensitive) and rejects anything else with a clear error — a typo like `flase` fails closed instead of coercing to on. Validation stays in the shared engine (no surface-specific second validator).
- Canonical stored form is `'1'` (on) / `'0'` (off), not `''` — both are valid bool inputs, so a stored value survives the round-trip through the validating writer that the snapshot/rollback path re-applies captured site options with.
- `templates/base.php` reads the option and passes `show_logo` into the footer; when on, the footer resolves the same logo as the header (`pp_logo_id` → `custom_logo` theme-mod → text wordmark). The header logo is unchanged and independent.
- AI-facing docs that described the footer logo as unreachable are corrected in the same change.

## Acceptance criteria (recorded decision — Option 1)

- [x] Add boolean validation for the site option (`bool` type in the whitelist + validator).
- [x] Whitelist `pp_footer_show_logo` for `update_site_option`.
- [x] Pass its value to the footer render path (`templates/base.php`).
- [x] Update docs so agents do not compose a `footer` to set it.

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → **1535 passed** (10 new `LogoTest` cases; Warnings 3 / Deprecations 2 match the unmodified-tree baseline).
- JS: `npm test` → **484 passed** (no JS changes).
- `bash scripts/package.sh` → version consistency OK across the five files; built zip deleted (releases are CI-built from tags).

## Reviews (this session)

- `/plan-eng-review` — plan judged right-sized and compliant; no unresolved decisions.
- `/review` — clean after one self-found fix (see below). Codex adversarial raised two findings, both refuted against source: the error-message echo mirrors the existing `attachment_id` branch, and the `value` param staying `type:string` is enforced consistently at the structural gate (`lib/actions.php:79-94`).
- `/document-generate` — corrected three stale claims in `AI_CONTEXT.md`; `lib/ai-context.php` and `nav/README` remained accurate.

## Accepted limitations / notes

- Review self-found bug (fixed in this PR): storing the OFF form as `''` would break the snapshot/rollback re-apply, because the validator rejects `''`. Fixed by storing `'0'` instead, with a round-trip regression test.
- Filed #281 (pre-existing, out of scope): the rollback path silently fails to restore an **unset/empty** site-option baseline (affects `pp_logo_id` today) because it re-applies through the validating writer. Same #233-class pattern on the site-option channel.

## Not done deliberately

No tag, release, or deploy — those are the maintainer's separate steps.