### PR TITLE
v0.16.104 fix: slot control for the grid featured first-card remnants — uniform card rows (#293)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -376,7 +376,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**148 style slots** across 7 components: hero (36), cta (26), grid (24), section (21), testimonials (19), faq (13), stats (9).
+**152 style slots** across 7 components: hero (36), grid (28), cta (26), section (21), testimonials (19), faq (13), stats (9).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.104] — 2026-07-13 — the grid's featured first-card remnants (accent top bar, texture stripe, glow) are finally slot-controllable: uniform card rows are one recipe away (#293)
+
+**Every 3-up feature row used to render with an unremovable "first card is special" statement: after #226 and #292 fixed the border and background slots, the featured first card still painted a 4px accent top bar, a blue texture stripe, and an inset blue glow from hardcoded literals no slot could reach. A neutral, uniform card row — the most common marketing section there is — was impossible through supported mechanisms. This release puts all three remnants behind style slots and ships a `uniform-cards` recipe that neutralizes the treatment in one step.**
+
+Four new grid slots follow the `var(--slot, <literal>)` idiom with byte-identical unset output. `--grid-card-bar-color` and `--grid-card-bar-height` control the card top bar on EVERY card with two-tier defaults (2px hairline on cards 2..N, 4px accent gradient on the featured card); they are shared rather than featured-only because the slot-contract guard collapses pseudo-classes onto the base subject, so featured-only bar slots would have flagged the base hairline literals as unwaivable bypasses — height `0` removes the bar everywhere. `--grid-featured-texture-color` slots the texture stripe's line color (`transparent` removes it), and `--grid-featured-shadow` chains ahead of the shared `--grid-card-shadow` at both the desktop and the previously unlisted mobile featured-glow rule, so the slot cannot silently no-op below 768px. The featured rules moved from the late cascade into the `COMPONENT: grid` block (cascade-equivalent — nothing else styles `.grid__item::before`, and the `:first-child` rule outranks the late base rules by specificity in either order) so the guard's in-block consumption check enforces the new slots. The `uniform-cards` recipe pins one shared bar (removed), texture (off on card 1), shadow, border, background, and title size; the residual differences it cannot reach (the faint 0.028-alpha texture on cards 2..N, a 0.25rem featured body padding-top at desktop, the dark-theme lift) are named in the recipe description rather than silently left behind.
+
+### Added
+
+- Grid slots `--grid-card-bar-color`, `--grid-card-bar-height`, `--grid-featured-texture-color`, and `--grid-featured-shadow`, plus the `uniform-cards` recipe. Set the three neutralizers (bar height `0`, texture `transparent`, one shared `--grid-card-shadow`) or apply the recipe for a uniform card row; the featured treatment stays the unset default (#293).
+
+### Docs
+
+- `AI_CONTEXT.md` and `README.md` slot totals updated from 148 to 152 (`grid` 24 → 28, breakdown reordered); `ai-instructions/style-component.md` documents the featured-treatment slots and the new recipe (10 → 11 recipes) (#293).
+
+### Tests
+
+- `SchemaValidationTest` covers the accepted neutralizers and typed values plus four rejected cross-type shapes for the new slots, and pins the `uniform-cards` recipe to declared slots with type-valid values. `StyleSlotContractTest` pins the two-tier fallback literals and the mobile featured-shadow chain. Four rendered E2E tests prove the unset featured defaults survive the rule move, the recipe renders a uniform row at desktop and mobile, `--grid-featured-shadow` has discriminating rendered power at both breakpoints, and the bar slots pin one identical bar on featured and plain cards (#293).
+
 ## [v0.16.103] — 2026-07-13 — `stats` and `faq` can finally follow page rhythm and type scale: padding and heading-size slots, matching the other section components (#304)
 
 **The `stats` and `faq` components now expose the same box-model and typography style slots the other section-level components already had, so a full page can be tuned to one consistent vertical rhythm and heading scale. Until now `stats` and `faq` declared color and background slots (added in #100) but no padding or heading-size slots, while `hero`, `section`, `grid`, and `cta` declared all of them. That gap meant any attempt to tighten a page's band spacing or dial its title scale left two components stranded at their built-in values. This release adds `--stats-padding-top`, `--stats-padding-bottom`, `--stats-title-size`, `--faq-padding-top`, `--faq-padding-bottom`, and `--faq-heading-size`, closing the schema asymmetry.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.103-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.104-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-148 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 10 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+152 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.16.99.
 
 **What exists today (v0.16.99):**
-- 12 components with schema contracts and 148 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 152 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — known exceptions live in a shrink-only ledger (issue [#309](https://github.com/FJCF76/PromptingPress/issues/309)), backed by rendered computed-style checks
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/ai-instructions/style-component.md
+++ b/ai-instructions/style-component.md
@@ -106,6 +106,15 @@ or a single-layer `box-shadow` (2-4 px/rem lengths plus an rgb/rgba/hsl/hsla col
 cta, and testimonials (card) components each expose namespaced `*-border-color`,
 `*-border-width`, `*-radius`, and `*-shadow` slots.
 
+The grid's **featured first-card treatment** (accent top bar, texture stripe, blue
+glow on card 1 of a cards-layout grid) is slot-controllable (#293):
+`--grid-card-bar-color`/`--grid-card-bar-height` pin one top bar on EVERY card
+(height `0` removes it everywhere); `--grid-featured-texture-color: transparent`
+removes the card-1 texture stripe; `--grid-featured-shadow` overrides the shared
+`--grid-card-shadow` on card 1 only (`none` removes the glow, or set
+`--grid-card-shadow` for one identical shadow on all cards). For a uniform row in
+one step, apply the `uniform-cards` recipe instead of setting the slots by hand.
+
 The `position` and `ratio` types (#108) control image focal point and aspect ratio,
 per-instance. `position` accepts 1-2 keyword/length tokens (no functions, no `var()`);
 `ratio` accepts `auto` (natural proportions) or a number/fraction. `--{hero,section}-image-position`
@@ -132,6 +141,7 @@ controls the `background_image`/cover-layout CSS background. Not exposed on logo
 | section | `spacious-editorial` | Wide body with generous padding |
 | grid | `dark-showcase` | Dark background with light cards |
 | grid | `dense-cards` | Compact card layout with tight spacing |
+| grid | `uniform-cards` | Neutralize the featured first-card treatment (top bar, texture, glow) for a uniform row |
 | cta | `dark-bold` | Dark background with large title |
 | cta | `accent-framed` | Accent border with rounded corners |
 | testimonials | `dark-showcase` | Dark background with light cards |

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1229,6 +1229,59 @@
   background: var(--grid-card-bg, var(--color-bg));
 }
 
+/* Card top bar + featured first-card treatment (issue 293). These composed-page
+   rules live here (not the final cascade, where they used to sit) so the issue 293
+   slots are consumed inside the COMPONENT: grid block per the slot-contract guard.
+   Cascade-equivalent: no other rule anywhere styles .grid__item::before, and the
+   :first-child rule outranks the final cascade's [0,3,1] base rules by specificity
+   in either order; the premium later winners (border-color, base box-shadow) still
+   win exactly as before. Unset output is byte-identical — every fallback below is
+   the literal that used to be hardcoded. */
+main > .grid:not(.grid--steps) .grid__item::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  /* The top bar routes through the issue 293 bar slots on EVERY card; the
+     featured :first-child rule below re-consumes them with louder defaults.
+     The slots are shared (not featured-only) because the slot-contract guard
+     collapses pseudo-classes onto the base subject, so a featured-only slot
+     would flag these base literals as unwaivable bypasses. Setting the slots
+     pins one bar on every card; --grid-card-bar-height: 0 removes it. */
+  height: var(--grid-card-bar-height, 2px);
+  background: var(--grid-card-bar-color, var(--color-border));
+}
+
+main > .grid:not(.grid--steps) .grid__item:first-child {
+  /* Featured-card accent border DEFAULT tier; a per-instance --grid-card-border
+     overrides it, mirroring --grid-card-bg below, so a declared style slot never
+     silently no-ops on the first card (issue 226). Note: the premium later-cascade
+     :first-child rule re-declares border-color with a --color-accent-strong
+     fallback and currently wins when the slot is unset; this declaration is the
+     base tier that takes over if that premium layer is ever removed. */
+  border-color: var(--grid-card-border, var(--color-border-accent));
+  /* Featured-card accent fill is the DEFAULT; a per-instance --grid-card-bg
+     overrides it so the first card stays uniform with the rest when an author
+     sets an explicit card color (e.g. uniform dark cards on a dark band). The
+     texture-stripe line color routes through the issue 293 slot; transparent
+     removes the stripe. */
+  background:
+    linear-gradient(90deg, var(--grid-featured-texture-color, rgba(37, 99, 235, 0.055)) 1px, transparent 1px) 0 0 / 2.75rem 100%,
+    var(--grid-card-bg, linear-gradient(180deg, var(--color-surface-accent) 0%, var(--color-surface) 100%));
+  /* Featured glow: the issue 293 featured-shadow slot wins first, then the shared
+     --grid-card-shadow exactly as before, then the glow literal. The mobile
+     featured rule in the final cascade re-declares this same chain. */
+  box-shadow: var(--grid-featured-shadow, var(--grid-card-shadow,
+    inset 0 0 0 1px rgba(37, 99, 235, 0.055),
+    0 18px 42px rgba(37, 99, 235, 0.10)));
+}
+
+main > .grid:not(.grid--steps) .grid__item:first-child::before {
+  height: var(--grid-card-bar-height, 4px);
+  background: var(--grid-card-bar-color, linear-gradient(90deg, var(--color-accent), color-mix(in srgb, var(--color-accent) 18%, transparent)));
+}
+
 /* ==========================================================================
    COMPONENT: table
    Data table with horizontal scroll on mobile.
@@ -2943,36 +2996,8 @@ main > .grid:not(.grid--steps) .grid__item {
     var(--grid-card-bg, linear-gradient(180deg, var(--color-bg) 0%, var(--color-surface) 100%));
 }
 
-main > .grid:not(.grid--steps) .grid__item::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  height: 2px;
-  background: var(--color-border);
-}
-
-main > .grid:not(.grid--steps) .grid__item:first-child {
-  /* Featured-card accent border is the DEFAULT; a per-instance --grid-card-border
-     overrides it, mirroring --grid-card-bg below, so a declared style slot never
-     silently no-ops on the first card (issue 226). */
-  border-color: var(--grid-card-border, var(--color-border-accent));
-  /* Featured-card accent fill is the DEFAULT; a per-instance --grid-card-bg
-     overrides it so the first card stays uniform with the rest when an author
-     sets an explicit card color (e.g. uniform dark cards on a dark band). */
-  background:
-    linear-gradient(90deg, rgba(37, 99, 235, 0.055) 1px, transparent 1px) 0 0 / 2.75rem 100%,
-    var(--grid-card-bg, linear-gradient(180deg, var(--color-surface-accent) 0%, var(--color-surface) 100%));
-  box-shadow: var(--grid-card-shadow,
-    inset 0 0 0 1px rgba(37, 99, 235, 0.055),
-    0 18px 42px rgba(37, 99, 235, 0.10));
-}
-
-main > .grid:not(.grid--steps) .grid__item:first-child::before {
-  height: 4px;
-  background: linear-gradient(90deg, var(--color-accent), color-mix(in srgb, var(--color-accent) 18%, transparent));
-}
+/* The card top-bar and featured first-card rules moved into the COMPONENT: grid
+   block (issue 293); the cascade-equivalence argument lives with the rules there. */
 
 main > .grid:not(.grid--steps) .grid__item:first-child .grid__item-title {
   color: var(--grid-item-title-color, var(--color-text));
@@ -3066,7 +3091,9 @@ main > .grid .grid__item-link::after {
   }
 
   main > .grid:not(.grid--steps) .grid__item:first-child {
-    box-shadow: var(--grid-card-shadow, 0 14px 32px rgba(37, 99, 235, 0.09));
+    /* Same featured-shadow chain as the component-block rule (issue 293), so the
+       slot does not silently no-op below 768px; only the glow literal differs. */
+    box-shadow: var(--grid-featured-shadow, var(--grid-card-shadow, 0 14px 32px rgba(37, 99, 235, 0.09)));
   }
 }
 

--- a/components/grid/schema.json
+++ b/components/grid/schema.json
@@ -91,6 +91,10 @@
       "--grid-card-border-width": { "type": "length", "default": "1px", "description": "Card border width" },
       "--grid-card-radius": { "type": "length", "default": "var(--radius)", "description": "Card border radius" },
       "--grid-card-shadow": { "type": "shadow", "default": "none", "description": "Card box shadow / glow (preset var(--shadow-sm|md|lg) or a bounded box-shadow)" },
+      "--grid-card-bar-color": { "type": "gradient", "default": "var(--color-border)", "description": "Card top-bar color or gradient (cards layout only; no bar exists on steps). The featured first card defaults to an accent gradient; setting this slot pins one bar color on every card" },
+      "--grid-card-bar-height": { "type": "length", "default": "2px", "description": "Card top-bar height (cards layout only; the featured first card defaults to 4px). 0 removes the bar on every card" },
+      "--grid-featured-texture-color": { "type": "color", "default": "rgba(37, 99, 235, 0.055)", "description": "Texture-stripe line color painted on the featured first card only (cards layout on composed pages). transparent removes the stripe" },
+      "--grid-featured-shadow": { "type": "shadow", "default": "var(--grid-card-shadow)", "description": "Box shadow of the featured first card only (cards layout on composed pages); overrides the shared --grid-card-shadow there. When both are unset a built-in blue glow renders. Set none (or set --grid-card-shadow for all cards) to remove the featured glow" },
       "--grid-card-padding": { "type": "length", "default": "var(--space-md)", "description": "Card body padding" },
       "--grid-card-gap": { "type": "length", "default": "var(--space-sm)", "description": "Gap between card body elements" },
       "--grid-item-title-size": { "type": "length", "default": "1.25rem", "description": "Card title font size" },
@@ -117,6 +121,17 @@
           "--grid-gap": "1rem",
           "--grid-card-padding": "1rem",
           "--grid-card-gap": "0.5rem"
+        }
+      },
+      "uniform-cards": {
+        "description": "Neutralize the featured first-card treatment for a uniform row: removes the top bars, the featured texture stripe, and the featured glow, and pins one shared border, background, shadow, and title size on every card. Residual differences that stay: the faint texture on cards 2+, a 0.25rem body padding-top difference on card 1 at desktop, and the dark-theme lift",
+        "slots": {
+          "--grid-card-bar-height": "0",
+          "--grid-featured-texture-color": "transparent",
+          "--grid-card-shadow": "0 10px 24px rgba(15, 23, 42, 0.055)",
+          "--grid-card-border": "var(--color-border)",
+          "--grid-card-bg": "var(--color-surface)",
+          "--grid-item-title-size": "1.25rem"
         }
       }
     }

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.103');
+define('PP_VERSION', '0.16.104');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.103",
+  "version": "0.16.104",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.103
+Stable tag: 0.16.104
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.103
+Version:          0.16.104
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -230,7 +230,7 @@ class SchemaValidationTest extends TestCase
         $expected = [
             'hero'    => 36,
             'section' => 21,
-            'grid'    => 24,
+            'grid'    => 28,
             'cta'     => 26,
         ];
 
@@ -440,6 +440,99 @@ class SchemaValidationTest extends TestCase
         ];
         $result = pp_validate_composition($composition);
         $this->assertTrue($result);
+    }
+
+    // ── Featured first-card remnant slots (issue 293) ────────────────────
+    //
+    // The three featured-card remnants (accent top bar, texture stripe, glow)
+    // gained slot control so a uniform card row is reachable through the shared
+    // validation engine. Accepted shapes: the documented neutralizers plus
+    // ordinary typed values. Rejected shapes: cross-type values, so a slot that
+    // LOOKS plausible but cannot render never reports success.
+
+    private function gridCompositionWithStyle(array $style): array
+    {
+        return [
+            [
+                'component' => 'grid',
+                'props'     => ['items' => [['title' => 'One'], ['title' => 'Two'], ['title' => 'Three']]],
+                'style'     => $style,
+            ],
+        ];
+    }
+
+    public function testGridFeaturedRemnantSlotsAcceptNeutralizers(): void
+    {
+        $result = pp_validate_composition($this->gridCompositionWithStyle([
+            '--grid-card-bar-height'        => '0',
+            '--grid-featured-texture-color' => 'transparent',
+            '--grid-featured-shadow'        => 'none',
+        ]));
+        $this->assertTrue($result, 'The documented uniform-row neutralizers must validate.');
+    }
+
+    public function testGridFeaturedRemnantSlotsAcceptTypedValues(): void
+    {
+        $result = pp_validate_composition($this->gridCompositionWithStyle([
+            '--grid-card-bar-height'        => '4px',
+            '--grid-card-bar-color'         => 'linear-gradient(90deg, #ea3900, #b32b00)',
+            '--grid-featured-texture-color' => 'rgba(37, 99, 235, 0.028)',
+            '--grid-featured-shadow'        => '0 10px 24px rgba(15, 23, 42, 0.055)',
+        ]));
+        $this->assertTrue($result, 'Ordinary typed values for the issue 293 slots must validate.');
+    }
+
+    public function testGridCardBarColorAcceptsPlainColor(): void
+    {
+        // gradient-typed slots accept plain colors too (the --grid-card-bg precedent).
+        $result = pp_validate_composition($this->gridCompositionWithStyle([
+            '--grid-card-bar-color' => '#e6e8eb',
+        ]));
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider featuredRemnantCrossTypeProvider
+     */
+    public function testGridFeaturedRemnantSlotsRejectCrossTypeValues(string $slot, string $value): void
+    {
+        $result = pp_validate_composition($this->gridCompositionWithStyle([$slot => $value]));
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('invalid_style_value', $result->get_error_code());
+    }
+
+    public static function featuredRemnantCrossTypeProvider(): array
+    {
+        return [
+            'color into bar-height'     => ['--grid-card-bar-height', '#ff0000'],
+            'length into texture-color' => ['--grid-featured-texture-color', '2rem'],
+            'keyword into shadow'       => ['--grid-featured-shadow', 'blue-glow'],
+            'shadow into bar-color'     => ['--grid-card-bar-color', '0 10px 24px rgba(0, 0, 0, 0.1)'],
+        ];
+    }
+
+    public function testGridDeclaresUniformCardsRecipe(): void
+    {
+        $schema  = json_decode(file_get_contents($this->themeRoot . '/components/grid/schema.json'), true);
+        $recipes = $schema['styling']['recipes'] ?? [];
+
+        $this->assertArrayHasKey('uniform-cards', $recipes, 'issue 293 acceptance: the uniform row must be a documented recipe.');
+        $slots = $recipes['uniform-cards']['slots'] ?? [];
+        $this->assertSame('0', $slots['--grid-card-bar-height'] ?? null);
+        $this->assertSame('transparent', $slots['--grid-featured-texture-color'] ?? null);
+        $this->assertArrayHasKey('--grid-card-shadow', $slots, 'Uniformity needs one shared shadow on all cards, not a missing featured glow.');
+
+        // Every recipe value must be valid for its slot's declared type — a recipe
+        // that expands into rejected values would fail at apply time.
+        $declared = $schema['styling']['style_slots'];
+        foreach ($slots as $name => $value) {
+            $this->assertArrayHasKey($name, $declared, "Recipe slot {$name} must be a declared style slot.");
+            $this->assertTrue(
+                _pp_validate_token_value((string) $value, $declared[$name]['type'] ?? null),
+                "uniform-cards recipe value for {$name} must validate against its declared type."
+            );
+        }
     }
 
     // ── Template-owned chrome rejection (#223) ───────────────────────────

--- a/tests/StyleSlotContractTest.php
+++ b/tests/StyleSlotContractTest.php
@@ -488,6 +488,53 @@ class StyleSlotContractTest extends TestCase
         );
     }
 
+    /**
+     * Featured first-card remnant slots (issue 293): value-level fallback pins.
+     *
+     * The generic checks above prove the slots are consumed and unbypassed; they do
+     * NOT pin the fallback literals. Byte-identical unset output depends on those
+     * literals being exactly the values that used to be hardcoded, in a two-tier
+     * shape (base card vs featured first card), plus the mobile featured-shadow
+     * chain — a fourth consumer the issue body never listed, where the slot would
+     * otherwise silently no-op below 768px.
+     */
+    public function testIssue293FeaturedRemnantSlotFallbacks(): void
+    {
+        $block = $this->stripComments($this->componentBlock('grid'));
+
+        // Bar slots, two-tier: base hairline vs featured accent gradient.
+        $this->assertStringContainsString('height: var(--grid-card-bar-height, 2px)', $block);
+        $this->assertStringContainsString('background: var(--grid-card-bar-color, var(--color-border))', $block);
+        $this->assertStringContainsString('height: var(--grid-card-bar-height, 4px)', $block);
+        $this->assertStringContainsString(
+            'background: var(--grid-card-bar-color, linear-gradient(90deg, var(--color-accent), color-mix(in srgb, var(--color-accent) 18%, transparent)))',
+            $block
+        );
+
+        // Texture stripe: featured-only color slot over the original 0.055 literal.
+        $this->assertStringContainsString(
+            'linear-gradient(90deg, var(--grid-featured-texture-color, rgba(37, 99, 235, 0.055)) 1px, transparent 1px)',
+            $block
+        );
+
+        // Featured glow: featured slot first, shared card shadow second (unchanged
+        // semantics), original glow literal last.
+        $this->assertMatchesRegularExpression(
+            '/box-shadow:\s*var\(--grid-featured-shadow,\s*var\(--grid-card-shadow,\s*inset 0 0 0 1px rgba\(37, 99, 235, 0\.055\),\s*0 18px 42px rgba\(37, 99, 235, 0\.10\)\)\)/',
+            $block
+        );
+
+        // Mobile featured glow (max-width: 767px, final cascade) re-declares the
+        // same chain with its own literal — delete the chain there and the slot
+        // reports success while mobile renders the old glow.
+        $css = $this->stripComments($this->css);
+        $this->assertStringContainsString(
+            'box-shadow: var(--grid-featured-shadow, var(--grid-card-shadow, 0 14px 32px rgba(37, 99, 235, 0.09)))',
+            $css,
+            'The mobile featured-glow rule must route through --grid-featured-shadow (issue 293).'
+        );
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     /**

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -49,9 +49,14 @@ function deletePage(id: number): void {
 }
 
 /** Dispatch a style_component action via the admin AJAX endpoint (picks up the nonce). */
-async function styleComponent(page: any, postId: number, style: Record<string, unknown>) {
+async function styleComponent(
+  page: any,
+  postId: number,
+  style: Record<string, unknown>,
+  recipe?: string,
+) {
   return page.evaluate(
-    async (args: { pid: number; style: Record<string, unknown> }) => {
+    async (args: { pid: number; style: Record<string, unknown>; recipe?: string }) => {
       const config = (window as any).ppAiChat;
       const data = new FormData();
       data.append('action', 'pp_ai_execute');
@@ -60,7 +65,12 @@ async function styleComponent(page: any, postId: number, style: Record<string, u
       data.append('name', 'style_component');
       data.append('params[post_id]', String(args.pid));
       data.append('params[component_index]', '0');
-      data.append('params[style]', JSON.stringify(args.style));
+      if (Object.keys(args.style).length > 0) {
+        data.append('params[style]', JSON.stringify(args.style));
+      }
+      if (args.recipe) {
+        data.append('params[recipe]', args.recipe);
+      }
       const resp = await fetch(config.ajaxUrl, {
         method: 'POST',
         credentials: 'same-origin',
@@ -68,8 +78,22 @@ async function styleComponent(page: any, postId: number, style: Record<string, u
       });
       return resp.json();
     },
-    { pid: postId, style },
+    { pid: postId, style, recipe },
   );
+}
+
+/** Computed featured-treatment surfaces of one grid card (issue 293). */
+function grabCardStyles(el: Element) {
+  const before = getComputedStyle(el, '::before');
+  const s = getComputedStyle(el);
+  return {
+    barHeight: before.height,
+    barImage: before.backgroundImage,
+    barColor: before.backgroundColor,
+    shadow: s.boxShadow,
+    bg: s.backgroundImage,
+    border: s.borderTopColor,
+  };
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -694,6 +718,196 @@ test.describe('Safe-surface rendered proof', () => {
     expect(plain.width).not.toBe('0px');
     expect(featured.style).not.toBe('none');
     expect(plain.style).not.toBe('none');
+  });
+
+  // Featured remnants (#293), half 1: the rule move into the COMPONENT: grid block
+  // must not change UNSET rendering. Pin the featured defaults at the computed level:
+  // 4px accent bar + inset glow on card 1, 2px hairline + no inset glow on card 2.
+  test('#293 unset grid keeps the featured first-card defaults after the rule move', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Grid Featured Defaults');
+    setComposition(pageId, [
+      {
+        component: 'grid',
+        props: {
+          id: 'pp-grid01',
+          title: 'Featured defaults survive',
+          items: [
+            { title: 'One', text: 'Featured card' },
+            { title: 'Two', text: 'Plain card' },
+          ],
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const cards = page.locator('.grid__item');
+    await expect(cards).toHaveCount(2, { timeout: 10000 });
+
+    const featured = await cards.nth(0).evaluate(grabCardStyles);
+    const plain = await cards.nth(1).evaluate(grabCardStyles);
+
+    expect(featured.barHeight).toBe('4px');
+    expect(featured.barImage).toContain('linear-gradient'); // accent gradient bar
+    expect(plain.barHeight).toBe('2px');
+    expect(plain.barImage).toBe('none'); // hairline is a background-color, not an image
+    expect(featured.shadow).toContain('inset'); // the blue glow's inset ring
+    expect(plain.shadow).not.toContain('inset');
+    expect(featured.bg).toContain('37, 99, 235'); // texture stripe literal
+  });
+
+  // Featured remnants (#293), half 2: the acceptance path, through the documented
+  // uniform-cards RECIPE (so the recipe expansion is exercised end-to-end, not a
+  // re-typed copy of its values) — including at a mobile width, where a separate
+  // featured-glow rule re-declares the shadow chain (the featured-shadow slot would
+  // otherwise silently no-op below 768px).
+  test('#293 uniform-cards recipe neutralizes the featured treatment @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Grid Uniform Row');
+    setComposition(pageId, [
+      {
+        component: 'grid',
+        props: {
+          id: 'pp-grid01',
+          title: 'Uniform card row',
+          items: [
+            { title: 'One', text: 'First' },
+            { title: 'Two', text: 'Second' },
+            { title: 'Three', text: 'Third' },
+          ],
+        },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    const res = await styleComponent(page, pageId, {}, 'uniform-cards');
+    expect(res.success).toBe(true);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const cards = page.locator('.grid__item');
+    await expect(cards).toHaveCount(3, { timeout: 10000 });
+
+    const featured = await cards.nth(0).evaluate(grabCardStyles);
+    const plain = await cards.nth(1).evaluate(grabCardStyles);
+
+    expect(featured.barHeight).toBe('0px'); // bar removed
+    expect(plain.barHeight).toBe('0px');
+    expect(featured.shadow).toBe(plain.shadow); // one shared shadow, no glow
+    expect(featured.shadow).not.toContain('inset');
+    expect(featured.border).toBe(plain.border); // accent-strong border neutralized
+    expect(featured.bg).not.toContain('37, 99, 235'); // texture stripe neutralized
+
+    // Mobile: the max-width 767px featured rule must route the same chain.
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto(`/?page_id=${pageId}`);
+    await expect(cards).toHaveCount(3, { timeout: 10000 });
+
+    const featuredMobile = await cards.nth(0).evaluate(grabCardStyles);
+    const plainMobile = await cards.nth(1).evaluate(grabCardStyles);
+    expect(featuredMobile.shadow).toBe(plainMobile.shadow);
+    expect(featuredMobile.shadow).not.toContain('inset');
+  });
+
+  // #293: --grid-featured-shadow must have discriminating rendered power of its own.
+  // The uniform-row test neutralizes via --grid-card-shadow, which the PRE-#293 CSS
+  // already routed — it would pass with the featured-shadow chain reverted. This
+  // test sets the featured slot to a distinctive value and proves it renders on the
+  // featured card only, at desktop AND mobile (the two chain sites), and that it
+  // outranks a simultaneously-set --grid-card-shadow.
+  test('#293 --grid-featured-shadow renders on the featured card at both breakpoints', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Grid Featured Shadow Slot');
+    setComposition(pageId, [
+      {
+        component: 'grid',
+        props: {
+          id: 'pp-grid01',
+          title: 'Featured shadow slot',
+          items: [
+            { title: 'One', text: 'Featured card' },
+            { title: 'Two', text: 'Plain card' },
+          ],
+        },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    const res = await styleComponent(page, pageId, {
+      '--grid-featured-shadow': '0 2px 4px rgba(1, 2, 3, 0.5)',
+      '--grid-card-shadow': '0 6px 12px rgba(7, 8, 9, 0.4)',
+    });
+    expect(res.success).toBe(true);
+
+    for (const width of [1280, 375]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      const cards = page.locator('.grid__item');
+      await expect(cards).toHaveCount(2, { timeout: 10000 });
+
+      const featured = await cards.nth(0).evaluate(grabCardStyles);
+      const plain = await cards.nth(1).evaluate(grabCardStyles);
+      expect(featured.shadow).toContain('1, 2, 3'); // featured slot wins on card 1
+      expect(plain.shadow).toContain('7, 8, 9'); // shared slot on cards 2..N
+      expect(plain.shadow).not.toContain('1, 2, 3');
+    }
+  });
+
+  // #293: the shared bar slots must pin ONE identical bar on the featured and
+  // plain cards simultaneously — the featured accent-gradient default has to be
+  // overridden, not layered under.
+  test('#293 bar slots pin an identical top bar on featured and plain cards', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Grid Pinned Bar');
+    setComposition(pageId, [
+      {
+        component: 'grid',
+        props: {
+          id: 'pp-grid01',
+          title: 'Pinned bar',
+          items: [
+            { title: 'One', text: 'Featured card' },
+            { title: 'Two', text: 'Plain card' },
+          ],
+        },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    const res = await styleComponent(page, pageId, {
+      '--grid-card-bar-color': 'rgb(9, 8, 7)',
+      '--grid-card-bar-height': '3px',
+    });
+    expect(res.success).toBe(true);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const cards = page.locator('.grid__item');
+    await expect(cards).toHaveCount(2, { timeout: 10000 });
+
+    const featured = await cards.nth(0).evaluate(grabCardStyles);
+    const plain = await cards.nth(1).evaluate(grabCardStyles);
+
+    expect(featured.barHeight).toBe('3px');
+    expect(plain.barHeight).toBe('3px');
+    expect(featured.barColor).toBe('rgb(9, 8, 7)');
+    expect(plain.barColor).toBe('rgb(9, 8, 7)');
+    expect(featured.barImage).toBe('none'); // gradient default overridden, not layered
+    expect(plain.barImage).toBe('none');
   });
 
   // Parent-constrains-child axis (#302's --section-body-width): the pre-fix bug

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -121,8 +121,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('schema declares 107 total style slots', () => {
-        expect(allSlots.length).toBe(107);
+    test('hero/section/grid/cta schemas declare 111 style slots (subset of the 152 total)', () => {
+        expect(allSlots.length).toBe(111);
     });
 
     allSlots.forEach(({ component, slotName }) => {


### PR DESCRIPTION
Closes #293

## Scope

Implements the recorded #293 decision (Option A, 2026-07-13): per-layer style slots for the three unstylable featured first-card remnants — accent top bar, texture stripe, inset glow — so a uniform card row is reachable through documented `style_component` slots. No `featured_first` opt-out prop (Option B stays declined per #226).

- `--grid-card-bar-color` + `--grid-card-bar-height` (top bar, ALL cards, two-tier defaults 2px hairline / 4px accent gradient; height `0` removes it everywhere). Shared rather than featured-only: the #305 guard collapses pseudo-classes onto the base subject token, so featured-only bar slots would flag the base `::before` literals as unwaivable bypasses — and the decision forbids waiver-ledger additions.
- `--grid-featured-texture-color` (featured stripe line color; `transparent` removes it).
- `--grid-featured-shadow` (chains ahead of the shared `--grid-card-shadow` at the desktop AND mobile featured-glow rules — the mobile rule was a fourth consumer the issue body did not list; without the chain the slot silently no-ops below 768px).
- `uniform-cards` recipe: bar off, texture off, one shared shadow/border/background/title size.
- Featured rules moved into the `COMPONENT: grid` block (cascade-equivalent; nothing else styles `.grid__item::before`; the `:first-child` rule outranks the late [0,3,1] base rules by specificity in either order) so the guard's in-block consumption check enforces the new slots. Unset output byte-identical; #305 guard green with zero waiver additions.

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` — 1597 tests, 6001 assertions, OK (3 warnings / 2 deprecations, identical to the unmodified-tree baseline).
- JS: `npm test` — 524 passed, including the auto-extended per-slot fallback tests and the 111-slot subset pin.
- E2E (local wp-env, Playwright): full `style-render` spec 48/48, including 4 new #293 tests — unset featured defaults survive the rule move; the `uniform-cards` recipe renders a uniform row at 1280px and 375px (bar 0, shadows equal, borders equal, texture neutralized); `--grid-featured-shadow` has discriminating rendered power at both breakpoints and outranks a simultaneously-set `--grid-card-shadow`; the bar slots pin one identical bar on featured and plain cards.
- `scripts/package.sh` validated the five-file version sync (zip deleted; releases are CI-built).

## Review

/plan-eng-review (clean; 3 architecture findings folded: guard-forced shared bar slots, in-block rule move, mobile shadow chain) and /review (specialists + Claude adversarial + Codex adversarial via `codex exec` with inlined diff) ran this session on this exact content. 15 findings raised: 9 fixed (including the cross-model schema-default finding — `--grid-featured-shadow`'s default is now the referential `var(--grid-card-shadow)` instead of an author-invalid inset multi-layer literal — and the recipe uniformity gap), 4 refuted with file:line evidence, 2 consciously skipped (below).

## Accepted limitations

- The `uniform-cards` recipe cannot reach three residuals, named in its description: the faint 0.028-alpha texture on cards 2..N (the recorded decision scopes the texture slot to the featured card), a 0.25rem featured body `padding-top` delta at desktop, and the `grid--dark` translateY lift. These are outside #293's three recorded remnants.
- The new slots only paint on composed pages' cards layout (the featured treatment itself only exists there); slot descriptions say so.

## 7A questions

One asked before implementation: #293 had no recorded decision (two materially different surfaces in the body). Answer: Option A per-layer slots, recorded as the ✅ decision comment on #293 (orchestrator-recorded under standing delegation, veto window open). No further 7A extensions; the one candidate (slotting the base texture on cards 2..N) was deliberately NOT taken — strict to the decision.

## Documentation

- `AI_CONTEXT.md`: style-slot total 148 → 152, breakdown reordered (grid 28 now second) — test-asserted.
- `README.md`: two count sites 148 → 152, recipes 10 → 11, version badge 0.16.104.
- `ai-instructions/style-component.md`: featured first-card treatment paragraph (which slot controls which remnant, uniform-row recipe path) + `uniform-cards` recipe table row.
- `CHANGELOG.md`: v0.16.104 entry (headline, lede, explanation, Added/Docs/Tests) — sell test 3/3.
- Runtime AI context (`lib/ai-context.php`) is schema-driven and picks up the new slots/recipe automatically.
- Coverage: all shipped surface has reference + how-to + explanation coverage; no documentation debt. Codex doc review: 6 findings raised, all refuted against repo evidence (details in the session log).
