### PR TITLE
v0.16.91 feat: add id, eyebrow, and theme props to the faq component (#231)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -112,7 +112,7 @@ site-customization permission.
 |-----------|--------------------------------|--------------------------------------------------|----------------------------------------------------|
 | hero      | components/hero/hero.php       | Full-width headline + optional CTA and image     | title (req), title_accent, eyebrow, subtitle, cta_text, cta_url, cta2_text, cta2_url, cta_variant, cta2_variant, layout, image_url, image_id, image_alt, spacing, width, split_ratio, vertical_align, proof, id |
 | section   | components/section/section.php | Text + optional image. 4 structural layouts      | body (req), title, title_accent, eyebrow, subheading, heading_align, image_url, image_id, image_alt, layout, theme, background_image, id |
-| faq       | components/faq/faq.php         | Native details/summary accordion. Zero JS. Auto-emits FAQPage JSON-LD. | items[] (req) {question, answer}, title, title_accent |
+| faq       | components/faq/faq.php         | Native details/summary accordion. Zero JS. Auto-emits FAQPage JSON-LD. | items[] (req) {question, answer}, title, title_accent, eyebrow, theme, id |
 | grid      | components/grid/grid.php       | Responsive card grid for real content objects    | items[] (req) {number, title, text, text_role, bullets[], image_url, image_alt, link_url, link_text}, title, title_accent, eyebrow, subheading, heading_align, layout, theme, id |
 | table     | components/table/table.php     | Data/comparison table, horizontal scroll mobile  | headers[] (req), rows[][] (req), title, caption    |
 | cta       | components/cta/cta.php         | Call-to-action block. Layout + color + bg-image  | title (req), title_accent, eyebrow, button_text (req), button_url (req), button_variant, text, layout, theme, background_image, id |
@@ -137,7 +137,7 @@ renders the header or footer twice, and the write is rejected with the error cod
 **Two consistent axes — `layout` (structure) and `theme` (color/tone).** There is no `variant` prop anywhere; the name is retired. Structure is always `layout`, color/tone is always `theme`, and they never overload one key:
 
 - **`layout`** (structural, changes DOM/rendering) is used by the components that have more than one structure: `hero` (`left`, `centered`, `split`, `cover`), `section` (`text-only`, `image-left`, `image-right`, `centered`), `grid` (`cards`, `steps`), `cta` (`full-width`, `inline`), `testimonials` (`grid`, `stack`).
-- **`theme`** (color/tone preset, `default` | `dark` | `inverted`) is used by the section-level components that carry a background tone: `section`, `stats`, `logos`, `embed`, `grid`, `cta`, `testimonials`.
+- **`theme`** (color/tone preset, `default` | `dark` | `inverted`) is used by the section-level components that carry a background tone: `section`, `stats`, `logos`, `embed`, `grid`, `cta`, `testimonials`, `faq`.
 - `hero` has no `theme` prop — its color comes entirely from style slots (`--hero-bg`, etc.).
 - Components with a single structure (`stats`, `logos`, `embed`) expose only `theme`, not `layout`.
 - `style_component` / recipes / style slots remain the final visual authority over any `theme` or default CSS.
@@ -374,7 +374,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**140 style slots** across 7 components: hero (36), cta (26), grid (24), section (21), testimonials (19), faq (8), stats (6).
+**142 style slots** across 7 components: hero (36), cta (26), grid (24), section (21), testimonials (19), faq (10), stats (6).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.91] — 2026-07-12 — The FAQ section can now carry an anchor id, an eyebrow pill, and a dark or inverted theme (#231)
+
+**`faq` was the only heading-bearing component that could not be anchor-linked or given a background tone. Every other section component (`hero`, `section`, `grid`, `cta`, `stats`, `testimonials`, `logos`, `embed`) already accepted an `id`, and the marketing ones an `eyebrow` and a `theme` — `faq` accepted none of them in its schema, so a nav item pointing at `#faq` had no target and the FAQ heading could not sit on a dark band. `faq` now accepts `id` (anchor plus stable component id), `eyebrow` (a kicker pill above the heading), and `theme` (`default` / `dark` / `inverted`), matching the rest of the set. A page with an FAQ section and a nav link to it is finally expressible.**
+
+The theme variant reuses the proven readability pattern from issue 222: the FAQ heading routes through a `--faq-heading-theme-color` fallback so the inverted color survives the high-specificity desktop typography rule instead of rendering dark-on-dark above 768px. Accordion cards keep their light background, so question and answer text stays dark and legible on an inverted band. The eyebrow gains two per-instance style slots (`--faq-eyebrow-color`, `--faq-eyebrow-bg`) so its pill can be recolored like every other component's eyebrow. Unknown `theme` values clamp to `default` at render time, matching `section`/`grid` (composition validation does not check enum values, so the render is the contract). AI-facing docs and the runtime AI context are updated in the same change so the chat and CLI know these props are now accepted.
+
+### Added
+
+- `faq` component now accepts `id`, `eyebrow`, and `theme` (`default` / `dark` / `inverted`) props, matching the other heading-bearing components. `id` anchors the section and becomes its stable component id; `eyebrow` renders as a pill above the heading; `theme` sets the background tone. Two new style slots (`--faq-eyebrow-color`, `--faq-eyebrow-bg`) recolor the eyebrow pill, bringing the FAQ slot count to 10 (#231).
+
+### Docs
+
+- Updated `AI_CONTEXT.md` (faq prop row, the `theme`-supporting component list, and the style-slot totals 140 → 142 / faq 8 → 10), `README.md` (slot totals), `ai-instructions/composition.md`, and `components/faq/README.md` to describe the new `id`/`eyebrow`/`theme` surface. The runtime AI context derives faq's props from its schema, so it picks up the new props automatically (#231).
+
+### Tests
+
+- New `ComponentPropsTest` render pins cover the FAQ `id` anchor, the eyebrow pill (present and absent), the eyebrow color slots, the `dark` and `inverted` theme classes, the default (no-modifier) case, and unknown-theme clamping. `SchemaValidationTest` now asserts `faq` declares a `theme` prop, and `OperateTest` pins `eyebrow` as an editable FAQ field (#231).
+
 ## [v0.16.90] — 2026-07-12 — AI-batch rollback restores an unset/empty site-option baseline instead of silently keeping the applied value (#281)
 
 **When an AI batch (`pp_ai_execute_batch`) changed a typed site option and a later step failed, the rollback re-applied every captured baseline through the validating writer `pp_update_site_option()`. An option that was unset before the run is captured as an empty string, and an empty string fails the `attachment_id` and `bool` value rules, so the writer rejected it and left the applied value in place — a rollback that silently did not roll back. Turn on a logo (`pp_logo_id`) or the footer logo (`pp_footer_show_logo`) as part of a batch that later fails, and the option stayed set. The rollback now restores the exact pre-run state: it deletes the option when the captured baseline was unset/empty, and writes any other captured value back verbatim, bypassing only the value validator. This is the same principle already documented for composition restore (issue 233): a restore is never blocked by current validation rules.**

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 47 CSS custom properties control the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-140 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 10 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+142 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 10 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.16.48.
 
 **What exists today (v0.16.48):**
-- 12 components with schema contracts and 140 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 142 per-instance style slots, plus named recipes
 - A contract test that guarantees every style slot a component declares actually reaches the page, honored at every breakpoint
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.90-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.91-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -45,7 +45,7 @@ See `AI_CONTEXT.md` → Component index for the current list. As of last update:
 |---------|-----------------------------------------|---------------------------------------------------------|
 | hero    | title                                   | title_accent, eyebrow, subtitle, cta_text, cta_url, cta2_text, cta2_url, cta_variant, cta2_variant, layout, image_url, image_id, image_alt, spacing, width, split_ratio, vertical_align, proof |
 | section | body                                    | title, title_accent, eyebrow, subheading, heading_align, layout, theme, image_url, image_id, image_alt, background_image |
-| faq     | items[] {question, answer}              | title, title_accent                                     |
+| faq     | items[] {question, answer}              | title, title_accent, eyebrow, theme, id                 |
 | grid    | items[] {title, text, ...}              | title, title_accent, eyebrow, subheading, heading_align, layout, theme |
 | table   | headers[], rows[][]                     | title, caption                                          |
 | cta     | title, button_text, button_url          | title_accent, eyebrow, text, layout, theme, background_image, button_variant |

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -838,9 +838,22 @@
   background: var(--faq-bg, var(--color-surface));
 }
 
+.faq__eyebrow {
+  display: inline-block;
+  padding: 0.35rem 0.85rem;
+  margin-bottom: var(--space-sm);
+  border-radius: 3px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--faq-eyebrow-color, var(--color-text));
+  background: var(--faq-eyebrow-bg, var(--color-surface-accent));
+}
+
 .faq__heading {
   margin-bottom: var(--space-lg);
-  color: var(--faq-heading-color, var(--color-text));
+  color: var(--faq-heading-color, var(--faq-heading-theme-color, var(--color-text)));
 }
 
 .faq__heading-accent {
@@ -923,6 +936,30 @@
 
 .faq__empty {
   padding: var(--space-md) 0;
+}
+
+/* FAQ background variants. .faq already carries a --color-surface band by
+   default, so --dark only adds the framing borders (mirrors .grid--dark /
+   .pp-section--dark). --inverted swaps the band for the inverted surface and
+   supplies the theme-color DEFAULT the desktop typography rule resolves at
+   use-time — the desktop `main > .faq .faq__heading` rule outranks any theme
+   selector, so the theme cannot win by specificity and instead feeds the
+   heading's own fallback chain (slot > theme > token), the issue 222 pattern.
+   .faq__item keeps its light background, so question/answer text stays dark —
+   no theming needed there (mirrors .grid--inverted keeping cards light). */
+.faq--dark {
+  background: var(--faq-bg, var(--color-surface));
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.faq--inverted {
+  background: var(--faq-bg, var(--color-bg-inverted));
+  --faq-heading-theme-color: var(--color-bg);
+}
+
+.faq--inverted .faq__heading {
+  color: var(--faq-heading-color, var(--color-bg));
 }
 
 /* ==========================================================================
@@ -2735,7 +2772,7 @@
   }
 
   main > .faq .faq__heading {
-    color: var(--faq-heading-color, var(--color-text));
+    color: var(--faq-heading-color, var(--faq-heading-theme-color, var(--color-text)));
   }
 
   main > .section .section__content,

--- a/components/faq/README.md
+++ b/components/faq/README.md
@@ -6,8 +6,11 @@ FAQ accordion using native HTML `<details>`/`<summary>` elements. No JavaScript 
 
 | Prop           | Type   | Required | Default                          | Description |
 |----------------|--------|----------|----------------------------------|-------------|
+| `id`           | string | No       | `''`                             | HTML id for anchor linking; also becomes the stable component id |
 | `title`        | string | No       | `'Frequently Asked Questions'`   | Section heading |
 | `title_accent` | string | No       | `''`                             | Exact substring of `title` to render in an accent color |
+| `eyebrow`      | string | No       | `''`                             | Short kicker/label rendered as a pill above the title |
+| `theme`        | enum   | No       | `'default'`                      | Background tone: `default`, `dark`, or `inverted` |
 | `items`        | array  | Yes      | —                                | Array of `{ question, answer }` objects |
 
 Each item in `items`:

--- a/components/faq/faq.php
+++ b/components/faq/faq.php
@@ -11,14 +11,30 @@
 $id           = $props['id']           ?? '';
 $title        = $props['title']        ?? 'Frequently Asked Questions';
 $title_accent = $props['title_accent'] ?? '';
+$eyebrow      = $props['eyebrow']      ?? '';
+$theme        = $props['theme']        ?? 'default';
 $items = $props['items'] ?? [];
+
+// Tone variant. Clamp to the known set so an unknown value renders as the
+// default surface rather than emitting an unstyled `faq--<garbage>` class
+// (mirrors section.php / grid.php — composition validation does not check
+// enum values, so the render is the actual contract).
+$allowed_themes = ['default', 'dark', 'inverted'];
+if (!in_array($theme, $allowed_themes, true)) {
+    $theme = 'default';
+}
+$theme_class = $theme !== 'default' ? ' faq--' . $theme : '';
 
 // Style slot overrides (per-instance visual customization).
 $slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'faq');
 $style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';
 ?>
-<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="faq" data-pp-component="faq"<?php echo $style_attr; ?>>
+<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="faq<?php echo esc_attr($theme_class); ?>" data-pp-component="faq"<?php echo $style_attr; ?>>
     <div class="container">
+
+        <?php if ($eyebrow) : ?>
+            <span class="faq__eyebrow"><?php echo esc_html($eyebrow); ?></span>
+        <?php endif; ?>
 
         <?php if ($title) : ?>
             <h2 class="faq__heading"><?php echo pp_render_heading_with_accent($title, $title_accent, 'faq__heading-accent'); ?></h2>

--- a/components/faq/schema.json
+++ b/components/faq/schema.json
@@ -2,6 +2,12 @@
   "component": "faq",
   "description": "FAQ accordion using native HTML details/summary elements. Zero JavaScript required. Each item has a question and an HTML answer. Always emits a FAQPage JSON-LD structured-data block alongside the visible markup.",
   "props": {
+    "id": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional HTML id attribute for anchor linking (e.g. navigation anchors). Also becomes the component's stable id."
+    },
     "title": {
       "type": "string",
       "required": false,
@@ -13,6 +19,19 @@
       "required": false,
       "default": "",
       "description": "Optional exact substring of title to render in an accent color. Must match title exactly (case-sensitive) or it is ignored."
+    },
+    "eyebrow": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional short kicker/label rendered as a pill above the title."
+    },
+    "theme": {
+      "type": "enum",
+      "values": ["default", "dark", "inverted"],
+      "required": false,
+      "default": "default",
+      "description": "Background color/tone. 'default' = surface background. 'dark' = dark surface with borders. 'inverted' = inverted background for strong contrast. Independent of content."
     },
     "items": {
       "type": "array",
@@ -31,6 +50,8 @@
     "style_slots": {
       "--faq-bg": { "type": "gradient", "default": "var(--color-surface)", "description": "Section background color or gradient" },
       "--faq-item-bg": { "type": "gradient", "default": "var(--color-bg)", "description": "Individual accordion item background color or gradient" },
+      "--faq-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
+      "--faq-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
       "--faq-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading text color" },
       "--faq-heading-accent-color": { "type": "color", "default": "var(--color-accent)", "description": "Color of the title_accent substring within the heading, if set" },
       "--faq-question-color": { "type": "color", "default": "var(--color-text)", "description": "Question (summary) text color" },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.90');
+define('PP_VERSION', '0.16.91');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -1666,6 +1666,7 @@ pp_register_component_fields('grid', [
 ]);
 
 pp_register_component_fields('faq', [
+    ['name' => 'eyebrow',          'type' => 'string'],
     ['name' => 'items[].question', 'type' => 'string'],
     ['name' => 'items[].answer',   'type' => 'html'],
 ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.90",
+  "version": "0.16.91",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.90
+Stable tag: 0.16.91
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.90
+Version:          0.16.91
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1016,6 +1016,73 @@ class ComponentPropsTest extends TestCase
         $this->assertStringNotContainsString('url(evil)', $html);
     }
 
+    // ── faq id / eyebrow / theme (#231) — parity with heading components ──
+
+    public function testFaqRendersIdForAnchorLinking(): void
+    {
+        // #231: faq is a heading component and must be anchor-linkable, like every
+        // other one. The id lands on the section element so `#faq` has a target.
+        $html = $this->render('faq', $this->faqProps(['id' => 'faq']));
+        $this->assertStringContainsString('<section id="faq"', $html);
+    }
+
+    public function testFaqOmitsIdAttributeWhenUnset(): void
+    {
+        $html = $this->render('faq', $this->faqProps());
+        $this->assertStringNotContainsString('<section id=', $html);
+    }
+
+    public function testFaqEyebrowRendersAsPill(): void
+    {
+        $html = $this->render('faq', $this->faqProps(['eyebrow' => 'KICKER']));
+        $this->assertStringContainsString('class="faq__eyebrow">KICKER<', $html);
+    }
+
+    public function testFaqEyebrowOmittedWhenUnset(): void
+    {
+        $html = $this->render('faq', $this->faqProps());
+        $this->assertStringNotContainsString('faq__eyebrow', $html);
+    }
+
+    public function testFaqEyebrowColorSlotsRender(): void
+    {
+        $html = $this->render('faq', $this->faqProps([
+            'eyebrow' => 'KICKER',
+            '__pp_style' => ['--faq-eyebrow-color' => '#ffffff', '--faq-eyebrow-bg' => '#111111'],
+        ]));
+        $this->assertStringContainsString('--faq-eyebrow-color: #ffffff', $html);
+        $this->assertStringContainsString('--faq-eyebrow-bg: #111111', $html);
+    }
+
+    public function testFaqDarkThemeAddsClass(): void
+    {
+        $html = $this->render('faq', $this->faqProps(['theme' => 'dark']));
+        $this->assertStringContainsString('class="faq faq--dark"', $html);
+    }
+
+    public function testFaqInvertedThemeAddsClass(): void
+    {
+        $html = $this->render('faq', $this->faqProps(['theme' => 'inverted']));
+        $this->assertStringContainsString('class="faq faq--inverted"', $html);
+    }
+
+    public function testFaqDefaultThemeAddsNoModifierClass(): void
+    {
+        $html = $this->render('faq', $this->faqProps());
+        $this->assertStringContainsString('class="faq"', $html);
+        $this->assertStringNotContainsString('faq--', $html);
+    }
+
+    public function testFaqUnknownThemeClampsToDefault(): void
+    {
+        // Composition validation does not check enum values (that is #147, deferred),
+        // so the render is the actual contract: an unknown theme must not emit an
+        // unstyled faq--<garbage> class (mirrors section/grid clamping).
+        $html = $this->render('faq', $this->faqProps(['theme' => 'neon']));
+        $this->assertStringNotContainsString('faq--neon', $html);
+        $this->assertStringContainsString('class="faq"', $html);
+    }
+
     public function testStatsRendersAllFourSlots(): void
     {
         $overrides = [

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -1435,9 +1435,10 @@ class OperateTest extends TestCase
         $this->assertSame('items[].link_text', $grid[5]['name']);
 
         $faq = pp_get_component_fields('faq');
-        $this->assertCount(2, $faq);
-        $this->assertSame('items[].question', $faq[0]['name']);
-        $this->assertSame('items[].answer', $faq[1]['name']);
+        $this->assertCount(3, $faq);
+        $this->assertSame('eyebrow', $faq[0]['name']);
+        $this->assertSame('items[].question', $faq[1]['name']);
+        $this->assertSame('items[].answer', $faq[2]['name']);
 
         $cta = pp_get_component_fields('cta');
         $this->assertCount(5, $cta);

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -208,7 +208,7 @@ class SchemaValidationTest extends TestCase
     public function testStructuralAndToneComponentsUseCanonicalKeys(): void
     {
         $expectLayout = ['hero', 'section', 'grid', 'cta', 'testimonials'];
-        $expectTheme  = ['section', 'stats', 'logos', 'embed', 'grid', 'cta', 'testimonials'];
+        $expectTheme  = ['section', 'stats', 'logos', 'embed', 'grid', 'cta', 'testimonials', 'faq'];
 
         foreach ($expectLayout as $component) {
             $schema = json_decode(file_get_contents($this->themeRoot . "/components/{$component}/schema.json"), true);


### PR DESCRIPTION
Closes #231

## Scope

`faq` was the only heading-bearing component that could not be anchor-linked or given a background tone. It now accepts `id`, `eyebrow`, and `theme` (`default`/`dark`/`inverted`), matching hero/section/grid/cta/stats/testimonials/logos/embed. Implements the issue's recorded decision exactly (accept the three props, matching the other heading components).

Per acceptance criteria:
- **id** — declared in schema; renders on the `<section>` for anchor links (`#faq`) and becomes the stable component id (`faq.php` already emitted it; now a supported/declared surface).
- **eyebrow** — renders as a `.faq__eyebrow` pill above the heading; two per-instance style slots (`--faq-eyebrow-color`, `--faq-eyebrow-bg`) recolor it, bringing faq to 10 style slots.
- **theme** — `faq--dark` / `faq--inverted` variants; the inverted heading routes through a `--faq-heading-theme-color` fallback so it survives the high-specificity desktop typography rule (issue 222 pattern). Accordion cards stay light so question/answer text stays dark. Unknown themes clamp to `default` at render (composition validation does not check enums, so the render is the contract — mirrors section/grid).

AI-facing docs updated in the same change: `AI_CONTEXT.md` (faq prop row, theme-component list, slot totals 140→142 / faq 8→10), `README.md` (slot totals), `ai-instructions/composition.md`, `components/faq/README.md`. The runtime AI context (`lib/ai-context.php`) derives faq's props from schema, so it picks up the new props automatically.

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → 1550 tests green (added 9). Warning/deprecation counts identical to base (3 warnings / 2 deprecations, pre-existing).
- JS: `npm test` → 484 green, including `package.test.js` version-consistency across all five version files.
- `bash scripts/package.sh` → version sync OK; built zip deleted (releases are CI-built from tags).
- New tests: `ComponentPropsTest` pins the id anchor, eyebrow pill (present/absent), eyebrow color slots, dark/inverted theme classes, default no-modifier case, and unknown-theme clamping. `SchemaValidationTest` asserts faq declares `theme`. `OperateTest` pins `eyebrow` as an editable faq field.

## Reviews (this session, current diff)
- `/plan-eng-review` — architecture cleared; mirrors the proven section/grid pattern.
- `/review` — zero actionable findings; one Codex false positive (id/theme "missing" from operate field registration) refuted: operate registers only text-editable fields, and every sibling (section/grid) omits id/theme there too.

## Accepted limitations
- README's `ai-instructions` file count ("13 files", actually 14) is stale but out of scope — tracked by #252. This change adds no ai-instructions file, so it does not touch that count.
- Adding the two `--faq-eyebrow-*` style slots is parity with grid/section (the issue invokes the grid comparison and the no-hierarchy principle); it stays within the recorded decision, not an expansion.

## Not done
- No tagging/release/deploy (CI-built from tags; maintainer does that separately).