### PR TITLE
v0.16.95 fix: --grid-card-border honored on non-featured grid cards (#292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.95] — 2026-07-12 — The `--grid-card-border` style slot is honored on every grid card again, not just the featured one (#292)
+
+**Setting a per-instance `--grid-card-border` on a `layout: cards` grid changed only the featured first card and was silently ignored on cards 2..N, the exact inverse of the bug issue 226 fixed. Two late "premium" cascade rules (`main > .grid .grid__item`, specificity [0,2,1]) re-declared `border-color: var(--color-border)` with no slot in the chain, so they outranked the base `.grid__item` rule and clobbered the author's declared value on non-featured cards. `style_component` reported success and `validate page` / `check page` / `validate site` all passed, so an AI operator got a green result with no visible effect. Both all-cards rules now route through `var(--grid-card-border, var(--color-border))`, matching the `:first-child` rule the issue 226 fix already corrected. Every card in a grid now honors a declared card-border color; an unset slot renders byte-identical to before.**
+
+The fix is the same idiom the original issue 226 change established: route the literal re-declaration through the style slot with the neutral `--color-border` as the fallback (the featured `:first-child` rules keep their accent-token fallbacks at higher specificity, so the featured look is unchanged). The `--grid-card-border` slot was already declared in `components/grid/schema.json` with default `var(--color-border)`; this restores the rendered behavior to match that contract. No accepted grammar or public surface changed. A CSS-lint regression pin mirrors the issue 226 guard on the all-cards selector so a future premium-cascade rule cannot re-open the same slot-defeating gap.
+
+### Fixed
+
+- Grid `cards` now honor a per-instance `--grid-card-border` on every card, not only the featured first card. The two `main > .grid .grid__item` cascade rules in `assets/css/components.css` route their `border-color` through `var(--grid-card-border, var(--color-border))` instead of a bare `var(--color-border)`, so a declared card-border color no longer silently no-ops on cards 2..N while the action reports success (#292).
+
+### Tests
+
+- `tests/js/css-lint.test.js` adds a regression pin for the all-cards selector `main > .grid .grid__item`: it asserts every `border-color` on that rule routes through `--grid-card-border` with the neutral `--color-border` fallback, and guards against selector drift by requiring at least two matching rules. Mirrors the existing issue 226 featured-card pin, which it could not cover (#292).
+
 ## [v0.16.94] — 2026-07-12 — The runtime AI docs no longer hardcode a stale "47 design tokens" count (#286)
 
 **The chat AI reads `AI_CONTEXT.md`, `AI_RULES.md`, and `ai-instructions/retheme.md` while it operates a site, and all three told it "47 design tokens" (or "47 CSS custom properties") control the visual system. `assets/css/base.css` now defines 51, so the count was four low everywhere the AI actually looks when driving a retheme. This is higher-stakes than the README copy issue #252 fixed: a wrong number in the runtime retheme instructions is a correctness problem in the product's core "an AI agent can retheme by updating tokens" capability, not just marketing prose. All seven occurrences now describe the token layer qualitatively ("A single layer of design tokens controls the entire visual system") instead of counting, so the claim stays true as tokens are added.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.94-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.95-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2891,7 +2891,11 @@ main > .grid .grid__list {
 
 main > .grid .grid__item {
   position: relative;
-  border-color: var(--color-border);
+  /* Route the all-cards border through the slot so a per-instance
+     --grid-card-border is honored on cards 2..N, not just the featured
+     first card (issue 292 — regression of issue 226). Unset keeps the
+     neutral --color-border default. */
+  border-color: var(--grid-card-border, var(--color-border));
   box-shadow: 0 12px 28px rgba(15, 23, 42, 0.045);
 }
 
@@ -3314,7 +3318,10 @@ main > .faq .faq__item,
 }
 
 main > .grid .grid__item {
-  border-color: var(--color-border);
+  /* Later-cascade winner for cards 2..N: route it through --grid-card-border
+     too (matching the earlier all-cards rule and the :first-child rule below)
+     or the slot stays ignored on every non-featured card (issue 292). */
+  border-color: var(--grid-card-border, var(--color-border));
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.055);
 }
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.94');
+define('PP_VERSION', '0.16.95');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.94",
+  "version": "0.16.95",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.94
+Stable tag: 0.16.95
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.94
+Version:          0.16.95
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -453,6 +453,93 @@ describe('CSS lint: featured grid card honors --grid-card-border (#226)', () => 
 });
 
 /**
+ * Non-featured grid cards honor the --grid-card-border style slot (#292).
+ *
+ * Regression of #226, inverted: the #226 fix routed the featured FIRST card's
+ * border-color through --grid-card-border, but the "premium" cascade rules that
+ * re-declare border-color for ALL cards (`main > .grid .grid__item`, specificity
+ * [0,2,1], which beats the base `.grid__item` rule [0,1,0]) kept a bare
+ * `var(--color-border)`. So a declared --grid-card-border silently no-opped on
+ * cards 2..N while `style_component` reported success.
+ *
+ * TWO all-cards rules set border-color and BOTH must route through the slot: the
+ * later one wins the cascade (equal specificity), the earlier one is the base
+ * all-cards rule. If either keeps a bare token, the slot is ignored on that path.
+ * Unlike the featured card, the fallback here is the NEUTRAL --color-border (the
+ * default card border), never an accent token — cards 2..N are not featured.
+ * The keystone StyleSlotContractTest only proves the slot is consumed *somewhere*
+ * in the grid block (the base `.grid__item` rule satisfies it), so it cannot catch
+ * this all-cards-specific gap — hence this targeted pin.
+ */
+describe('CSS lint: non-featured grid cards honor --grid-card-border (#292)', () => {
+    const SELECTOR = 'main > .grid .grid__item';
+
+    // Brace-matched extraction of every rule whose selector is EXACTLY this
+    // (whitespace-normalized). `:not(.grid--steps)` / `:first-child` / `::before`
+    // and comma-group rules share the prefix but have more text before `{`, so
+    // `\s*\{` never matches them.
+    function bodiesForExactSelector(selector) {
+        const css = stripComments(COMPONENTS_CSS).replace(/\s+/g, ' ');
+        const re = new RegExp(
+            selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\{',
+            'g'
+        );
+        const bodies = [];
+        let match;
+        while ((match = re.exec(css)) !== null) {
+            let i = re.lastIndex;
+            let depth = 1;
+            const start = i;
+            while (i < css.length && depth > 0) {
+                if (css[i] === '{') depth++;
+                else if (css[i] === '}') depth--;
+                i++;
+            }
+            bodies.push(css.slice(start, i - 1));
+        }
+        return bodies;
+    }
+
+    const bodies = bodiesForExactSelector(SELECTOR);
+    const borderBodies = bodies.filter(b => /border-color\s*:/.test(b));
+
+    // Guard against the selector silently drifting: a zero-match scan would make
+    // every assertion below vacuously pass.
+    test('finds the all-cards grid rules that set border-color', () => {
+        expect(borderBodies.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('every border-color on the all-cards rule routes through --grid-card-border', () => {
+        const offenders = [];
+        borderBodies.forEach(body => {
+            const decls = body.match(/border-color\s*:[^;}]+/g) || [];
+            decls.forEach(d => {
+                if (!/border-color\s*:\s*var\(\s*--grid-card-border\b/.test(d)) {
+                    offenders.push(d.trim());
+                }
+            });
+        });
+        expect(offenders).toEqual([]);
+    });
+
+    // Fallback integrity: the non-featured card border falls back to the NEUTRAL
+    // --color-border, never an accent token — cards 2..N must not adopt the
+    // featured accent look when --grid-card-border is unset.
+    test('--grid-card-border falls back to the neutral --color-border on all cards', () => {
+        const bad = [];
+        borderBodies.forEach(body => {
+            const decls = body.match(/border-color\s*:[^;}]+/g) || [];
+            decls.forEach(d => {
+                if (!/var\(\s*--grid-card-border\s*,\s*var\(\s*--color-border\s*\)\s*\)/.test(d)) {
+                    bad.push(d.trim());
+                }
+            });
+        });
+        expect(bad).toEqual([]);
+    });
+});
+
+/**
  * Grid desktop column layout (#224).
  *
  * The desktop column count is driven by the `data-pp-count` attribute that


### PR DESCRIPTION
Closes #292

## Summary

Regression of #226, inverted. `--grid-card-border` was honored only on the featured first card and silently ignored on every other card in a `layout: cards` grid. Two late "premium" cascade rules `main > .grid .grid__item` (specificity `[0,2,1]`) re-declared `border-color: var(--color-border)` with no slot in the chain, outranking the base `.grid__item` rule `[0,1,0]` and clobbering the author's declared value on cards 2..N. `style_component` reported success and `validate page` / `check page` / `validate site` all passed, so the no-op was unverifiable for an AI operator.

## Fix

Route both all-cards `border-color` re-declarations through `var(--grid-card-border, var(--color-border))`, exactly as the `:first-child` rule the #226 fix already corrected. The featured `:first-child` rules keep their accent-token fallbacks at higher specificity, so the featured look is unchanged; an unset slot renders byte-identical to before. The slot was already declared in `components/grid/schema.json` with default `var(--color-border)`, so this restores rendered behavior to the documented contract. No accepted grammar or public surface changed. Fix idiom matches #141's recorded approach for the border-slot scope (route the premium literal through `var(--slot, <literal>)`); #302 (padding/typography slots) is out of scope and untouched.

## Files changed

- `assets/css/components.css` — two `main > .grid .grid__item` rules routed through the slot (code)
- `tests/js/css-lint.test.js` — parallel css-lint regression pin on the all-cards selector, mirroring the #226 featured-card guard (tests)
- Version bump to v0.16.95 across the five synced files + CHANGELOG entry

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` — 1564 tests, 5744 assertions, green (3 warnings / 2 deprecations are the pre-existing baseline; diff touches no PHP)
- JS: `npm test` (vitest) — 503 tests green (css-lint 186, +3 new)
- Red-before-green proven: the two new assertion tests FAIL on the pre-fix CSS and pass after the fix; the "finds ≥2 rules" drift guard passes on both
- `bash scripts/package.sh` — version consistency OK across all five files
- Independent adversarial review: NO FINDINGS (unset rendering byte-identical, no accent bleed onto featured/steps/inverted, matcher matches exactly the two intended rules)

## Reviews

`/plan-eng-review` (scope accepted, 0 issues) and `/review` (0 findings, quality 10/10) ran this session on this exact diff; both clean.

## Accepted limitations

- CSS-lint pins the source rule (static guarantee). Computed-style E2E enforcement of the slot contract is #305's separate scope, not absorbed here.
- No 7A questions arose; the fix stays strictly within the issue's recorded decision.
