### PR TITLE
v0.16.107 feat: make cta.title optional (heading-less standalone button) (#294)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -115,7 +115,7 @@ site-customization permission.
 | faq       | components/faq/faq.php         | Native details/summary accordion. Zero JS. Auto-emits FAQPage JSON-LD. | items[] (req) {question, answer}, title, title_accent, eyebrow, theme, id |
 | grid      | components/grid/grid.php       | Responsive card grid for real content objects    | items[] (req) {number, title, text, text_role, bullets[], image_url, image_alt, link_url, link_text}, title, title_accent, eyebrow, subheading, heading_align, layout, theme, id |
 | table     | components/table/table.php     | Data/comparison table, horizontal scroll mobile  | headers[] (req), rows[][] (req), title, caption    |
-| cta       | components/cta/cta.php         | Call-to-action block. Layout + color + bg-image  | title (req), title_accent, eyebrow, button_text (req), button_url (req), button_variant, text, layout, theme, background_image, id |
+| cta       | components/cta/cta.php         | Call-to-action block. Layout + color + bg-image  | title, title_accent, eyebrow, button_text (req), button_url (req), button_variant, text, layout, theme, background_image, id |
 | stats     | components/stats/stats.php     | Horizontal row of large-number metrics + labels  | items[] (req) {number, label}, title, title_accent, theme, background_image, id |
 | logos     | components/logos/logos.php     | Flex-wrap image grid — logo strips or icon tiles | items[] (req) {image_url, image_alt, image_id?, label?}, title, theme, id |
 | embed     | components/embed/embed.php     | WP shortcode / plugin content wrapper            | content (req), title, theme, id                    |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.107] — 2026-07-13 — a call-to-action can finally be just a button: `cta.title` is now optional, so a heading-less standalone button is one component away (#294)
+
+**There was no sanctioned way to render a standalone button — a button not attached to a heading. `cta.title` was required, and links written into `section.body` render as plain text with no button treatment, so a common marketing pattern (a centered "closing" button after a steps or feature section) could not be matched. This release makes `cta.title` optional: omit it (and `text`) and the CTA renders just its button row, with no empty heading element in the DOM. `button_text` and `button_url` stay required, and `id`/anchors, `layout`, `theme`, and every style slot keep working unchanged.**
+
+The required-title rule was relaxed in the one shared validation engine (`pp_validate_composition`), driven by the component schema's `required` flag rather than a CTA special case, so there is no second validation path. The CTA template now emits the `.cta__text` wrapper only when an eyebrow, title, or body is present, so a title-less CTA produces no bare `<h2>` and no stray flex gap above the button. A CTA that supplies a title renders byte-identically to before. The change reuses the validated CTA surface and shared engines, so no new component or schema was added.
+
+### Added
+
+- `cta.title` is now optional. A CTA with only `button_text` and `button_url` renders a standalone button row (no heading element), the sanctioned heading-less button pattern for closing buttons after a steps or feature section. `id`/anchor and all CTA style slots still apply (#294).
+
+### Docs
+
+- `AI_CONTEXT.md`, `README.md`, and `ai-instructions/composition.md` now describe `cta.title` as optional and document the title-less CTA as the standalone-button pattern; the runtime AI catalog (`lib/ai-context.php`) reflects the change automatically from the schema (#294).
+
+### Tests
+
+- `ComponentPropsTest` pins the title-less render (button present, no `<h2>`, no `.cta__text` wrapper, `id` anchor preserved) and that an eyebrow-only or titled CTA still renders the wrapper; `SchemaValidationTest` pins that a title-less CTA passes `pp_validate_composition` while a CTA missing `button_text` or `button_url` is still rejected (#294).
+
 ## [v0.16.106] — 2026-07-13 — a checklist written in a section body finally renders as a list: markers and indent are restored inside `.section__content` (#295)
 
 **Any `<ul>`/`<ol>` an author or the AI wrote into `section.body` rendered as bare, flush-left, unmarked lines — visually indistinguishable from a stack of one-line paragraphs. The global reset (`base.css` `*{padding:0}` plus `ul,ol{list-style:none}`) stripped both the marker and the indent, and no rule inside the section rich-text surface restored them. Every marketing page with a "why us" checklist hit this in the one long-form body surface the product offers. This release restores default list rendering (disc/decimal markers, indent, and item rhythm) scoped to `.section__content`, where the section body HTML actually renders.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.106-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.107-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -135,7 +135,7 @@ No blocks. No shortcodes. No visual-builder serialization. AI can read, write, d
 | section | Text + optional image; 4 `layout`s (text-only, image-left, image-right, centered) + `theme` (default, dark, inverted) | `body` |
 | grid | Responsive card grid; `layout` (cards, steps) + `theme` (default, dark, inverted) | `items[]` |
 | faq | Native `details/summary` accordion, zero JavaScript | `items[]` |
-| cta | Call-to-action block with layout, color axis, and background image | `title`, `button_text`, `button_url` |
+| cta | Call-to-action block with layout, color axis, and background image; `title` optional (omit for a standalone button row) | `button_text`, `button_url` |
 | stats | Large-number metrics with labels and optional background image | `items[]` |
 | logos | Flex-wrap image strip for partner/client logos | `items[]` |
 | table | Data/comparison table, horizontal scroll on mobile | `headers[]`, `rows[][]` |

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -48,11 +48,19 @@ See `AI_CONTEXT.md` → Component index for the current list. As of last update:
 | faq     | items[] {question, answer}              | title, title_accent, eyebrow, theme, id                 |
 | grid    | items[] {title, text, ...}              | title, title_accent, eyebrow, subheading, heading_align, layout, theme |
 | table   | headers[], rows[][]                     | title, caption                                          |
-| cta     | title, button_text, button_url          | title_accent, eyebrow, text, layout, theme, background_image, button_variant |
+| cta     | button_text, button_url                 | title, title_accent, eyebrow, text, layout, theme, background_image, button_variant |
 | stats   | items[] {number, label}                 | title, title_accent, theme, background_image            |
 | logos   | items[] {image_url, image_alt, image_id?, label?} | title, theme                                  |
 | embed   | content                                 | title, theme                                            |
 | testimonials | items[] {quote}                    | title, title_accent, eyebrow, subheading, heading_align, layout, theme |
+
+### cta: standalone button (heading-less)
+
+`cta.title` is optional. Omit `title` (and `text`) to render just the button row with no heading element — the sanctioned way to place a standalone button, e.g. a centered "closing" button after a steps or feature section. `button_text` and `button_url` are still required, and `id`, `layout`, `theme`, and all style slots keep working.
+
+```json
+{ "component": "cta", "props": { "button_text": "Get started free →", "button_url": "/signup" } }
+```
 
 ### section.theme
 

--- a/assets/js/pp-editor-logic.js
+++ b/assets/js/pp-editor-logic.js
@@ -501,13 +501,14 @@ function formatDiffsForIssue(diffs, pageTitle, postId) {
  * row, e.g. `grid — Our WordPress Services`.
  *
  * Prefers a field literally named `title` when it has a value, regardless of
- * whether the component's schema marks it required — most components (grid,
- * faq, section, stats, table, logos, embed) declare `title` as optional
+ * whether the component's schema marks it required — most components (cta,
+ * grid, faq, section, stats, table, logos, embed) declare `title` as optional
  * ("omit if context makes it clear"), but it's still the best available
- * label whenever it's actually set (#76). Only `cta` and `hero` mark `title`
- * required, which is why hero already worked before this fix — falling back
- * to the first required string field (e.g. cta's/hero's own required title,
- * or a component with no title field at all) preserves that exact behavior.
+ * label whenever it's actually set (#76). Only `hero` marks `title` required
+ * (cta.title became optional in #294), which is why hero already worked before
+ * this fix — falling back to the first required string field (e.g. hero's own
+ * required title, or a title-less cta's required `button_text`) preserves that
+ * exact behavior.
  *
  * @param {{ fields: Array<{name: string, type: string, required: boolean, value: *}> }} compData
  * @returns {string}  Truncated preview text, or '' if nothing usable.

--- a/components/cta/cta.php
+++ b/components/cta/cta.php
@@ -59,6 +59,10 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
     <?php endif; ?>
     <div class="container">
         <div class="cta__inner">
+            <?php // Skip the text block entirely when there is no eyebrow/title/text: a
+                  // title-less CTA is the standalone-button pattern (issue 294), so it must
+                  // render just the button row — no empty heading and no stray flex gap. ?>
+            <?php if ($eyebrow || $title || $text) : ?>
             <div class="cta__text">
                 <?php if ($eyebrow) : ?>
                     <span class="cta__eyebrow"><?php echo esc_html($eyebrow); ?></span>
@@ -71,6 +75,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                     <p class="cta__body"><?php echo esc_html($text); ?></p>
                 <?php endif; ?>
             </div>
+            <?php endif; ?>
 
             <a href="<?php echo esc_url($button_url); ?>" class="cta__button btn<?php echo esc_attr($button_variant_class); ?>">
                 <?php echo esc_html($button_text); ?>

--- a/components/cta/schema.json
+++ b/components/cta/schema.json
@@ -1,6 +1,6 @@
 {
   "component": "cta",
-  "description": "Call-to-action block with title, optional supporting text, and a button. Two layouts: full-width (centered, bg surface) and inline (flex row).",
+  "description": "Call-to-action block with an optional title, optional supporting text, and a button. Two layouts: full-width (centered, bg surface) and inline (flex row). Omit title (and text) to render a standalone button row with no heading — the sanctioned heading-less button pattern.",
   "props": {
     "id": {
       "type": "string",
@@ -10,8 +10,9 @@
     },
     "title": {
       "type": "string",
-      "required": true,
-      "description": "CTA headline."
+      "required": false,
+      "default": "",
+      "description": "Optional CTA headline. Omit (along with text) to render a standalone button row with no heading element — the sanctioned heading-less button pattern (issue 294). id/anchor and all style slots still apply."
     },
     "title_accent": {
       "type": "string",

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.106');
+define('PP_VERSION', '0.16.107');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.106",
+  "version": "0.16.107",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.106
+Stable tag: 0.16.107
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.106
+Version:          0.16.107
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -319,6 +319,55 @@ class ComponentPropsTest extends TestCase
         $this->assertStringNotContainsString('btn--', $html);
     }
 
+    // ── Title-less CTA = standalone button row (issue 294) ─────────────────
+
+    public function testCtaTitlelessRendersNoHeading(): void
+    {
+        // A CTA with only button props renders the button, but no <h2> heading
+        // and no empty text wrapper (which would add a stray flex gap / break
+        // the inline space-between layout).
+        $html = $this->render('cta', ['button_text' => 'Empezar', 'button_url' => '/signup']);
+        $this->assertStringContainsString('class="cta__button btn"', $html);
+        $this->assertStringContainsString('Empezar', $html);
+        $this->assertStringNotContainsString('cta__title', $html);
+        $this->assertStringNotContainsString('<h2', $html);
+        $this->assertStringNotContainsString('cta__text', $html);
+    }
+
+    public function testCtaTitlelessKeepsAnchorId(): void
+    {
+        // id/anchor must keep working on a title-less CTA.
+        $html = $this->render('cta', [
+            'id'          => 'closing-cta',
+            'button_text' => 'Go',
+            'button_url'  => '/',
+        ]);
+        $this->assertStringContainsString('id="closing-cta"', $html);
+    }
+
+    public function testCtaWithTitleStillRendersHeading(): void
+    {
+        // Regression guard: supplying a title must still emit the heading and
+        // the text wrapper (unchanged behavior).
+        $html = $this->render('cta', $this->ctaProps());
+        $this->assertStringContainsString('cta__text', $html);
+        $this->assertStringContainsString('<h2 class="cta__title"', $html);
+    }
+
+    public function testCtaEyebrowOnlyStillRendersTextWrapper(): void
+    {
+        // The text wrapper appears whenever eyebrow OR title OR text is present,
+        // even without a title.
+        $html = $this->render('cta', [
+            'eyebrow'     => 'NEW',
+            'button_text' => 'Go',
+            'button_url'  => '/',
+        ]);
+        $this->assertStringContainsString('cta__text', $html);
+        $this->assertStringContainsString('cta__eyebrow', $html);
+        $this->assertStringNotContainsString('<h2', $html);
+    }
+
     // ── Hero CTA variants (props, set via update_component) — #93 ───────────
     // Extends the shared .btn--*/--btn-* primitive (established for CTA above)
     // to hero's two CTA buttons, which previously hardcoded bare .btn / .btn--outline

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -163,7 +163,7 @@ class SchemaValidationTest extends TestCase
         );
     }
 
-    // ── CTA schema requires title, button_text, button_url ────────────────
+    // ── CTA schema requires button_text, button_url; title is optional ────
 
     public function testCtaSchemaRequiredProps(): void
     {
@@ -172,12 +172,29 @@ class SchemaValidationTest extends TestCase
 
         $this->assertNotNull($schema);
 
-        foreach (['title', 'button_text', 'button_url'] as $required) {
+        foreach (['button_text', 'button_url'] as $required) {
             $this->assertTrue(
                 !empty($schema['props'][$required]['required']),
                 "CTA prop '{$required}' should be marked as required."
             );
         }
+    }
+
+    /**
+     * issue 294: cta.title is optional so a title-less CTA renders a standalone
+     * button row (the sanctioned heading-less button pattern). The required-props
+     * gate is schema-driven, so this flag is what relaxes validation.
+     */
+    public function testCtaSchemaTitleIsOptional(): void
+    {
+        $schemaFile = $this->themeRoot . '/components/cta/schema.json';
+        $schema     = json_decode(file_get_contents($schemaFile), true);
+
+        $this->assertNotNull($schema);
+        $this->assertFalse(
+            $schema['props']['title']['required'] ?? false,
+            "CTA 'title' prop should be optional (required = false or absent)."
+        );
     }
 
     // ── Consistent layout/theme naming (issue #69) ──────────────────────
@@ -440,6 +457,42 @@ class SchemaValidationTest extends TestCase
         ];
         $result = pp_validate_composition($composition);
         $this->assertTrue($result);
+    }
+
+    // ── Title-less CTA passes shared validation (issue 294) ───────────────
+
+    public function testTitlelessCtaPassesValidation(): void
+    {
+        // The shared engine's required-props gate is schema-driven, so relaxing
+        // cta.title in schema.json is what lets a title-less CTA validate.
+        $composition = [
+            ['component' => 'cta', 'props' => ['button_text' => 'Go', 'button_url' => '/']],
+        ];
+        $result = pp_validate_composition($composition);
+        $this->assertTrue($result, 'A title-less CTA with button props must validate.');
+    }
+
+    public function testCtaMissingButtonTextStillRejected(): void
+    {
+        // Relaxing title must NOT relax button_text — it is still required.
+        $composition = [
+            ['component' => 'cta', 'props' => ['button_url' => '/']],
+        ];
+        $result = pp_validate_composition($composition);
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('invalid_composition', $result->get_error_code());
+        $this->assertStringContainsString('button_text', $result->get_error_message());
+    }
+
+    public function testCtaMissingButtonUrlStillRejected(): void
+    {
+        $composition = [
+            ['component' => 'cta', 'props' => ['button_text' => 'Go']],
+        ];
+        $result = pp_validate_composition($composition);
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('invalid_composition', $result->get_error_code());
+        $this->assertStringContainsString('button_url', $result->get_error_message());
     }
 
     // ── Featured first-card remnant slots (issue 293) ────────────────────
@@ -907,17 +960,18 @@ class SchemaValidationTest extends TestCase
 
     public function testMultipleMissingRequiredPropsOnOneItemReportOneError(): void
     {
-        // Exercises the `continue 2` in the REQUIRED-PROP loop. `cta` requires title,
-        // button_text and button_url; all three are absent. Without `continue 2` this item
-        // would emit three errors, shifting every later index and breaking the invariant
-        // that errors[0] is the only error pp_validate_composition() would have returned.
+        // Exercises the `continue 2` in the REQUIRED-PROP loop. `cta` requires
+        // button_text and button_url (title is optional since issue 294); both are
+        // absent. Without `continue 2` this item would emit two errors, shifting every
+        // later index and breaking the invariant that errors[0] is the only error
+        // pp_validate_composition() would have returned.
         $errors = pp_validate_composition_errors([
             ['component' => 'cta', 'props' => []],
         ]);
 
         $this->assertCount(1, $errors, 'an item stops at its first failing prop check');
         $this->assertSame('invalid_composition', $errors[0]->get_error_code());
-        $this->assertStringContainsString('title', $errors[0]->get_error_message());
+        $this->assertStringContainsString('button_text', $errors[0]->get_error_message());
     }
 
     public function testMissingPropSkipsTheStyleChecksForThatItem(): void
@@ -929,7 +983,7 @@ class SchemaValidationTest extends TestCase
         ]);
 
         $this->assertCount(1, $errors);
-        $this->assertStringContainsString('title', $errors[0]->get_error_message());
+        $this->assertStringContainsString('button_text', $errors[0]->get_error_message());
     }
 
     public function testMultipleInvalidStyleSlotsOnOneItemReportOneError(): void


### PR DESCRIPTION
Closes #294

## Summary
Makes `cta.title` optional so a title-less CTA renders just its button row — the sanctioned heading-less standalone-button pattern (recorded decision: **Option A**). No new component or schema.

## Scope (against #294 acceptance criteria)
- **Title-less CTA renders only the button row, no empty heading** — `components/cta/cta.php` emits the `.cta__text` wrapper only when eyebrow/title/text is present; the `<h2>` was already guarded. A title-less CTA produces no bare `<h2>` and no stray flex gap above the button.
- **Relax the required-title rule in the shared engine only** — `components/cta/schema.json` sets `title.required: false` (+ `default: ""`). `pp_validate_composition_errors()` is schema-driven (reads `prop_def['required']`), so no CTA special case and no second validation path. `button_text`/`button_url` stay required.
- **`id`/anchor and style slots keep working** — unchanged; pinned by test.
- **AI docs updated in the same change** — `AI_CONTEXT.md`, `README.md`, `ai-instructions/composition.md` document the optional title + standalone-button pattern; runtime catalog (`lib/ai-context.php`) reflects it automatically from the schema.

## Validation
- PHPUnit: **1612 passed** (`./vendor/bin/phpunit --configuration phpunit.xml`)
- Vitest: **525 passed** (`npm test`)
- `bash scripts/package.sh`: version consistency OK across all five files (0.16.107); built zip deleted (CI builds releases from tags).
- New tests: `ComponentPropsTest` (title-less render: button present, no `<h2>`, no `.cta__text` wrapper, `id` anchor preserved; eyebrow-only/titled still render the wrapper) and `SchemaValidationTest` (title-less passes `pp_validate_composition`; missing `button_text`/`button_url` still rejected). Updated the two `continue 2` invariant tests that used a title-less CTA as a fixture (now hit `button_text` first).

## gstack workflows
- `/plan-eng-review` — clean, no unresolved decisions.
- `/review` + adversarial pass — one informational finding (stale JS docblock at `pp-editor-logic.js:507`) auto-fixed; no critical, no trust-boundary/XSS.
- `/document-generate` — doc surfaces consistent, no further changes needed.

## Accepted limitations
- Scoped strictly to Option A. The issue's alternative options (button-styled links inside `section.body`, a dedicated `button` component) are intentionally out of scope per the recorded decision.
- Pre-existing behavior retained: a literal `"0"` title is falsy in the wrapper guard (same as the prior `if ($title)` guard) — not introduced here, astronomically unlikely for a headline.

## Not performed
No tag, release, or deploy — those are the maintainer's separate steps.
