### PR TITLE
v0.16.121 feat: shared check/dash/arrow list markers on section lists (#339)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -111,7 +111,7 @@ site-customization permission.
 | Component | File                           | Description                                      | Key props                                          |
 |-----------|--------------------------------|--------------------------------------------------|----------------------------------------------------|
 | hero      | components/hero/hero.php       | Full-width headline + optional CTA and image     | title (req), title_accent, eyebrow, subtitle, cta_text, cta_url, cta2_text, cta2_url, cta_variant, cta2_variant, layout, image_url, image_id, image_alt, spacing, width, split_ratio, vertical_align, proof, id |
-| section   | components/section/section.php | Text + optional image or content panel. 5 structural layouts | body (req), title, title_accent, eyebrow, subheading, heading_align, image_url, image_id, image_alt, layout, theme, background_image, panel_heading, panel_body, panel_items, panel_cta_text, panel_cta_url, panel_cta_variant, id |
+| section   | components/section/section.php | Text + optional image or content panel. 5 structural layouts | body (req), title, title_accent, eyebrow, subheading, heading_align, image_url, image_id, image_alt, layout, theme, background_image, panel_heading, panel_body, panel_items, panel_items_marker, panel_cta_text, panel_cta_url, panel_cta_variant, body_marker, id |
 | faq       | components/faq/faq.php         | Native details/summary accordion. Zero JS. Auto-emits FAQPage JSON-LD. | items[] (req) {question, answer}, title, title_accent, eyebrow, theme, id |
 | grid      | components/grid/grid.php       | Responsive card grid for real content objects    | items[] (req) {number, title, text, text_role, bullets[], image_url, image_alt, link_url, link_text, style (per-card style overrides — card-scoped grid slots, set in composition not style_component)}, title, title_accent, eyebrow, subheading, heading_align, layout, theme, id |
 | table     | components/table/table.php     | Data/comparison table, horizontal scroll mobile  | headers[] (req), rows[][] (req), title, caption    |
@@ -380,7 +380,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**169 style slots** across 7 components: hero (38), grid (30), section (29), cta (27), testimonials (21), faq (14), stats (10).
+**171 style slots** across 7 components: hero (38), section (31), grid (30), cta (27), testimonials (21), faq (14), stats (10).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.121] — 2026-07-14 — check-mark lists are no longer trapped inside grid cards: any section list can carry a marker (#339)
+
+**The orange check-mark bullet existed in exactly one place — a grid card's `bullets` — and nowhere else. A `section` body list and a `text-panel`'s `panel_items` could only render plain grey discs, so the purpose-built "checklist beside a panel" section could not style the checklist it exists to hold. That is fixed: `section` now takes `panel_items_marker` and `body_marker`, each choosing `disc` (the unchanged default), `check`, `dash`, or `arrow`, and the marker colour is authorable through the `--section-panel-marker-color` and `--section-body-marker-color` style slots. The same check-mark treatment the grid always had is now one shared definition reachable from every list-rendering surface. Leave the props unset and every existing list renders exactly as before.**
+
+The capability here is generic on purpose: a list can carry a marker other than a disc, and the marker's glyph and colour are authorable — a disc, a check, a dash, and an arrow are all just marker values, not a bespoke "checklist" widget. The grid's shipped bullet treatment was lifted into a single shared list-marker definition that the grid, the panel list, and the section body list all consume, so there is one place the check mark lives, not three copies. `disc` adds no class at all, which is what keeps every list that does not opt in byte-identical to before, down to the grid's own bullets. The marker colour defaults to the site accent (mirroring the grid's existing bullet colour) and is overridable per instance, so a check-list on a dark panel can be re-coloured without touching CSS. Body markers apply to a list authored as a direct child of the section body, leaving nested lists on their default disc. No colour or size opinion is baked into the component: the marker's look is a style-slot value the site-building AI chooses.
+
+### Added
+
+- `section` prop `panel_items_marker` (`disc` default / `check` / `dash` / `arrow`) — the marker for a text-panel's `panel_items` list. Pair it with the `--section-panel-marker-color` style slot (defaults to the site accent) to colour a check-list on a dark panel.
+- `section` prop `body_marker` (`disc` default / `check` / `dash` / `arrow`) — the marker for top-level `<ul>` lists in a section's `body`, coloured through the `--section-body-marker-color` style slot. This makes a check-list expressible in prose without moving the content into a grid or panel.
+
+### Fixed
+
+- The check-mark list treatment was reachable only from grid cards; `section.body` and `text-panel` `panel_items` could produce nothing but grey discs (found in the 1.0-H acceptance dogfood). The treatment is now a shared marker any list-rendering surface can opt into, so the reference "benefits beside a panel" checklist reproduces natively, glyph and colour matching. The grid's existing bullets render byte-identically.
+
+### Docs
+
+- `ai-instructions/composition.md` documents `panel_items_marker` and `body_marker` (with a body check-list example); `AI_CONTEXT.md`, `README.md`, and the `section` component README and schema carry the two new props and colour slots. The site-building AI now knows a check-list is reachable from any section list, not just the grid.
+
+### Tests
+
+- `tests/SectionTextPanelTest.php` pins the marker class wiring for every value, the `disc` default and invalid-value clamp for both props, and the section-block colour-slot mapping. `tests/e2e/style-render.spec.ts` proves the marker actually paints over the disc rules in a real WordPress 7.0 browser: the panel and body check lists compute `list-style: none` with the operator's marker colour, the grid bullet still honours `--grid-bullet-color` after the refactor, a nested body list keeps its disc, and dash and arrow render too. `tests/SchemaValidationTest.php` and `tests/js/css-lint.test.js` track the two new style slots.
+
 ## [v0.16.120] — 2026-07-13 — the footer can finally be organised: labelled columns, a delimited bottom bar, and a light logo for a dark band (#335)
 
 **Issue #300 gave the footer a dark marketing tone but no structure, so it rendered as an undifferentiated run of blurb, links, contact string, and copyright. Four new site options add the organisation a marketing footer needs, all through the same `update_site_option` surface, still with no footer builder. `pp_footer_menu_label` and `pp_footer_contact_label` put a heading over the menu and the contact columns. `pp_footer_note` moves the copyright into its own delimited bottom bar and renders a secondary line opposite it. `pp_footer_logo_id` gives the footer its own logo, so a light logo variant can sit on a dark footer while `pp_logo_id` stays the header logo. Every one is optional; unset, the footer renders as it did before — this adds structure, it does not change any default.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.120-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.121-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-169 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+171 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.16.99.
 
 **What exists today (v0.16.99):**
-- 12 components with schema contracts and 169 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 171 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — known exceptions live in a shrink-only ledger (issue [#309](https://github.com/FJCF76/PromptingPress/issues/309)), backed by rendered computed-style checks
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -101,10 +101,13 @@ Panel props (all optional; ignored by other layouts):
 | `panel_heading` | Panel heading (`<h3>`). |
 | `panel_body` | Optional plain-text intro paragraph above the list (text only, no HTML). |
 | `panel_items` | Array of plain-text strings rendered as a bulleted list. |
+| `panel_items_marker` | List marker for `panel_items`: `disc` (default) / `check` / `dash` / `arrow`. Not a distinct list type — just the glyph. |
 | `panel_cta_text` + `panel_cta_url` | The panel's CTA button. Both are required for the button to render. |
 | `panel_cta_variant` | Button style: `primary` (default) / `secondary` / `outline` / `ghost`. |
 
 The panel falls back to a plain `text-only` section when it has no content (no heading, no body, no list items, and no complete CTA). Style the panel per-instance with the `--section-panel-*` slots (`-bg`, `-border-color`, `-border-width`, `-radius`, `-padding`, `-text`) via `style_component` — set `--section-panel-bg` to a dark color and `--section-panel-text` to a light color for a dark panel. The panel CTA color follows the standard button (site accent); pick `panel_cta_variant` to change its style.
+
+To turn `panel_items` into a check-list (the common "benefits beside a panel" pattern), set `panel_items_marker: "check"` and recolor the marker with the `--section-panel-marker-color` slot (defaults to the site accent; set a light value on a dark panel). `dash` and `arrow` are the other marker values; `disc` is the plain default. The same marker capability is available on `grid` card bullets (always a check) and on `section` body lists (`body_marker`, below) — one shared treatment, so a check-list is reachable from any list-rendering surface, not just the grid.
 
 ```json
 {
@@ -120,6 +123,21 @@ The panel falls back to a plain `text-only` section when it has no content (no h
     "panel_cta_url": "/signup"
   },
   "style": { "--section-panel-bg": "#0f172a", "--section-panel-text": "#f8fafc" }
+}
+```
+
+#### section body list markers: `body_marker`
+
+`body_marker` (`disc` default / `check` / `dash` / `arrow`) sets the marker on **top-level** `<ul>` lists authored in a section's `body` — the same shared marker treatment the panel and grid use. `disc` leaves body lists exactly as before; `check`/`dash`/`arrow` apply to lists written as a direct child of the body (nested lists keep their disc). Recolor the marker with the `--section-body-marker-color` slot (defaults to the site accent). Use it when a prose section needs a check-list without moving the content into a grid or panel.
+
+```json
+{
+  "component": "section",
+  "props": {
+    "title": "What you get",
+    "body": "<ul><li>Transparent pricing</li><li>Cancel anytime</li></ul>",
+    "body_marker": "check"
+  }
 }
 ```
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -851,6 +851,9 @@
 .section__content {
   color: var(--section-text, var(--section-text-theme-color, var(--color-text)));
   max-width: var(--section-body-width, 42rem);
+  /* Body list-marker colour (issue 339): read by the shared marker rules only
+     when the operator opts into a non-disc body_marker; inert otherwise. */
+  --pp-list-marker-color: var(--section-body-marker-color, var(--color-accent));
 }
 
 /* Restore list markers + indent for lists authored in section.body rich text.
@@ -866,6 +869,11 @@
   margin: 0 0 var(--space-md);
 }
 
+/* The disc here is intentionally beaten, on SOURCE ORDER at equal specificity
+   (0,1,1), by the shared issue-339 marker rules (.section__content--marker-* > ul)
+   further down this file. Do NOT raise this rule's specificity or move it below
+   that block, or non-disc body markers stop painting (the tests/e2e/style-render
+   #339 pins guard this). */
 .section__content ul {
   list-style: disc;
 }
@@ -940,11 +948,16 @@
 
 /* Restore list markers + indent stripped by the base reset (base.css
    ul,ol{list-style:none} + *{padding:0}), same approach as .section__content
-   (issue 295). No style slot governs list-style/padding here. issue 104 */
+   (issue 295). No style slot governs list-style/padding here. issue 104.
+   This disc is intentionally beaten on SOURCE ORDER at equal specificity (0,1,0)
+   by the shared issue-339 .pp-marker-list rules below when panel_items_marker opts
+   in — do not raise its specificity or move it below that block. */
 .section__panel-list {
   list-style: disc;
   padding-left: var(--space-lg);
   margin: 0 0 var(--space-md);
+  /* Panel list-marker colour (issue 339): inert until panel_items_marker opts in. */
+  --pp-list-marker-color: var(--section-panel-marker-color, var(--color-accent));
 }
 
 .section__panel-list li {
@@ -1329,19 +1342,81 @@
   font-size: 0.9375rem;
   line-height: 1.5;
   flex: 1;
+  /* Map grid's authorable bullet colour onto the shared marker plumbing var.
+     Unset resolves to --color-accent, byte-identical to the historical grid
+     treatment (issue 339). */
+  --pp-list-marker-color: var(--grid-bullet-color, var(--color-accent));
 }
 
-.grid__item-bullet {
-  padding-left: 1.5rem;
+/* ── Shared list-marker treatment (issue 339) ───────────────────────────────
+   Promotes the check-mark bullet — historically locked inside grid cards — to a
+   reusable marker any list-rendering surface can opt into. A marker is a GLYPH
+   plus a COLOUR, both authorable; nothing here encodes a use-case. `disc` is the
+   untouched default and adds NO class, so a list that does not opt in renders
+   byte-identically. check / dash / arrow are just marker values.
+
+   The base .pp-marker-list is INERT on its own (indent + empty positioned ::before,
+   no glyph); a glyph comes only from the paired --check/--dash/--arrow modifier.
+   section.php always emits the base and a modifier together, so a bare base never
+   ships. A future consumer must pair them too.
+
+   Colour flows in through --pp-list-marker-color (internal plumbing, NOT a schema
+   style_slot): each consuming component maps its own authorable colour slot onto
+   it inside that component's own block (grid: --grid-bullet-color above; section:
+   --section-panel-marker-color / --section-body-marker-color).
+
+   One definition, three consumers:
+   - grid cards        .grid__item-bullet         (always a check, unchanged)
+   - text-panel list   .pp-marker-list on the <ul> the renderer emits
+   - section.body list .section__content--marker-* on the container we control,
+                       scoped to its DIRECT-CHILD <ul> so nested/plugin lists keep
+                       their default disc.
+   These rules sit at grid's historical bullet position — after the COMPONENT:
+   section block — so the section body/panel selectors below beat the issue-295
+   disc rules on source order at equal specificity. --------------------------- */
+.pp-marker-list,
+.section__content--marker-check > ul,
+.section__content--marker-dash > ul,
+.section__content--marker-arrow > ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.grid__item-bullet,
+.pp-marker-list > li,
+.section__content--marker-check > ul > li,
+.section__content--marker-dash > ul > li,
+.section__content--marker-arrow > ul > li {
   position: relative;
+  padding-left: 1.5rem;
 }
 
-.grid__item-bullet::before {
-  content: "\2713";
+.grid__item-bullet::before,
+.pp-marker-list > li::before,
+.section__content--marker-check > ul > li::before,
+.section__content--marker-dash > ul > li::before,
+.section__content--marker-arrow > ul > li::before {
   position: absolute;
   left: 0;
-  color: var(--grid-bullet-color, var(--color-accent));
   font-weight: 700;
+  color: var(--pp-list-marker-color, var(--color-accent));
+}
+
+/* Glyph per marker value. */
+.grid__item-bullet::before,
+.pp-marker-list--check > li::before,
+.section__content--marker-check > ul > li::before {
+  content: "\2713"; /* check mark */
+}
+
+.pp-marker-list--dash > li::before,
+.section__content--marker-dash > ul > li::before {
+  content: "\2013"; /* en dash */
+}
+
+.pp-marker-list--arrow > li::before,
+.section__content--marker-arrow > ul > li::before {
+  content: "\2192"; /* rightwards arrow */
 }
 
 .grid__item-link {

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -873,7 +873,7 @@
    (0,1,1), by the shared issue-339 marker rules (.section__content--marker-* > ul)
    further down this file. Do NOT raise this rule's specificity or move it below
    that block, or non-disc body markers stop painting (the tests/e2e/style-render
-   #339 pins guard this). */
+   issue-339 pins guard this). */
 .section__content ul {
   list-style: disc;
 }

--- a/components/section/README.md
+++ b/components/section/README.md
@@ -19,6 +19,8 @@ Generic text + optional image section. Use this for "what is this", "how it work
 | `layout`           | enum   | No       | `'text-only'` | Structural layout: `text-only` / `image-left` / `image-right` / `centered` |
 | `theme`            | enum   | No       | `'default'`   | Background color/tone: `default` / `dark` / `inverted` |
 | `background_image` | string | No       | `''`          | Optional background image URL with dark overlay for text readability |
+| `body_marker`        | enum   | No       | `'disc'`      | List marker for top-level `<ul>` lists in `body`: `disc` / `check` / `dash` / `arrow`. Colour via the `--section-body-marker-color` slot |
+| `panel_items_marker` | enum   | No       | `'disc'`      | text-panel layout: list marker for `panel_items`: `disc` / `check` / `dash` / `arrow`. Colour via the `--section-panel-marker-color` slot |
 
 ## Variants
 

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -118,6 +118,20 @@
       "required": false,
       "default": "primary",
       "description": "text-panel layout only: style of the panel CTA button (shares the .btn variants). 'primary' = filled accent, 'secondary' = muted surface fill, 'outline' = accent border, 'ghost' = borderless. On a dark panel, 'primary' (accent fill with light label) and 'outline' both read well."
+    },
+    "panel_items_marker": {
+      "type": "enum",
+      "values": ["disc", "check", "dash", "arrow"],
+      "required": false,
+      "default": "disc",
+      "description": "text-panel layout only: list marker for panel_items. 'disc' (default) is the plain bulleted list, unchanged. 'check' renders a check mark, 'dash' an en dash, 'arrow' a rightwards arrow. The marker colour is authorable via the --section-panel-marker-color style slot (defaults to the site accent), so a check-list on a dark panel can be re-coloured. Just a marker choice — not a distinct list type."
+    },
+    "body_marker": {
+      "type": "enum",
+      "values": ["disc", "check", "dash", "arrow"],
+      "required": false,
+      "default": "disc",
+      "description": "List marker for top-level <ul> lists in body. 'disc' (default) leaves body lists exactly as before. 'check' renders a check mark, 'dash' an en dash, 'arrow' a rightwards arrow. Applies only to lists authored as a direct child of the body (nested lists keep their disc). The marker colour is authorable via the --section-body-marker-color style slot (defaults to the site accent). Just a marker choice — not a distinct list type."
     }
   },
   "styling": {
@@ -153,7 +167,9 @@
       "--section-panel-border-width": { "type": "length", "default": "0", "description": "text-panel layout: border width of the content panel" },
       "--section-panel-radius": { "type": "length", "default": "var(--radius)", "description": "text-panel layout: corner radius of the content panel" },
       "--section-panel-padding": { "type": "length", "default": "var(--space-lg)", "description": "text-panel layout: inner padding of the content panel" },
-      "--section-panel-text": { "type": "color", "default": "var(--color-text)", "description": "text-panel layout: text color inside the content panel (heading, body, and list) — set a light value for a dark panel" }
+      "--section-panel-text": { "type": "color", "default": "var(--color-text)", "description": "text-panel layout: text color inside the content panel (heading, body, and list) — set a light value for a dark panel" },
+      "--section-panel-marker-color": { "type": "color", "default": "var(--color-accent)", "description": "text-panel layout: marker (glyph) color of the panel list when panel_items_marker is check/dash/arrow. Mirrors grid's --grid-bullet-color. Set a light value for a check-list on a dark panel. Ignored while panel_items_marker is 'disc'." },
+      "--section-body-marker-color": { "type": "color", "default": "var(--color-accent)", "description": "Marker (glyph) color of body lists when body_marker is check/dash/arrow. Ignored while body_marker is 'disc'." }
     },
     "recipes": {
       "accent-panel": {

--- a/components/section/section.php
+++ b/components/section/section.php
@@ -29,6 +29,8 @@ $panel_items        = is_array($props['panel_items'] ?? null) ? $props['panel_it
 $panel_cta_text     = $props['panel_cta_text']     ?? '';
 $panel_cta_url      = $props['panel_cta_url']      ?? '';
 $panel_cta_variant  = $props['panel_cta_variant']  ?? 'primary';
+$panel_items_marker = $props['panel_items_marker'] ?? 'disc';
+$body_marker        = $props['body_marker']        ?? 'disc';
 
 // Only string, non-empty list entries render (mirrors grid bullets).
 $panel_items = array_values(array_filter(
@@ -42,6 +44,28 @@ if (!in_array($panel_cta_variant, $allowed_panel_cta_variants, true)) {
 }
 // primary is the bare .btn; other variants add a .btn--{variant} modifier.
 $panel_cta_variant_class = $panel_cta_variant !== 'primary' ? ' btn--' . $panel_cta_variant : '';
+
+// List-marker selection (issue 339). A list can carry a marker other than the
+// default disc — check / dash / arrow — with an authorable marker colour (the
+// --section-panel-marker-color / --section-body-marker-color slots). Generic
+// marker values only; nothing encodes a use-case. `disc` is the default and adds
+// NO class, so an un-opted list renders byte-identically to before.
+$allowed_markers = ['disc', 'check', 'dash', 'arrow'];
+if (!in_array($panel_items_marker, $allowed_markers, true)) {
+    $panel_items_marker = 'disc';
+}
+if (!in_array($body_marker, $allowed_markers, true)) {
+    $body_marker = 'disc';
+}
+// text-panel list opts in with the shared .pp-marker-list treatment on its <ul>.
+$panel_list_marker_class = $panel_items_marker !== 'disc'
+    ? ' pp-marker-list pp-marker-list--' . $panel_items_marker
+    : '';
+// section.body opts in with a modifier on the container we control; the shared
+// rules style its direct-child <ul> (nested/plugin lists keep their disc).
+$content_marker_class = $body_marker !== 'disc'
+    ? ' section__content--marker-' . $body_marker
+    : '';
 
 // The panel CTA needs BOTH a label and a URL to render.
 $has_panel_cta = $panel_cta_text !== '' && $panel_cta_url !== '';
@@ -119,7 +143,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                         <?php endif; ?>
                     </div>
                 <?php endif; ?>
-                <div class="section__content">
+                <div class="section__content<?php echo esc_attr($content_marker_class); ?>">
                     <?php echo wp_kses_post($body); ?>
                 </div>
             </div>
@@ -141,7 +165,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                             <?php endif; ?>
                         </div>
                     <?php endif; ?>
-                    <div class="section__content">
+                    <div class="section__content<?php echo esc_attr($content_marker_class); ?>">
                         <?php echo wp_kses_post($body); ?>
                     </div>
                 </div>
@@ -154,7 +178,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                         <p class="section__panel-body"><?php echo esc_html($panel_body); ?></p>
                     <?php endif; ?>
                     <?php if (!empty($panel_items)) : ?>
-                        <ul class="section__panel-list">
+                        <ul class="section__panel-list<?php echo esc_attr($panel_list_marker_class); ?>">
                             <?php foreach ($panel_items as $panel_item) : ?>
                                 <li class="section__panel-item"><?php echo esc_html($panel_item); ?></li>
                             <?php endforeach; ?>
@@ -191,7 +215,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                             <?php endif; ?>
                         </div>
                     <?php endif; ?>
-                    <div class="section__content">
+                    <div class="section__content<?php echo esc_attr($content_marker_class); ?>">
                         <?php echo wp_kses_post($body); ?>
                     </div>
                 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.120');
+define('PP_VERSION', '0.16.121');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.120",
+  "version": "0.16.121",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.120
+Stable tag: 0.16.121
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.120
+Version:          0.16.121
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -246,7 +246,7 @@ class SchemaValidationTest extends TestCase
     {
         $expected = [
             'hero'    => 38,
-            'section' => 29,
+            'section' => 31,
             'grid'    => 30,
             'cta'     => 27,
         ];

--- a/tests/SectionTextPanelTest.php
+++ b/tests/SectionTextPanelTest.php
@@ -351,4 +351,170 @@ class SectionTextPanelTest extends TestCase
             $this->componentsCss
         );
     }
+
+    // ── 4. List markers (issue 339) ───────────────────────────────────────
+    //
+    // A list can carry a marker other than the default disc — check / dash /
+    // arrow — with an authorable marker colour, on the panel list AND on body
+    // lists. Generic marker capability; `disc` is the untouched default. The
+    // shared paint lives in components.css; StyleSlotContractTest proves the
+    // colour slots are consumed and unbypassed. Here we pin the render-time
+    // class wiring, the clamp, the byte-identical default, and the section
+    // block's colour-slot mapping. The cross-sheet PAINT (that the marker
+    // actually renders over the issue-295 disc rules) is pinned in
+    // tests/e2e/style-render.spec.ts.
+
+    public function testPanelItemsMarkerCheckAddsSharedTreatmentClasses(): void
+    {
+        $html = $this->render($this->fullPanelProps(['panel_items_marker' => 'check']));
+        $this->assertStringContainsString(
+            'class="section__panel-list pp-marker-list pp-marker-list--check"',
+            $html
+        );
+    }
+
+    public function testPanelItemsMarkerDashAndArrowSelectTheirModifier(): void
+    {
+        $dash = $this->render($this->fullPanelProps(['panel_items_marker' => 'dash']));
+        $this->assertStringContainsString('pp-marker-list pp-marker-list--dash', $dash);
+
+        $arrow = $this->render($this->fullPanelProps(['panel_items_marker' => 'arrow']));
+        $this->assertStringContainsString('pp-marker-list pp-marker-list--arrow', $arrow);
+    }
+
+    public function testPanelItemsMarkerDefaultsToDiscWithNoExtraClass(): void
+    {
+        // Byte-identical to the pre-339 markup: a plain section__panel-list.
+        $html = $this->render($this->fullPanelProps());
+        $this->assertStringContainsString('<ul class="section__panel-list">', $html);
+        $this->assertStringNotContainsString('pp-marker-list', $html);
+    }
+
+    public function testPanelItemsMarkerDiscExplicitIsAlsoBare(): void
+    {
+        $html = $this->render($this->fullPanelProps(['panel_items_marker' => 'disc']));
+        $this->assertStringContainsString('<ul class="section__panel-list">', $html);
+        $this->assertStringNotContainsString('pp-marker-list', $html);
+    }
+
+    public function testPanelItemsMarkerInvalidValueClampsToDisc(): void
+    {
+        $html = $this->render($this->fullPanelProps(['panel_items_marker' => 'checklist']));
+        $this->assertStringContainsString('<ul class="section__panel-list">', $html);
+        $this->assertStringNotContainsString('pp-marker-list', $html);
+        $this->assertStringNotContainsString('checklist', $html);
+    }
+
+    public function testBodyMarkerCheckAddsContainerModifier(): void
+    {
+        $html = $this->render([
+            'body'        => '<ul><li>Fast</li><li>Honest</li></ul>',
+            'body_marker' => 'check',
+        ]);
+        $this->assertStringContainsString(
+            'class="section__content section__content--marker-check"',
+            $html
+        );
+    }
+
+    public function testBodyMarkerAppliesInTextPanelLayoutToo(): void
+    {
+        // The body column exists in every layout that renders body; the marker
+        // modifier must reach it in the text-panel layout as well.
+        $html = $this->render($this->fullPanelProps(['body_marker' => 'arrow']));
+        $this->assertStringContainsString('section__content--marker-arrow', $html);
+    }
+
+    public function testBodyMarkerDefaultsToDiscWithNoModifier(): void
+    {
+        $html = $this->render(['body' => '<ul><li>Fast</li></ul>']);
+        $this->assertStringContainsString('<div class="section__content">', $html);
+        $this->assertStringNotContainsString('section__content--marker', $html);
+    }
+
+    public function testBodyMarkerInvalidValueClampsToDisc(): void
+    {
+        $html = $this->render(['body' => '<ul><li>Fast</li></ul>', 'body_marker' => 'feature-list']);
+        $this->assertStringContainsString('<div class="section__content">', $html);
+        $this->assertStringNotContainsString('section__content--marker', $html);
+        $this->assertStringNotContainsString('feature-list', $html);
+    }
+
+    public function testBodyMarkerDashSelectsItsModifier(): void
+    {
+        // Symmetry with the panel matrix: every non-disc value wires a modifier.
+        $html = $this->render(['body' => '<ul><li>Fast</li></ul>', 'body_marker' => 'dash']);
+        $this->assertStringContainsString('class="section__content section__content--marker-dash"', $html);
+    }
+
+    public function testBodyMarkerDiscExplicitIsAlsoBare(): void
+    {
+        $html = $this->render(['body' => '<ul><li>Fast</li></ul>', 'body_marker' => 'disc']);
+        $this->assertStringContainsString('<div class="section__content">', $html);
+        $this->assertStringNotContainsString('section__content--marker', $html);
+    }
+
+    public function testMarkerPropsPassSharedValidation(): void
+    {
+        $composition = [[
+            'component' => 'section',
+            'props'     => $this->fullPanelProps([
+                'panel_items_marker' => 'check',
+                'body_marker'        => 'arrow',
+            ]),
+        ]];
+        $this->assertTrue(
+            pp_validate_composition($composition),
+            'The panel_items_marker and body_marker props must be known to the shared engine.'
+        );
+    }
+
+    public function testMarkerColorSlotsValidateAndMapInSectionBlock(): void
+    {
+        // The two new colour slots pass the shared style-slot engine …
+        $composition = [[
+            'component' => 'section',
+            'props'     => ['body' => '<p>x</p>', 'layout' => 'text-panel', 'panel_heading' => 'H'],
+            'style'     => [
+                '--section-panel-marker-color' => '#ea3900',
+                '--section-body-marker-color'  => '#16a34a',
+            ],
+        ]];
+        $this->assertTrue(
+            pp_validate_composition($composition),
+            'Both marker-colour slots must validate against the shared style-slot engine.'
+        );
+
+        // … and are mapped onto the shared plumbing var INSIDE the section block
+        // (StyleSlotContractTest check 1 requires each slot consumed in its own
+        // block; the mapping is what satisfies it).
+        $block = $this->sectionBlock();
+        $this->assertMatchesRegularExpression(
+            '/--pp-list-marker-color:\s*var\(--section-panel-marker-color,/',
+            $block,
+            '--section-panel-marker-color must map onto --pp-list-marker-color in the section block.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/--pp-list-marker-color:\s*var\(--section-body-marker-color,/',
+            $block,
+            '--section-body-marker-color must map onto --pp-list-marker-color in the section block.'
+        );
+    }
+
+    public function testSharedMarkerGlyphsDefinedOnceInStylesheet(): void
+    {
+        // One definition, shared by grid + panel + body: the check glyph is
+        // defined for the grid bullet, the panel .pp-marker-list--check, and the
+        // body .section__content--marker-check together — not duplicated per
+        // component. Pin that the three consumers share a single content rule.
+        $css = $this->componentsCss;
+        $this->assertMatchesRegularExpression(
+            '/\.grid__item-bullet::before,\s*\.pp-marker-list--check > li::before,\s*\.section__content--marker-check > ul > li::before\s*\{\s*content:\s*"\\\\2713"/s',
+            $css,
+            'The check glyph must be one shared rule across grid, panel, and body consumers.'
+        );
+        // The dash and arrow marker values also exist (generic, not check-only).
+        $this->assertStringContainsString('content: "\2013"', $css);
+        $this->assertStringContainsString('content: "\2192"', $css);
+    }
 }

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -2061,4 +2061,230 @@ test.describe('#333 chrome site options render', () => {
     const inlineStyle = await header.evaluate((el) => el.getAttribute('style'));
     expect(inlineStyle).toBeNull();
   });
+
+  /**
+   * #339 — the promoted list marker must actually PAINT on the panel and body
+   * lists, over the issue-295 disc rules. StyleSlotContractTest scans only
+   * components.css, so it cannot see that `.section__content ul { list-style: disc }`
+   * (0,1,1) and `.section__panel-list { list-style: disc }` (0,1,0) are beaten by
+   * the shared marker rules on source order — that is exactly the #342 guard gap
+   * (a marker that validates but never paints is the #302 failure mode). Only a
+   * rendered box proves it. Lead with list-style + a slot-driven marker colour
+   * (robust); the ::before content is checked tolerantly (CSSOM quotes `content`
+   * inconsistently across engines).
+   */
+  test('#339 text-panel check marker paints over the disc rule + honors its colour slot @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Panel Check Marker');
+    setComposition(pageId, [
+      {
+        component: 'section',
+        props: {
+          id: 'pp-sec01',
+          layout: 'text-panel',
+          title: 'Honest',
+          body: '<p>Left.</p>',
+          panel_heading: 'Included',
+          panel_items: ['No fine print', 'No lock-in'],
+          panel_items_marker: 'check',
+        },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    // A vivid colour no theme token uses, so a failure to reach the marker is obvious.
+    const res = await styleComponent(page, pageId, { '--section-panel-marker-color': '#ff0080' });
+    expect(res.success).toBe(true);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const list = page.locator('.section__panel-list');
+    await expect(list).toBeVisible({ timeout: 10000 });
+
+    // The disc rule is beaten: the <ul> renders no native marker.
+    const listStyle = await list.evaluate((el) => getComputedStyle(el).listStyleType);
+    expect(listStyle).toBe('none');
+
+    // The glyph paints, in the operator's chosen colour.
+    const marker = await page.locator('.section__panel-item').first().evaluate((el) => {
+      const b = getComputedStyle(el, '::before');
+      return { content: b.content, color: b.color };
+    });
+    expect(marker.content).not.toBe('none');
+    expect(marker.content).not.toBe('normal');
+    expect(marker.color).toBe('rgb(255, 0, 128)');
+  });
+
+  test('#339 body check marker paints on the top-level list + honors its colour slot @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Body Check Marker');
+    setComposition(pageId, [
+      {
+        component: 'section',
+        props: {
+          id: 'pp-sec01',
+          title: 'Honest',
+          body: '<ul><li>No fine print</li><li>No lock-in</li></ul>',
+          body_marker: 'check',
+        },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    const res = await styleComponent(page, pageId, { '--section-body-marker-color': '#ff0080' });
+    expect(res.success).toBe(true);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const list = page.locator('.section__content--marker-check > ul');
+    await expect(list).toBeVisible({ timeout: 10000 });
+
+    const listStyle = await list.evaluate((el) => getComputedStyle(el).listStyleType);
+    expect(listStyle).toBe('none');
+
+    const marker = await list.locator('> li').first().evaluate((el) => {
+      const b = getComputedStyle(el, '::before');
+      return { content: b.content, color: b.color };
+    });
+    expect(marker.content).not.toBe('none');
+    expect(marker.content).not.toBe('normal');
+    expect(marker.color).toBe('rgb(255, 0, 128)');
+  });
+
+  test('#339 an unstyled body list is unchanged — still a disc, no marker class @smoke', async ({
+    page,
+  }) => {
+    // Defaults stay neutral and byte-identical: disc adds no class and no ::before.
+    pageId = createPage('E2E Body Marker Default');
+    setComposition(pageId, [
+      {
+        component: 'section',
+        props: { id: 'pp-sec01', title: 'Plain', body: '<ul><li>Still a disc</li></ul>' },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const content = page.locator('.section__content');
+    await expect(content).toBeVisible({ timeout: 10000 });
+
+    const cls = await content.evaluate((el) => el.getAttribute('class'));
+    expect(cls).toBe('section__content');
+
+    const listStyle = await content.locator('ul').evaluate((el) => getComputedStyle(el).listStyleType);
+    expect(listStyle).toBe('disc');
+  });
+
+  test('#339 grid bullets still honor --grid-bullet-color after the shared-treatment refactor @smoke', async ({
+    page,
+  }) => {
+    // Regression proof for the byte-identical grid claim: #339 moved grid's bullet
+    // rules into the shared block and rewired the colour through the internal
+    // --pp-list-marker-color indirection. StyleSlotContractTest only proves
+    // --grid-bullet-color is *consumed*; only a rendered box proves the grid
+    // check mark still paints in the operator's colour after the rewrite.
+    pageId = createPage('E2E Grid Bullet Color Regression');
+    setComposition(pageId, [
+      {
+        component: 'grid',
+        props: {
+          id: 'pp-grid01',
+          items: [{ title: 'Perimeter', text: 'x', bullets: ['HTTP headers', 'SSL/TLS'] }],
+        },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    const res = await styleComponent(page, pageId, { '--grid-bullet-color': '#ff0080' });
+    expect(res.success).toBe(true);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const bullet = page.locator('.grid__item-bullet').first();
+    await expect(bullet).toBeVisible({ timeout: 10000 });
+
+    const marker = await bullet.evaluate((el) => {
+      const b = getComputedStyle(el, '::before');
+      return { content: b.content, color: b.color };
+    });
+    expect(marker.content).not.toBe('none');
+    expect(marker.color).toBe('rgb(255, 0, 128)');
+  });
+
+  test('#339 a nested body list keeps its disc under a check marker (direct-child scoping) @smoke', async ({
+    page,
+  }) => {
+    // The body marker is scoped to the DIRECT-CHILD <ul> on purpose, so nested
+    // lists (and plugin/embed markup) keep their default disc. Pin that scoping.
+    pageId = createPage('E2E Body Marker Nested');
+    setComposition(pageId, [
+      {
+        component: 'section',
+        props: {
+          id: 'pp-sec01',
+          title: 'Nested',
+          body: '<ul><li>Top<ul><li>Nested child</li></ul></li></ul>',
+          body_marker: 'check',
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const top = page.locator('.section__content--marker-check > ul');
+    await expect(top).toBeVisible({ timeout: 10000 });
+    expect(await top.evaluate((el) => getComputedStyle(el).listStyleType)).toBe('none');
+
+    // The nested <ul> is NOT a direct child of the container → keeps disc.
+    const nested = top.locator('ul').first();
+    expect(await nested.evaluate((el) => getComputedStyle(el).listStyleType)).toBe('disc');
+  });
+
+  test('#339 dash and arrow markers also paint, not just check @smoke', async ({ page }) => {
+    // The dash (–) and arrow (→) glyphs must survive the same cross-sheet
+    // cascade as check; otherwise a broken source-order interaction for them would
+    // ship (only check had a rendered pin before). One page exercises both: panel
+    // dash + body arrow.
+    pageId = createPage('E2E Dash And Arrow Markers');
+    setComposition(pageId, [
+      {
+        component: 'section',
+        props: {
+          id: 'pp-sec01',
+          layout: 'text-panel',
+          title: 'Both',
+          body: '<ul><li>Arrowed</li></ul>',
+          body_marker: 'arrow',
+          panel_heading: 'Dashed',
+          panel_items: ['Dashed item'],
+          panel_items_marker: 'dash',
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const panelItem = page.locator('.section__panel-item').first();
+    await expect(panelItem).toBeVisible({ timeout: 10000 });
+    const dash = await panelItem.evaluate((el) => getComputedStyle(el, '::before').content);
+    expect(dash).toContain('–');
+
+    const bodyItem = page.locator('.section__content--marker-arrow > ul > li').first();
+    const arrow = await bodyItem.evaluate((el) => getComputedStyle(el, '::before').content);
+    expect(arrow).toContain('→');
+  });
 });

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -121,8 +121,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('hero/section/grid/cta schemas declare 124 style slots (subset of the 169 total)', () => {
-        expect(allSlots.length).toBe(124);
+    test('hero/section/grid/cta schemas declare 126 style slots (subset of the 171 total)', () => {
+        expect(allSlots.length).toBe(126);
     });
 
     allSlots.forEach(({ component, slotName }) => {


### PR DESCRIPTION
Closes #339.

## What & why

The orange check-mark bullet existed only inside a grid card's `bullets` and nowhere else. A `section` body list and a `text-panel`'s `panel_items` could render only plain grey discs, so the purpose-built "checklist beside a panel" section (issue 104) could not style the checklist it exists to hold. Found in the 1.0-H acceptance dogfood.

This promotes the grid's shipped check-mark treatment into **one shared list-marker definition** consumed by grid cards, the panel list, and section body lists.

## Scope

- **Generic marker capability, not a "checklist" widget.** A list can carry a marker other than a disc; a disc, a check, a dash, and an arrow are all just marker values. No domain enum, no named look-alike class.
- New `section` props: `panel_items_marker` and `body_marker`, each `disc` (default) / `check` / `dash` / `arrow`, render-clamped exactly like the existing `panel_cta_variant` (unknown → `disc`).
- Two colour slots mirroring the grid's `--grid-bullet-color`: `--section-panel-marker-color` and `--section-body-marker-color` (default site accent), so a check-list on a dark panel is re-colourable.
- **Grid is byte-identical.** Its bullet rules were lifted into the shared block; colour flows through an internal `--pp-list-marker-color` plumbing var mapped per component. `disc` adds no class, so every list that does not opt in renders exactly as before.
- AI docs updated in the same change (`ai-instructions/composition.md`, `AI_CONTEXT.md`, `README.md`, section README + schema); `lib/ai-context.php` auto-derives the props/enum-values/slots at runtime.

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` — 1787 tests green (warnings/deprecations match the clean tree).
- JS: `npm test` — 553 green.
- E2E: 7 `#339` computed-style pins verified in a live WordPress 7.0 browser (wp-env) — panel + body check lists compute `list-style: none` with the operator's marker colour; the grid bullet still honours `--grid-bullet-color` after the refactor; a nested body list keeps its disc; dash and arrow render. These run in the post-merge E2E job.
- StyleSlotContractTest (checks 1/6/7 + bypass guard) and the issue-332 immunity guard all stay green; the two new slot names carry no WP-core border-trigger substring.

## Reviews (this session, on this exact diff)

- `/plan-eng-review` — architecture locked; Codex outside voice refined the placement (single static CSS file, shared block at the grid bullet location so the body/panel selectors beat the issue-295 disc rules on source order) and body direct-child scoping.
- `/review` — testing + maintainability specialists + Codex adversarial. All findings resolved in-branch: trimmed the two descendant marker classes out of `variant_classes` (that field documents root variant classes only), added source-order forward-pointer comments at the disc rules, added a grid-colour regression pin, a nested-list scoping pin, dash/arrow paint pins, and the missing `body_marker` dash/explicit-disc cases. No finding extended the recorded decision.

## Accepted limitations

- Body markers apply to lists authored as a **direct child** of the section body; nested lists keep their default disc (bounds the blast radius; documented in the schema).
- No `font-family` opinion is baked in for the glyphs — `✓` / `–` / `→` are common Unicode present in system/web fonts, and baking a font would be a design opinion the theme deliberately leaves to tokens.

## Pairs with #334 (not implemented here)

The marker is a `<ul>` class plus an `<li>::before`, orthogonal to the `<li>`'s inner structure, so #334 can build paired label/value rows on `panel_items` on top of this without ripping out the marker layer.
