### PR TITLE
v0.16.106 fix: section.body lists render markers + indent (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.106] — 2026-07-13 — a checklist written in a section body finally renders as a list: markers and indent are restored inside `.section__content` (#295)
+
+**Any `<ul>`/`<ol>` an author or the AI wrote into `section.body` rendered as bare, flush-left, unmarked lines — visually indistinguishable from a stack of one-line paragraphs. The global reset (`base.css` `*{padding:0}` plus `ul,ol{list-style:none}`) stripped both the marker and the indent, and no rule inside the section rich-text surface restored them. Every marketing page with a "why us" checklist hit this in the one long-form body surface the product offers. This release restores default list rendering (disc/decimal markers, indent, and item rhythm) scoped to `.section__content`, where the section body HTML actually renders.**
+
+The fix re-declares `list-style`, `padding-left`, and `margin` for `ul`/`ol`/`li` under `.section__content` — the inner wrapper that carries `wp_kses_post($body)` in `section.php`. The `.section__content ul` selector (specificity 0,1,1) outweighs the base `ul,ol` reset (0,0,1), so the markers come back without `!important`. Indent and rhythm route through the existing `--space-*` tokens (`--space-lg` indent, `--space-md` list margin, `--space-xs` item gap), matching the repo's spacing idiom. The rule is scoped to `.section__content`, which renders only the author rich-text body — no PP component nests there — so there is no blast radius to other components. No style slot governs list markers or padding here, so no slot routing and no waiver-ledger change; no new prop, token, grammar, or action surface was added, and the AI-facing docs describe no list-rendering behavior that this changes.
+
+### Fixed
+
+- Lists authored in `section.body` (`<ul>`/`<ol>`) now render with markers and indent inside `.section__content` instead of as bare flush-left lines. `ul` gets `disc`, `ol` gets `decimal`, with token-based indent and item spacing (#295).
+
+### Tests
+
+- `SectionBodyListTest` pins the restore: `.section__content ul`/`ol` marker declarations (`disc`/`decimal`), token-based `padding-left` indent and `li` rhythm, the `base.css` reset that is the cause, and that the section renderer places body HTML inside `.section__content`. The four fix-pinning assertions are red on the pre-fix tree (#295).
+
 ## [v0.16.105] — 2026-07-13 — the hero proof line can finally be lifted off a dark hero: it has its own color slot instead of a hardcoded muted token (#296)
 
 **A hero's proof line — the small trust signals rendered below the CTA — shipped in a hardcoded `var(--color-muted)` with no per-instance color slot. On any dark hero (`--hero-bg` set to a dark color or gradient) that produced a low-contrast, dark-on-dark line that no supported action could fix, while `validate page` and `check page` both passed. This is the same "a literal token defeats per-instance theming" family as #222/#248/#292. This release adds a `--hero-proof-color` style slot so an operator can set the proof color to a light value on a dark hero.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.105-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.106-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -742,6 +742,35 @@
   max-width: var(--section-body-width, 42rem);
 }
 
+/* Restore list markers + indent for lists authored in section.body rich text.
+   The global reset (base.css *{padding:0} + ul,ol{list-style:none}) strips both,
+   so any <ul>/<ol> in section.body rendered as flush-left, unmarked lines,
+   indistinguishable from stacked paragraphs. Re-declare markers, indent, and
+   rhythm scoped to .section__content (where wp_kses_post($body) lands) — the
+   .section__content ul selector (0,1,1) outweighs the base ul,ol reset (0,0,1).
+   No style slot governs list-style/padding here, so no slot routing. issue 295 */
+.section__content ul,
+.section__content ol {
+  padding-left: var(--space-lg);
+  margin: 0 0 var(--space-md);
+}
+
+.section__content ul {
+  list-style: disc;
+}
+
+.section__content ol {
+  list-style: decimal;
+}
+
+.section__content li {
+  margin-bottom: var(--space-xs);
+}
+
+.section__content li:last-child {
+  margin-bottom: 0;
+}
+
 /* Image variants: side-by-side grid at md+ */
 .section__grid {
   display: flex;

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.105');
+define('PP_VERSION', '0.16.106');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.105",
+  "version": "0.16.106",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.105
+Stable tag: 0.16.106
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.105
+Version:          0.16.106
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/SectionBodyListTest.php
+++ b/tests/SectionBodyListTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * tests/SectionBodyListTest.php
+ *
+ * Section body list rendering (issue 295): lists authored in section.body must
+ * render with markers + indent. The global reset (base.css *{padding:0} +
+ * ul,ol{list-style:none}) strips both, so components.css must re-declare marker,
+ * indent, and rhythm scoped to .section__content — the surface where the body
+ * HTML (wp_kses_post($body)) actually lands (section.php).
+ *
+ * These are CSS-content pins (same approach as TypographyRoleTest): PHPUnit does
+ * not execute CSS, so we assert the source declares the restore rules rather than
+ * a computed style. The rendered-cascade half is covered by the section renderer
+ * putting body HTML inside .section__content, asserted here too.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class SectionBodyListTest extends TestCase
+{
+    private string $themeRoot;
+    private string $componentsCss;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->themeRoot     = dirname(__DIR__);
+        $this->componentsCss = file_get_contents($this->themeRoot . '/assets/css/components.css');
+        $GLOBALS['_pp_test_store'] = [
+            'post_meta' => [], 'posts' => [], 'options' => [], 'next_id' => 100, 'custom_css' => '',
+        ];
+    }
+
+    private function render(string $component, array $props): string
+    {
+        ob_start();
+        pp_get_component($component, $props);
+        return ob_get_clean();
+    }
+
+    // ── The defect: base reset strips list rendering ──────────────────────
+
+    public function testBaseCssResetStripsListMarkers(): void
+    {
+        // Documents the cause: the global reset the fix must override.
+        $base = file_get_contents($this->themeRoot . '/assets/css/base.css');
+        $this->assertMatchesRegularExpression(
+            '/ul,\s*\n?\s*ol\s*\{\s*list-style:\s*none/',
+            $base,
+            'base.css reset (ul,ol{list-style:none}) is the cause issue 295 fixes; if it changes, revisit the section list restore.'
+        );
+    }
+
+    // ── The fix: markers restored, scoped to the rich-text surface ────────
+
+    public function testSectionContentRestoresUnorderedMarkers(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/\.section__content ul\b/',
+            $this->componentsCss,
+            'components.css must scope a list rule to .section__content ul.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/\.section__content ul\s*\{[^}]*list-style:\s*disc/s',
+            $this->componentsCss,
+            '.section__content ul must restore disc markers (issue 295).'
+        );
+    }
+
+    public function testSectionContentRestoresOrderedMarkers(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/\.section__content ol\s*\{[^}]*list-style:\s*decimal/s',
+            $this->componentsCss,
+            '.section__content ol must restore decimal markers (issue 295).'
+        );
+    }
+
+    public function testSectionContentRestoresIndentViaSpacingToken(): void
+    {
+        // Indent must come back (marker room) and use a spacing token, not a literal.
+        $this->assertMatchesRegularExpression(
+            '/\.section__content ul,\s*\n?\s*\.section__content ol\s*\{[^}]*padding-left:\s*var\(--space-/s',
+            $this->componentsCss,
+            '.section__content ul/ol must restore padding-left through a var(--space-*) token (issue 295).'
+        );
+    }
+
+    public function testSectionContentRestoresListItemRhythm(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/\.section__content li\s*\{[^}]*margin-bottom:\s*var\(--space-/s',
+            $this->componentsCss,
+            '.section__content li must carry token-based vertical rhythm (issue 295).'
+        );
+    }
+
+    // ── The anchor: body HTML actually renders inside .section__content ───
+
+    public function testSectionBodyRendersInsideSectionContent(): void
+    {
+        $html = $this->render('section', [
+            'layout' => 'text-only',
+            'title'  => 'Why us',
+            'body'   => '<ul><li>First</li><li>Second</li></ul>',
+        ]);
+        $this->assertStringContainsString('section__content', $html,
+            'section must wrap body HTML in .section__content so the issue 295 list rule applies.');
+        // The <ul> the fix targets must survive into the content surface.
+        $this->assertMatchesRegularExpression(
+            '/section__content[^>]*>.*<ul>.*<li>First<\/li>/s',
+            $html,
+            'authored <ul> in section.body must render inside .section__content.'
+        );
+    }
+}


### PR DESCRIPTION
Closes #295

## Scope

Lists authored in `section.body` (`<ul>`/`<ol>`) rendered as bare, flush-left, unmarked lines — indistinguishable from stacked paragraphs. The global reset (`base.css` `*{padding:0}` + `ul,ol{list-style:none}`) strips both marker and indent, and no rule inside the section rich-text surface restored them.

Per the issue's recorded direction (and its `size:S` / `status:ready` framing), this takes the first "Expected" option: **restore default list rendering inside the section body**, scoped to `.section__content` — the inner wrapper that carries `wp_kses_post($body)` in `section.php`. The checklist-affordance and doc-only alternatives were ruled out as surface-expanding / larger than `size:S`.

- `.section__content ul` → `list-style: disc`; `.section__content ol` → `list-style: decimal`
- `padding-left: var(--space-lg)` (indent), `margin: 0 0 var(--space-md)` (list rhythm), `li` `margin-bottom: var(--space-xs)` with `:last-child` reset
- Specificity `.section__content ul` (0,1,1) outweighs the base `ul,ol` reset (0,0,1) — no `!important`
- Scoped to `.section__content`, which renders only author rich-text (no PP component nests there) — no blast radius
- No style slot governs list-style/padding here → no `var(--slot, …)` routing, no waiver-ledger change (#305 guard unaffected)
- No new prop/token/grammar/action; AI-facing docs describe no list-rendering behavior this changes (`/document-generate`: no docs needed)

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → **1604 passed** (3 warnings, 2 deprecations — both pre-existing, confirmed identical on the stashed tree)
- JS: `npm test` → **525 passed**
- New `SectionBodyListTest` (6 tests): its 4 fix-pinning assertions are **red on the pre-fix tree** (verified via stash), green after
- `bash scripts/package.sh` → version consistency OK across all five files; emitted zip deleted

## Accepted limitations

- Nested lists inside `section.body` get default nesting (no extra top/bottom polish) — the issue's use case is flat checklists; nested-list spacing is out of scope.
- Physical `padding-left` (not `padding-inline-start`) matches the repo convention (zero logical/RTL CSS anywhere in the theme); RTL is out of scope for #295.

## gstack workflows

`/plan-eng-review` (approved, scoped), `/review` (clean; Codex adversarial findings verified against source and refuted or ruled out of scope), `/document-generate` (no docs needed). No 7A question was needed.