### PR TITLE
v0.16.93 docs: drop stale hardcoded non-test counts from README (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.93] — 2026-07-12 — The README no longer asserts stale hardcoded counts for design tokens and AI workflow files (#252)
+
+**The README described the theme with two baked-in numbers that had quietly gone wrong. It claimed "47 CSS custom properties" / "47 design tokens" when `assets/css/base.css` now defines 51, and "13 files" of AI workflow guides when `ai-instructions/` now holds 14. A number baked into prose goes stale the moment a token or a file is added, and the token count is load-bearing for the product pitch ("an AI agent can retheme an entire site by updating tokens"), so being four off read as a credibility problem, not a typo. The README now describes both qualitatively instead of counting: "design tokens in one CSS file", "CSS custom properties", "Task-specific AI workflow guides". The claims stay true as the theme grows.**
+
+This follows the resolution issue #250 took for stale test counts: stop asserting a hardcoded number in prose rather than refreshing it, which would just reset the drift clock. All six "47" occurrences in `README.md` and the one "13 files" count were reworded or dropped. The `docs/`-lint guard's `MUST_NOT_CATCH` list pinned the exact phrase "47 CSS custom properties control the entire visual system" as a known-legitimate non-test number; that phrase no longer exists in the README, so the now-fictional pin was removed. The identical stale "47 design tokens" claim in the runtime AI docs (`AI_CONTEXT.md`, `AI_RULES.md`, `ai-instructions/retheme.md`) was left for a separate issue rather than silently widening this change.
+
+### Docs
+
+- `README.md` no longer hardcodes the design-token / CSS-custom-property count or the `ai-instructions/` file count. Six "47 tokens / 47 CSS custom properties" claims and one "13 files" claim were replaced with qualitative descriptions or dropped, so the counts can no longer drift as tokens and guides are added (#252).
+
+### Tests
+
+- `tests/js/docs-lint.test.js` drops the `MUST_NOT_CATCH` pin for "47 CSS custom properties control the entire visual system"; that phrase was removed from the README, so pinning it as a live known-legitimate string was misleading. The guard's remaining entries still assert the test-count regex does not false-positive on legitimate non-test numbers (#252).
+
 ## [v0.16.92] — 2026-07-12 — The operating-loop playbooks now tell the agent where the `--run-id` run token comes from (#228)
 
 **An AI following `playbook-create-page.md` literally could not get past step 3. The playbook's mandatory 8-step loop declares `wp pp apply preflight --run-id=<uuid>` at PREFLIGHT but never said where `<uuid>` comes from. Read as written, `<uuid>` means "any UUID", so an agent generates a fresh UUID v4 — it passes format validation, then PREFLIGHT cannot record run state and the next EDIT step fails. The run token is not a self-generated UUID: it is the `run_id` that `wp pp operate inspect` appends to its JSON. The three loop playbooks (`create-page`, `inspect-fix`, `revise-section`) now say so at INSPECT (capture the `run_id`) and at PREFLIGHT (`<uuid>` is that captured token), note the 2-hour install-scoped TTL, and link `docs/reference-apply-cli.md`. The documented happy path for AI-maintained pages is now executable from the playbook alone.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.92-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.93-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ PromptingPress goes the other direction:
 
 - **Explicit composition data** — pages are JSON arrays, not serialized builder state
 - **Typed components with schemas** — AI knows what's editable and what values are valid
-- **File-owned design rules** — 47 design tokens, no visual overrides to hunt down
+- **File-owned design rules** — design tokens in one CSS file, no visual overrides to hunt down
 - **Minimal frontend assumptions** — no framework, no bundler, no builder runtime on the visitor-facing site
 - **Fast, maintainable WordPress output** — the architecture is designed to stay lean
 
@@ -44,7 +44,7 @@ PromptingPress goes the other direction:
 | 🧩 **Page structure** | Layout scattered across blocks, builders, shortcodes, and theme options | Page layout is one JSON array in post meta — inspectable, diffable, version-controllable |
 | 🛡️ **Edit safety** | Changes via file edits, block editor, or plugin-specific APIs | Every change goes through one typed action layer — validate, preview, execute, rollback |
 | 🪶 **Frontend weight** | Builder runtime, serialized markup, framework dependencies | ~97 KB CSS + 3.6 KB vanilla JS. No framework. No bundler. No builder runtime. |
-| 🎨 **Design control** | Colors and spacing set through visual overrides or inline CSS | 47 design tokens in one CSS file; site overrides in the database, survive theme updates |
+| 🎨 **Design control** | Colors and spacing set through visual overrides or inline CSS | Design tokens in one CSS file; site overrides in the database, survive theme updates |
 | 📄 **Component contracts** | Ad hoc theme files, no contracts on what a component accepts | Every component has `schema.json` with typed props, required fields, and validation |
 
 > **When page structure is explicit and every edit path is validated, AI stops guessing and starts operating — and the frontend stays lean.**
@@ -156,7 +156,7 @@ Components are plain PHP partials that render semantic HTML with CSS custom prop
 
 | Asset | Size | What it does |
 |-------|------|-------------|
-| `base.css` | 9 KB | Design tokens — 47 CSS custom properties |
+| `base.css` | 9 KB | Design tokens — CSS custom properties |
 | `components.css` | 84 KB | All 12 component styles, CSS variables only |
 | `utilities.css` | 3 KB | Layout helpers |
 | `main.js` | 3.6 KB | Hamburger nav toggle + sticky-header height measurement — one IIFE, zero dependencies |
@@ -169,7 +169,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 ### 🎨 Design tokens — visual system without file edits
 
-47 CSS custom properties control the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
+A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
 142 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 10 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
@@ -183,7 +183,7 @@ wp pp apply execute update_design_token \
   --params='{"token":"--color-accent","value":"#b45309"}'
 ```
 
-**Why this matters:** An AI agent can retheme an entire site by updating 47 tokens — with preview, backup, and rollback on every change. No CSS files to parse, no specificity wars, no visual editor toggles to find.
+**Why this matters:** An AI agent can retheme an entire site by updating design tokens — with preview, backup, and rollback on every change. No CSS files to parse, no specificity wars, no visual editor toggles to find.
 
 ---
 
@@ -311,9 +311,9 @@ No theme files were edited. No WordPress internals were called. No visual builde
 /lib/guardrails.php        Surface classification, CSS conflicts, integrity checks
 /lib/setup.php             Theme activation, homepage provisioning, integrity lifecycle (daily cron + pre-update block)
 /lib/components.php        Component auto-loader (stable contract — don't edit)
-/assets/css/base.css       Design token defaults (47 design tokens)
+/assets/css/base.css       Design token defaults
 /assets/css/components.css Component styles (CSS variables only, no raw hex)
-/ai-instructions/          Task-specific AI workflow guides (13 files)
+/ai-instructions/          Task-specific AI workflow guides
 AI_CONTEXT.md              Machine-readable site map — AI starts here
 AI_RULES.md                Hard coding invariants
 ```

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.92');
+define('PP_VERSION', '0.16.93');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.92",
+  "version": "0.16.93",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.92
+Stable tag: 0.16.93
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.92
+Version:          0.16.93
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/docs-lint.test.js
+++ b/tests/js/docs-lint.test.js
@@ -93,7 +93,6 @@ describe('docs lint: the guard itself is not decoration', () => {
         'schema validation, 20 typed actions, apply layer',
         'against a live **WordPress 7.0** instance (requires Docker)',
         'boot wp-env container (WordPress 7.0)',
-        '47 CSS custom properties control the entire visual system',
     ];
 
     test.each(MUST_CATCH)('catches a hardcoded count: %s', (s) => {


### PR DESCRIPTION
Closes #252

## Scope

The last open v1.0.0 gate item. `README.md` asserted two hardcoded non-test counts that had drifted:

- **"47 CSS custom properties" / "47 design tokens"** — `assets/css/base.css` now defines **51** unique `--*` properties.
- **"Task-specific AI workflow guides (13 files)"** — `ai-instructions/` now holds **14** files.

Per the recorded decision (2026-07-11, same principle as #250), both were resolved by dropping the hardcoded number and describing the thing qualitatively, so the count can't re-drift as tokens and guides are added — not by refreshing 47 → 51 / 13 → 14.

### Against acceptance criteria

- Stale `ai-instructions` file count removed (README:316) — dropped "(13 files)".
- Stale CSS custom-property / token count claims removed (README) — **all six** "47" occurrences reworded/dropped (lines 31, 47, 159, 172, 186, 314), not only the two the issue table enumerated; the recorded decision says "in README" (plural claims), and leaving four stale "47"s would be internally inconsistent.
- Docs-lint `MUST_NOT_CATCH` pin revisited — removed the now-fictional `"47 CSS custom properties control the entire visual system"` entry from `tests/js/docs-lint.test.js`, since that phrase no longer appears in the README. The guard's remaining entries still pin the test-count regex against false positives on legitimate non-test numbers.

## Validation

- `npm test` → 483 passed (incl. `docs-lint.test.js` 18/18 after the pin removal).
- `./vendor/bin/phpunit --configuration phpunit.xml` → 1564 tests, 5744 assertions, OK (3 warnings / 2 deprecations, unchanged from base — a docs edit touches no PHP).
- `bash scripts/package.sh` → "Version consistency: OK" for 0.16.93 across all five synced files; emitted zip deleted.

## Reviews (this session, on this diff)

- `/plan-eng-review` — proportional review, no findings (docs-only, 2 files).
- `/review` — critical pass no findings; specialists auto-skipped (<50 lines); adversarial reasoned inline.
- `/document-generate` — no doc updates required by this diff.

## 7A question

None. No review finding extended the recorded decision.

## Accepted limitations / noticed-not-touched

- The identical stale **"47 design tokens"** claim survives in the runtime AI docs (`AI_CONTEXT.md`, `AI_RULES.md`, `ai-instructions/retheme.md`). #252 was deliberately scoped to `README.md` (it exists because #250 declined to widen scope), so those were **not** touched here and are filed separately as **#286**.
- Adjacent hardcoded numbers left untouched as out of scope and current: "142 per-instance style slots" (updated in #231), "10 named recipes", "12 component styles".
