### PR TITLE
v0.16.100 fix: propagate WP_Error code into validate-stage action envelope (#312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.100] — 2026-07-13 — A rejected write now carries its machine-readable error code on every path, not just some: validate-stage rejections match execute-stage rejections (#312)
+
+**Every action envelope documents an `error_code` alongside the human `error` message so a client can key on the code (`composition_conflict` → reload prompt, `unknown_prop` → point at the field) instead of parsing prose. Execute-stage rejections carried it; the validate-stage early-return in `pp_execute_action()` did not. It hand-built its envelope and omitted `error_code` entirely, so a whole class of rejections — a template-owned component in the body (`template_owned_component`), duplicate component ids (`duplicate_component_id`), a missing required prop (`invalid_composition`), and the new unknown prop key (`unknown_prop`) — reached the dashboard save handler and the AI chat with an empty code. Callers could only string-match the message. This release propagates the validating `WP_Error`'s code into that envelope, so validate-stage rejections now carry the same machine-readable `error_code` as execute-stage rejections, matching the uniform `{ok, error, error_code}` shape the action model already documents.**
+
+Low severity — the human message was always present and clear — but it defeated the machine-readable-code contract for every rejection surfaced by an action's `validate` callback, and the action envelope is a public AI-facing surface worth fixing before v1.0.0 freezes it. The fix is one line: the early-return envelope adds `'error_code' => $validation->get_error_code()`, mirroring the `_pp_action_error()` helper that every other rejection path already routes through. No accepted grammar, action behavior, rendered output, or documented shape changed; the code now matches the canonical shape `AI_CONTEXT.md` already describes.
+
+### Fixed
+
+- `pp_execute_action()`'s pre-execute validation rejection now includes `error_code` in its result envelope, propagated from the validating `WP_Error`, so validate-stage rejections (`template_owned_component`, `duplicate_component_id`, `invalid_composition` for a missing required prop, and `unknown_prop`) carry a machine-readable code to the dashboard save handler and AI chat instead of an empty one — consistent with execute-stage rejections built by `_pp_action_error()` (#312).
+
+### Tests
+
+- `tests/ActionsTest.php`: dedicated coverage asserts `error_code` is populated for each validate-stage rejection class — `template_owned_component`, `duplicate_component_id`, `invalid_composition` (missing-required), and `unknown_prop`; the existing `update_component` / `add_component` / `update_composition` unknown-prop tests were strengthened from asserting the message only to also asserting the code (#312).
+
 ## [v0.16.99] — 2026-07-13 — An unknown component prop no longer saves clean and does nothing: the composition validator rejects prop keys not in the component's schema (#147)
 
 **Set a prop that a component does not have — a typo like `titel`, or a field the component never defined — and until now the write reported `ok: true`, the key persisted in `_pp_composition`, and the renderer silently ignored it. The change looked applied and wasn't. That is the same "reported success without real effect" failure the v1.0.0 gate exists to eliminate (issue 302 on the style axis), reachable here on the props axis through every write path. Issue 120 had already closed it for the `wp pp patch <selector>` CLI entry point, but only there. This release closes it at the choke point: `pp_validate_composition()` now rejects any composition whose component carries a prop key not declared in that component's `schema.json` `props`, with a distinct `unknown_prop` error, so `create_page`, `update_composition`, `add_component`, `update_component`, and the dashboard editor's save all fail loudly instead of persisting a dead key.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.99-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.100-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.99');
+define('PP_VERSION', '0.16.100');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -538,12 +538,18 @@ function pp_execute_action(string $name, array $params): array {
     if (is_wp_error($validation)) {
         $action = pp_get_action($name);
         return [
-            'ok'      => false,
-            'action'  => $name,
-            'scope'   => $action['scope'] ?? 'unknown',
-            'target'  => [],
-            'changes' => [],
-            'error'   => $validation->get_error_message(),
+            'ok'         => false,
+            'action'     => $name,
+            'scope'      => $action['scope'] ?? 'unknown',
+            'target'     => [],
+            'changes'    => [],
+            'error'      => $validation->get_error_message(),
+            // Propagate the WP_Error code so validate-stage rejections carry the same
+            // machine-readable error_code as execute-stage rejections built by
+            // _pp_action_error() (#13 uniform shape). Without this, clients can only
+            // string-match the message for template_owned_component / duplicate_component_id
+            // / invalid_composition (missing-required) / unknown_prop (#312).
+            'error_code' => $validation->get_error_code(),
         ];
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.99",
+  "version": "0.16.100",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.99
+Stable tag: 0.16.100
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.99
+Version:          0.16.100
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -486,13 +486,12 @@ class ActionsTest extends TestCase
             'props'           => ['not_a_real_prop' => 'x'],
         ]);
 
-        // Rejected (issue 147 acceptance). The envelope carries the message; the
-        // pre-execute validate branch drops the WP_Error code (a pre-existing gap
-        // affecting every validate-stage rejection, filed separately), so assert on
-        // the observable contract callers actually see.
+        // Rejected (issue 147 acceptance). The envelope carries both the message and,
+        // since #312, the machine-readable error_code from the validate-stage WP_Error.
         $this->assertFalse($result['ok'], 'an unknown prop key must not persist behind ok:true');
         $this->assertStringContainsString('not_a_real_prop', $result['error']);
         $this->assertStringContainsString('no prop', $result['error']);
+        $this->assertSame('unknown_prop', $result['error_code'], 'validate-stage rejection must carry its code (#312)');
         // The pre-existing composition is untouched — no phantom key written.
         $this->assertArrayNotHasKey('not_a_real_prop', pp_get_composition($id)[0]['props']);
     }
@@ -511,6 +510,7 @@ class ActionsTest extends TestCase
         $this->assertFalse($result['ok']);
         $this->assertStringContainsString('phantom_field', $result['error']);
         $this->assertStringContainsString('no prop', $result['error']);
+        $this->assertSame('unknown_prop', $result['error_code'], 'validate-stage rejection must carry its code (#312)');
         $this->assertCount(1, pp_get_composition($id), 'the rejected component was not appended');
     }
 
@@ -539,6 +539,73 @@ class ActionsTest extends TestCase
 
         $this->assertFalse($result['ok']);
         $this->assertStringContainsString('bogus', $result['error']);
+        $this->assertSame('unknown_prop', $result['error_code'], 'validate-stage rejection must carry its code (#312)');
+    }
+
+    // ── Validate-stage rejections carry the WP_Error code in the envelope (#312) ──
+    //
+    // pp_execute_action() runs pp_validate_action() first; that early-return envelope
+    // used to omit error_code entirely, so a whole class of rejections reached callers
+    // (the AJAX save handler at lib/admin.php:581) with an empty code — they could only
+    // string-match the human message. #312 propagates $validation->get_error_code() so
+    // validate-stage rejections match execute-stage rejections built by _pp_action_error().
+    // One assertion per rejection class the issue enumerates.
+
+    public function testValidateStageErrorCodeTemplateOwnedComponent(): void
+    {
+        // Composing a template-owned component (nav) is rejected with its own code (#223).
+        $result = pp_execute_action('create_page', [
+            'title'       => 'Chrome in body',
+            'composition' => [['component' => 'nav', 'props' => []]],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('template_owned_component', $result['error_code']);
+    }
+
+    public function testValidateStageErrorCodeDuplicateComponentId(): void
+    {
+        // Two components sharing a non-empty props.id is rejected at write time (#238).
+        $result = pp_execute_action('create_page', [
+            'title'       => 'Duplicate ids',
+            'composition' => [
+                ['component' => 'hero', 'props' => ['title' => 'A', 'id' => 'dup']],
+                ['component' => 'section', 'props' => ['body' => 'B', 'id' => 'dup']],
+            ],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('duplicate_component_id', $result['error_code']);
+    }
+
+    public function testValidateStageErrorCodeMissingRequiredProp(): void
+    {
+        // A component missing a required prop (hero without "title") rejects as
+        // invalid_composition — the generic validation code, still non-empty.
+        $result = pp_execute_action('create_page', [
+            'title'       => 'Missing required prop',
+            'composition' => [['component' => 'hero', 'props' => []]],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('invalid_composition', $result['error_code']);
+    }
+
+    public function testValidateStageErrorCodeUnknownProp(): void
+    {
+        // The #147 rule: an undeclared prop key rejects with unknown_prop, now carried
+        // in the envelope for update_component's validate-stage path too.
+        $id = pp_create_page('Unknown prop code', 'draft');
+        pp_update_composition($id, [['component' => 'hero', 'props' => ['title' => 'Hi']]]);
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 0,
+            'props'           => ['ghost_prop' => 'x'],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('unknown_prop', $result['error_code']);
     }
 
     // ── restore/preview surface the unknown_prop finding without blocking (#233) ──


### PR DESCRIPTION
Closes #312

## Scope

`pp_execute_action()` runs `pp_validate_action()` first; when that pre-execute validation returns a `WP_Error`, the early-return envelope (lib/actions.php:540-547) was hand-built and omitted `error_code` entirely. Every other rejection path goes through `_pp_action_error()`, which always includes `error_code`. So execute-stage rejections (e.g. `composition_conflict`) carried a machine-readable code, but validate-stage rejections did not — clients (the AJAX save handler at lib/admin.php:581, the AI chat) could only string-match the human message.

**Fix (one line, per the issue's recorded spec):** add `'error_code' => $validation->get_error_code()` to the early-return envelope, matching `_pp_action_error()` and the uniform `{ok, error, error_code}` shape documented at lib/actions.php:1064 (#13) and in AI_CONTEXT.md:477. No accepted grammar, action behavior, rendered output, or documented shape changed — the code now matches the shape the docs already describe.

Covers every validate-stage rejection class the issue enumerates: `template_owned_component`, `duplicate_component_id`, `invalid_composition` (missing-required prop), and `unknown_prop` (#147).

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` — 1588 tests, 5906 assertions, green (4 new tests; warnings/deprecations identical to base tree).
- JS: `npm test` — 514 tests, green.
- `bash scripts/package.sh` — Version consistency OK across all five files; generated zip deleted (CI builds release zips).

## Tests

- `tests/ActionsTest.php`: new dedicated coverage asserts `error_code` is populated for each validate-stage rejection class (`template_owned_component`, `duplicate_component_id`, `invalid_composition`, `unknown_prop`); strengthened the existing `update_component` / `add_component` / `update_composition` unknown-prop tests from message-only to also assert the code.

## Reviews

- `/plan-eng-review` and `/review` (Claude adversarial + testing/maintainability specialists) ran this session on this exact diff — clean, no blocking findings. One informational note (the envelope could be refactored to call `_pp_action_error()`) was declined to keep the smallest diff and honor the recorded one-line decision.

## Accepted limitations

- The validate-stage envelope remains hand-built rather than delegating to `_pp_action_error()`; a DRY refactor was out of scope for the recorded decision and would touch pre-existing code.

## 7A question

None — the fix matched the recorded decision exactly (one-line envelope change; all four rejection classes already carry non-empty codes).
