### PR TITLE
v0.16.117 fix: hero proof line follows the hero's alignment (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.117] — 2026-07-13 — the hero proof line now follows the hero's alignment (#338)
+
+**In a centered hero, the proof line under the buttons rendered flush LEFT while the eyebrow, title, subtitle and buttons above it were all centered. The operator had already said the hero was centered, and no style slot existed to correct the proof line, so the layout simply could not be fixed through any documented surface. The proof line now follows the hero's alignment: centered in the centered and cover layouts, left-packed in the left and split layouts. Nothing to set, and no change to compositions that already exist.**
+
+The cause was a flexbox default. `.hero__proof` is a flex container, and its `justify-content` was never declared, so it sat at the initial value and packed its items to the left. The centered hero DOES inherit `text-align: center` onto that row, which is why the styles looked correct on inspection, but a flex container ignores `text-align` when it places its items: the box was centered while the words inside it were not. The left and split heroes wanted left-packing anyway, so the missing declaration read as correct everywhere it was looked at. The hero's flex rows now declare their packing explicitly and take it from the layout variant, which means the proof row and the button row both center in a centered hero and both stay left in a left-aligned one. This is the same class as the hero eyebrow (#225) and the CTA eyebrow (#255): a flexbox default quietly overriding the component's alignment intent.
+
+### Fixed
+
+- The hero proof line follows the hero's alignment instead of always packing left (#338). `.hero__proof` and `.hero__cta-group` now declare `justify-content` explicitly; `.hero--centered` and `.hero--cover` center both rows, while `.hero--left` and `.hero--split` keep them packed to the leading edge. The button row carried the same undeclared default and could left-pack in a centered hero as soon as the buttons wrapped, so it is fixed in the same change. Alignment is driven by the layout the operator already chose, not by a new style slot. Left and split heroes render exactly as before.
+
+### Tests
+
+- `tests/e2e/style-render.spec.ts` pins the behavior in a real browser, measuring where the glyphs actually land rather than what the stylesheet declares — this bug was invisible at the declaration level, which is how it shipped. The proof content is measured with a Range over the row's contents, so the pins cover the bare-text proof (an anonymous flex item with no element to select) as well as element children, across the left, centered and cover layouts at desktop and mobile, plus a wrapped proof row where each flex line is checked on its own. Scope pins prove the fix does not over-apply: a split hero's proof line must stay left-packed, and the cover hero's overlay must still cover its section. A wrapped CTA group is pinned per layout, since that row's fault only becomes visible once the buttons wrap. Every pin carries a non-vacuity floor that fails if the content ever fills its column, where centered and left-packed would render identically.
+- `tests/js/css-lint.test.js` adds declaration guards for both hero rows: base packing, the centered/cover overrides, the absence of any left/split override, and — the cascade risk the fixture pages cannot see — that no other rule and no other stylesheet re-justifies these rows, which an ID-scoped rule could otherwise do on real pages while every rendered pin stayed green.
+
+---
+
 ## [v0.16.116] — 2026-07-13 — border style slots no longer paint an unwanted 3px border (#332)
 
 **Setting any border-related style slot — even to `0` — could paint a 3px solid border around the whole component that nobody asked for. Thirteen documented slots across six components were affected, on any stock WordPress install. This release makes the component roots immune, so a border slot now produces exactly the border it specifies and nothing else. The slot names are unchanged: existing compositions keep working, and nothing about how you set a border needs to change.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.116-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.117-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -387,11 +387,17 @@
   line-height: 1.6;
 }
 
+/* align-self places the GROUP's box; justify-content packs the buttons INSIDE it. The
+   two are independent, and only align-self was declared: while the box shrink-wraps its
+   buttons the distinction is invisible, but as soon as the buttons WRAP the box fills the
+   content column and the rows pack left again — centered hero included. Declare the
+   packing explicitly rather than inheriting the flexbox initial value (issue 338). */
 .hero__cta-group {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-sm);
   align-self: flex-start;
+  justify-content: flex-start;
 }
 
 .hero__cta {
@@ -414,10 +420,20 @@
 
 .hero--centered .hero__cta-group {
   align-self: center;
+  justify-content: center;
 }
 
 .hero--centered .hero__cta {
   align-self: center;
+}
+
+/* The proof row is the one flex row .hero__content never shrink-wraps (it sets no
+   align-items, so .hero__proof stretches). Its BOX is therefore centered already; its
+   ITEMS are not, and text-align:center — which this layout does inherit — has no say in
+   where a flex container puts its items. Centering follows the layout variant, so a
+   centered hero needs no second instruction from the operator (issue 338). */
+.hero--centered .hero__proof {
+  justify-content: center;
 }
 
 /* Left variant — used by inner pages; compact vertical rhythm */
@@ -451,6 +467,9 @@
 }
 
 /* Cover variant: full-width background image with overlay */
+/* A flex row whose single item is .container. The container's auto inline margins already
+   absorb the free space, so this centering is what already happens — declared here only so
+   the row states its intent instead of resting on the flexbox initial value (issue 338). */
 .hero--cover {
   position: relative;
   background-size: cover;
@@ -459,6 +478,7 @@
   min-height: 70vh;
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .hero__overlay {
@@ -493,10 +513,16 @@
 
 .hero--cover .hero__cta-group {
   align-self: center;
+  justify-content: center;
 }
 
 .hero--cover .hero__cta {
   align-self: center;
+}
+
+/* Cover centers its content like .hero--centered, so its proof row packs the same way. */
+.hero--cover .hero__proof {
+  justify-content: center;
 }
 
 .hero--cover .btn--outline {
@@ -709,12 +735,19 @@
   }
 }
 
-/* Proof slot: trust signals after CTA */
+/* Proof slot: trust signals after CTA.
+   justify-content is the row's packing, and it is NOT inherited from the layout: the
+   left/split heroes want it at flex-start, and leaving it at the flexbox initial value
+   (normal -> flex-start) got them that for free — which is exactly why the centered hero
+   silently shipped a left-packed proof line. The variant rules above win on specificity with
+   or without this declaration; it is here so the row STATES its packing, and a reader does
+   not have to recall the flexbox initial value to know what a left hero does (issue 338). */
 .hero__proof {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-sm);
   align-items: center;
+  justify-content: flex-start;
   margin-top: var(--space-md);
   font-size: 0.875rem;
   /* Route the proof color through a per-instance slot so a dark hero can lift it

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.116');
+define('PP_VERSION', '0.16.117');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.116",
+  "version": "0.16.117",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.116
+Stable tag: 0.16.117
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.116
+Version:          0.16.117
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -84,6 +84,117 @@ async function styleComponent(
   );
 }
 
+/**
+ * Where a flex row's CONTENT actually sits, versus the column it is supposed to align to
+ * (issue 338).
+ *
+ * The row's own box proves nothing here: `.hero__proof` STRETCHES (its parent
+ * `.hero__content` is a flex column that sets no align-items), so the box is already
+ * centered in a centered hero while the content packs left inside it. Measuring
+ * `boundingBox()` — what the #225 eyebrow pins do, because there the box IS the bug —
+ * would pass on the broken CSS.
+ *
+ * Content is measured with a Range over the row's contents rather than a child locator:
+ * the operator's proof is arbitrary wp_kses_post HTML and is usually a BARE TEXT RUN,
+ * which becomes an anonymous flex item with no element to select. Union the fragment
+ * rects from getClientRects() (not getBoundingClientRect, whose single rect is the one a
+ * browser could legitimately report at line-box width) so what is measured is where the
+ * glyphs landed.
+ *
+ * The reference is the CONTENT COLUMN, not the row's own box: that is the centerline the
+ * reader perceives, and it stays the right question even if a future change shrink-wraps
+ * the row.
+ */
+function measureRowContent(el: Element) {
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  const rects = Array.from(range.getClientRects()).filter((r) => r.width > 0 && r.height > 0);
+  // rectCount is reported so callers can prove the Range measured SOMETHING. Math.min of an
+  // empty list is Infinity, so an unrendered row would produce contentWidth === -Infinity —
+  // which silently SATISFIES a "content is narrower than the column" floor. The guard against
+  // a vacuous pin needs its own guard.
+  const left = Math.min(...rects.map((r) => r.left));
+  const right = Math.max(...rects.map((r) => r.right));
+
+  // The reference is the column's CONTENT box, not its border box: .hero__content has neither
+  // padding nor border, but .hero__surface (the split proof's parent) carries both, and
+  // measuring against its border box would read its 32px padding as a 32px misalignment.
+  // Split renders the proof inside .hero__surface instead of .hero__content.
+  const column = (el.closest('.hero__content') ?? el.parentElement) as Element;
+  const box = column.getBoundingClientRect();
+  const cs = getComputedStyle(column);
+  const padLeft = parseFloat(cs.paddingLeft) + parseFloat(cs.borderLeftWidth);
+  const padRight = parseFloat(cs.paddingRight) + parseFloat(cs.borderRightWidth);
+  const columnLeft = box.left + padLeft;
+  const columnWidth = box.width - padLeft - padRight;
+
+  // Per-FLEX-LINE boxes, for wrapped rows. justify-content packs each line independently, so
+  // a wrapped row's union rect (above) cannot see which line is misplaced. Children sharing a
+  // top edge are on the same line. Empty for a bare-text proof, which has no element children.
+  const byTop = new Map<number, { left: number; right: number }>();
+  for (const child of Array.from(el.children)) {
+    const r = child.getBoundingClientRect();
+    if (r.width === 0) continue;
+    const key = Math.round(r.top);
+    const cur = byTop.get(key);
+    if (cur) {
+      cur.left = Math.min(cur.left, r.left);
+      cur.right = Math.max(cur.right, r.right);
+    } else {
+      byTop.set(key, { left: r.left, right: r.right });
+    }
+  }
+
+  return {
+    rectCount: rects.length,
+    contentLeft: left,
+    contentWidth: right - left,
+    contentCenter: (left + right) / 2,
+    columnLeft,
+    columnWidth,
+    columnCenter: columnLeft + columnWidth / 2,
+    justifyContent: getComputedStyle(el).justifyContent,
+    lines: [...byTop.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([, v]) => ({ left: v.left, width: v.right - v.left, center: (v.left + v.right) / 2 })),
+  };
+}
+
+// Sub-pixel layout noise, not a meaningful offset. The bug this file guards misplaces content
+// by hundreds of pixels, so a 2px window fails on the regression without pinning exact metrics.
+const ALIGN_TOLERANCE_PX = 2;
+// "Centered" and "left" are only DIFFERENT questions while the content is narrower than the
+// column it sits in. A row that fills its column reads the same under either alignment, so any
+// pin on it would pass on any justify-content. Rows must clear this bar to be worth asserting.
+const NON_VACUITY_MAX_FILL = 0.9;
+
+/** One measured box (content run, flex line, or button) against the column it aligns to. */
+type AlignedBox = { left: number; width: number; center: number };
+type ColumnBox = { columnLeft: number; columnWidth: number; columnCenter: number };
+
+function expectBoxAligned(box: AlignedBox, column: ColumnBox, align: 'start' | 'center') {
+  expect(box.width).toBeGreaterThan(0);
+  expect(box.width).toBeLessThan(column.columnWidth * NON_VACUITY_MAX_FILL);
+
+  if (align === 'center') {
+    // The bug: the words sat flush left inside a perfectly centered box.
+    expect(Math.abs(box.center - column.columnCenter)).toBeLessThan(ALIGN_TOLERANCE_PX);
+  } else {
+    expect(Math.abs(box.left - column.columnLeft)).toBeLessThan(ALIGN_TOLERANCE_PX);
+  }
+}
+
+/** Assert a measured row is real (see measureRowContent) and aligned as the layout intends. */
+function expectRowAligned(m: ReturnType<typeof measureRowContent>, align: 'start' | 'center') {
+  // The Range measured actual glyphs, not an empty box.
+  expect(m.rectCount).toBeGreaterThan(0);
+  expectBoxAligned(
+    { left: m.contentLeft, width: m.contentWidth, center: m.contentCenter },
+    m,
+    align,
+  );
+}
+
 /** Computed featured-treatment surfaces of one grid card (issue 293). */
 function grabCardStyles(el: Element) {
   const before = getComputedStyle(el, '::before');
@@ -1322,4 +1433,340 @@ test.describe('Safe-surface rendered proof', () => {
     expect(border.left).toBe('0px');
     expect(border.color).toBe('rgb(255, 0, 128)');
   });
+
+  /*
+   * #338 — the hero proof line rendered LEFT-ALIGNED in a centered hero.
+   *
+   * Third instance of the class #225 and #255 already hit: a flexbox default silently
+   * overriding the component's alignment intent. `.hero__proof` is a flex container with
+   * no justify-content, so its items packed at the initial `flex-start`. `text-align:
+   * center` IS inherited onto it from `.hero--centered .hero__inner` — and a flex
+   * container ignores text-align when placing its items. The box was centered; the words
+   * inside it were not.
+   *
+   * This is invisible at the declaration level, which is exactly how it shipped: every
+   * slot worked, the composition validated, and the computed style said `text-align:
+   * center`. Reading one computed property is what made the first dogfood pass call it
+   * "already centered". So these pins measure GEOMETRY — where the glyphs actually
+   * landed relative to the content column — and never trust a single declaration.
+   *
+   * Both proof shapes are covered, because they produce different flex items:
+   *   - a bare text run  -> ONE anonymous flex item (the shape the dogfood used)
+   *   - element children -> one flex item PER element, which also wrap independently
+   * Both viewports are covered, per the #86/#225 lesson recorded above: "mobile always
+   * passed" is how the last cascade bug in this file hid.
+   */
+  const proofLayouts: { layout: string; align: 'start' | 'center' }[] = [
+    { layout: 'left', align: 'start' },
+    { layout: 'centered', align: 'center' },
+    { layout: 'cover', align: 'center' },
+  ];
+  const proofShapes: { label: string; proof: string }[] = [
+    { label: 'bare text', proof: 'No card required' },
+    { label: 'element children', proof: '<span>No card</span><span>No setup</span>' },
+  ];
+  const proofViewports = [
+    { label: 'desktop', width: 1280, height: 900 },
+    { label: 'mobile', width: 375, height: 800 },
+  ];
+
+  for (const { layout, align } of proofLayouts) {
+    for (const shape of proofShapes) {
+      for (const viewport of proofViewports) {
+        // Post-merge main runs ONLY the @smoke subset, so the subset must carry BOTH halves
+        // of the invariant, not just the reported bug. Centered/bare text/desktop is the
+        // shipped bug (packing must be centered). Left/bare text/desktop is the mirror-image
+        // regression an unscoped `.hero__proof { justify-content: center }` would cause
+        // (packing must stay left) — a fix that over-applies is as wrong as one that
+        // under-applies, and only a rendered pin can tell them apart.
+        const smoke =
+          (layout === 'centered' || layout === 'left') &&
+          shape.label === 'bare text' &&
+          viewport.label === 'desktop'
+            ? ' @smoke'
+            : '';
+
+        test(`#338 hero proof content follows the layout's alignment (${layout}, ${shape.label}, ${viewport.label})${smoke}`, async ({
+          page,
+        }) => {
+          pageId = createPage(`E2E Hero Proof ${layout} ${shape.label} ${viewport.label}`);
+          setComposition(pageId, [
+            {
+              component: 'hero',
+              props: {
+                id: 'pp-hero01',
+                layout,
+                // A long title widens .hero__content, so the proof row has room to be
+                // wrong in — with a narrow column, left and centre would coincide.
+                title: 'A deliberately long hero headline that widens the content column',
+                proof: shape.proof,
+              },
+            },
+          ]);
+
+          await page.setViewportSize({ width: viewport.width, height: viewport.height });
+          await page.goto(`/?page_id=${pageId}`);
+
+          const proof = page.locator('.hero__proof');
+          await expect(proof).toBeVisible({ timeout: 10000 });
+
+          expectRowAligned(await proof.evaluate(measureRowContent), align);
+        });
+      }
+    }
+  }
+
+  /*
+   * The other half of the fix: the split hero renders its proof markup inside
+   * `.hero__surface` (components/hero/hero.php), NOT under `.hero__content`, and split is
+   * a LEFT-aligned layout. The centered/cover overrides must not leak into it — an
+   * unscoped `.hero__proof { justify-content: center }` would fix the reported bug and
+   * silently centre every left-aligned proof line on the site, with all the pins above
+   * still green. Same scope failure #255 records for the CTA.
+   */
+  /*
+   * Both viewports, but they can assert different things, and the difference is the point.
+   *
+   * At >=1024px `.hero--split .hero__inner` is a GRID, so `.hero__surface` is stretched by its
+   * track: the column is wider than the proof, and left-vs-centre is a real question that
+   * geometry can answer.
+   *
+   * Below that the split hero is a flex column with `align-items: flex-start`, so
+   * `.hero__surface` SHRINK-WRAPS its content. The row and its column are then the same box,
+   * and no packing is observable — every alignment renders identically. Asserting geometry
+   * there would be a pin that cannot fail. So mobile asserts the computed declaration (proving
+   * the centered/cover overrides did not leak into split in that media context) and asserts
+   * the shrink-wrap itself, so that if `.hero__surface` ever stops shrink-wrapping — the
+   * moment geometry becomes meaningful again — this fails loudly instead of quietly guarding
+   * nothing.
+   */
+  for (const viewport of proofViewports) {
+    test(`#338 a split hero keeps its proof line left-packed — the fix stays scoped (${viewport.label})`, async ({
+      page,
+    }) => {
+      pageId = createPage(`E2E Hero Proof Split Scope ${viewport.label}`);
+      setComposition(pageId, [
+        {
+          component: 'hero',
+          props: {
+            id: 'pp-hero01',
+            layout: 'split',
+            title: 'A deliberately long hero headline that widens the content column',
+            // Split passes the proof markup through verbatim into .hero__surface, so the
+            // class comes from the authored markup — the shape `.hero__surface .hero__proof`
+            // already exists to style.
+            proof: '<div class="hero__proof">No card required</div>',
+          },
+        },
+      ]);
+
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto(`/?page_id=${pageId}`);
+
+      const proof = page.locator('.hero__proof');
+      await expect(proof).toBeVisible({ timeout: 10000 });
+
+      const m = await proof.evaluate(measureRowContent);
+
+      // The declaration half, asserted in BOTH media contexts: split must inherit the base
+      // packing. A leak of the centered/cover override would show up here first.
+      expect(m.justifyContent).toBe('flex-start');
+
+      if (viewport.label === 'desktop') {
+        expectRowAligned(m, 'start');
+      } else {
+        // The surface shrink-wraps: row == column, so alignment is unobservable by
+        // construction. Pin the shrink-wrap rather than pretend to pin the alignment.
+        expect(m.rectCount).toBeGreaterThan(0);
+        expect(m.contentWidth).toBeGreaterThan(m.columnWidth * NON_VACUITY_MAX_FILL);
+      }
+    });
+  }
+
+  /*
+   * justify-content packs each flex LINE independently, and `.hero__proof` is `flex-wrap:
+   * wrap`. The pins above all measure single-line rows, where the union of the content rects
+   * is the whole story. A wrapped row is where packing is most visible — the partially filled
+   * LAST line is the one a reader sees hanging left under a centered hero — and a rule that
+   * packed only the first line would keep every other pin in this file green.
+   *
+   * Lines are recovered by grouping the Range's client rects by their top edge, then each
+   * line is checked on its own. The union-vs-column floor used elsewhere cannot work here:
+   * a wrapped row's full lines fill the column by definition.
+   */
+  for (const { layout, align } of [
+    { layout: 'centered', align: 'center' },
+    { layout: 'left', align: 'start' },
+  ] as const) {
+    test(`#338 every line of a wrapped proof row follows the layout's alignment (${layout})`, async ({
+      page,
+    }) => {
+      pageId = createPage(`E2E Hero Proof Wrapped ${layout}`);
+      setComposition(pageId, [
+        {
+          component: 'hero',
+          props: {
+            id: 'pp-hero01',
+            layout,
+            title: 'A deliberately long hero headline that widens the content column',
+            // Enough items that they cannot sit on one line, and an item count that leaves
+            // the last line partially filled (where centering vs left-packing diverges).
+            proof:
+              '<span>No card required</span><span>No setup</span><span>No install</span>' +
+              '<span>No lock-in</span><span>Cancel anytime</span>',
+          },
+        },
+      ]);
+
+      await page.setViewportSize({ width: 375, height: 800 });
+      await page.goto(`/?page_id=${pageId}`);
+
+      const proof = page.locator('.hero__proof');
+      await expect(proof).toBeVisible({ timeout: 10000 });
+
+      const m = await proof.evaluate(measureRowContent);
+
+      // Precondition: the row really wrapped. On one line this pin proves nothing new.
+      expect(m.lines.length).toBeGreaterThan(1);
+
+      // The LAST line is the partially filled one, so its packing is unambiguous. Full lines
+      // span the column and read the same under either alignment; expectBoxAligned's
+      // non-vacuity floor enforces that the line asserted here is genuinely short.
+      expectBoxAligned(m.lines[m.lines.length - 1], m, align);
+    });
+  }
+
+  /*
+   * `.hero--cover { justify-content: center }` is the one declaration in this change with no
+   * behavior of its own: `.container`'s auto inline margins already absorb the free space. It
+   * is declared so the row states its intent, but "inert" is a claim worth pinning, because a
+   * flex container's justify-content DOES set the static position of its absolutely positioned
+   * children — and `.hero__overlay` is exactly that. It is only harmless because the overlay
+   * pins all four sides with `inset: 0`. If that ever becomes width-based, this declaration
+   * would silently offset the overlay, and nothing else here would notice.
+   */
+  test('#338 the cover hero overlay still covers the whole section', async ({ page }) => {
+    pageId = createPage('E2E Hero Cover Overlay');
+    setComposition(pageId, [
+      {
+        component: 'hero',
+        props: {
+          id: 'pp-hero01',
+          layout: 'cover',
+          title: 'A deliberately long hero headline that widens the content column',
+          proof: 'No card required',
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const hero = page.locator('.hero--cover');
+    await expect(hero).toBeVisible({ timeout: 10000 });
+
+    const cover = await hero.evaluate((el) => {
+      const overlay = el.querySelector('.hero__overlay') as Element;
+      const h = el.getBoundingClientRect();
+      const o = overlay.getBoundingClientRect();
+      return {
+        heroLeft: h.left,
+        heroWidth: h.width,
+        overlayLeft: o.left,
+        overlayWidth: o.width,
+        justifyContent: getComputedStyle(el).justifyContent,
+      };
+    });
+
+    expect(cover.justifyContent).toBe('center');
+    // The overlay is flush with the section on both edges — justify-content did not shift it.
+    expect(Math.abs(cover.overlayLeft - cover.heroLeft)).toBeLessThan(1);
+    expect(Math.abs(cover.overlayWidth - cover.heroWidth)).toBeLessThan(1);
+  });
+
+  /*
+   * The CTA group carries the SAME unset-justify-content hole, but it hides: `align-self:
+   * center` shrink-wraps the group's box, so where the box packs its buttons never comes
+   * up — until the buttons WRAP. Then the box fills the content column and the rows pack
+   * left, in a centered hero, exactly like the proof line did. Left unfixed, this is the
+   * bug's next reappearance, one row up.
+   *
+   * The wrap is forced through the documented `--hero-content-width` slot rather than a
+   * narrow viewport, because below 768px `main .btn` is `width: 100%` — full-bleed buttons
+   * have no alignment left to get wrong, so a mobile fixture cannot discriminate the bug.
+   * Narrowing the column at DESKTOP keeps the buttons at their natural width and makes the
+   * packing observable. The wrap is asserted before the alignment: a fixture whose buttons
+   * stopped wrapping would otherwise turn this pin green while guarding nothing.
+   */
+  for (const { layout, align } of [
+    { layout: 'centered', align: 'center' },
+    // Cover carries its own `.hero--cover .hero__cta-group` override. Without it here, that
+    // rule's only evidence would be a declaration pin — the standard that let #338 ship.
+    { layout: 'cover', align: 'center' },
+    { layout: 'left', align: 'start' },
+  ] as const) {
+    test(`#338 a wrapped hero cta group follows the layout's alignment (${layout})`, async ({
+      page,
+    }) => {
+      pageId = createPage(`E2E Hero CTA Wrap ${layout}`);
+      setComposition(pageId, [
+        {
+          component: 'hero',
+          props: {
+            id: 'pp-hero01',
+            layout,
+            title: 'A deliberately long hero headline that widens the content column',
+            cta_text: 'Get started',
+            cta_url: '/start',
+            cta2_text: 'Book a demo',
+            cta2_url: '/contact',
+          },
+        },
+      ]);
+
+      await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+      await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+      // Narrower than the two buttons side by side (each floors at `main .btn`'s
+      // min-width: 13.25rem), so they must wrap — and wide enough that one button is well
+      // short of filling its row, so "centered" and "left" stay different answers.
+      const res = await styleComponent(page, pageId, { '--hero-content-width': '26rem' });
+      expect(res.success).toBe(true);
+
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+
+      const group = page.locator('.hero__cta-group');
+      await expect(group).toBeVisible({ timeout: 10000 });
+
+      const boxes = await group.evaluate((el) => {
+        const g = el.getBoundingClientRect();
+        return {
+          justifyContent: getComputedStyle(el).justifyContent,
+          // The group IS the column its buttons align to.
+          columnLeft: g.left,
+          columnWidth: g.width,
+          columnCenter: g.left + g.width / 2,
+          buttons: Array.from(el.children).map((c) => {
+            const r = c.getBoundingClientRect();
+            return { left: r.left, top: r.top, width: r.width, center: r.left + r.width / 2 };
+          }),
+        };
+      });
+
+      expect(boxes.justifyContent).toBe(align === 'center' ? 'center' : 'flex-start');
+      expect(boxes.buttons).toHaveLength(2);
+
+      // Precondition: the buttons really are on separate rows. Without the wrap the group box
+      // shrink-wraps to its content and every assertion below is trivially true. If this ever
+      // fails, suspect `main .btn`'s min-width (13.25rem) or --space-sm, not the hero.
+      expect(Math.abs(boxes.buttons[0].top - boxes.buttons[1].top)).toBeGreaterThan(1);
+
+      // Each wrapped row holds one button narrower than the group, so its placement within
+      // that row is a real constraint.
+      for (const button of boxes.buttons) {
+        expectBoxAligned(button, boxes, align);
+      }
+    });
+  }
 });

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -864,6 +864,99 @@ describe('CSS lint: hero eyebrow is a pill, not a full-width band', () => {
 });
 
 /**
+ * Hero flex rows declare their packing (#338).
+ *
+ * `.hero__proof` was a flex container with NO justify-content, so its items packed at the
+ * initial `flex-start` — left-aligned, inside a hero the operator asked to be centered.
+ * `text-align: center` is inherited onto the row and has no say in where a flex container
+ * places its items, so nothing in the computed styles looked wrong.
+ *
+ * These are DECLARATION pins and they are deliberately not the proof. The bug was
+ * invisible at the declaration level, which is exactly how it shipped; the rendered proof
+ * lives in tests/e2e/style-render.spec.ts (#338), which measures where the glyphs actually
+ * land. What these add is cheap coverage of the cascade risk the rendered pins cannot see
+ * on a fixture page: the four benchmark IDs carry `#home-hero .hero__proof` rules whose
+ * (1,1,0) specificity outranks every class rule below, so a justify-content declared there
+ * would beat the fix on real pages while every E2E fixture stayed green.
+ */
+describe('CSS lint: hero flex rows declare their justification', () => {
+    // Last match wins among equal-specificity rules, same as the #225 guard above.
+    function justifyFor(needle, selector, media = null) {
+        const decls = rulesMatching(needle)
+            .filter(r => r.media === media && r.selectors.includes(selector))
+            .map(r => /justify-content\s*:\s*([^;}]+)/.exec(r.body))
+            .filter(Boolean);
+        return decls.length ? decls[decls.length - 1][1].trim() : null;
+    }
+
+    // Both hero rows that pack items along the inline axis. The proof row is the one that
+    // shipped the bug; the cta group hid the identical hole behind `align-self`, which
+    // shrink-wraps its box until the buttons wrap.
+    const ROWS = ['.hero__proof', '.hero__cta-group'];
+
+    test.each(ROWS)('%s declares its base packing instead of inheriting flex-start', row => {
+        expect(justifyFor(row, row)).toBe('flex-start');
+    });
+
+    // The two center-aligned layouts pack their rows to match, driven by the layout
+    // variant class — not by a new style slot the operator would have to set after
+    // already having said the hero is centered.
+    test.each(ROWS)('the centered layout centers %s', row => {
+        expect(justifyFor(row, `.hero--centered ${row}`)).toBe('center');
+    });
+
+    test.each(ROWS)('the cover layout centers %s', row => {
+        expect(justifyFor(row, `.hero--cover ${row}`)).toBe('center');
+    });
+
+    // Scope guard: left and split are left-aligned layouts and must inherit the base
+    // flex-start. An override here would silently center a proof line that should hug the
+    // leading edge — the mirror-image regression of the bug being fixed.
+    test.each(ROWS)('the left and split layouts inherit the base flex-start for %s', row => {
+        expect(justifyFor(row, `.hero--left ${row}`)).toBeNull();
+        expect(justifyFor(row, `.hero--split ${row}`)).toBeNull();
+    });
+
+    // The cascade risk that would defeat the fix with every pin above still green: an
+    // ID-specificity rule (the benchmark pages already own `#home-hero .hero__proof` for
+    // margin/width) or a media-scoped rule re-declaring the packing. Only the three known
+    // class rules may justify these rows.
+    test.each(ROWS)('no other rule anywhere re-justifies %s', row => {
+        const owners = [row, `.hero--centered ${row}`, `.hero--cover ${row}`];
+        rulesMatching(row)
+            .filter(r => r.media || !r.selectors.every(s => owners.includes(s)))
+            .forEach(r => expect(r.body).not.toMatch(/justify-content\s*:/));
+    });
+
+    // ...and "anywhere" has to mean anywhere, not just components.css. A justify-content on
+    // these rows from ANY other enqueued stylesheet would beat the fix on real pages with
+    // every pin above green — the cascade does not care which file a rule was authored in.
+    // These rows are components.css's to own, so no other sheet may name them at all.
+    test.each(ROWS)('no other stylesheet declares %s', row => {
+        const dir = path.resolve(__dirname, '../../assets/css');
+        for (const file of fs.readdirSync(dir).filter(f => f.endsWith('.css'))) {
+            if (file === 'components.css') continue;
+            const css = stripComments(fs.readFileSync(path.join(dir, file), 'utf-8'));
+            expect(css).not.toMatch(new RegExp(row.replace('.', '\\.') + '(?![\\w-])'));
+        }
+    });
+
+    // The rows only pack along the inline axis while they are flex ROWS. If any rule made
+    // one a column, justify-content would silently start controlling the BLOCK axis and
+    // every pin above would become dead code — the same "the mechanism moved out from
+    // under the pin" failure the #225 parent-is-a-flex-column guard exists for.
+    test.each(ROWS)('%s is a flex row in every media context', row => {
+        const rules = rulesMatching(row);
+        const base = rules.find(r => r.selectors.includes(row) && !r.media);
+        // Without this, a renamed or media-scoped base rule fails as a TypeError on
+        // `base.body` instead of naming the regression.
+        expect(base).toBeDefined();
+        expect(base.body).toMatch(/display\s*:\s*flex\s*;/);
+        rules.forEach(r => expect(r.body).not.toMatch(/flex-direction\s*:\s*column/));
+    });
+});
+
+/**
  * CTA eyebrow stays a pill, above the title (#255).
  *
  * Same visual failure as #225, different mechanism. `#home-cta .cta__text` is


### PR DESCRIPTION
Closes #338

## Scope

In a centered hero the proof line rendered flush **left** while the eyebrow, title, subtitle and buttons above it were centered. `.hero__proof` is a flex container whose `justify-content` was never declared, so it sat at the flexbox initial value and packed its items to the leading edge. `text-align: center` **is** inherited onto that row from `.hero--centered .hero__inner` — which is why the computed styles looked correct — but a flex container ignores `text-align` when placing its items. The box was centered; the words inside it were not.

Same class as #225 (hero eyebrow blockified into a band) and #255 (cta eyebrow stretched by `display: contents`): a flexbox default silently overriding the component's alignment intent.

### Acceptance criteria

| AC | Status |
|----|--------|
| Centered hero: proof content visually centered under the buttons; left hero: stays left | Done — `.hero--centered` / `.hero--cover` center `.hero__proof`; `.hero--left` / `.hero--split` fall through to the base `flex-start` |
| Any other hero flex row with an unset `justify-content` is declared explicitly | Done — audited every flex rule in the stylesheet. The hero's rows are `.hero__proof`, `.hero__cta-group` and the `.hero--cover` wrapper; all three now declare it |
| Unset output for the left/default hero is unchanged | Done — `flex-start` is the initial value's behavior; the 4 left-layout rendered pins **pass on the pre-fix CSS**, so they prove no change rather than merely passing |
| A **rendered/computed** pin asserts the centering (source-only lint is not sufficient) | Done — 22 Playwright pins measuring real geometry against real WordPress |

Alignment is driven by the **layout variant class**, not a new style slot: the operator already said the hero is centered and should not have to say it twice. No schema, prop, or AI-doc change (no accepted grammar changed).

The **CTA group carried the identical hole**, hidden because `align-self` shrink-wraps its box — it left-packs in a centered hero as soon as the buttons wrap. Fixed in the same change, since that is the bug's next appearance one row up.

## Validation

- `./vendor/bin/phpunit` — **1724 passed** (3 warnings / 2 deprecations, identical to an unmodified tree; verified by stashing)
- `npm test` — **545 passed** (16 files), including 14 new css-lint declaration guards
- `npx playwright test tests/e2e/style-render.spec.ts` — **79 passed, 0 failed** against real WordPress via wp-env

**Discrimination check (the pins were verified to fail on the broken CSS):** with the fix reverted and the new tests in place, all 8 centered/cover proof pins **FAIL** and the 4 left-layout pins **PASS**. The pins catch the real bug and the left-layout pins are genuine non-regression proof, not padding.

Every pin carries a non-vacuity floor. That floor caught a vacuous pin of my own: at mobile, split's `.hero__surface` shrink-wraps, so row == column and alignment is unobservable *by construction*. That case now asserts the declaration plus the shrink-wrap itself, so it fails loudly if the box ever stretches instead of quietly guarding nothing.

## Accepted limitations

- `.hero--cover { justify-content: center }` is inert today (`.container`'s auto inline margins already absorb the free space). It is declared because AC 2 asks for it, and its inertness is pinned by a rendered overlay-coverage test — a flex container's `justify-content` does set the static position of abs-positioned children, and `.hero__overlay` is one; it is only harmless because the overlay pins all four sides with `inset: 0`.
- Long unbreakable proof tokens can still overflow the row. Orthogonal to centering, and already handled upstream by `overflow-wrap: break-word` in base.css:149.

## Reviews

/plan-eng-review and /review both ran on this content (pre-commit, working tree). Codex ran as the outside voice on both the plan and the diff and found no production blocker. The testing specialist caught the `Math.min(...[]) === Infinity` hole in the non-vacuity guard; the maintainability specialist caught a comment that taught a false model of the cascade. Both fixed.