### PR TITLE
v0.16.105 fix: hero.proof color slot (#296)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -376,7 +376,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**152 style slots** across 7 components: hero (36), grid (28), cta (26), section (21), testimonials (19), faq (13), stats (9).
+**153 style slots** across 7 components: hero (37), grid (28), cta (26), section (21), testimonials (19), faq (13), stats (9).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.105] — 2026-07-13 — the hero proof line can finally be lifted off a dark hero: it has its own color slot instead of a hardcoded muted token (#296)
+
+**A hero's proof line — the small trust signals rendered below the CTA — shipped in a hardcoded `var(--color-muted)` with no per-instance color slot. On any dark hero (`--hero-bg` set to a dark color or gradient) that produced a low-contrast, dark-on-dark line that no supported action could fix, while `validate page` and `check page` both passed. This is the same "a literal token defeats per-instance theming" family as #222/#248/#292. This release adds a `--hero-proof-color` style slot so an operator can set the proof color to a light value on a dark hero.**
+
+The base `.hero__proof` rule now routes its color through `var(--hero-proof-color, var(--color-muted))`, the same `var(--slot, <literal>)` idiom the rest of the hero color slots use. Unset output is byte-identical to before — the proof line keeps rendering in `--color-muted` until an operator sets the slot — so nothing about the shipped pages changes on upgrade. The proof line has a single color declaration (no premium, inverted-theme, or media-query rule re-declares it), so the one base rule is the whole surface. The slot is enforced live by the existing style-slot contract test, which auto-discovers every schema slot and fails the build if one is not consumed by the CSS or is bypassed by a literal. No new prop, token, recipe, or action surface was added.
+
+### Fixed
+
+- The `hero.proof` line now honors a `--hero-proof-color` style slot (default `var(--color-muted)`). Set it per instance with `style_component` to give a dark hero a readable, light-colored proof line instead of the fixed dark-on-dark muted token. Byte-identical when unset (#296).
+
+### Docs
+
+- `AI_CONTEXT.md` and `README.md` style-slot totals updated from 152 to 153 (`hero` 36 → 37) to match the schemas (#296).
+
+### Tests
+
+- `StyleSlotContractTest` pins the `var(--hero-proof-color, var(--color-muted))` base-rule fallback for byte-identical unset output; `SchemaValidationTest` and `OperateTest` hero slot-count pins and the `css-lint` subset count bump from 36/111 to 37/112 in lockstep with the new slot (#296).
+
 ## [v0.16.104] — 2026-07-13 — the grid's featured first-card remnants (accent top bar, texture stripe, glow) are finally slot-controllable: uniform card rows are one recipe away (#293)
 
 **Every 3-up feature row used to render with an unremovable "first card is special" statement: after #226 and #292 fixed the border and background slots, the featured first card still painted a 4px accent top bar, a blue texture stripe, and an inset blue glow from hardcoded literals no slot could reach. A neutral, uniform card row — the most common marketing section there is — was impossible through supported mechanisms. This release puts all three remnants behind style slots and ships a `uniform-cards` recipe that neutralizes the treatment in one step.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.104-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.105-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-152 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+153 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.16.99.
 
 **What exists today (v0.16.99):**
-- 12 components with schema contracts and 152 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 153 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — known exceptions live in a shrink-only ledger (issue [#309](https://github.com/FJCF76/PromptingPress/issues/309)), backed by rendered computed-style checks
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -665,7 +665,10 @@
   align-items: center;
   margin-top: var(--space-md);
   font-size: 0.875rem;
-  color: var(--color-muted);
+  /* Route the proof color through a per-instance slot so a dark hero can lift it
+     off the dark background; unset resolves to --color-muted, byte-identical to
+     the prior hardcoded value (issue 296). */
+  color: var(--hero-proof-color, var(--color-muted));
 }
 
 /* ==========================================================================

--- a/components/hero/schema.json
+++ b/components/hero/schema.json
@@ -153,6 +153,7 @@
       "--hero-title-weight": { "type": "number", "default": "var(--font-weight-heading)", "description": "Title font weight" },
       "--hero-subtitle-size": { "type": "length", "default": "1.0625rem", "description": "Subtitle font size" },
       "--hero-subtitle-color": { "type": "color", "default": "var(--color-muted)", "description": "Subtitle text color" },
+      "--hero-proof-color": { "type": "color", "default": "var(--color-muted)", "description": "Proof line text color (trust signals below the CTA); route it to a light value on dark heroes so it is not dark-on-dark" },
       "--hero-content-gap": { "type": "length", "default": "var(--space-md)", "description": "Gap between content elements" },
       "--hero-content-width": { "type": "length", "default": "var(--measure-centered)", "description": "Max width of the content column" },
       "--hero-overlay-bg": { "type": "gradient", "default": "var(--overlay-bg)", "description": "Cover-layout overlay background color or gradient (e.g. a transparent-to-dark scrim for text legibility over an image)" },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.104');
+define('PP_VERSION', '0.16.105');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.104",
+  "version": "0.16.105",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.104
+Stable tag: 0.16.105
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.104
+Version:          0.16.105
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -1960,7 +1960,7 @@ class OperateTest extends TestCase
         $result = pp_inspect_composition($post_id);
         $this->assertCount(1, $result);
         $this->assertArrayHasKey('style_slots', $result[0]);
-        $this->assertCount(36, $result[0]['style_slots']); // hero has 36 slots (33 + 3 position/aspect-ratio, issue 108)
+        $this->assertCount(37, $result[0]['style_slots']); // hero has 37 slots (36 + --hero-proof-color, issue 296)
 
         // Verify slot structure.
         $first_slot = $result[0]['style_slots'][0];

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -228,7 +228,7 @@ class SchemaValidationTest extends TestCase
     public function testStyleSlotsExistForV1Components(): void
     {
         $expected = [
-            'hero'    => 36,
+            'hero'    => 37,
             'section' => 21,
             'grid'    => 28,
             'cta'     => 26,

--- a/tests/StyleSlotContractTest.php
+++ b/tests/StyleSlotContractTest.php
@@ -535,6 +535,29 @@ class StyleSlotContractTest extends TestCase
         );
     }
 
+    /**
+     * Hero proof-line color slot (issue 296): byte-identical-unset fallback pin.
+     *
+     * The base .hero__proof rule hardcoded `color: var(--color-muted)` with no
+     * per-instance slot, so every dark hero shipped a dark-on-dark proof line
+     * (same literal-token-defeats-theming family as #222/#248/#292). Routing it
+     * through --hero-proof-color lets a dark hero lift the proof color. The generic
+     * checks above already prove the slot is consumed and unbypassed; this pins the
+     * exact fallback literal so unset output stays byte-identical to the old value.
+     * The proof line has a single color declaration (no premium/inverted re-declare),
+     * so this one rule is the whole surface.
+     */
+    public function testIssue296HeroProofColorSlotFallback(): void
+    {
+        $block = $this->stripComments($this->componentBlock('hero'));
+        $this->assertStringContainsString(
+            'color: var(--hero-proof-color, var(--color-muted))',
+            $block,
+            'The .hero__proof base rule must route color through --hero-proof-color '
+            . 'with --color-muted as the fallback (issue 296, byte-identical unset).'
+        );
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     /**

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -121,8 +121,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('hero/section/grid/cta schemas declare 111 style slots (subset of the 152 total)', () => {
-        expect(allSlots.length).toBe(111);
+    test('hero/section/grid/cta schemas declare 112 style slots (subset of the 153 total)', () => {
+        expect(allSlots.length).toBe(112);
     });
 
     allSlots.forEach(({ component, slotName }) => {


### PR DESCRIPTION
Closes #296

## Scope

The hero component's proof line (`.hero__proof`, the trust signals below the CTA) hardcoded `color: var(--color-muted)` with no per-instance style slot, so any dark hero (`--hero-bg` set dark) rendered a dark-on-dark, low-contrast proof line that no supported action could fix while `validate page` / `check page` passed. Same "literal token defeats per-instance theming" family as #222/#248/#292.

**Fix (per the issue's Expected + the #305 slot-contract idiom):** add a `--hero-proof-color` style slot to `components/hero/schema.json` (type `color`, default `var(--color-muted)`, placed after `--hero-subtitle-color` for naming symmetry), and route the single base `.hero__proof` rule through `var(--hero-proof-color, var(--color-muted))`. Unset output is byte-identical — proof keeps rendering in `--color-muted` until an operator sets the slot.

The proof line has exactly one `color` declaration (verified: no premium, inverted-theme, or media-query rule re-declares it), so the one base rule is the whole surface — nothing else to route, and the #305 slot-contract guard auto-discovers the new slot with no waiver added (ledger stays 6/7).

### Acceptance criteria
- `--hero-proof-color` slot exists (default `var(--color-muted)`) — done
- `.hero__proof` participates in the slot's cascade, byte-identical when unset — done

### Files
- Code: `components/hero/schema.json`, `assets/css/components.css`
- Tests: `tests/StyleSlotContractTest.php` (new byte-identical fallback pin), `tests/SchemaValidationTest.php` (hero 36→37), `tests/OperateTest.php` (hero 37), `tests/js/css-lint.test.js` (subset 111→112)
- Docs: `AI_CONTEXT.md`, `README.md` (slot totals 152→153, hero 36→37)
- Version: `style.css`, `package.json`, `functions.php`, `readme.txt`, `README.md` badge, `CHANGELOG.md`

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — 1598 tests, 6014 assertions, 0 failures (3 warnings / 2 PHPUnit deprecations are pre-existing framework-level, unchanged vs base).
- `npm test` — 525 tests passing.
- `bash scripts/package.sh` — "Version consistency: OK" across all five version files; the built zip was deleted (releases are CI-built from tags).
- `/plan-eng-review` (clean, 0 issues) and `/review` (clean, 0 findings; Claude adversarial subagent independently verified byte-identical unset semantics, no competing `.hero__proof` color declaration, and count consistency) ran this session on this exact diff.

## Accepted limitations
- Default stays `var(--color-muted)` (not `--hero-text`) to preserve byte-identical unset output, per the issue's recorded Expected; a dark hero sets the slot explicitly.
- No new E2E computed-style pin: the proof line has no premium/desktop cascade override (unlike #302/#292), so there is no cross-block cascade to prove in-browser; the auto-discovery guard + fallback unit pin cover it.

## 7A questions
None — no review finding extended the recorded decision.
