### PR TITLE
v0.16.92 docs: source run_id from `wp pp operate inspect` in operating-loop playbooks (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.92] — 2026-07-12 — The operating-loop playbooks now tell the agent where the `--run-id` run token comes from (#228)
+
+**An AI following `playbook-create-page.md` literally could not get past step 3. The playbook's mandatory 8-step loop declares `wp pp apply preflight --run-id=<uuid>` at PREFLIGHT but never said where `<uuid>` comes from. Read as written, `<uuid>` means "any UUID", so an agent generates a fresh UUID v4 — it passes format validation, then PREFLIGHT cannot record run state and the next EDIT step fails. The run token is not a self-generated UUID: it is the `run_id` that `wp pp operate inspect` appends to its JSON. The three loop playbooks (`create-page`, `inspect-fix`, `revise-section`) now say so at INSPECT (capture the `run_id`) and at PREFLIGHT (`<uuid>` is that captured token), note the 2-hour install-scoped TTL, and link `docs/reference-apply-cli.md`. The documented happy path for AI-maintained pages is now executable from the playbook alone.**
+
+The sourcing knowledge already lived in `docs/reference-apply-cli.md` and `AI_CONTEXT.md`; the playbooks just never restated or linked it, so an agent given only the playbook was stuck. `operating-loop.md` already documented the run token (Rule 1 plus the CLI reference table) and needed no change. A grep-based invariant test now pins the rule: it auto-discovers every `ai-instructions/*.md` file, and any doc that instructs `apply preflight --run-id` must also state that the run token comes from `wp pp operate inspect`, so a future playbook cannot reintroduce the same gap.
+
+### Docs
+
+- `ai-instructions/playbook-create-page.md`, `playbook-inspect-fix.md`, and `playbook-revise-section.md` now source the run token: INSPECT captures the `run_id` that `wp pp operate inspect` appends, PREFLIGHT states `<uuid>` is that captured token (not a freshly generated UUID), and both note the 2-hour install-scoped TTL and link `docs/reference-apply-cli.md` (#228).
+
+### Tests
+
+- New `InvariantTest::testLoopPlaybookSourcesRunIdFromInspect` auto-discovers every `ai-instructions/*.md` and asserts that any doc instructing `apply preflight --run-id` also documents that the run token comes from `wp pp operate inspect`, pinning the doc fix against regression (#228).
+
 ## [v0.16.91] — 2026-07-12 — The FAQ section can now carry an anchor id, an eyebrow pill, and a dark or inverted theme (#231)
 
 **`faq` was the only heading-bearing component that could not be anchor-linked or given a background tone. Every other section component (`hero`, `section`, `grid`, `cta`, `stats`, `testimonials`, `logos`, `embed`) already accepted an `id`, and the marketing ones an `eyebrow` and a `theme` — `faq` accepted none of them in its schema, so a nav item pointing at `#faq` had no target and the FAQ heading could not sit on a dark band. `faq` now accepts `id` (anchor plus stable component id), `eyebrow` (a kicker pill above the heading), and `theme` (`default` / `dark` / `inverted`), matching the rest of the set. A page with an FAQ section and a nav link to it is finally expressible.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.91-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.92-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/playbook-create-page.md
+++ b/ai-instructions/playbook-create-page.md
@@ -16,6 +16,7 @@ Run `wp pp operate inspect`. Review:
 - Existing composition pages (avoid duplicate slugs)
 - CSS conflicts (note any that might affect new components)
 - Drift state (note for PREFLIGHT)
+- **The `run_id`.** `wp pp operate inspect` appends a `run_id` field (a UUID v4) to its JSON output. Capture it — this is your **run token**, and you pass it via `--run-id` to every mutating command in the steps below (PREFLIGHT, EDIT, APPLY). Generating your own UUID does **not** work: only the token minted by `inspect` can record run state, so a self-generated one passes format validation but then fails PREFLIGHT/EDIT. The token is install-scoped and expires 2 hours after `inspect`; re-run `inspect` if it expires. Full contract: `docs/reference-apply-cli.md`.
 
 ### 2. PLAN
 Map the brief to PromptingPress components:
@@ -25,7 +26,7 @@ Map the brief to PromptingPress components:
 - Note any design token changes needed (stored in database, not file-based)
 
 ### 3. PREFLIGHT
-Run a site-scoped `wp pp apply preflight --run-id=<uuid>` (no `--post_id` — the page does not exist yet). This covers the site-scoped page creation in EDIT. Creating a page through `create_page` with its composition inline is a single site-scoped mutation, so the site preflight is sufficient.
+Run a site-scoped `wp pp apply preflight --run-id=<uuid>` (no `--post_id` — the page does not exist yet). `<uuid>` is the `run_id` you captured from INSPECT, not a freshly generated UUID. This covers the site-scoped page creation in EDIT. Creating a page through `create_page` with its composition inline is a single site-scoped mutation, so the site preflight is sufficient.
 
 ### 4. EDIT
 Execute actions in order:

--- a/ai-instructions/playbook-inspect-fix.md
+++ b/ai-instructions/playbook-inspect-fix.md
@@ -17,6 +17,7 @@ Run `wp pp operate inspect --post_id=<page_id>`. Review:
 - Composition smells (may identify the root cause)
 - Design tokens (token issues cause visual bugs)
 - CSS conflicts (custom CSS may be overriding components)
+- **The `run_id`.** `wp pp operate inspect` appends a `run_id` field (a UUID v4) to its JSON output. Capture it — this is your **run token**, passed via `--run-id` to every mutating command below (PREFLIGHT, EDIT, APPLY). A self-generated UUID passes format validation but then fails PREFLIGHT/EDIT because only the token minted by `inspect` records run state. It is install-scoped and expires 2 hours after `inspect`; re-run `inspect` if it expires. Full contract: `docs/reference-apply-cli.md`.
 
 Capture a **broken-state screenshot**: `wp pp screenshot capture --post_id=<page_id> --playbook=inspect-fix`
 
@@ -35,7 +36,7 @@ Declare the fix:
 - What the fixed state should look like
 
 ### 3. PREFLIGHT
-Run `wp pp apply preflight --run-id=<uuid>`, adding `--post_id=<page_id>` when the fix mutates a page's composition (and planned_files for file mutations). This records the PREFLIGHT covering the target and unlocks the fix in EDIT.
+Run `wp pp apply preflight --run-id=<uuid>`, adding `--post_id=<page_id>` when the fix mutates a page's composition (and planned_files for file mutations). `<uuid>` is the `run_id` you captured from INSPECT, not a freshly generated UUID. This records the PREFLIGHT covering the target and unlocks the fix in EDIT.
 
 ### 4. EDIT
 Execute the minimal fix. Do not refactor adjacent code. Do not "improve" unrelated sections. A composition fix is gated: it requires the page-covering PREFLIGHT from step 3.

--- a/ai-instructions/playbook-revise-section.md
+++ b/ai-instructions/playbook-revise-section.md
@@ -15,6 +15,7 @@ Run `wp pp operate inspect --post_id=<page_id>`. Review:
 - Current composition (identify the target section by index)
 - Composition smells (may reveal existing issues)
 - Design tokens (ensure revision is consistent)
+- **The `run_id`.** `wp pp operate inspect` appends a `run_id` field (a UUID v4) to its JSON output. Capture it — this is your **run token**, passed via `--run-id` to every mutating command below (PREFLIGHT, EDIT, APPLY). A self-generated UUID passes format validation but then fails PREFLIGHT/EDIT because only the token minted by `inspect` records run state. It is install-scoped and expires 2 hours after `inspect`; re-run `inspect` if it expires. Full contract: `docs/reference-apply-cli.md`.
 
 Capture a **before-screenshot**: `wp pp screenshot capture --post_id=<page_id> --playbook=revise-section`
 
@@ -25,7 +26,7 @@ Capture a **before-screenshot**: `wp pp screenshot capture --post_id=<page_id> -
 - If file mutations are needed, list planned_files
 
 ### 3. PREFLIGHT
-Run `wp pp apply preflight --run-id=<uuid> --post_id=<page_id>` (add planned_files if file mutations are needed). This records a PREFLIGHT covering the page and unlocks the typed mutation in EDIT. Without it, the edit refuses to run.
+Run `wp pp apply preflight --run-id=<uuid> --post_id=<page_id>` (add planned_files if file mutations are needed). `<uuid>` is the `run_id` you captured from INSPECT, not a freshly generated UUID. This records a PREFLIGHT covering the page and unlocks the typed mutation in EDIT. Without it, the edit refuses to run.
 
 ### 4. EDIT
 Use `update_component` (patch semantics — only the props you pass change) targeted by `component_id` (prefer an authored `id` prop — auto-generated `pp-<hex8>` ids are stable across this in-place path but not across a full `update_composition` re-apply) or `component_index`, or `wp pp operate patch` with a semantic selector for a single field. Do not rewrite the entire composition via `update_composition` — modify only the target section. Both paths are gated: they require the page-covering PREFLIGHT from step 3 and a `--run-id`.

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.91');
+define('PP_VERSION', '0.16.92');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.91",
+  "version": "0.16.92",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.91
+Stable tag: 0.16.92
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.91
+Version:          0.16.92
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/InvariantTest.php
+++ b/tests/InvariantTest.php
@@ -199,6 +199,83 @@ class InvariantTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    // ── Operating-loop playbooks must source the run token ────────────────
+
+    /**
+     * Every operating-loop doc that instructs the agent to run
+     * `wp pp apply preflight --run-id=<uuid>` must also tell the agent WHERE
+     * that run token comes from: `wp pp operate inspect`. Without this, an
+     * agent reads `<uuid>` as "any UUID", generates one, and it fails at
+     * PREFLIGHT/EDIT because a self-minted token records no run state
+     * (issue 228). This pins the doc fix so the sourcing sentence cannot be
+     * dropped again.
+     *
+     * The provider auto-discovers every `ai-instructions/*.md` file rather
+     * than a hard-coded allowlist, so a NEW playbook that adds the
+     * `--run-id` instruction without the sourcing note is caught
+     * automatically — the invariant covers "every operating-loop doc", not
+     * just the four that existed when it was written.
+     *
+     * @dataProvider aiInstructionDocProvider
+     */
+    public function testLoopPlaybookSourcesRunIdFromInspect(string $relPath): void
+    {
+        $path = $this->themeRoot . '/' . $relPath;
+        $this->assertFileExists($path, "Missing ai-instructions doc: {$relPath}");
+
+        $content = file_get_contents($path);
+        $this->assertNotFalse($content);
+
+        // Only docs that actually instruct a `--run-id` preflight need the
+        // sourcing statement. If a doc never pairs `apply preflight` with
+        // `--run-id`, it is not in the failure class — skip it.
+        if (!preg_match('/apply preflight[^\n]*--run-id/i', $content)) {
+            $this->addToAssertionCount(1);
+            return;
+        }
+
+        // The run-token source (`wp pp operate inspect`) must be named in the
+        // same sentence as a run-id / run-token mention — not merely present
+        // somewhere unrelated in the file. `[^.]` keeps the match inside one
+        // sentence; the `s` flag lets a sentence span wrapped lines. Tolerant
+        // of `run_id`, `run-id`, `run id`, and "run token", and of the inline
+        // `operate inspect -> apply preflight --run-id` sequence form.
+        $sourced = preg_match(
+            '/(run[-_ ]?id|run token)[^.]{0,220}operate inspect'
+            . '|operate inspect[^.]{0,220}(run[-_ ]?id|run token)/is',
+            $content
+        );
+
+        $this->assertSame(
+            1,
+            $sourced,
+            "{$relPath} instructs `apply preflight --run-id` but never states that "
+            . 'the run token comes from `wp pp operate inspect`. An agent will read '
+            . '`<uuid>` as "any UUID" and fail at PREFLIGHT (issue 228). Add a '
+            . 'sourcing sentence tying `run_id` to `wp pp operate inspect`.'
+        );
+    }
+
+    public static function aiInstructionDocProvider(): array
+    {
+        $dir   = dirname(__DIR__) . '/ai-instructions';
+        $files = glob($dir . '/*.md') ?: [];
+        sort($files);
+
+        $cases = [];
+        foreach ($files as $file) {
+            $cases[basename($file)] = ['ai-instructions/' . basename($file)];
+        }
+
+        // Fail loudly if discovery finds nothing — an empty data provider
+        // would make this invariant silently vacuous.
+        if ($cases === []) {
+            $cases['__none_found__'] = ['ai-instructions/__none_found__'];
+        }
+
+        return $cases;
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
 
     private function phpFilesIn(string $dir): array


### PR DESCRIPTION
Closes #228

## Summary

`ai-instructions/playbook-create-page.md` declares an 8-step mandatory loop whose step 3 runs `wp pp apply preflight --run-id=<uuid>`, but never says where `<uuid>` comes from. Read literally, an agent generates a fresh UUID v4 — it passes format validation (`pp_operate_valid_run_id`), but PREFLIGHT then cannot record run state and the next EDIT step fails. The run token is the `run_id` that `wp pp operate inspect` appends to its JSON, not a self-generated UUID.

The same gap existed in the two sibling loop playbooks (`inspect-fix`, `revise-section`), which the issue flagged for audit. `operating-loop.md` already documents the run token (Rule 1 + CLI reference table) and needed no change.

## Changes

- **`playbook-create-page.md`, `playbook-inspect-fix.md`, `playbook-revise-section.md`** — INSPECT now tells the agent to capture the `run_id` that `wp pp operate inspect` appends; PREFLIGHT states `<uuid>` is that captured token (not a freshly generated UUID); both note the 2-hour install-scoped TTL (`PP_OPERATE_RUN_TTL = 7200`, verified in `lib/operate.php:585`) and link `docs/reference-apply-cli.md`.
- **`tests/InvariantTest.php`** — new `testLoopPlaybookSourcesRunIdFromInspect` auto-discovers every `ai-instructions/*.md` and asserts any doc instructing `apply preflight --run-id` also documents that the run token comes from `wp pp operate inspect`. Auto-discovery (not a hardcoded allowlist) means a future playbook with the gap is caught automatically.

## Scope / audit

Audited all `ai-instructions/*.md` for the `apply preflight --run-id` pattern. The three loop playbooks lacked sourcing and are fixed. `composition.md`, `retheme.md`, and `set-logo.md` already show the `operate inspect -> apply preflight --run-id` sequence; `validate-site.md` references preflight without a `--run-id` fill-in; `operating-loop.md` documents it in Rule 1. All 14 docs pass the new invariant.

Docs consistency verified against `docs/reference-apply-cli.md:112`, `AI_CONTEXT.md:443`, and `docs/running-an-ai-agent.md:65` — the change restates what those authoritative references already say; no doc claim is invalidated. `lib/ai-context.php` carries no run_id/preflight claims.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — 1564 passing, 3 warnings, 2 deprecations (baseline; the +14 tests are the auto-discovered doc data sets).
- `npm test` (vitest) — 484 passing.
- New test proven to catch the bug: it reports `sourced=0` (fails) on the pre-fix `playbook-create-page.md`, passes post-fix.
- Version sync validated with `scripts/package.sh` (five files at 0.16.92); build zip deleted.

## Reviews

`/plan-eng-review`, `/review`, and Codex outside-voice/adversarial passes ran this session on this exact working tree (pre-commit). Codex's strongest finding — the test's original hardcoded 4-file allowlist — was incorporated (switched to auto-discovery). No 7A questions arose (docs-only, no accepted-behavior change).

## Accepted limitations

- The invariant's trigger requires `apply preflight` and `--run-id` on the same line (matches all current usage); a future line-wrapped command would be skipped rather than flagged (conservative under-enforcement, not a false pass).
- No deploy/tag/release performed — CI builds the release zip from tags separately.
