### PR TITLE
v0.16.101 fix: 2-item grid row spans the container to align with the section rail (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.101] — 2026-07-13 — A two-card grid now lines up with the section above it instead of floating in a narrower centered block (#303)
+
+**A `grid` with two cards no longer renders on its own narrower, centered rail. Until now a two-item card row was capped at 832px and centered with automatic side margins, so an intro paragraph on the section rail and its paired two feature cards visibly belonged to two different alignment systems — the cards started well to the right of the heading above them. The three-card row already spanned the full section container (fixed in #224); this release gives the two-card row the same treatment, so "intro text plus two feature cards" reads as one aligned section.**
+
+The two-card desktop rule in `assets/css/components.css` dropped its `max-width: 52rem` cap and its `auto` left/right margins, so the row now fills the section container and its left edge sits on the same rail as the section heading and intro copy. The two-column layout itself is unchanged: two cards still lay out side by side, and the mobile and tablet breakpoints (single column below 768px, two columns from 768px) are untouched — only the desktop centering-and-narrowing was removed. This mirrors the recorded direction on the issue and the shipped #224 three-card fix: a CSS-only change with no new style slot, prop, token, or schema surface, so no composition, action, or AI-facing behavior changed.
+
+### Fixed
+
+- A two-item `grid` card row spans the section container and aligns with the section rail at desktop widths, instead of being capped at 832px and centered — so an intro section and its paired two-card grid read as one aligned block. Mirrors the three-card treatment from #224; CSS-only, no new slot (#303).
+
+### Tests
+
+- `tests/js/css-lint.test.js`: new pins assert the two-item desktop rule spans the container (no `max-width` / `max-inline-size` / `width` narrowing and no reintroduced `auto` inline margins) and is declared exactly once; the existing two-across column pin is retained (#303).
+
 ## [v0.16.100] — 2026-07-13 — A rejected write now carries its machine-readable error code on every path, not just some: validate-stage rejections match execute-stage rejections (#312)
 
 **Every action envelope documents an `error_code` alongside the human `error` message so a client can key on the code (`composition_conflict` → reload prompt, `unknown_prop` → point at the field) instead of parsing prose. Execute-stage rejections carried it; the validate-stage early-return in `pp_execute_action()` did not. It hand-built its envelope and omitted `error_code` entirely, so a whole class of rejections — a template-owned component in the body (`template_owned_component`), duplicate component ids (`duplicate_component_id`), a missing required prop (`invalid_composition`), and the new unknown prop key (`unknown_prop`) — reached the dashboard save handler and the AI chat with an empty code. Callers could only string-match the message. This release propagates the validating `WP_Error`'s code into that envelope, so validate-stage rejections now carry the same machine-readable `error_code` as execute-stage rejections, matching the uniform `{ok, error, error_code}` shape the action model already documents.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.100-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.101-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -3009,10 +3009,14 @@ main > .grid .grid__item-link::after {
   }
 
   main > .grid:not(.grid--steps) .grid__list[data-pp-count="2"] {
+    /* Two-across rows span the container like the 3-card rule, instead of being
+       capped at 52rem and centered. The centered cap left the pair on a narrower
+       rail than the intro copy above it (measured at desktop: pair left-edge 304px
+       vs section rail 176px), so "intro text + two feature cards" could never read
+       as one aligned section. Removing the max-width + auto margins aligns the pair
+       with the section rail, mirroring the count-3 treatment (issue 303, sibling of
+       issue 224). */
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    max-width: 52rem;
-    margin-right: auto;
-    margin-left: auto;
   }
 
   main > .grid:not(.grid--steps) .grid__item:first-child .grid__item-body {

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.100');
+define('PP_VERSION', '0.16.101');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.100",
+  "version": "0.16.101",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.100
+Stable tag: 0.16.101
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.100
+Version:          0.16.101
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -617,9 +617,10 @@ describe('CSS lint: grid desktop columns by item count', () => {
             .toHaveLength(1);
     });
 
-    // Scope guards (#224 changed the 3-item case only). If a future change
-    // generalizes the desktop grid, these are the pins that should be revisited
-    // deliberately rather than broken silently.
+    // Scope guard (#224 changed the 3-item case only; #303 aligned the 2-item
+    // case). The 4-item case is deliberately still narrowed — if a future change
+    // generalizes it, this pin should be revisited deliberately, not broken
+    // silently.
     test('a 4-item cards grid still lays out 2 x 2', () => {
         expect(columnsFor('main > .grid:not(.grid--steps) .grid__list[data-pp-count="4"]'))
             .toBe('repeat(2, minmax(0, 1fr))');
@@ -628,6 +629,27 @@ describe('CSS lint: grid desktop columns by item count', () => {
     test('a 2-item cards grid still lays out 2 across', () => {
         expect(columnsFor('main > .grid:not(.grid--steps) .grid__list[data-pp-count="2"]'))
             .toBe('repeat(2, minmax(0, 1fr))');
+    });
+
+    // #303: the 2-item row must span the container so it aligns with the section
+    // rail (heading x=176), not sit on a narrower centered rail (x=304). The cap
+    // came from a `max-width` + auto inline margins, so assert neither survives —
+    // and guard the adjacent width/inline-size levers so a future re-narrowing
+    // through any of them fails this pin (not just a literal `max-width`).
+    test('a 2-item cards grid spans the container (no narrowing, no auto-centering)', () => {
+        const bodies = rulesFor('main > .grid:not(.grid--steps) .grid__list[data-pp-count="2"]');
+        expect(bodies.length).toBeGreaterThan(0);
+        bodies.forEach(body => {
+            expect(body).not.toMatch(/max-width\s*:/);
+            expect(body).not.toMatch(/max-inline-size\s*:/);
+            expect(body).not.toMatch(/\bwidth\s*:/);
+            expect(body).not.toMatch(/margin(-left|-right|-inline[a-z-]*)?\s*:\s*[^;]*\bauto\b/);
+        });
+    });
+
+    test('the 2-item rule is declared exactly once (no later re-override)', () => {
+        expect(rulesFor('main > .grid:not(.grid--steps) .grid__list[data-pp-count="2"]'))
+            .toHaveLength(1);
     });
 
     test('the steps layout keeps its own 3-column rule', () => {


### PR DESCRIPTION
Closes #303

## Scope

A 2-item `grid` card row (`.grid__list[data-pp-count="2"]`) was hard-capped at `max-width: 52rem` (832px) and centered with `auto` inline margins, so a 2-card grid could never align with the section rail: the section heading/intro sit at x=176 while the card pair started at x=304. "Intro text + two feature cards" read as two different alignment systems.

This removes the `max-width` cap and the `auto` margins from the count-2 desktop rule so the row spans the container and its left edge lands on the section rail, mirroring the already-shipped count-3 fix (#224). The 2-column layout is unchanged (`repeat(2, minmax(0, 1fr))`), and the sub-1024px breakpoints (1 column < 768px, 2 columns from 768px) are untouched — only the desktop centering/narrowing was removed.

## Recorded decision

Per the issue body's primary "Expected" direction (and the orchestrator pointer to it): make count-2 span the container like count-3. CSS-only, **no new style slot / prop / token / schema** — symmetric with the accepted #224 count-3 treatment (which also removed its cap with no slot). No accepted grammar, action behavior, or AI-facing capability changed, so `/document-generate` found no docs to update.

## Files changed

- `assets/css/components.css` — count-2 desktop rule drops `max-width: 52rem` + `margin-left/right: auto`; explanatory comment added.
- `tests/js/css-lint.test.js` — new pins: the count-2 desktop rule spans the container (no `max-width` / `max-inline-size` / `width` narrowing, no reintroduced `auto` inline margins) and is declared exactly once; existing 2-across column pin retained.
- Five-file version bump to v0.16.101 + CHANGELOG entry.

## Validation

- `npm test` (vitest): **516 passed** (css-lint file: 199 passed, including the new count-2 pins).
- `./vendor/bin/phpunit --configuration phpunit.xml`: **1588 tests OK** (3 warnings / 2 PHPUnit deprecations are the pre-existing baseline — the diff touches only CSS + a JS test, zero PHP; `StyleSlotContractTest.php` passed, confirming the #305 slot guard is not tripped since `max-width` is not a schema slot).
- `bash scripts/package.sh`: version consistency OK across all five files; built zip deleted (releases are CI-built from tags).

## Reviews (this working tree, 2026-07-13)

- `/plan-eng-review` — clean.
- `/review` — clean; one mechanical comment-clarity fix applied (softened the illustrative pixel coordinates in the CSS comment).
- Codex outside-voice (plan) + Codex adversarial (diff) — no findings extending the recorded decision; the "global selector widens all 2-card grids" and "wide cards" notes are the intended, count-3-consistent behavior.

Per the ship dedup rule these ran on this exact tree; review subagents were not re-dispatched. Test suites were re-run.

Do not tag/release/deploy from this PR — CI builds the release zip from tags.
