### PR TITLE
v0.16.90 fix: restore unset/empty site-option baseline on AI-batch rollback (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.90] — 2026-07-12 — AI-batch rollback restores an unset/empty site-option baseline instead of silently keeping the applied value (#281)
+
+**When an AI batch (`pp_ai_execute_batch`) changed a typed site option and a later step failed, the rollback re-applied every captured baseline through the validating writer `pp_update_site_option()`. An option that was unset before the run is captured as an empty string, and an empty string fails the `attachment_id` and `bool` value rules, so the writer rejected it and left the applied value in place — a rollback that silently did not roll back. Turn on a logo (`pp_logo_id`) or the footer logo (`pp_footer_show_logo`) as part of a batch that later fails, and the option stayed set. The rollback now restores the exact pre-run state: it deletes the option when the captured baseline was unset/empty, and writes any other captured value back verbatim, bypassing only the value validator. This is the same principle already documented for composition restore (issue 233): a restore is never blocked by current validation rules.**
+
+The fix lives in the action layer (`_pp_restore_batch_snapshot()`), not the writer — `pp_update_site_option()` keeps its create-time validation for normal writes. The whitelist boundary stays enforced: the batch snapshotter records every `update_site_option` step's key up front, before execute rejects an unauthorized one, so a non-whitelisted key can appear in the snapshot captured as empty; the restore skips any key that is not in `pp_allowed_site_options()` so it can never delete an unrelated core WordPress option. Only whitelisted options are touched, and only their value validation is bypassed on the restore path.
+
+### Fixed
+
+- AI-batch rollback (`_pp_restore_batch_snapshot()`) now restores an unset/empty typed site-option baseline (e.g. a never-set `pp_logo_id` or `pp_footer_show_logo`) by deleting the option, and re-applies any other captured baseline verbatim, instead of routing it back through the validating writer that rejected the empty value and silently kept the applied change. The site-option whitelist is still enforced on the restore path — a non-whitelisted key captured in the snapshot is never written or deleted (#281).
+
+### Tests
+
+- New `ActionsTest` cases pin the rollback: an unset `attachment_id` (`pp_logo_id`) and an unset `bool` (`pp_footer_show_logo`) baseline both roll back to unset; an explicitly-set typed value round-trips through rollback; an empty-string (`string`-typed) baseline rolls back to the observable empty state; a captured baseline that current validation would reject (issue 233-class) is still restored verbatim; and a non-whitelisted option present in the snapshot is left untouched (never deleted) (#281).
+
 ## [v0.16.89] — 2026-07-12 — `pp_footer_show_logo` site option makes the footer logo reachable again (#234)
 
 **#223 made `nav`/`footer` template-owned chrome, so composing a `footer` to pass `show_logo: true` is now rejected — which left the footer logo with no supported surface to turn it on (`footer.show_logo` defaults off, and nothing else set it). This adds `pp_footer_show_logo`, a boolean site option on the same safe `update_site_option` surface as `pp_logo_id`. `templates/base.php` reads it and passes `show_logo` into the footer; when on, the footer resolves the same logo as the header (`pp_logo_id` → `custom_logo` theme-mod → text wordmark). The header logo (`pp_logo_id`) is unchanged and independent.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.89-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.90-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.89');
+define('PP_VERSION', '0.16.90');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -896,7 +896,34 @@ function _pp_restore_batch_snapshot(array $snapshot): array {
     }
 
     foreach ($snapshot['site_options'] as $key => $value) {
-        pp_update_site_option($key, (string) $value);
+        // Only whitelisted options are ours to touch. The batch snapshotter records
+        // every update_site_option step's key up front (before execute rejects an
+        // unauthorized one), so a non-whitelisted key can appear here captured as ''
+        // (pp_site_option returns WP_Error for it). Restoring raw would delete_option()
+        // an unrelated core WP option — pp_update_site_option used to block that via its
+        // whitelist check, so the guard has to stay. Only VALUE validation is bypassed.
+        if (!isset(pp_allowed_site_options()[$key])) {
+            continue;
+        }
+        // Restore the captured baseline faithfully, bypassing pp_update_site_option's
+        // create-time validator. That validator can reject a legitimate captured
+        // baseline and silently drop the write (issue 281): an unset/empty baseline is
+        // captured as '' (pp_site_option => (string) get_option($key, '')), and ''
+        // fails the attachment_id/bool rules; likewise a once-valid value a newer rule
+        // now rejects (e.g. a pp_logo_id whose attachment was later deleted) would fail
+        // re-validation. Either case would leave the applied value in place instead of
+        // rolling back. This is the same class as restore_composition (issue 233):
+        // a restore is never blocked by current validation rules. A captured baseline
+        // is trusted pre-run state (its keys are already whitelisted — only
+        // update_site_option steps populate this map), so it restores verbatim without
+        // re-validation: an empty capture means "was unset/empty" and is restored by
+        // deleting the option (observably identical to '' via pp_site_option); every
+        // other value is written raw.
+        if ((string) $value === '') {
+            delete_option($key);
+        } else {
+            update_option($key, (string) $value);
+        }
     }
 
     if ($snapshot['custom_css'] !== null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.89",
+  "version": "0.16.90",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.89
+Stable tag: 0.16.90
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.89
+Version:          0.16.90
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -3292,6 +3292,134 @@ class ActionsTest extends TestCase
         $this->assertSame('Original Name', $GLOBALS['_pp_test_store']['options']['blogname']);
     }
 
+    // ── issue 281: rollback restores an unset/empty typed site-option baseline ──
+    // The pre-run baseline of a never-set typed option (attachment_id / bool) is
+    // captured as '' (pp_site_option => (string) get_option($key, '')). Replaying
+    // '' through the validating writer pp_update_site_option was silently rejected
+    // (attachment_id needs a real image; bool needs 1/0/true/false), leaving the
+    // applied value in place. Rollback must restore the option to "unset".
+
+    public function testBatchRestoresUnsetAttachmentIdOptionOnLaterFailure(): void
+    {
+        // pp_logo_id starts unset. Seed a valid image so the apply step succeeds.
+        $GLOBALS['_pp_test_store']['posts'][51] = ['post_type' => 'attachment'];
+        $GLOBALS['_pp_test_store']['attachment_is_image'][51] = true;
+
+        $batch = pp_ai_execute_batch([
+            ['type' => 'action', 'name' => 'update_site_option', 'params' => ['key' => 'pp_logo_id', 'value' => '51']],
+            ['type' => 'action', 'name' => 'unknown_action', 'params' => []],
+        ]);
+
+        $this->assertFalse($batch['ok']);
+        $this->assertTrue($batch['rolled_back']);
+        // Rolled back to unset — not left at the applied '51'.
+        $this->assertArrayNotHasKey('pp_logo_id', $GLOBALS['_pp_test_store']['options']);
+        $this->assertSame('', get_option('pp_logo_id', ''));
+    }
+
+    public function testBatchRestoresUnsetBoolOptionOnLaterFailure(): void
+    {
+        // pp_footer_show_logo starts unset.
+        $batch = pp_ai_execute_batch([
+            ['type' => 'action', 'name' => 'update_site_option', 'params' => ['key' => 'pp_footer_show_logo', 'value' => '1']],
+            ['type' => 'action', 'name' => 'unknown_action', 'params' => []],
+        ]);
+
+        $this->assertFalse($batch['ok']);
+        $this->assertTrue($batch['rolled_back']);
+        $this->assertArrayNotHasKey('pp_footer_show_logo', $GLOBALS['_pp_test_store']['options']);
+        $this->assertSame('', get_option('pp_footer_show_logo', ''));
+    }
+
+    public function testBatchRestoresEmptyStringBaselineOnLaterFailure(): void
+    {
+        // A string-typed option (blogdescription) whose baseline is empty. Capture
+        // cannot tell "unset" from "explicitly ''" (both read as '' via
+        // get_option($key, '')), so rollback restores the observable empty state.
+        // Pins the user-observable contract: the applied value does not survive.
+        $batch = pp_ai_execute_batch([
+            ['type' => 'action', 'name' => 'update_site_option', 'params' => ['key' => 'blogdescription', 'value' => 'New tagline']],
+            ['type' => 'action', 'name' => 'unknown_action', 'params' => []],
+        ]);
+
+        $this->assertFalse($batch['ok']);
+        $this->assertTrue($batch['rolled_back']);
+        $this->assertSame('', get_option('blogdescription', ''));
+    }
+
+    public function testBatchRestoresExplicitlySetTypedOptionOnLaterFailure(): void
+    {
+        // pp_logo_id explicitly set to a valid image at baseline; the apply step
+        // switches it to a different valid image. Rollback must restore the exact
+        // pre-run value (the non-empty path writes it raw).
+        $GLOBALS['_pp_test_store']['posts'][51] = ['post_type' => 'attachment'];
+        $GLOBALS['_pp_test_store']['attachment_is_image'][51] = true;
+        $GLOBALS['_pp_test_store']['posts'][52] = ['post_type' => 'attachment'];
+        $GLOBALS['_pp_test_store']['attachment_is_image'][52] = true;
+        $GLOBALS['_pp_test_store']['options']['pp_logo_id'] = '51';
+
+        $batch = pp_ai_execute_batch([
+            ['type' => 'action', 'name' => 'update_site_option', 'params' => ['key' => 'pp_logo_id', 'value' => '52']],
+            ['type' => 'action', 'name' => 'unknown_action', 'params' => []],
+        ]);
+
+        $this->assertFalse($batch['ok']);
+        $this->assertTrue($batch['rolled_back']);
+        $this->assertSame('51', $GLOBALS['_pp_test_store']['options']['pp_logo_id']);
+    }
+
+    public function testRestoreBatchSnapshotReappliesBaselineCurrentRulesReject(): void
+    {
+        // issue 233-class case on the site-option channel: a non-empty baseline that was
+        // valid when captured but current validation now rejects (e.g. pp_logo_id
+        // whose attachment was deleted mid-run — no seeded image for id 51, so
+        // pp_update_site_option would reject '51'). The restore path must reapply
+        // the captured baseline verbatim, never blocked by current validation.
+        $GLOBALS['_pp_test_store']['options']['pp_logo_id'] = '99'; // stray applied value
+
+        $snapshot = [
+            'created_posts'   => [],
+            'posts'           => [],
+            'site_options'    => ['pp_logo_id' => '51'],
+            'custom_css'      => null,
+            'token_overrides' => null,
+            'font_urls'       => null,
+            'menus'           => null,
+        ];
+
+        $errors = _pp_restore_batch_snapshot($snapshot);
+
+        $this->assertSame([], $errors);
+        // Restored verbatim despite '51' failing the current attachment_id rule.
+        $this->assertSame('51', get_option('pp_logo_id', ''));
+    }
+
+    public function testRestoreBatchSnapshotLeavesNonWhitelistedOptionsUntouched(): void
+    {
+        // The batch snapshotter captures every update_site_option step's key before
+        // execute rejects a non-whitelisted one, storing '' for it (pp_site_option
+        // returns WP_Error). The restore path must NOT delete_option() an arbitrary
+        // core option just because it appears in the snapshot with an empty baseline —
+        // the whitelist boundary stays enforced.
+        $GLOBALS['_pp_test_store']['options']['active_plugins'] = 'a:1:{i:0;s:5:"x/x.php";}';
+
+        $snapshot = [
+            'created_posts'   => [],
+            'posts'           => [],
+            'site_options'    => ['active_plugins' => ''],
+            'custom_css'      => null,
+            'token_overrides' => null,
+            'font_urls'       => null,
+            'menus'           => null,
+        ];
+
+        $errors = _pp_restore_batch_snapshot($snapshot);
+
+        $this->assertSame([], $errors);
+        // The non-whitelisted option is left exactly as it was — not deleted.
+        $this->assertSame('a:1:{i:0;s:5:"x/x.php";}', get_option('active_plugins', ''));
+    }
+
     public function testBatchRollsBackCustomCssOnLaterFailure(): void
     {
         $GLOBALS['_pp_test_store']['custom_css'] = '.hero { color: red; }';


### PR DESCRIPTION
Closes #281

## Scope

`_pp_restore_batch_snapshot()` (the AI-batch apply-rollback path in `lib/actions.php`) re-applied every captured site-option baseline through the validating writer `pp_update_site_option()`. An option that was unset before the run is captured as `''` (`pp_site_option()` = `(string) get_option($key, '')`), and `''` fails the `attachment_id`/`bool` value rules, so the writer returned a `WP_Error` and did not write — leaving the applied value in place. A rollback that silently did not roll back.

The fix restores the exact pre-run state, bypassing only the value validator (the writer keeps validating normal writes):
- captured baseline `''` (was unset/empty) -> `delete_option($key)` (restores unset; observably identical to `''` via `pp_site_option`).
- any other captured value -> `update_option($key, $value)` raw, so a baseline that current validation would now reject still restores.

This applies the recorded restore principle from #233 ("a restore is never blocked by current validation rules") to the site-option rollback channel, per #281's behavioral contract.

**Security boundary preserved.** The batch snapshotter records every `update_site_option` step's key up front (before execute rejects an unauthorized one), so a non-whitelisted key can appear in the snapshot captured as `''`. The restore skips any key not in `pp_allowed_site_options()`, so it can never `delete_option()` an unrelated core WP option. Only whitelisted options are touched; only value validation is bypassed.

## Acceptance criteria

- Rolling back restores the exact pre-run state, including "option was unset/empty" — met (delete-on-empty).
- No option is silently left at the applied value after a failed batch — met.

## Tests

New `ActionsTest` cases:
- unset `attachment_id` (`pp_logo_id`) baseline rolls back to unset;
- unset `bool` (`pp_footer_show_logo`) baseline rolls back to unset;
- explicitly-set typed value round-trips through rollback;
- empty-string (`string`-typed) baseline rolls back to the observable empty state;
- a captured baseline current validation would reject (#233-class) is restored verbatim via `_pp_restore_batch_snapshot()` directly;
- a non-whitelisted option present in the snapshot is left untouched (never deleted).

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` -> 1541 tests OK (was 1535 on main; +6 new). Warnings 3 / PHPUnit Deprecations 2 match the unmodified tree (verified via stash).
- `npm test` (vitest) -> 484 passed.
- `bash scripts/package.sh` -> "Version consistency: OK" for the five synced files at 0.16.90; built zip deleted (releases are CI-built from tags).

## Accepted limitation

Snapshot capture cannot distinguish "option unset" from "option explicitly set to `''`" (both read as `''`). For `string`-typed options an empty baseline is restored by deleting the row rather than writing `''`; every in-theme read defaults to `''`, so this is observably identical through the theme. This matches (and improves on) the prior behavior, which created a `''` row for a genuinely-unset option.

## Reviews

`/plan-eng-review` (clean), `/review` + Claude adversarial pass (clean after fixing one self-introduced regression: an early version deleted non-whitelisted options on rollback — now guarded and regression-tested) ran today on this exact working tree.

Do not tag/release/deploy — handled separately by the maintainer.
