### PR TITLE
v0.16.111 fix: cap footer logo height (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.111] — 2026-07-13 — the footer logo is now capped to a sane height, so a real wordmark no longer renders near full size and dominates the footer (#299)
+
+**Setting a real logo image (via `pp_logo_id` + `pp_footer_show_logo`) used to blow up the footer: a 664×150 wordmark rendered at roughly 491×111 px because the footer logo `<img>` had no size cap at all, while the header logo has always been constrained to a sensible height. The footer is template-owned with no style slots, so there was no way to fix it from the outside. This release adds a height cap to the footer logo that matches the header treatment, so any real-world logo aspect ratio renders at a reasonable size.**
+
+The footer logo image is now capped the same way the header logo is (`max-height: 2.5rem`, width auto, aspect preserved). A tall or wide wordmark is scaled down to footer proportions instead of rendering near its intrinsic size. Nothing about how you set the logo changes: `pp_logo_id` still sets the image and `pp_footer_show_logo` still turns the footer logo on. This is a pure styling fix with no new options.
+
+### Fixed
+
+- The footer logo now has a height cap consistent with the header logo, so a real logo image (e.g. a 664×150 wordmark) renders at footer scale instead of near its intrinsic size and dominating the footer (#299).
+
+### Tests
+
+- `LogoTest` pins the footer logo CSS contract: the `.site-footer__logo-image` rule caps height, keeps width auto, and preserves aspect; its cap matches the header logo cap so the two treatments cannot silently drift apart; and the rendered footer `<img>` actually carries the capped class so the rule cannot become dead CSS (#299).
+
 ## [v0.16.110] — 2026-07-13 — a `section` can now put text beside a styleable content panel with its own heading, list, and CTA, so the asymmetric "text + supporting card" marketing layout is native (#104)
 
 **`section` could only do two columns as text + image (`layout: image-left`/`image-right`). The high-conversion pattern where a text column sits beside a contained panel — a card with its own sub-heading, checklist, and call-to-action button — had no native form, so multi-element sections collapsed into one stacked centered block, a visible drop in polish. This release adds `layout: "text-panel"`: the left column is the normal section (eyebrow/title/body), the right column is a server-validated content panel built entirely from props — no nested components, so the "components never nest components" rule holds.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.110-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.111-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1809,6 +1809,17 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
   }
 }
 
+/* Cap the footer logo the same way the nav caps it (.nav__logo-image). The
+   footer is template-owned with zero style slots, so a real-world wordmark
+   (e.g. 664x150) would otherwise render near intrinsic size and dominate the
+   footer. Literal cap, consistent with the nav treatment. issue 299 */
+.site-footer__logo-image {
+  display: block;
+  max-height: 2.5rem;
+  width: auto;
+  object-fit: contain;
+}
+
 .site-footer__nav ul {
   display: flex;
   flex-wrap: wrap;

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.110');
+define('PP_VERSION', '0.16.111');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.110",
+  "version": "0.16.111",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.110
+Stable tag: 0.16.111
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.110
+Version:          0.16.111
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/LogoTest.php
+++ b/tests/LogoTest.php
@@ -482,4 +482,59 @@ class LogoTest extends TestCase
         $this->assertInstanceOf(\WP_Error::class, $result);
         $this->assertSame('invalid_logo_id', $result->get_error_code());
     }
+
+    // ── issue 299: footer logo has a height cap, consistent with the nav ─────
+
+    /** Extract a single CSS declaration block by selector from components.css. */
+    private function cssRuleBlock(string $selector): ?string
+    {
+        $css = file_get_contents(dirname(__DIR__) . '/assets/css/components.css');
+        // Match "<selector> { ... }" (selector anchored at a line start to avoid
+        // catching it as part of a grouped/compound selector).
+        $pattern = '/(?:^|\})\s*' . preg_quote($selector, '/') . '\s*\{([^}]*)\}/m';
+        return preg_match($pattern, $css, $m) ? $m[1] : null;
+    }
+
+    public function testFooterLogoImageHasHeightCap(): void
+    {
+        // Regression for issue 299: without a cap a real wordmark (664x150)
+        // rendered near intrinsic size and dominated the footer. The footer is
+        // template-owned with zero style slots, so the fix is a literal cap.
+        $block = $this->cssRuleBlock('.site-footer__logo-image');
+        $this->assertNotNull($block, '.site-footer__logo-image rule missing from components.css');
+        $this->assertMatchesRegularExpression('/max-height:\s*2\.5rem/', $block);
+        $this->assertMatchesRegularExpression('/width:\s*auto/', $block);
+        $this->assertMatchesRegularExpression('/object-fit:\s*contain/', $block);
+        $this->assertMatchesRegularExpression('/display:\s*block/', $block);
+
+        // Bind the capped selector to the template element it sizes: the footer
+        // <img> must actually carry site-footer__logo-image, or the cap is dead
+        // CSS while every source-text assertion above still passes.
+        $this->seedAttachment(72, 'https://example.com/wordmark.png', 'Brand');
+        update_option('pp_logo_id', '72');
+        $html = $this->renderFooter(['location' => 'footer', 'show_logo' => true]);
+        $this->assertStringContainsString('class="site-footer__logo-image"', $html);
+    }
+
+    public function testFooterLogoCapMatchesNavCap(): void
+    {
+        // The recorded direction for issue 299 is "consistent with the nav
+        // treatment": the footer must use the same max-height as the nav so the
+        // two logo treatments cannot silently drift apart.
+        $nav    = $this->cssRuleBlock('.nav__logo-image');
+        $footer = $this->cssRuleBlock('.site-footer__logo-image');
+        $this->assertNotNull($nav, '.nav__logo-image rule missing from components.css');
+        $this->assertNotNull($footer, '.site-footer__logo-image rule missing from components.css');
+        $extractMaxHeight = static function (string $block): ?string {
+            // Do not require a trailing ";" — max-height may be the last
+            // declaration in a block; stop at ";" or the closing "}".
+            return preg_match('/max-height:\s*([^;}]+)/', $block, $m) ? trim($m[1]) : null;
+        };
+        $this->assertNotNull($extractMaxHeight($nav), 'nav logo has no max-height');
+        $this->assertSame(
+            $extractMaxHeight($nav),
+            $extractMaxHeight($footer),
+            'footer logo max-height must match the nav logo cap (issue 299 direction)'
+        );
+    }
 }


### PR DESCRIPTION
Closes #299

## Scope

The footer logo `<img class="site-footer__logo-image">` had no CSS size cap, so setting a real logo (via `pp_logo_id` + `pp_footer_show_logo`) rendered it near intrinsic size: a 664×150 wordmark rendered at roughly 491×111 px and dominated the footer. The header logo has always been capped; the footer was not.

The footer is template-owned with zero style slots, so the fix is a literal CSS cap on `.site-footer__logo-image` mirroring the header `.nav__logo-image` treatment (`display: block; max-height: 2.5rem; width: auto; object-fit: contain;`). No new schema slot is added (recorded direction in #299: "a height cap consistent with the nav treatment"). #300 (dark marketing footer) explicitly does not own logo sizing — that is this issue's job.

## Changes

- `assets/css/components.css` — add `.site-footer__logo-image` height cap in the footer component block.
- `tests/LogoTest.php` — two CSS-contract tests: the footer logo caps height (width auto, aspect preserved), the cap matches the header logo cap so the two treatments cannot silently drift, and the rendered footer `<img>` actually carries the capped class (so the rule cannot become dead CSS).

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — **1685 passing** (2 new in LogoTest; Warnings/Deprecations identical to the unmodified tree).
- `npm test` — **531 passing**.
- `bash scripts/package.sh` — five-file version sync OK at 0.16.111; built zip deleted (releases are CI-built).
- Reviews: `/plan-eng-review` (clean) and `/review` (2 test-hardening findings applied: render-class binding + regex robustness) ran this session on this diff; Codex adversarial + Claude adversarial + testing/maintainability specialists ran, no actionable defects.

## Accepted limitations

- No `max-width: 100%` guard: the recorded direction is "consistent with the nav treatment," and the nav omits it; the reported bug is height dominance, not width overflow. An ultra-wide banner logo on a very narrow viewport is a separate, unreported edge — noted as a candidate follow-up, deliberately not expanded here.
- Coverage is a unit-level CSS-source + render-class assertion (the repo's established pattern); a rendered computed-style E2E pin was not added (E2E is not required for this change).