### PR TITLE
v0.16.110 feat: two-column text + content-panel section layout (#104)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -111,7 +111,7 @@ site-customization permission.
 | Component | File                           | Description                                      | Key props                                          |
 |-----------|--------------------------------|--------------------------------------------------|----------------------------------------------------|
 | hero      | components/hero/hero.php       | Full-width headline + optional CTA and image     | title (req), title_accent, eyebrow, subtitle, cta_text, cta_url, cta2_text, cta2_url, cta_variant, cta2_variant, layout, image_url, image_id, image_alt, spacing, width, split_ratio, vertical_align, proof, id |
-| section   | components/section/section.php | Text + optional image. 4 structural layouts      | body (req), title, title_accent, eyebrow, subheading, heading_align, image_url, image_id, image_alt, layout, theme, background_image, id |
+| section   | components/section/section.php | Text + optional image or content panel. 5 structural layouts | body (req), title, title_accent, eyebrow, subheading, heading_align, image_url, image_id, image_alt, layout, theme, background_image, panel_heading, panel_body, panel_items, panel_cta_text, panel_cta_url, panel_cta_variant, id |
 | faq       | components/faq/faq.php         | Native details/summary accordion. Zero JS. Auto-emits FAQPage JSON-LD. | items[] (req) {question, answer}, title, title_accent, eyebrow, theme, id |
 | grid      | components/grid/grid.php       | Responsive card grid for real content objects    | items[] (req) {number, title, text, text_role, bullets[], image_url, image_alt, link_url, link_text, style (per-card style overrides — card-scoped grid slots, set in composition not style_component)}, title, title_accent, eyebrow, subheading, heading_align, layout, theme, id |
 | table     | components/table/table.php     | Data/comparison table, horizontal scroll mobile  | headers[] (req), rows[][] (req), title, caption    |
@@ -136,7 +136,7 @@ renders the header or footer twice, and the write is rejected with the error cod
 
 **Two consistent axes — `layout` (structure) and `theme` (color/tone).** There is no `variant` prop anywhere; the name is retired. Structure is always `layout`, color/tone is always `theme`, and they never overload one key:
 
-- **`layout`** (structural, changes DOM/rendering) is used by the components that have more than one structure: `hero` (`left`, `centered`, `split`, `cover`), `section` (`text-only`, `image-left`, `image-right`, `centered`), `grid` (`cards`, `steps`), `cta` (`full-width`, `inline`), `testimonials` (`grid`, `stack`).
+- **`layout`** (structural, changes DOM/rendering) is used by the components that have more than one structure: `hero` (`left`, `centered`, `split`, `cover`), `section` (`text-only`, `image-left`, `image-right`, `centered`, `text-panel`), `grid` (`cards`, `steps`), `cta` (`full-width`, `inline`), `testimonials` (`grid`, `stack`).
 - **`theme`** (color/tone preset, `default` | `dark` | `inverted`) is used by the section-level components that carry a background tone: `section`, `stats`, `logos`, `embed`, `grid`, `cta`, `testimonials`, `faq`.
 - `hero` has no `theme` prop — its color comes entirely from style slots (`--hero-bg`, etc.).
 - Components with a single structure (`stats`, `logos`, `embed`) expose only `theme`, not `layout`.
@@ -376,7 +376,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**153 style slots** across 7 components: hero (37), grid (28), cta (26), section (21), testimonials (19), faq (13), stats (9).
+**159 style slots** across 7 components: hero (37), grid (28), section (27), cta (26), testimonials (19), faq (13), stats (9).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.110] — 2026-07-13 — a `section` can now put text beside a styleable content panel with its own heading, list, and CTA, so the asymmetric "text + supporting card" marketing layout is native (#104)
+
+**`section` could only do two columns as text + image (`layout: image-left`/`image-right`). The high-conversion pattern where a text column sits beside a contained panel — a card with its own sub-heading, checklist, and call-to-action button — had no native form, so multi-element sections collapsed into one stacked centered block, a visible drop in polish. This release adds `layout: "text-panel"`: the left column is the normal section (eyebrow/title/body), the right column is a server-validated content panel built entirely from props — no nested components, so the "components never nest components" rule holds.**
+
+The panel is described with flat props (`panel_heading`, `panel_body`, `panel_items[]`, `panel_cta_text`/`panel_cta_url`, `panel_cta_variant`), validated by the same shared engine as every other component (unknown keys rejected by the prop-key gate, the CTA URL escaped through `esc_url`, list items escaped and non-string entries dropped). The panel renders only when it has real content (a heading, a body, list items, or a complete CTA); otherwise the section degrades to `text-only` so authored content is never silently lost. Six new `--section-panel-*` style slots (background, border color, border width, radius, padding, text color) make the panel styleable per instance — set a dark background and light text for the dark-panel-beside-light-text pattern. The columns sit side by side at 768px and up and stack text-then-panel on mobile. The panel uses its own CSS classes so the desktop premium-typography cascade cannot override its text on a dark panel. The panel CTA reuses the shared button primitive and its `panel_cta_variant` (primary/secondary/outline/ghost); it deliberately does not add its own button-color slots, so the site's primary-button color stays the single source of truth.
+
+### Added
+
+- `section` gains `layout: "text-panel"` — a two-column layout with a styleable content panel on the right, built from props (`panel_heading`, `panel_body`, `panel_items[]`, `panel_cta_text`, `panel_cta_url`, `panel_cta_variant`) with no nested components. Six `--section-panel-*` style slots (bg, border-color, border-width, radius, padding, text) style the panel per instance; the panel falls back to `text-only` when it has no content, stacks text-then-panel on mobile, and keeps its text controllable on a dark panel (#104).
+
+### Docs
+
+- `AI_CONTEXT.md` (section now lists five structural layouts and the panel props; the style-slot total tracks the six new slots), `README.md`, and `ai-instructions/composition.md` (new `text-panel` section with the panel-props table and a worked example) document the layout, its props, and the panel style slots (#104).
+
+### Tests
+
+- `SectionTextPanelTest` pins the render of both columns, the panel list (with non-string/empty entries skipped), the CTA rendering only when both label and URL are set, variant class selection and invalid-variant fallback, URL escaping, heading/body/item escaping, the fallback to `text-only` for heading-only / items-only / CTA-only / body-only / empty panels, non-array `panel_items` coercion, the six panel style slots validating through the shared engine, an unknown panel prop still being rejected, and the CSS contract (every panel slot consumed with a fallback, list markers restored, columns top-aligned at desktop); `SchemaValidationTest` and the CSS-lint slot counts track the new slots (#104).
+
 ## [v0.16.109] — 2026-07-13 — per-card grid `style` now rejects the section-scoped slots that silently did nothing on a card, so an override either renders or fails loudly (#323)
 
 **Per-card style (`props.items[].style`, shipped in v0.16.108) accepted every grid style slot, but only the slots consumed on the card itself actually render there. Setting a container or heading slot on one card — `--grid-gap`, `--grid-bg`, `--grid-heading-color`, `--grid-padding-*` — validated, persisted, reported success, and changed nothing, because those slots are read on the section, list, and header, not the card. That is the reported-success-without-effect trap the product works to eliminate. This release restricts `items[].style` to the card-scoped slots and rejects the rest with the existing `invalid_style_slot` error, which now names the card and points you at the grid-level `style` where those slots belong.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.109-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.110-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-153 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+159 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.16.99.
 
 **What exists today (v0.16.99):**
-- 12 components with schema contracts and 153 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 159 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — known exceptions live in a shrink-only ledger (issue [#309](https://github.com/FJCF76/PromptingPress/issues/309)), backed by rendered computed-style checks
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -86,8 +86,42 @@ Example — alternating section rhythm:
 | `centered`    | Short-form text (taglines, intros) with center-aligned text. |
 | `image-left`  | Narrative + supporting image, image on the left.             |
 | `image-right` | Narrative + supporting image, image on the right.            |
+| `text-panel`  | Text column beside a styleable content panel (heading + list + CTA) on the right. |
 
 `text-only` fills the container width — titles and headings match adjacent components (grid, table, CTA). Prose text is constrained for readable line length. `centered` constrains the body block to a narrower column with center-aligned text — use for short intros and taglines, not for multi-paragraph marketing content.
+
+#### section.layout: "text-panel"
+
+An asymmetric two-column layout: the left column is the normal section (eyebrow/title/subheading + `body`), the right column is a self-contained, styleable **content panel** built from props (no nested components). Use it for "text + supporting card/CTA" marketing sections, e.g. a checklist beside a dark panel with its own heading, bullet list, and call-to-action button. Columns sit side by side at ≥768px and stack text-then-panel on mobile.
+
+Panel props (all optional; ignored by other layouts):
+
+| Prop | Renders |
+|------|---------|
+| `panel_heading` | Panel heading (`<h3>`). |
+| `panel_body` | Optional plain-text intro paragraph above the list (text only, no HTML). |
+| `panel_items` | Array of plain-text strings rendered as a bulleted list. |
+| `panel_cta_text` + `panel_cta_url` | The panel's CTA button. Both are required for the button to render. |
+| `panel_cta_variant` | Button style: `primary` (default) / `secondary` / `outline` / `ghost`. |
+
+The panel falls back to a plain `text-only` section when it has no content (no heading, no body, no list items, and no complete CTA). Style the panel per-instance with the `--section-panel-*` slots (`-bg`, `-border-color`, `-border-width`, `-radius`, `-padding`, `-text`) via `style_component` — set `--section-panel-bg` to a dark color and `--section-panel-text` to a light color for a dark panel. The panel CTA color follows the standard button (site accent); pick `panel_cta_variant` to change its style.
+
+```json
+{
+  "component": "section",
+  "props": {
+    "eyebrow": "Honest tool",
+    "title": "No fine print",
+    "body": "<ul><li>Transparent pricing</li><li>Cancel anytime</li></ul>",
+    "layout": "text-panel",
+    "panel_heading": "Who is it for?",
+    "panel_items": ["Freelancers", "Small agencies", "In-house teams"],
+    "panel_cta_text": "Get started",
+    "panel_cta_url": "/signup"
+  },
+  "style": { "--section-panel-bg": "#0f172a", "--section-panel-text": "#f8fafc" }
+}
+```
 
 ### grid.layout: "steps"
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -796,6 +796,62 @@
   border-radius: var(--section-image-radius, var(--radius));
 }
 
+/* text-panel layout: text column + styleable content panel (issue 104).
+   Reuses .section__grid (two columns at >=768px, stacked text-then-panel on
+   mobile) but top-aligns the columns instead of centering like the image
+   variants. The panel box and text route through --section-panel-* slots. The
+   panel deliberately uses its own classes (not .section__content/.section__title)
+   so the desktop premium-typography cascade cannot clobber the panel text on a
+   dark panel — --section-panel-text stays the authority. */
+@media (min-width: 768px) {
+  .section--text-panel .section__grid {
+    align-items: start;
+  }
+}
+
+.section__panel {
+  padding: var(--section-panel-padding, var(--space-lg));
+  background: var(--section-panel-bg, var(--color-surface));
+  color: var(--section-panel-text, var(--color-text));
+  border: var(--section-panel-border-width, 0) solid var(--section-panel-border-color, transparent);
+  border-radius: var(--section-panel-radius, var(--radius));
+}
+
+.section__panel-heading {
+  color: var(--section-panel-text, var(--color-text));
+  margin-bottom: var(--space-md);
+}
+
+.section__panel-body {
+  margin-top: 0;
+  margin-bottom: var(--space-md);
+}
+
+/* Restore list markers + indent stripped by the base reset (base.css
+   ul,ol{list-style:none} + *{padding:0}), same approach as .section__content
+   (issue 295). No style slot governs list-style/padding here. issue 104 */
+.section__panel-list {
+  list-style: disc;
+  padding-left: var(--space-lg);
+  margin: 0 0 var(--space-md);
+}
+
+.section__panel-list li {
+  margin-bottom: var(--space-xs);
+}
+
+.section__panel-list li:last-child {
+  margin-bottom: 0;
+}
+
+/* Panel CTA spacing. Color/variant come from the shared .btn primitive and the
+   panel_cta_variant prop (primary/secondary/outline/ghost); the panel does not
+   introduce its own button-color slots, so the premium main .btn cascade stays
+   the single source of primary-button color. issue 104 */
+.section__panel-cta {
+  margin-top: var(--space-sm);
+}
+
 /* Section background variants */
 .pp-section--dark {
   background-color: var(--color-surface);

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -1,6 +1,6 @@
 {
   "component": "section",
-  "description": "Generic text section with an optional image. Supports four structural layouts: text-only, image-left, image-right, centered.",
+  "description": "Generic text section with an optional image or content panel. Supports five structural layouts: text-only, image-left, image-right, centered, text-panel.",
   "props": {
     "id": {
       "type": "string",
@@ -64,10 +64,10 @@
     },
     "layout": {
       "type": "enum",
-      "values": ["text-only", "image-left", "image-right", "centered"],
+      "values": ["text-only", "image-left", "image-right", "centered", "text-panel"],
       "required": false,
       "default": "text-only",
-      "description": "Column layout. 'centered' centers text with no image (image_url suppressed). Falls back to text-only if image_url is empty for image layouts."
+      "description": "Column layout. 'centered' centers text with no image (image_url suppressed). 'text-panel' places the text column beside a styleable content panel (panel_heading/panel_body/panel_items + panel CTA) on the right at >=768px, stacked text-then-panel on mobile. Falls back to text-only if image_url is empty for image layouts, or if a text-panel layout has no panel content."
     },
     "theme": {
       "type": "enum",
@@ -81,11 +81,48 @@
       "required": false,
       "default": "",
       "description": "Optional background image URL. When set, renders as a CSS background-image with a dark overlay for text readability. Combines with any theme. Text automatically uses light colors for contrast."
+    },
+    "panel_heading": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "text-panel layout only: heading of the right-hand content panel (rendered as an <h3>). Ignored by other layouts."
+    },
+    "panel_body": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "text-panel layout only: optional plain-text intro paragraph inside the panel, above the list. Escaped as text (no HTML). Distinct from panel_items, which renders as a bulleted list."
+    },
+    "panel_items": {
+      "type": "array",
+      "required": false,
+      "default": [],
+      "description": "text-panel layout only: array of plain-text strings rendered as a bulleted list inside the panel. Non-string or empty entries are skipped."
+    },
+    "panel_cta_text": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "text-panel layout only: label of the panel's call-to-action button. The button renders only when both panel_cta_text and panel_cta_url are set."
+    },
+    "panel_cta_url": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "text-panel layout only: destination URL of the panel's call-to-action button (passed through esc_url). The button renders only when both panel_cta_text and panel_cta_url are set."
+    },
+    "panel_cta_variant": {
+      "type": "enum",
+      "values": ["primary", "secondary", "outline", "ghost"],
+      "required": false,
+      "default": "primary",
+      "description": "text-panel layout only: style of the panel CTA button (shares the .btn variants). 'primary' = filled accent, 'secondary' = muted surface fill, 'outline' = accent border, 'ghost' = borderless. On a dark panel, 'primary' (accent fill with light label) and 'outline' both read well."
     }
   },
   "styling": {
     "root_class": "section",
-    "variant_classes": ["section--text-only", "section--image-left", "section--image-right", "section--centered", "pp-section--dark", "pp-section--inverted"],
+    "variant_classes": ["section--text-only", "section--image-left", "section--image-right", "section--centered", "section--text-panel", "pp-section--dark", "pp-section--inverted"],
     "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted", "--overlay-bg"],
     "style_slots": {
       "--section-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the section" },
@@ -108,7 +145,13 @@
       "--section-image-aspect-ratio": { "type": "ratio", "default": "auto", "description": "image-left/image-right image aspect ratio (e.g. '16/9', '1'). Default 'auto' preserves the image's natural proportions" },
       "--section-bg-position": { "type": "position", "default": "center", "description": "background_image focal point" },
       "--section-overlay-bg": { "type": "gradient", "default": "var(--overlay-bg)", "description": "Background image overlay color or gradient (e.g. a transparent-to-dark scrim for text legibility over an image)" },
-      "--section-shadow": { "type": "shadow", "default": "none", "description": "Box shadow of the section (preset var(--shadow-sm|md|lg) or a bounded box-shadow)" }
+      "--section-shadow": { "type": "shadow", "default": "none", "description": "Box shadow of the section (preset var(--shadow-sm|md|lg) or a bounded box-shadow)" },
+      "--section-panel-bg": { "type": "gradient", "default": "var(--color-surface)", "description": "text-panel layout: background color or gradient of the right-hand content panel" },
+      "--section-panel-border-color": { "type": "color", "default": "transparent", "description": "text-panel layout: border color of the content panel" },
+      "--section-panel-border-width": { "type": "length", "default": "0", "description": "text-panel layout: border width of the content panel" },
+      "--section-panel-radius": { "type": "length", "default": "var(--radius)", "description": "text-panel layout: corner radius of the content panel" },
+      "--section-panel-padding": { "type": "length", "default": "var(--space-lg)", "description": "text-panel layout: inner padding of the content panel" },
+      "--section-panel-text": { "type": "color", "default": "var(--color-text)", "description": "text-panel layout: text color inside the content panel (heading, body, and list) — set a light value for a dark panel" }
     },
     "recipes": {
       "accent-panel": {

--- a/components/section/section.php
+++ b/components/section/section.php
@@ -22,14 +22,51 @@ $layout           = $props['layout']           ?? 'text-only';
 $theme            = $props['theme']            ?? 'default';
 $background_image = $props['background_image'] ?? '';
 
-$allowed_layouts = ['text-only', 'image-left', 'image-right', 'centered'];
+// text-panel layout: right-hand content panel props (see schema.json).
+$panel_heading      = $props['panel_heading']      ?? '';
+$panel_body         = $props['panel_body']         ?? '';
+$panel_items        = is_array($props['panel_items'] ?? null) ? $props['panel_items'] : [];
+$panel_cta_text     = $props['panel_cta_text']     ?? '';
+$panel_cta_url      = $props['panel_cta_url']      ?? '';
+$panel_cta_variant  = $props['panel_cta_variant']  ?? 'primary';
+
+// Only string, non-empty list entries render (mirrors grid bullets).
+$panel_items = array_values(array_filter(
+    $panel_items,
+    static fn ($item) => is_string($item) && $item !== ''
+));
+
+$allowed_panel_cta_variants = ['primary', 'secondary', 'outline', 'ghost'];
+if (!in_array($panel_cta_variant, $allowed_panel_cta_variants, true)) {
+    $panel_cta_variant = 'primary';
+}
+// primary is the bare .btn; other variants add a .btn--{variant} modifier.
+$panel_cta_variant_class = $panel_cta_variant !== 'primary' ? ' btn--' . $panel_cta_variant : '';
+
+// The panel CTA needs BOTH a label and a URL to render.
+$has_panel_cta = $panel_cta_text !== '' && $panel_cta_url !== '';
+
+// The panel column renders only when it has some content; otherwise text-panel
+// degrades to a plain text section (mirrors the image-layout fallback below).
+// panel_body counts so a body-only panel never silently drops authored content.
+$has_panel = $panel_heading !== ''
+    || $panel_body !== ''
+    || !empty($panel_items)
+    || $has_panel_cta;
+
+$allowed_layouts = ['text-only', 'image-left', 'image-right', 'centered', 'text-panel'];
 if (!in_array($layout, $allowed_layouts, true)) {
     $layout = 'text-only';
 }
 
 // Centered layout suppresses image regardless.
+// text-panel falls back to text-only when the panel has no content.
 // For image layouts, fall back to text-only if no image URL.
-if ($layout !== 'centered' && !$image_url) {
+if ($layout === 'text-panel') {
+    if (!$has_panel) {
+        $layout = 'text-only';
+    }
+} elseif ($layout !== 'centered' && !$image_url) {
     $layout = 'text-only';
 }
 
@@ -84,6 +121,50 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                 <?php endif; ?>
                 <div class="section__content">
                     <?php echo wp_kses_post($body); ?>
+                </div>
+            </div>
+
+        <?php elseif ($layout === 'text-panel') : ?>
+
+            <div class="section__grid">
+                <div class="section__body">
+                    <?php if ($title || $eyebrow || $subheading) : ?>
+                        <div class="section__header<?php echo esc_attr($header_align_class); ?>">
+                            <?php if ($eyebrow) : ?>
+                                <span class="section__eyebrow"><?php echo esc_html($eyebrow); ?></span>
+                            <?php endif; ?>
+                            <?php if ($title) : ?>
+                                <h2 class="section__title"><?php echo pp_render_heading_with_accent($title, $title_accent, 'section__title-accent'); ?></h2>
+                            <?php endif; ?>
+                            <?php if ($subheading) : ?>
+                                <p class="section__subheading"><?php echo esc_html($subheading); ?></p>
+                            <?php endif; ?>
+                        </div>
+                    <?php endif; ?>
+                    <div class="section__content">
+                        <?php echo wp_kses_post($body); ?>
+                    </div>
+                </div>
+
+                <div class="section__panel">
+                    <?php if ($panel_heading) : ?>
+                        <h3 class="section__panel-heading"><?php echo esc_html($panel_heading); ?></h3>
+                    <?php endif; ?>
+                    <?php if ($panel_body) : ?>
+                        <p class="section__panel-body"><?php echo esc_html($panel_body); ?></p>
+                    <?php endif; ?>
+                    <?php if (!empty($panel_items)) : ?>
+                        <ul class="section__panel-list">
+                            <?php foreach ($panel_items as $panel_item) : ?>
+                                <li class="section__panel-item"><?php echo esc_html($panel_item); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+                    <?php if ($has_panel_cta) : ?>
+                        <a href="<?php echo esc_url($panel_cta_url); ?>" class="section__panel-cta btn<?php echo esc_attr($panel_cta_variant_class); ?>">
+                            <?php echo esc_html($panel_cta_text); ?>
+                        </a>
+                    <?php endif; ?>
                 </div>
             </div>
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.109');
+define('PP_VERSION', '0.16.110');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.109",
+  "version": "0.16.110",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.109
+Stable tag: 0.16.110
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.109
+Version:          0.16.110
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -246,7 +246,7 @@ class SchemaValidationTest extends TestCase
     {
         $expected = [
             'hero'    => 37,
-            'section' => 21,
+            'section' => 27,
             'grid'    => 28,
             'cta'     => 26,
         ];

--- a/tests/SectionTextPanelTest.php
+++ b/tests/SectionTextPanelTest.php
@@ -1,0 +1,354 @@
+<?php
+/**
+ * tests/SectionTextPanelTest.php
+ *
+ * Section text-panel layout (issue 104): a two-column "text + content panel"
+ * layout where the right column is a server-validated panel built from PROPS
+ * (panel_heading / panel_body / panel_items / panel CTA) — NOT nested
+ * components, so the "components never nest components" invariant holds. The
+ * panel is styleable per-instance through the --section-panel-* style slots.
+ *
+ * Three layers are pinned here:
+ *   1. Render — the panel column, list, and CTA render (and degrade) correctly,
+ *      and the left column keeps the normal section header/content markup.
+ *   2. Validation — the new flat props and the new style slots pass the SHARED
+ *      engine (pp_validate_composition), and an unknown panel-ish prop is still
+ *      rejected by the #147 prop-key gate.
+ *   3. CSS contract — the panel box + text route through the slots, the list
+ *      markers are restored (base reset strips them), the panel CTA color routes
+ *      through the documented per-component --btn-* idiom, and the two columns
+ *      top-align at >=768px. (The generic "every slot is consumed / unbypassed"
+ *      proof is owned by StyleSlotContractTest #305; these are the value-level
+ *      and structure pins that file does not assert.)
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class SectionTextPanelTest extends TestCase
+{
+    private string $themeRoot;
+    private string $componentsCss;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->themeRoot     = dirname(__DIR__);
+        $this->componentsCss = file_get_contents($this->themeRoot . '/assets/css/components.css');
+        $GLOBALS['_pp_test_store'] = [
+            'post_meta' => [], 'posts' => [], 'options' => [], 'next_id' => 100, 'custom_css' => '',
+        ];
+    }
+
+    private function render(array $props): string
+    {
+        ob_start();
+        pp_get_component('section', $props);
+        return ob_get_clean();
+    }
+
+    private function fullPanelProps(array $overrides = []): array
+    {
+        return array_merge([
+            'layout'          => 'text-panel',
+            'eyebrow'         => 'Honest',
+            'title'           => 'No fine print',
+            'body'            => '<p>Left column copy.</p>',
+            'panel_heading'   => 'Who is it for?',
+            'panel_body'      => 'Teams of every size.',
+            'panel_items'     => ['Freelancers', 'Small agencies'],
+            'panel_cta_text'  => 'Get started',
+            'panel_cta_url'   => '/signup',
+        ], $overrides);
+    }
+
+    // ── 1. Render ─────────────────────────────────────────────────────────
+
+    public function testTextPanelRendersBothColumns(): void
+    {
+        $html = $this->render($this->fullPanelProps());
+
+        $this->assertStringContainsString('section--text-panel', $html, 'root carries the layout class.');
+        $this->assertStringContainsString('section__grid', $html, 'two columns share the section grid.');
+        // Left column: normal section header + content.
+        $this->assertStringContainsString('section__body', $html);
+        $this->assertMatchesRegularExpression('/section__content[^>]*>\s*<p>Left column copy\.<\/p>/s', $html);
+        // Right column: the panel.
+        $this->assertStringContainsString('class="section__panel"', $html);
+        $this->assertStringContainsString('<h3 class="section__panel-heading">Who is it for?</h3>', $html);
+        $this->assertStringContainsString('Teams of every size.', $html);
+    }
+
+    public function testPanelListRendersEachItem(): void
+    {
+        $html = $this->render($this->fullPanelProps());
+        $this->assertStringContainsString('<ul class="section__panel-list">', $html);
+        $this->assertStringContainsString('<li class="section__panel-item">Freelancers</li>', $html);
+        $this->assertStringContainsString('<li class="section__panel-item">Small agencies</li>', $html);
+    }
+
+    public function testPanelListSkipsNonStringAndEmptyEntries(): void
+    {
+        $html = $this->render($this->fullPanelProps([
+            'panel_items' => ['Keep', '', ['nested'], 42, 'Also keep'],
+        ]));
+        $this->assertSame(2, substr_count($html, 'section__panel-item'), 'only non-empty string items render.');
+        $this->assertStringContainsString('>Keep</li>', $html);
+        $this->assertStringContainsString('>Also keep</li>', $html);
+    }
+
+    public function testPanelCtaRendersWithTextAndUrl(): void
+    {
+        $html = $this->render($this->fullPanelProps());
+        $this->assertMatchesRegularExpression(
+            '/<a href="\/signup" class="section__panel-cta btn">\s*Get started\s*<\/a>/s',
+            $html
+        );
+    }
+
+    public function testPanelCtaSuppressedWithoutUrl(): void
+    {
+        $html = $this->render($this->fullPanelProps(['panel_cta_url' => '']));
+        $this->assertStringNotContainsString('section__panel-cta', $html, 'CTA needs both a label and a URL.');
+    }
+
+    public function testPanelCtaSuppressedWithoutText(): void
+    {
+        $html = $this->render($this->fullPanelProps(['panel_cta_text' => '']));
+        $this->assertStringNotContainsString('section__panel-cta', $html);
+    }
+
+    public function testPanelCtaVariantAddsModifier(): void
+    {
+        $html = $this->render($this->fullPanelProps(['panel_cta_variant' => 'outline']));
+        $this->assertStringContainsString('class="section__panel-cta btn btn--outline"', $html);
+    }
+
+    public function testPanelCtaInvalidVariantFallsBackToPrimary(): void
+    {
+        $html = $this->render($this->fullPanelProps(['panel_cta_variant' => 'rainbow']));
+        // primary is the bare .btn — no btn-- modifier.
+        $this->assertStringContainsString('class="section__panel-cta btn"', $html);
+        $this->assertStringNotContainsString('btn--rainbow', $html);
+    }
+
+    public function testPanelCtaUrlIsEscaped(): void
+    {
+        // The CTA href routes through esc_url — a URL with an illegal space is
+        // sanitized rather than emitted verbatim.
+        $html = $this->render($this->fullPanelProps([
+            'panel_cta_url' => 'https://example.com/a b',
+        ]));
+        $this->assertStringContainsString('href="https://example.com/ab"', $html);
+        $this->assertStringNotContainsString('example.com/a b', $html);
+    }
+
+    public function testPanelHeadingAndBodyAreEscaped(): void
+    {
+        $html = $this->render($this->fullPanelProps([
+            'panel_heading' => 'A & B <x>',
+            'panel_body'    => 'C & D <y>',
+            'panel_items'   => ['E & F <z>'],
+        ]));
+        $this->assertStringNotContainsString('<x>', $html);
+        $this->assertStringNotContainsString('<y>', $html);
+        $this->assertStringNotContainsString('<z>', $html);
+        $this->assertStringContainsString('A &amp; B', $html);
+    }
+
+    // ── Fallback: no panel content degrades to text-only ──────────────────
+
+    public function testTextPanelWithoutContentFallsBackToTextOnly(): void
+    {
+        $html = $this->render([
+            'layout' => 'text-panel',
+            'title'  => 'Just text',
+            'body'   => '<p>Nothing on the right.</p>',
+        ]);
+        $this->assertStringContainsString('section--text-only', $html, 'empty panel degrades to text-only.');
+        $this->assertStringNotContainsString('section--text-panel', $html);
+        $this->assertStringNotContainsString('section__panel', $html);
+    }
+
+    public function testTextPanelWithOnlyHeadingStillRendersPanel(): void
+    {
+        $html = $this->render([
+            'layout'        => 'text-panel',
+            'title'         => 'Has a panel',
+            'body'          => '<p>Body.</p>',
+            'panel_heading' => 'Solo heading',
+        ]);
+        $this->assertStringContainsString('section--text-panel', $html);
+        $this->assertStringContainsString('class="section__panel"', $html);
+    }
+
+    public function testTextPanelWithOnlyItemsStillRendersPanel(): void
+    {
+        $html = $this->render([
+            'layout'      => 'text-panel',
+            'title'       => 'Has a panel',
+            'body'        => '<p>Body.</p>',
+            'panel_items' => ['Only a list'],
+        ]);
+        $this->assertStringContainsString('section--text-panel', $html);
+        $this->assertStringContainsString('<li class="section__panel-item">Only a list</li>', $html);
+    }
+
+    public function testTextPanelWithOnlyCtaStillRendersPanel(): void
+    {
+        $html = $this->render([
+            'layout'         => 'text-panel',
+            'title'          => 'Has a panel',
+            'body'           => '<p>Body.</p>',
+            'panel_cta_text' => 'Only a button',
+            'panel_cta_url'  => '/go',
+        ]);
+        $this->assertStringContainsString('section--text-panel', $html);
+        $this->assertStringContainsString('section__panel-cta', $html);
+    }
+
+    public function testTextPanelWithOnlyBodyRendersPanelNotDropped(): void
+    {
+        // panel_body counts toward $has_panel, so a body-only panel is never
+        // silently dropped to text-only (authored content preservation).
+        $html = $this->render([
+            'layout'     => 'text-panel',
+            'title'      => 'Has a panel',
+            'body'       => '<p>Left.</p>',
+            'panel_body' => 'A supporting note.',
+        ]);
+        $this->assertStringContainsString('section--text-panel', $html);
+        $this->assertStringContainsString('<p class="section__panel-body">A supporting note.</p>', $html);
+    }
+
+    public function testNonArrayPanelItemsCoerceToEmptyWithoutWarning(): void
+    {
+        // A non-array panel_items (e.g. a string) must coerce to no list and not
+        // emit a PHP warning — with a heading present so the panel still renders.
+        $html = $this->render([
+            'layout'        => 'text-panel',
+            'title'         => 'Has a panel',
+            'body'          => '<p>Left.</p>',
+            'panel_heading' => 'H',
+            'panel_items'   => 'oops-not-an-array',
+        ]);
+        $this->assertStringContainsString('class="section__panel"', $html);
+        $this->assertStringNotContainsString('section__panel-item', $html);
+        $this->assertStringNotContainsString('section__panel-list', $html);
+    }
+
+    // ── Style slots reach the rendered root ───────────────────────────────
+
+    public function testPanelStyleSlotsRenderInlineOnRoot(): void
+    {
+        $html = $this->render($this->fullPanelProps([
+            '__pp_style' => [
+                '--section-panel-bg'   => '#0f172a',
+                '--section-panel-text' => '#f8fafc',
+            ],
+        ]));
+        $this->assertStringContainsString('--section-panel-bg: #0f172a', $html);
+        $this->assertStringContainsString('--section-panel-text: #f8fafc', $html);
+    }
+
+    // ── 2. Validation (shared engine) ─────────────────────────────────────
+
+    public function testTextPanelPropsPassSharedValidation(): void
+    {
+        $composition = [[
+            'component' => 'section',
+            'props'     => $this->fullPanelProps(['panel_cta_variant' => 'ghost']),
+        ]];
+        $this->assertTrue(
+            pp_validate_composition($composition),
+            'A section with all text-panel props must validate.'
+        );
+    }
+
+    public function testTextPanelStyleSlotMapValidates(): void
+    {
+        $composition = [[
+            'component' => 'section',
+            'props'     => ['body' => '<p>x</p>', 'layout' => 'text-panel', 'panel_heading' => 'H'],
+            'style'     => [
+                '--section-panel-bg'           => '#0f172a',
+                '--section-panel-border-color' => '#334155',
+                '--section-panel-border-width' => '1px',
+                '--section-panel-radius'       => '1rem',
+                '--section-panel-padding'      => '2rem',
+                '--section-panel-text'         => '#f8fafc',
+            ],
+        ]];
+        $this->assertTrue(
+            pp_validate_composition($composition),
+            'All six --section-panel-* slots must validate against the shared style-slot engine.'
+        );
+    }
+
+    public function testUnknownPanelPropIsRejected(): void
+    {
+        // The #147 prop-key gate reads schema.json props; a plausible-but-absent
+        // panel key must still be rejected (reported-success-without-effect class).
+        $composition = [[
+            'component' => 'section',
+            'props'     => ['body' => '<p>x</p>', 'layout' => 'text-panel', 'panel_footer' => 'nope'],
+        ]];
+        $result = pp_validate_composition($composition);
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('unknown_prop', $result->get_error_code());
+        $this->assertStringContainsString('panel_footer', $result->get_error_message());
+    }
+
+    // ── 3. CSS contract (value-level + structure pins) ────────────────────
+
+    private function sectionBlock(): string
+    {
+        // The COMPONENT: section block through the next COMPONENT header.
+        preg_match(
+            '/COMPONENT:\s*section\b(.*?)(?=\/\*\s*={5,}[^*]*?COMPONENT:|\z)/s',
+            $this->componentsCss,
+            $m
+        );
+        return $m[1] ?? '';
+    }
+
+    public function testEveryPanelSlotConsumedWithFallbackInSectionBlock(): void
+    {
+        $block = $this->sectionBlock();
+        $slots = [
+            '--section-panel-bg', '--section-panel-border-color', '--section-panel-border-width',
+            '--section-panel-radius', '--section-panel-padding', '--section-panel-text',
+        ];
+        foreach ($slots as $slot) {
+            $this->assertMatchesRegularExpression(
+                '/var\(' . preg_quote($slot, '/') . ',/',
+                $block,
+                "{$slot} must be consumed as var({$slot}, <fallback>) inside the COMPONENT: section block."
+            );
+        }
+    }
+
+    public function testPanelListRestoresMarkersAndIndent(): void
+    {
+        $block = $this->sectionBlock();
+        $this->assertMatchesRegularExpression(
+            '/\.section__panel-list\s*\{[^}]*list-style:\s*disc/s',
+            $block,
+            'the panel list must restore disc markers stripped by the base reset (issue 104).'
+        );
+        $this->assertMatchesRegularExpression(
+            '/\.section__panel-list\s*\{[^}]*padding-left:\s*var\(--space-/s',
+            $block,
+            'the panel list indent must use a spacing token.'
+        );
+    }
+
+    public function testTextPanelColumnsTopAlignAtDesktop(): void
+    {
+        // The panel column must top-align (align-items:start) rather than center
+        // like the image variants — pinned inside a >=768px media rule.
+        $this->assertMatchesRegularExpression(
+            '/@media \(min-width: 768px\)\s*\{\s*\.section--text-panel \.section__grid\s*\{[^}]*align-items:\s*start/s',
+            $this->componentsCss
+        );
+    }
+}

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -121,8 +121,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('hero/section/grid/cta schemas declare 112 style slots (subset of the 153 total)', () => {
-        expect(allSlots.length).toBe(112);
+    test('hero/section/grid/cta schemas declare 118 style slots (subset of the 159 total)', () => {
+        expect(allSlots.length).toBe(118);
     });
 
     allSlots.forEach(({ component, slotName }) => {


### PR DESCRIPTION
Closes #104

## Scope

Adds `section` `layout: "text-panel"` — an asymmetric two-column layout: the left column is the normal section (eyebrow/title/body), the right column is a server-validated **content panel** built entirely from props. No nested-component container is introduced, so the "components never nest components" invariant holds (per the recorded design decision on #104: props-based panel column, #69 `layout` naming).

**New props** (flat, on `section`): `panel_heading`, `panel_body`, `panel_items[]`, `panel_cta_text`, `panel_cta_url`, `panel_cta_variant` (primary/secondary/outline/ghost).

**New style slots** (6): `--section-panel-bg`, `--section-panel-border-color`, `--section-panel-border-width`, `--section-panel-radius`, `--section-panel-padding`, `--section-panel-text`.

**Behavior:** panel renders only with real content (heading OR body OR items OR a complete CTA), else falls back to `text-only` (no silent content loss); columns are side-by-side at ≥768px, stacked text-then-panel on mobile; the CTA URL is `esc_url`-escaped and renders only when both label and URL are set; list items are escaped with non-string/empty entries skipped; the panel uses its own CSS classes so the desktop premium-typography cascade cannot clobber its text on a dark panel.

## Acceptance criteria (all met)
- Left text column + right styleable panel (heading + list + CTA) as an asymmetric two-column layout ✓
- Panel fully server-validated (props via the shared prop-key gate; style slots via the shared `_pp_validate_style_slot_map`); no nested-component rendering ✓
- Style slots cover bg/border/radius/padding (+ text color) on the panel ✓
- Naming aligns with #69's `layout` model ✓

## Validation
- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → **1683 passed** (0 failures; warnings/deprecations identical to the clean tree: 3/2). New `SectionTextPanelTest` = 21 tests.
- JS: `npm test` (vitest) → **531 passed** (16 files, incl. `css-lint`).
- 5-file version sync validated by `bash scripts/package.sh` (zip deleted; releases are CI-built from tags).

## Reviews
- `/plan-eng-review` — 0 blocking findings; approach grounded in code.
- `/review` — testing + maintainability + design specialists dispatched. One CRITICAL (design): the panel CTA-color slots were dead against the premium `main .btn` cascade. **Resolved by dropping the two CTA-color slots** (`--section-panel-cta-bg`/`-cta-text`) — the acceptance criteria only require bg/border/radius/padding + text; the panel CTA color follows the shared button primitive and `panel_cta_variant`. This removes a reported-success-without-effect dead slot rather than papering over it.

## Accepted limitations
- Panel CTA color is not per-instance-settable by design (avoids fighting the premium `main .btn` cascade and keeps the primary-button color as one source of truth). The dark-panel-with-accent-CTA benchmark case works via the default primary button + `panel_cta_variant`.
- The section header/content markup is inlined in the text-panel branch (consistent with the existing 3x pattern for text-only/image layouts); a shared partial extraction is deferred as a repo-wide follow-up, not scoped to #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
