### PR TITLE
v0.16.103 feat: stats/faq padding + heading-size style slots (#304)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -376,7 +376,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**142 style slots** across 7 components: hero (36), cta (26), grid (24), section (21), testimonials (19), faq (10), stats (6).
+**148 style slots** across 7 components: hero (36), cta (26), grid (24), section (21), testimonials (19), faq (13), stats (9).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
-## [v0.16.102] — 2026-07-13 — A one-card grid now fills the row instead of hugging the left with dead space beside it (#297)
+## [v0.16.103] — 2026-07-13 — `stats` and `faq` can finally follow page rhythm and type scale: padding and heading-size slots, matching the other section components (#304)
+
+**The `stats` and `faq` components now expose the same box-model and typography style slots the other section-level components already had, so a full page can be tuned to one consistent vertical rhythm and heading scale. Until now `stats` and `faq` declared color and background slots (added in #100) but no padding or heading-size slots, while `hero`, `section`, `grid`, and `cta` declared all of them. That gap meant any attempt to tighten a page's band spacing or dial its title scale left two components stranded at their built-in values. This release adds `--stats-padding-top`, `--stats-padding-bottom`, `--stats-title-size`, `--faq-padding-top`, `--faq-padding-bottom`, and `--faq-heading-size`, closing the schema asymmetry.**
+
+Each new slot routes through the same `var(--slot, <literal>)` idiom the padding and title-size slots on `section`/`grid`/`cta` already use, at every layer the components render through: the base rule, the desktop premium typography and rhythm rules, the mobile rhythm rules, and the adjacent-sibling spacing rules. Unset output is byte-identical to before, so nothing about the shipped pages changes until an operator sets a slot. Because `stats` and `faq` render their headings at the plain `h2` base size (they have no desktop premium type rule of their own, unlike `section`/`grid`), the two heading-size slots fall back to that `1.875rem` base rather than `inherit`, keeping the resting scale exactly as it renders today. The slots are enforced live by the existing style-slot contract test, which auto-discovers every schema slot and fails the build if one is not consumed by the CSS or is bypassed by a literal re-declaration. No new prop, token, recipe, or action surface was added.
+
+### Added
+
+- `stats` gains `--stats-padding-top`, `--stats-padding-bottom`, and `--stats-title-size`; `faq` gains `--faq-padding-top`, `--faq-padding-bottom`, and `--faq-heading-size`. Set them per instance with `style_component` to control each band's vertical rhythm and heading scale, matching the padding and title-size slots already on `hero`/`section`/`grid`/`cta`. Byte-identical when unset (#304).
+
+### Docs
+
+- `AI_CONTEXT.md` and `README.md` slot totals updated from 142 to 148 (`faq` 10 → 13, `stats` 6 → 9) to match the schemas (#304).
 
 **A `grid` with a single item no longer sits in the left half of a two-column track with empty space on the right. Until now a one-item card fell through to the generic two-column desktop rule, so the lone card rendered at roughly half the container width and stranded a matching gap beside it — the natural "panel" composition (an audience box, a terminal mock, a single highlighted card) always looked half-finished. This release gives the single-item grid its own full-width track, so the card spans the section container and its left edge sits on the same rail as the heading and intro copy above it.**
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.102-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.103-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-142 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 10 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+148 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 10 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.16.99.
 
 **What exists today (v0.16.99):**
-- 12 components with schema contracts and 142 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 148 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — known exceptions live in a shrink-only ledger (issue [#309](https://github.com/FJCF76/PromptingPress/issues/309)), backed by rendered computed-style checks
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -841,8 +841,8 @@
    ========================================================================== */
 
 .faq {
-  padding-top: var(--space-xl);
-  padding-bottom: var(--space-xl);
+  padding-top: var(--faq-padding-top, var(--space-xl));
+  padding-bottom: var(--faq-padding-bottom, var(--space-xl));
   background: var(--faq-bg, var(--color-surface));
 }
 
@@ -860,6 +860,11 @@
 }
 
 .faq__heading {
+  /* Route the heading size through the slot (issue 304). This base rule governs
+     widths below the desktop premium typography breakpoint, where the heading
+     renders at the h2 base size (base.css); the desktop clamp is routed through
+     the same slot below. Fallback keeps unset output byte-identical. */
+  font-size: var(--faq-heading-size, 1.875rem);
   margin-bottom: var(--space-lg);
   color: var(--faq-heading-color, var(--faq-heading-theme-color, var(--color-text)));
 }
@@ -1694,12 +1699,16 @@
    ========================================================================== */
 
 .stats {
-  padding-top: var(--space-xl);
-  padding-bottom: var(--space-xl);
+  padding-top: var(--stats-padding-top, var(--space-xl));
+  padding-bottom: var(--stats-padding-bottom, var(--space-xl));
   background: var(--stats-bg, transparent);
 }
 
 .stats__heading {
+  /* Route the heading size through the slot (issue 304). stats has no premium
+     typography rule, so the fallback is the h2 base size (base.css) — unset
+     output is byte-identical, and an operator can now tune the scale. */
+  font-size: var(--stats-title-size, 1.875rem);
   margin-bottom: var(--space-lg);
   text-align: center;
   color: var(--stats-title-color, var(--color-text));
@@ -2784,7 +2793,7 @@
      .section__title / .grid__heading rules ([0,1,0]) and silently ignoring a
      declared --section-title-size / --grid-heading-size. Route each through its
      size slot with the clamp() as the fallback so unset output is unchanged. faq
-     has no heading-size slot yet (issue 304), so it keeps the literal. */
+     now routes through --faq-heading-size too (issue 304). */
   main > .grid .grid__heading {
     color: var(--grid-heading-color, var(--grid-heading-theme-color, var(--color-text)));
     font-size: var(--grid-heading-size, clamp(2.25rem, 3vw, 2.62rem));
@@ -2797,7 +2806,7 @@
 
   main > .faq .faq__heading {
     color: var(--faq-heading-color, var(--faq-heading-theme-color, var(--color-text)));
-    font-size: clamp(2.25rem, 3vw, 2.62rem);
+    font-size: var(--faq-heading-size, clamp(2.25rem, 3vw, 2.62rem));
   }
 
   main > .section .section__content,
@@ -3313,7 +3322,7 @@ main .btn:focus-visible,
    two-tier rule (SHARED: Adjacent-Sibling Rhythm, ~line 2124: 32px = var(--space-lg)
    between stacked components on desktop) AND defeating every --*-padding-top slot on
    an adjacent component. Drop the flat override; the base rule restores the 32px
-   two-tier default for component types with no padding slot (hero/stats/faq/...).
+   two-tier default for component types with no padding slot (hero/...).
    For the slot-bearing components, route the adjacent top-padding through the slot
    with var(--space-lg) as the fallback so the slot controls adjacent spacing too.
    Desktop-scoped and placed last so it wins over the base rule; mobile keeps the
@@ -3328,14 +3337,20 @@ main .btn:focus-visible,
   main > [data-pp-component] + .cta {
     padding-top: var(--cta-padding-top, var(--space-lg));
   }
+  main > [data-pp-component] + .stats {
+    padding-top: var(--stats-padding-top, var(--space-lg));
+  }
+  main > [data-pp-component] + .faq {
+    padding-top: var(--faq-padding-top, var(--space-lg));
+  }
 }
 
 /* Own section padding, routed through each component's padding slots (issue 302).
    This premium rule re-declared padding-top/bottom as bare clamp() literals,
    outranking the base .section/.grid/.cta rules ([0,1,0]) and silently ignoring a
    declared --*-padding-top/bottom. Split per component and route through the slot
-   with the clamp() as the fallback (unset output unchanged). faq has no padding
-   slot yet (issue 304), so it keeps the literal. */
+   with the clamp() as the fallback (unset output unchanged). faq now routes
+   through --faq-padding-top/bottom too (issue 304). */
 .section {
   padding-top: var(--section-padding-top, clamp(4.25rem, 6vw, 5rem));
   padding-bottom: var(--section-padding-bottom, clamp(4.25rem, 6vw, 5rem));
@@ -3352,8 +3367,8 @@ main .btn:focus-visible,
 }
 
 .faq {
-  padding-top: clamp(4.25rem, 6vw, 5rem);
-  padding-bottom: clamp(4.25rem, 6vw, 5rem);
+  padding-top: var(--faq-padding-top, clamp(4.25rem, 6vw, 5rem));
+  padding-bottom: var(--faq-padding-bottom, clamp(4.25rem, 6vw, 5rem));
 }
 
 /* Page-specific texture flourish (4 benchmark pages) layered ON TOP of the
@@ -3476,10 +3491,17 @@ main .btn,
   main > [data-pp-component] + .cta {
     padding-top: var(--cta-padding-top, 3.35rem);
   }
+  main > [data-pp-component] + .stats {
+    padding-top: var(--stats-padding-top, 3.35rem);
+  }
+  main > [data-pp-component] + .faq {
+    padding-top: var(--faq-padding-top, 3.35rem);
+  }
 
   /* Own mobile padding, routed through the padding slots so a declared
-     --*-padding-top/bottom takes effect at mobile too (issue 302). faq keeps the
-     literal (no slot yet, issue 304). Fallbacks equal the prior literals. */
+     --*-padding-top/bottom takes effect at mobile too (issue 302). faq now routes
+     through --faq-padding-top/bottom too (issue 304). Fallbacks equal the prior
+     literals. */
   .section {
     padding-top: var(--section-padding-top, 3.35rem);
     padding-bottom: var(--section-padding-bottom, 3.35rem);
@@ -3491,8 +3513,8 @@ main .btn,
   }
 
   .faq {
-    padding-top: 3.35rem;
-    padding-bottom: 3.35rem;
+    padding-top: var(--faq-padding-top, 3.35rem);
+    padding-bottom: var(--faq-padding-bottom, 3.35rem);
   }
 
   #home-cta,

--- a/components/faq/schema.json
+++ b/components/faq/schema.json
@@ -48,10 +48,13 @@
     "variant_classes": [],
     "tokens": ["--space-xl", "--space-2xl", "--color-border", "--color-surface"],
     "style_slots": {
+      "--faq-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the FAQ section" },
+      "--faq-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the FAQ section" },
       "--faq-bg": { "type": "gradient", "default": "var(--color-surface)", "description": "Section background color or gradient" },
       "--faq-item-bg": { "type": "gradient", "default": "var(--color-bg)", "description": "Individual accordion item background color or gradient" },
       "--faq-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
       "--faq-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
+      "--faq-heading-size": { "type": "length", "default": "1.875rem", "description": "Section heading font size" },
       "--faq-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading text color" },
       "--faq-heading-accent-color": { "type": "color", "default": "var(--color-accent)", "description": "Color of the title_accent substring within the heading, if set" },
       "--faq-question-color": { "type": "color", "default": "var(--color-text)", "description": "Question (summary) text color" },

--- a/components/stats/schema.json
+++ b/components/stats/schema.json
@@ -48,7 +48,10 @@
     "variant_classes": ["stats--dark", "stats--inverted"],
     "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted", "--overlay-bg"],
     "style_slots": {
+      "--stats-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the stats section" },
+      "--stats-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the stats section" },
       "--stats-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
+      "--stats-title-size": { "type": "length", "default": "1.875rem", "description": "Section heading (title) font size" },
       "--stats-title-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading text color" },
       "--stats-title-accent-color": { "type": "color", "default": "var(--color-accent)", "description": "Color of the title_accent substring within the heading, if set" },
       "--stats-number-color": { "type": "color", "default": "var(--color-accent)", "description": "Stat number (large metric value) text color" },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.102');
+define('PP_VERSION', '0.16.103');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.102",
+  "version": "0.16.103",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.102
+Stable tag: 0.16.103
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.102
+Version:          0.16.103
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Closes #304

## Summary

`stats` and `faq` gain the box-model and typography style slots the other section-level components already had, closing a schema asymmetry (follow-up to #100). New slots: `--stats-padding-top`, `--stats-padding-bottom`, `--stats-title-size`, `--faq-padding-top`, `--faq-padding-bottom`, `--faq-heading-size`. This makes it possible to tune a full page to one consistent vertical rhythm and heading scale.

## Scope (acceptance criteria)

- **`--stats-padding-top/bottom`, `--faq-padding-top/bottom`** — declared in each schema; every existing literal padding declaration on `.stats` / `.faq` is routed through `var(--slot, <literal>)` at each layer it renders through: base rule, desktop premium own-padding, desktop + mobile adjacent-sibling rhythm, and mobile own-padding.
- **`--faq-heading-size`** — routes the desktop premium `clamp()` on `main > .faq .faq__heading` and adds a base consumption on `.faq__heading` inside the faq block.
- **`--stats-title-size`** — added for symmetry; consumed on `.stats__heading`.
- **Byte-identical unset.** Heading-size slots fall back to the `h2` base size `1.875rem` (not `inherit`): unlike `section`/`grid`, `stats`/`faq` have no desktop premium type rule, so `inherit` would have shrunk the resting heading. Padding fallbacks equal the prior literals at every layer.

## Interaction with the #305 slot-contract guard

`tests/StyleSlotContractTest.php` auto-discovers every schema slot and fails the build if a slot is not consumed via `var(--slot)` on a type-compatible property, or is bypassed by a same-subject literal re-declaration. All six new slots pass (guard: 9/9, 473 assertions). No waiver-ledger entry added (ledger is shrink-only).

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — 1588 passed (5925 assertions). Warnings/deprecations (3/2) are pre-existing and identical on a clean tree (diff contains zero PHP).
- `npm test` — 520 passed.
- `bash scripts/package.sh` — version consistency OK across all five files; built zip deleted (releases are CI-built from tags).

## AI docs

Per-component slot lists are runtime-derived via `pp_get_style_slots()`; only the hardcoded aggregate needed updating. `AI_CONTEXT.md` + `README.md` slot total 142 → 148 (faq 10 → 13, stats 6 → 9). `SchemaValidationTest` enforces this count.

## Reviews

- `/plan-eng-review` — no findings that extend the recorded decision; scope confirmed minimal and symmetric.
- `/review` (critical pass + Codex adversarial) — clean. Codex flagged the new adjacent-sibling rules as possibly non-byte-identical; verified false positive (incomplete-context artifact): the generic `main > [data-pp-component] + [data-pp-component]` rule already governed adjacent spacing at `var(--space-lg)` / `3.35rem`, and the new same-specificity rules preserve those fallbacks in later source order.

## Accepted limitations

- CSS-only styling change; no prop, token, recipe, or action surface added.
- The dogfood's observed asymmetric stats band (80/64px) is a rhythm artifact of the adjacent-sibling rule; this issue adds the control surface to fix it per instance, it does not change the default rhythm.

## Decided without asking (rule-3)

- Heading-size fallback `1.875rem` rather than `inherit` (byte-identical rendering, since stats/faq have no premium type rule).
- Included adjacent-sibling routing for `.stats`/`.faq` (mirroring the section/grid/cta pattern from #302) so the padding slots are genuinely alive in the common adjacent case, not just guard-passing.

Not tagging / releasing / deploying — maintainer handles those from the tag.
