### PR TITLE
v0.16.102 fix: single-item grid renders a full-width track (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.102] — 2026-07-13 — A one-card grid now fills the row instead of hugging the left with dead space beside it (#297)
+
+**A `grid` with a single item no longer sits in the left half of a two-column track with empty space on the right. Until now a one-item card fell through to the generic two-column desktop rule, so the lone card rendered at roughly half the container width and stranded a matching gap beside it — the natural "panel" composition (an audience box, a terminal mock, a single highlighted card) always looked half-finished. This release gives the single-item grid its own full-width track, so the card spans the section container and its left edge sits on the same rail as the heading and intro copy above it.**
+
+A new `data-pp-count="1"` rule in `assets/css/components.css` sets one full-width column (`minmax(0, 1fr)`) from the 768px breakpoint up. It takes effect from the first two-column breakpoint rather than only at desktop, because the stranding appears the moment the base rule switches to two columns; nothing above 768px re-declares it, so the full-width track holds through tablet and desktop. This completes the per-count grid family alongside the two-card (#303) and three-card (#224) fixes and follows the same "span the container, align with the section rail" direction. The multi-card layouts are untouched — two cards still lay out two across, three across three, four as a two-by-two — and mobile stays a single stacked column. CSS-only, with no new style slot, prop, token, or schema surface, so no composition, action, or AI-facing behavior changed.
+
+### Fixed
+
+- A single-item `grid` renders one full-width track at tablet and desktop widths instead of a two-column track that stranded the lone card in the left half with dead space on the right, so panel-style single-card grids fill the row and align with the section rail. Completes the per-count grid family alongside #303/#224; CSS-only, no new slot (#297).
+
+### Tests
+
+- `tests/js/css-lint.test.js`: new pins assert the single-item desktop rule resolves to one full-width track (`minmax(0, 1fr)`), spans the container (no `max-width` / `max-inline-size` / `width` narrowing, no `auto` inline margins), is declared exactly once, and — selector-agnostically — that no count-1 rule anywhere reintroduces a multi-column track (#297).
+- `tests/ComponentPropsTest.php`: the grid item-count attribute pin now also asserts a one-item grid emits `data-pp-count="1"`, so the CSS rule's matching contract cannot silently break (#297).
+
 ## [v0.16.101] — 2026-07-13 — A two-card grid now lines up with the section above it instead of floating in a narrower centered block (#303)
 
 **A `grid` with two cards no longer renders on its own narrower, centered rail. Until now a two-item card row was capped at 832px and centered with automatic side margins, so an intro paragraph on the section rail and its paired two feature cards visibly belonged to two different alignment systems — the cards started well to the right of the heading above them. The three-card row already spanned the full section container (fixed in #224); this release gives the two-card row the same treatment, so "intro text plus two feature cards" reads as one aligned section.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.101-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.102-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2982,6 +2982,20 @@ main > .grid .grid__item-link::after {
   font-weight: 700;
 }
 
+@media (min-width: 768px) {
+  main > .grid:not(.grid--steps) .grid__list[data-pp-count="1"] {
+    /* A lone card must never sit in a two-column track (issue 297): the base
+       768px rule sets repeat(2, 1fr), stranding a single item in the left
+       column with dead space on the right. One full-width track spans the
+       container so the card's left edge aligns with the section rail, mirroring
+       the count-2/count-3 "span the container" treatment (issues 303/224). This
+       sits at 768px, not 1024px like the other count rules, because the
+       stranding exists from the first two-column breakpoint, and no count-1
+       override in the 1024px block re-declares it, so it holds through desktop. */
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 @media (min-width: 1024px) {
   main > .grid .grid__list {
     gap: var(--grid-gap, 1.05rem);

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.101');
+define('PP_VERSION', '0.16.102');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.101",
+  "version": "0.16.102",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.101
+Stable tag: 0.16.102
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.101
+Version:          0.16.102
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1214,6 +1214,12 @@ class ComponentPropsTest extends TestCase
 
         $html = $this->render('grid', ['items' => array_slice($items, 0, 2)]);
         $this->assertStringContainsString('data-pp-count="2"', $html);
+
+        // #297: a single-item grid must emit count="1" so the CSS count-1 rule
+        // (full-width track) can match it, instead of falling through to the
+        // two-column base and stranding the lone card in the left column.
+        $html = $this->render('grid', ['items' => array_slice($items, 0, 1)]);
+        $this->assertStringContainsString('data-pp-count="1"', $html);
     }
 
     public function testGridEyebrowSubheadingAndCenterAlignRender(): void

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -658,6 +658,114 @@ describe('CSS lint: grid desktop columns by item count', () => {
 });
 
 /**
+ * Grid single-item column layout (#297).
+ *
+ * A one-item grid falls through to the generic `@media (min-width: 768px)` rule
+ * that sets `repeat(2, 1fr)`, so the lone card sits in the left column with dead
+ * space on the right from 768px up. The fix is a `data-pp-count="1"` rule that
+ * takes effect from the SAME 768px breakpoint (not 1024px like the count-2/3/4
+ * family), because the stranding starts at the first two-column breakpoint. So
+ * these pins extract the `min-width: 768px` blocks, not the 1024px ones, and
+ * also assert the rule is declared exactly once across the whole file (a later
+ * 1024px re-override would silently reintroduce the bug at desktop).
+ */
+describe('CSS lint: single-item grid column (#297)', () => {
+    // Extract the bodies of every `@media (min-width: 768px)` block by brace matching.
+    function tabletBlocks(css) {
+        const blocks = [];
+        const opener = /@media\s*\(min-width:\s*768px\)\s*\{/g;
+        let match;
+        while ((match = opener.exec(css)) !== null) {
+            let depth = 1;
+            let i = opener.lastIndex;
+            while (i < css.length && depth > 0) {
+                if (css[i] === '{') depth++;
+                else if (css[i] === '}') depth--;
+                i++;
+            }
+            blocks.push(css.slice(opener.lastIndex, i - 1));
+        }
+        return blocks;
+    }
+
+    const COUNT1 = 'main > .grid:not(.grid--steps) .grid__list[data-pp-count="1"]';
+
+    // Return the bodies of every rule matching COUNT1 in the given CSS scope,
+    // anchored to a rule start so it cannot bind to a longer selector ending
+    // with the same text.
+    function count1Rules(scope) {
+        const escaped = COUNT1.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        // Anchor on start-of-scope OR either brace: a rule that is the first in a
+        // `@media { ... }` block is preceded by `{`, while back-to-back rules are
+        // preceded by `}`. Both must count so the whole-file "declared once" scan
+        // sees the media-nested rule. The anchor still prevents binding to a
+        // longer selector that merely ends with the same text.
+        const pattern = new RegExp(`(?:^|[}{])\\s*${escaped}\\s*\\{([^}]*)\\}`, 'g');
+        const bodies = [];
+        let match;
+        while ((match = pattern.exec(scope)) !== null) {
+            bodies.push(match[1]);
+            pattern.lastIndex -= 1;
+        }
+        return bodies;
+    }
+
+    const stripped = stripComments(COMPONENTS_CSS);
+    const tablet = tabletBlocks(stripped).join('\n');
+
+    test('a 1-item cards grid gets a single full-width track at tablet/desktop', () => {
+        expect(tablet).not.toEqual('');
+        const bodies = count1Rules(tablet);
+        expect(bodies.length).toBeGreaterThan(0);
+        const columns = bodies
+            .map(body => /grid-template-columns\s*:\s*([^;]+);/.exec(body))
+            .filter(Boolean)
+            .pop();
+        expect(columns && columns[1].trim()).toBe('minmax(0, 1fr)');
+    });
+
+    test('a 1-item cards grid spans the container (no narrowing, no auto-centering)', () => {
+        const bodies = count1Rules(tablet);
+        expect(bodies.length).toBeGreaterThan(0);
+        bodies.forEach(body => {
+            expect(body).not.toMatch(/max-width\s*:/);
+            expect(body).not.toMatch(/max-inline-size\s*:/);
+            expect(body).not.toMatch(/\bwidth\s*:/);
+            expect(body).not.toMatch(/margin(-left|-right|-inline[a-z-]*)?\s*:\s*[^;]*\bauto\b/);
+        });
+    });
+
+    // The rule must be declared exactly once across the WHOLE file, so no later
+    // block (e.g. the 1024px count family) re-overrides count-1 back to two
+    // columns at desktop while the tablet pin above stays green.
+    test('the 1-item rule is declared exactly once (no later re-override)', () => {
+        expect(count1Rules(stripped)).toHaveLength(1);
+    });
+
+    // Selector-agnostic backstop: the "declared exactly once" pin above matches
+    // only the exact count-1 selector string, so a re-override that reintroduces
+    // the bug with a functionally-equivalent but textually-different selector
+    // (e.g. dropping `:not(.grid--steps)`, or a broader
+    // `main > .grid .grid__list[data-pp-count="1"]`) would slip past it. So also
+    // assert that EVERY rule whose selector targets count-1 and sets a column
+    // track resolves to the single full-width track — no multi-column
+    // reintroduction anywhere in the file, whatever the selector prefix.
+    test('no count-1 selector anywhere sets a multi-column track', () => {
+        const rulePattern = /([^{}]*\[data-pp-count="1"\][^{}]*)\{([^}]*)\}/g;
+        let match;
+        let seen = 0;
+        while ((match = rulePattern.exec(stripped)) !== null) {
+            const cols = /grid-template-columns\s*:\s*([^;]+);/.exec(match[2]);
+            if (cols) {
+                seen++;
+                expect(cols[1].trim()).toBe('minmax(0, 1fr)');
+            }
+        }
+        expect(seen).toBeGreaterThan(0);
+    });
+});
+
+/**
  * Hero eyebrow stays a pill (#225).
  *
  * `.hero__eyebrow` declares `display: inline-block`, but it is a direct child of


### PR DESCRIPTION
Closes #297

## Summary

A `grid` with a single item rendered a two-column track (`data-pp-count="1"` fell through to the generic 768px+ `repeat(2, 1fr)` base rule), so the lone card sat in the left half of the container with dead space on the right. This is the natural "panel" composition (audience box, terminal mock, single highlighted card) and it always looked half-finished.

This adds a `data-pp-count="1"` rule to `assets/css/components.css` setting one full-width track (`grid-template-columns: minmax(0, 1fr)`) from the 768px breakpoint up, so a single card spans the section container and its left edge aligns with the section rail.

## Recorded decision (issue #297 body, "Expected")

> `data-pp-count="1"` renders one full-width track, or a centered constrained track — anything except half-filled two columns.

Both were accepted. I chose the **full-width single track**, consistent with the sibling count-2 (#303) and count-3 (#224) fixes that both moved to "span the container, align with the section rail." Placed at `min-width: 768px` (not 1024px like the other count rules) because the stranding exists from the first two-column breakpoint; nothing above 768px re-declares count-1, so the full-width track holds through desktop.

## Scope

- Acceptance criterion: `data-pp-count="1"` no longer renders half-filled two columns → met (full-width track).
- Multi-card layouts (count 2/3/4) and mobile single-column stacking are untouched; the `grid--steps` variant is excluded via `:not(.grid--steps)`.
- No 7A question was needed — the choice between full-width and centered-constrained is within the issue's recorded latitude, and sibling precedent (#303/#224) points to full-width.

## Validation

- `npm test` (vitest): 520 passed (16 files) — +1 new css-lint test.
- `./vendor/bin/phpunit`: 1588 passed, 5907 assertions. The 3 warnings / 2 PHPUnit deprecations are pre-existing (identical on a clean tree; my change adds +1 assertion only).
- `bash scripts/package.sh`: version consistency OK across all five files; built zip deleted (releases are CI-built).

### Tests added

- `tests/js/css-lint.test.js`: single-item desktop rule resolves to one full-width track (`minmax(0, 1fr)`), spans the container (no `max-width`/`max-inline-size`/`width`/`auto`-margin narrowing), is declared exactly once, and a selector-agnostic backstop that no count-1 rule anywhere reintroduces a multi-column track.
- `tests/ComponentPropsTest.php`: a one-item grid emits `data-pp-count="1"` (guards the CSS matching contract).

## Reviews

- `/plan-eng-review` + a Codex outside-voice pass ran on this plan; `/review` + a Codex/Claude adversarial pass ran on this exact diff. One informational finding (a literal-selector "declared once" guard could miss a functionally-equivalent re-override) was folded in as the selector-agnostic backstop test above. No critical findings.
- `/document-generate`: no doc updates needed — CSS-only rendering refinement of a single-item edge case; no accepted grammar, prop, token, or schema surface changed.

## Accepted limitations

- The single card now spans the full container width. For very narrow "panel" content this is wider than a centered-constrained card would be; this is the explicit design choice per the issue's first Expected option and the #303/#224 direction, not a defect.

Not tagged/released/deployed — CI builds the release zip from tags; the maintainer handles that separately.
