### PR TITLE
v0.16.94 docs: stop hardcoding stale design-token count in runtime AI docs (#286)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -33,7 +33,7 @@ documented in `schema.json` in the same folder. CSS is in `/assets/css/component
 **To add a component:** Follow the steps in `ai-instructions/add-component.md`. The
 auto-loader picks up any component at `/components/{name}/{name}.php` — no registration needed.
 
-**To retheme:** Read `ai-instructions/retheme.md`. Update the 47 design tokens via `update_design_token` apply (overrides stored in database, defaults in `assets/css/base.css`).
+**To retheme:** Read `ai-instructions/retheme.md`. Update design tokens via `update_design_token` apply (overrides stored in database, defaults in `assets/css/base.css`).
 
 **To style a specific component instance:** Read `ai-instructions/style-component.md`. Use the `style_component` action to set per-instance CSS custom properties (style slots) without editing CSS files.
 
@@ -74,7 +74,7 @@ site-customization permission.
 |--------------------------|---------------------------------|----------------------------------|
 | /templates/              | Page layouts                    | Release-level only — inspect for site work |
 | /components/             | Reusable sections               | Release-level only — inspect for site work |
-| /assets/css/base.css     | Design token defaults (47 design tokens) | Release-level only — site tokens via update_design_token |
+| /assets/css/base.css     | Design token defaults | Release-level only — site tokens via update_design_token |
 | /assets/css/components.css | Component styles              | Release-level only — inspect for site work |
 | /assets/css/utilities.css | Spacing / text utilities       | Release-level only — inspect for site work |
 | /assets/js/pp-editor-logic.js | Pure JS logic (testable)   | Release-level only — run npm test after |
@@ -341,7 +341,7 @@ not ACF fields. `pp_field()` returns null when ACF is not installed.
 
 ## Design tokens
 
-47 CSS custom properties control the entire visual system. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the `pp_token_overrides` database option and output as inline CSS after the base stylesheet (CSS cascade resolves precedence automatically).
+A single layer of CSS custom properties controls the entire visual system. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the `pp_token_overrides` database option and output as inline CSS after the base stylesheet (CSS cascade resolves precedence automatically).
 
 To change a token: use `pp_execute_apply('update_design_token', ['token' => '...', 'value' => '...'])`. To revert: use `reset_design_token` or `reset_all_design_tokens`.
 
@@ -623,7 +623,7 @@ Assembled by `pp_ai_system_prompt()`:
 - Component catalog (names + prop schemas with enum values, style slots, and recipes)
 - Action signatures (names, scopes, param types)
 - Apply signatures (names, domains, param types)
-- Design token inventory (47 tokens with current effective values and types)
+- Design token inventory (current effective values and types for every token)
 - Style slot value rules (type-specific guidance for the LLM)
 - Pre-proposal verification checklist (target correct component, confirm slot exists, confirm value is representable)
 - Response format instructions (conversational vs structured proposal)

--- a/AI_RULES.md
+++ b/AI_RULES.md
@@ -55,7 +55,7 @@ for site work those paths remain inspect-only.
 ## Design system
 
 To restyle the site, read `ai-instructions/retheme.md`.
-47 design tokens control the entire visual system. Product defaults live in `assets/css/base.css`; site-specific overrides are stored in the `pp_token_overrides` database option and output as inline CSS. Overrides survive theme updates.
+A single layer of design tokens controls the entire visual system. Product defaults live in `assets/css/base.css`; site-specific overrides are stored in the `pp_token_overrides` database option and output as inline CSS. Overrides survive theme updates.
 Each token has a type annotation in its comment (color, length, font-family, number, duration, raw, shadow).
 To change a token programmatically, use `pp_execute_apply('update_design_token', ['token' => '--color-accent', 'value' => '#b45309'])`.
 To revert a token to its default, use `pp_execute_apply('reset_design_token', ['token' => '--color-accent'])`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.94] — 2026-07-12 — The runtime AI docs no longer hardcode a stale "47 design tokens" count (#286)
+
+**The chat AI reads `AI_CONTEXT.md`, `AI_RULES.md`, and `ai-instructions/retheme.md` while it operates a site, and all three told it "47 design tokens" (or "47 CSS custom properties") control the visual system. `assets/css/base.css` now defines 51, so the count was four low everywhere the AI actually looks when driving a retheme. This is higher-stakes than the README copy issue #252 fixed: a wrong number in the runtime retheme instructions is a correctness problem in the product's core "an AI agent can retheme by updating tokens" capability, not just marketing prose. All seven occurrences now describe the token layer qualitatively ("A single layer of design tokens controls the entire visual system") instead of counting, so the claim stays true as tokens are added.**
+
+This applies the same resolution as issues #250 and #252: stop asserting a hardcoded number in prose rather than refreshing 47 → 51, which would just reset the drift clock. `lib/ai-context.php` was already count-free (it generates the token inventory dynamically from live values), and the legitimate "8 base color tokens" subset in `retheme.md` Step 1 — which is self-verifying against the eight seed colors listed right below it — was deliberately left intact. A new `docs/`-lint guard pins the rule so the stale count cannot creep back into any of the three runtime docs.
+
+### Docs
+
+- `AI_RULES.md`, `AI_CONTEXT.md`, and `ai-instructions/retheme.md` no longer hardcode the design-token / CSS-custom-property count. All seven "47 design tokens" / "47 CSS custom properties" / "47 tokens" claims were replaced with qualitative descriptions, so the count can no longer drift as tokens are added to `base.css` (#286).
+
+### Tests
+
+- `tests/js/docs-lint.test.js` adds a design-token-count guard over the three runtime AI docs (`AI_RULES.md`, `AI_CONTEXT.md`, `ai-instructions/retheme.md`). Its `TOKEN_COUNT_CLAIM` regex catches total-count claims like "47 design tokens", "51 total design tokens", and "47 CSS custom properties", with `MUST_CATCH` / `MUST_NOT_CATCH` self-checks that keep it from decaying into a no-op and keep the legitimate "8 base color tokens" subset exempt (#286).
+
 ## [v0.16.93] — 2026-07-12 — The README no longer asserts stale hardcoded counts for design tokens and AI workflow files (#252)
 
 **The README described the theme with two baked-in numbers that had quietly gone wrong. It claimed "47 CSS custom properties" / "47 design tokens" when `assets/css/base.css` now defines 51, and "13 files" of AI workflow guides when `ai-instructions/` now holds 14. A number baked into prose goes stale the moment a token or a file is added, and the token count is load-bearing for the product pitch ("an AI agent can retheme an entire site by updating tokens"), so being four off read as a credibility problem, not a typo. The README now describes both qualitatively instead of counting: "design tokens in one CSS file", "CSS custom properties", "Task-specific AI workflow guides". The claims stay true as the theme grows.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.93-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.94-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/retheme.md
+++ b/ai-instructions/retheme.md
@@ -1,7 +1,7 @@
 # Retheme PromptingPress
 
 Change the entire color scheme, fonts, shape language, spacing scale, and shadows
-through 47 design tokens.
+through the design tokens.
 
 **To retheme a SITE, use the apply/DB path — do not edit `base.css`.** Token values
 for a specific site are set with `update_design_token` (stored in the
@@ -134,7 +134,7 @@ The output should be empty. If it returns matches, replace each with the corresp
 | schema.json files        | Machine-readable contracts — not styling |
 | functions.php            | Use `enqueue_font` apply instead of editing directly |
 
-The entire visual output of the site flows through the 47 design tokens and the apply/action model. Editing files directly is unnecessary for a retheme — use `update_design_token` for global tokens, `enqueue_font` for fonts, and `style_component` for per-instance visual overrides.
+The entire visual output of the site flows through the design tokens and the apply/action model. Editing files directly is unnecessary for a retheme — use `update_design_token` for global tokens, `enqueue_font` for fonts, and `style_component` for per-instance visual overrides.
 
 ---
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.93');
+define('PP_VERSION', '0.16.94');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.93",
+  "version": "0.16.94",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.93
+Stable tag: 0.16.94
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.93
+Version:          0.16.94
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/docs-lint.test.js
+++ b/tests/js/docs-lint.test.js
@@ -31,6 +31,20 @@ const LIVE_DOCS = [
     ['AI_RULES.md', AI_RULES],
 ];
 
+// Runtime AI-facing docs: the chat AI reads these while operating a site (the
+// retheme flow especially). A hardcoded design-token count here is a
+// correctness problem, not just stale marketing copy — see issue 286. The
+// count drifted 47 -> 51 as tokens were added to base.css; the fix is to stop
+// asserting a number, not to refresh it. base.css is the source of truth.
+const AI_CONTEXT = stripBadges(read('AI_CONTEXT.md'));
+const RETHEME = stripBadges(read('ai-instructions/retheme.md'));
+
+const RUNTIME_AI_DOCS = [
+    ['AI_RULES.md', AI_RULES],
+    ['AI_CONTEXT.md', AI_CONTEXT],
+    ['ai-instructions/retheme.md', RETHEME],
+];
+
 // A count-shaped claim: a number, then up to three words, then a test noun.
 // Catches "1230 PHP tests", "409 JS unit tests", "48 Playwright E2E specs",
 // "34 specs:", "1479 tests, 5496 assertions". Deliberately does NOT match
@@ -43,6 +57,65 @@ describe('docs lint: no hardcoded test counts in live docs', () => {
     test.each(LIVE_DOCS)('%s asserts no hardcoded test count', (name, content) => {
         const hits = content.match(new RegExp(COUNT_CLAIM, 'gi')) || [];
         expect(hits).toEqual([]);
+    });
+});
+
+// A design-token total-count claim: "47 design tokens", "51 total design
+// tokens", "47 CSS custom properties", or a bare "47 tokens". Three arms:
+//   1. number + up to 3 qualifier words + "design tokens"  (catches rephrases
+//      like "51 total design tokens" / "51 available design tokens")
+//   2. number + up to 3 qualifier words + "CSS custom properties"
+//   3. number DIRECTLY before "tokens" (0 words between)
+// Arm 3 stays at zero intervening words on purpose: it flags a bare count like
+// "47 tokens" while leaving the one legitimate subset phrase in these docs,
+// "8 base color tokens" (retheme.md Step 1, self-verifying against the 8 seed
+// colors listed right below it), untouched — "base color" between the number
+// and "tokens" keeps it out of arm 3, and it has no "design"/"CSS custom" to
+// trip arms 1-2. The fix for a real regression is to drop the number, not
+// refresh 47 -> 51 (issue 286).
+const TOKEN_COUNT_CLAIM = new RegExp(
+    [
+        '\\d[\\d,]*[ \\t]+(?:[A-Za-z-]+[ \\t]+){0,3}design[ \\t]+tokens?\\b',
+        '\\d[\\d,]*[ \\t]+(?:[A-Za-z-]+[ \\t]+){0,3}CSS[ \\t]+custom[ \\t]+propert(?:y|ies)\\b',
+        '\\d[\\d,]*[ \\t]+tokens?\\b',
+    ].join('|'),
+    'i',
+);
+
+describe('docs lint: no hardcoded design-token count in runtime AI docs', () => {
+    test.each(RUNTIME_AI_DOCS)('%s asserts no hardcoded design-token count', (name, content) => {
+        const hits = content.match(new RegExp(TOKEN_COUNT_CLAIM, 'gi')) || [];
+        expect(hits).toEqual([]);
+    });
+});
+
+describe('docs lint: the token-count guard is not decoration', () => {
+    // If these ever stop matching, the regex has been loosened into a no-op.
+    const MUST_CATCH = [
+        '47 design tokens control the entire visual system', // AI_RULES original
+        'Update the 47 design tokens via update_design_token', // AI_CONTEXT original
+        'Design token defaults (47 design tokens)',            // AI_CONTEXT table original
+        '47 CSS custom properties control the entire visual system', // AI_CONTEXT original
+        'Design token inventory (47 tokens with current effective values)', // inventory original
+        'through 47 design tokens.',                           // retheme original
+        '51 design tokens',                                    // the refresh we reject
+        '51 tokens',
+        '51 total design tokens',                              // rephrase with a qualifier word
+        '51 available design tokens',                          // rephrase with a qualifier word
+    ];
+    const MUST_NOT_CATCH = [
+        'The 8 base color tokens in assets/css/base.css',      // qualified subset, self-verifying
+        'changing --color-accent auto-derives the four accent variants',
+        'automatic backup (keeps last 5)',
+        'against a live WordPress 7.0 instance',
+    ];
+
+    test.each(MUST_CATCH)('catches a hardcoded token count: %s', (s) => {
+        expect(TOKEN_COUNT_CLAIM.test(s)).toBe(true);
+    });
+
+    test.each(MUST_NOT_CATCH)('does not false-positive on: %s', (s) => {
+        expect(TOKEN_COUNT_CLAIM.test(s)).toBe(false);
     });
 });
 


### PR DESCRIPTION
Closes #286

## Scope

The runtime AI-facing docs the chat AI reads while operating a site hardcoded a stale design-token count. `AI_RULES.md`, `AI_CONTEXT.md`, and `ai-instructions/retheme.md` all said "47 design tokens" / "47 CSS custom properties" control the visual system; `assets/css/base.css` now defines 51. Per the issue's recorded decision (same resolution as #250 / #252), all seven occurrences are reworded qualitatively — no number — rather than refreshed 47 → 51, which would just reset the drift clock.

### Changed
- `AI_RULES.md` (1), `AI_CONTEXT.md` (4), `ai-instructions/retheme.md` (2) — all seven "47" count claims replaced with qualitative wording (mirrors the README pattern from #252, e.g. "A single layer of design tokens controls the entire visual system").
- `tests/js/docs-lint.test.js` — new `TOKEN_COUNT_CLAIM` regression guard over the three runtime docs, with `MUST_CATCH` / `MUST_NOT_CATCH` self-checks (catches "47 design tokens", "51 total design tokens", "47 CSS custom properties"; exempts the legitimate self-verifying "8 base color tokens" subset in retheme.md Step 1).

### Deliberately untouched
- `lib/ai-context.php` is already count-free — it generates the token inventory dynamically from live values.
- "8 base color tokens" in retheme.md Step 1 is accurate and self-verifying (the 8 seed colors are listed directly below it); out of scope for #286.

## Validation
- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → 1564 tests OK, 5744 assertions (3 warnings / 2 deprecations pre-existing, unchanged — diff touches no PHP).
- JS: `npm test` (vitest) → 500 passed (16 files), +2 vs base from the new guard's rephrase self-checks.
- `bash scripts/package.sh` → Version consistency OK across all five files; built zip deleted (releases are CI-built from tags).

## Reviews (this session, on this exact diff)
- `/plan-eng-review`: approved — docs-only, established #250/#252 pattern, no open decisions.
- `/review` + Codex adversarial (via `codex exec`, diff inlined): Codex flagged the guard's regex would miss a rephrased regression ("51 total design tokens"). Verified against the repo, accepted as a within-decision test strengthening — regex widened to 3 arms and rephrase cases added to `MUST_CATCH`. Its bare-"8 tokens" concern was partly rejected with rationale (only the documented subset phrase is exempt). No unresolved findings.
- `/document-generate` (staleness scan): no additional doc updates needed; no stale token counts remain anywhere in `docs/`, README, or the dynamic `lib/ai-context.php`.

## Not in scope
No tag / release / deploy — those are the maintainer's separate step.