### PR TITLE
v0.16.122 feat: text-panel paired label/value rows (#334)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -380,7 +380,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**171 style slots** across 7 components: hero (38), section (31), grid (30), cta (27), testimonials (21), faq (14), stats (10).
+**172 style slots** across 7 components: hero (38), section (32), grid (30), cta (27), testimonials (21), faq (14), stats (10).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.122] — 2026-07-14 — a text-panel can finally hold paired data: label/value rows, a monospace option, and a per-row accent (#334)
+
+**A `text-panel`'s `panel_items` accepted only plain strings, rendered as bullets, so the one thing a content panel most often holds — paired data — had nowhere to go. A pricing summary, a spec sheet, a plan comparison, a stat readout, a config list: all collapsed into flat prose bullets. Now a `panel_items` entry can be a `{ "label": "...", "value": "..." }` object that renders as a two-part row, label left and value right, alongside the existing string bullets in the same list (mix them freely). A new `--section-panel-font` style slot takes `var(--font-mono)` for a monospace panel, and any single row can be emphasised or de-emphasised with a per-row `style` map that sets the panel's own text-colour slot. Leave `panel_items` as strings and every existing panel renders byte-identically.**
+
+The capability is deliberately generic: paired label/value rows, a font slot, and a per-row colour are the parts a spec sheet, a pricing table, and a status readout all share, so none of them is a first-class product feature — each is a composition of these parts. There is no `terminal` or `diagnostic` panel mode, no `ok`/`warn`/`fail` vocabulary, and no meter primitive; a monospace data panel is just `--section-panel-font: var(--font-mono)` plus paired rows plus a dark `--section-panel-bg`. The per-row accent reuses the existing `--section-panel-text` slot rather than inventing a new colour grammar: that slot is now item-eligible, so a per-row `style` map may recolour one row through the same shared style engine and item-scope gate that grid cards use (issue 306/323), with no second validator. Rows are not bullets, so a paired row carries no marker glyph even when the list's string items show a check or dash. Existing all-string `panel_items` arrays render exactly as before, down to the bytes.
+
+### Added
+
+- `section` `panel_items` entries may now be a `{ label, value }` object rendered as a two-part row (label left, value right), mixable with plain-string bullets in one list. Both label and value are plain text, escaped like the string form.
+- `--section-panel-font` style slot (default `inherit`) — set it to `var(--font-mono)`, or any font stack, for a monospace content panel. Unset, the panel inherits the page font unchanged.
+- Per-row accent: a paired-row entry may carry a `style` map setting the now item-eligible `--section-panel-text` slot, recolouring that one row to emphasise or de-emphasise it. Validated by the shared style engine and item-scope gate — no new colour grammar, no domain vocabulary.
+
+### Docs
+
+- `ai-instructions/composition.md` documents the paired-row grammar with two worked examples (a string panel and a monospace spec panel with a per-row accent); `AI_CONTEXT.md`, `README.md`, and the `section` component README and schema carry the new item shape and font slot. The shared per-item style guidance in `lib/ai-context.php` and the shared validator's scope error message are now component-neutral, since a second component (the panel) now uses that path.
+
+### Tests
+
+- `tests/SectionTextPanelTest.php` pins the paired-row markup, mixed string-and-row lists, the byte-identical string form, per-row style validation (accepted slot, rejected ineligible slot, rejected bad value), the mono-font slot, and the marker suppression on rows. `tests/StyleSlotContractTest.php` extends the issue-332 border-immunity baseline to the per-row surface and pins the new slot's consumer. `tests/e2e/style-render.spec.ts` proves in a real WordPress 7.0 browser that the mono font reaches the panel, a per-row accent recolours only its row, and a paired row shows no marker while a string bullet beside it still does. `tests/SchemaValidationTest.php` and `tests/js/css-lint.test.js` track the new slot.
+
 ## [v0.16.121] — 2026-07-14 — check-mark lists are no longer trapped inside grid cards: any section list can carry a marker (#339)
 
 **The orange check-mark bullet existed in exactly one place — a grid card's `bullets` — and nowhere else. A `section` body list and a `text-panel`'s `panel_items` could only render plain grey discs, so the purpose-built "checklist beside a panel" section could not style the checklist it exists to hold. That is fixed: `section` now takes `panel_items_marker` and `body_marker`, each choosing `disc` (the unchanged default), `check`, `dash`, or `arrow`, and the marker colour is authorable through the `--section-panel-marker-color` and `--section-body-marker-color` style slots. The same check-mark treatment the grid always had is now one shared definition reachable from every list-rendering surface. Leave the props unset and every existing list renders exactly as before.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.121-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.122-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-171 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+172 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.16.99.
 
 **What exists today (v0.16.99):**
-- 12 components with schema contracts and 171 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 172 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — known exceptions live in a shrink-only ledger (issue [#309](https://github.com/FJCF76/PromptingPress/issues/309)), backed by rendered computed-style checks
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -100,12 +100,14 @@ Panel props (all optional; ignored by other layouts):
 |------|---------|
 | `panel_heading` | Panel heading (`<h3>`). |
 | `panel_body` | Optional plain-text intro paragraph above the list (text only, no HTML). |
-| `panel_items` | Array of plain-text strings rendered as a bulleted list. |
-| `panel_items_marker` | List marker for `panel_items`: `disc` (default) / `check` / `dash` / `arrow`. Not a distinct list type — just the glyph. |
+| `panel_items` | Array of panel entries. Each entry is EITHER a plain-text string (a bullet) OR a paired-row object `{ "label": "...", "value": "..." }` rendered as a two-part row (label left, value right). Mix freely in one array. A paired-row entry may carry an optional `"style"` map (see below). |
+| `panel_items_marker` | List marker for the string entries of `panel_items`: `disc` (default) / `check` / `dash` / `arrow`. Not a distinct list type — just the glyph. Paired rows are never bullets, so they never show a marker. |
 | `panel_cta_text` + `panel_cta_url` | The panel's CTA button. Both are required for the button to render. |
 | `panel_cta_variant` | Button style: `primary` (default) / `secondary` / `outline` / `ghost`. |
 
-The panel falls back to a plain `text-only` section when it has no content (no heading, no body, no list items, and no complete CTA). Style the panel per-instance with the `--section-panel-*` slots (`-bg`, `-border-color`, `-border-width`, `-radius`, `-padding`, `-text`) via `style_component` — set `--section-panel-bg` to a dark color and `--section-panel-text` to a light color for a dark panel. The panel CTA color follows the standard button (site accent); pick `panel_cta_variant` to change its style.
+The panel falls back to a plain `text-only` section when it has no content (no heading, no body, no list items, and no complete CTA). Style the panel per-instance with the `--section-panel-*` slots (`-bg`, `-border-color`, `-border-width`, `-radius`, `-padding`, `-text`, `-font`) via `style_component` — set `--section-panel-bg` to a dark color and `--section-panel-text` to a light color for a dark panel. Set `--section-panel-font` to `var(--font-mono)` for a monospace panel (spec sheets, config or stat readouts). The panel CTA color follows the standard button (site accent); pick `panel_cta_variant` to change its style.
+
+**Paired label/value rows.** When a panel summarises data — a pricing summary, spec sheet, plan comparison, stat readout, or config/contact list — give `panel_items` entries the object form `{ "label": "...", "value": "..." }` instead of strings. Each renders as a two-part row: label on the left, value on the right, both plain text. String and paired-row entries mix in one array (a string is still a bullet). To emphasise or de-emphasise one row against its siblings, add a per-row `"style"` map that sets `--section-panel-text` (the panel's text-colour slot, the only per-row slot) — no new colour grammar, no status vocabulary. A monospace data panel (a spec sheet, config readout, or stat summary) is just a composition of these generic parts (`--section-panel-font: var(--font-mono)` + paired rows + a dark `--section-panel-bg` + a per-row accent), not a named mode. Set per-row `style` through the composition (`update_component` / `update_composition` / `create_page`), not `style_component`.
 
 To turn `panel_items` into a check-list (the common "benefits beside a panel" pattern), set `panel_items_marker: "check"` and recolor the marker with the `--section-panel-marker-color` slot (defaults to the site accent; set a light value on a dark panel). `dash` and `arrow` are the other marker values; `disc` is the plain default. The same marker capability is available on `grid` card bullets (always a check) and on `section` body lists (`body_marker`, below) — one shared treatment, so a check-list is reachable from any list-rendering surface, not just the grid.
 
@@ -123,6 +125,33 @@ To turn `panel_items` into a check-list (the common "benefits beside a panel" pa
     "panel_cta_url": "/signup"
   },
   "style": { "--section-panel-bg": "#0f172a", "--section-panel-text": "#f8fafc" }
+}
+```
+
+A monospace spec panel with paired label/value rows, one row emphasised via a per-row `style`:
+
+```json
+{
+  "component": "section",
+  "props": {
+    "title": "Environment",
+    "body": "<p>Everything this deploy runs on.</p>",
+    "layout": "text-panel",
+    "panel_heading": "Runtime",
+    "panel_items": [
+      { "label": "WordPress", "value": "6.7.1" },
+      { "label": "PHP", "value": "8.3" },
+      { "label": "Uptime", "value": "99.9%", "style": { "--section-panel-text": "#22d3ee" } },
+      "All checks passing"
+    ],
+    "panel_cta_text": "View status",
+    "panel_cta_url": "/status"
+  },
+  "style": {
+    "--section-panel-bg": "#0f172a",
+    "--section-panel-text": "#f8fafc",
+    "--section-panel-font": "var(--font-mono)"
+  }
 }
 ```
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -104,7 +104,8 @@
    selector still counts, so core's rule weighs (0,0,1) — low, NOT zero. A class or
    attribute selector weighs (0,1,0) and outranks it outright. So declaring the border
    baseline on every element that can carry inline slot custom properties (the 12
-   component roots + the per-card .grid__item of issue 306) makes core's rule a no-op
+   component roots, the per-card .grid__item of issue 306, and the per-row
+   .section__panel-row of issue 334) makes core's rule a no-op
    for us — and it stays a no-op for slots that do not exist yet. (Note the corollary:
    a BARE ELEMENT selector of ours would only tie core at (0,0,1) and could lose on
    source order. The baseline must keep a class/attribute selector to hold its rank.)
@@ -129,7 +130,8 @@
    ========================================================================== */
 
 [data-pp-component],
-.grid__item {
+.grid__item,
+.section__panel-row {
   border-style: none;
   border-width: 0;
 }
@@ -932,6 +934,10 @@
   padding: var(--section-panel-padding, var(--space-lg));
   background: var(--section-panel-bg, var(--color-surface));
   color: var(--section-panel-text, var(--color-text));
+  /* Panel font (issue 334): inherit by default (unchanged), var(--font-mono) for
+     a monospace spec/stat panel. Descendants inherit, so heading/body/list/rows
+     all pick it up unless a nested rule sets its own family. */
+  font-family: var(--section-panel-font, inherit);
   border: var(--section-panel-border-width, 0) solid var(--section-panel-border-color, transparent);
   border-radius: var(--section-panel-radius, var(--radius));
 }
@@ -966,6 +972,33 @@
 
 .section__panel-list li:last-child {
   margin-bottom: 0;
+}
+
+/* Paired rows (issue 334): a { label, value } entry renders as a two-part row
+   inside the same panel list, label left / value right. A row is NOT a bullet,
+   so it carries its own list-style:none and its glyph marker is suppressed below.
+   Row text colour routes through the SAME --section-panel-text slot as the rest
+   of the panel, which is item_eligible so a per-row style map can recolour one
+   row (emphasise/de-emphasise) via cascade proximity on the inline row style. */
+.section__panel-row {
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-md);
+  color: var(--section-panel-text, var(--color-text));
+}
+
+.section__panel-row-value {
+  text-align: right;
+}
+
+/* Suppress the shared issue-339 marker glyph on paired rows only. The marker
+   layer paints via `.pp-marker-list--{marker} > li::before` (specificity 0,1,2);
+   this two-class selector (0,2,1) outranks it so a mixed list keeps markers on
+   its string bullets while rows stay markerless. content:none also neutralizes
+   the base .pp-marker-list `li::before` reserved box. */
+.section__panel-list > .section__panel-row::before {
+  content: none;
 }
 
 /* Panel CTA spacing. Color/variant come from the shared .btn primitive and the

--- a/components/section/README.md
+++ b/components/section/README.md
@@ -20,7 +20,11 @@ Generic text + optional image section. Use this for "what is this", "how it work
 | `theme`            | enum   | No       | `'default'`   | Background color/tone: `default` / `dark` / `inverted` |
 | `background_image` | string | No       | `''`          | Optional background image URL with dark overlay for text readability |
 | `body_marker`        | enum   | No       | `'disc'`      | List marker for top-level `<ul>` lists in `body`: `disc` / `check` / `dash` / `arrow`. Colour via the `--section-body-marker-color` slot |
-| `panel_items_marker` | enum   | No       | `'disc'`      | text-panel layout: list marker for `panel_items`: `disc` / `check` / `dash` / `arrow`. Colour via the `--section-panel-marker-color` slot |
+| `panel_items_marker` | enum   | No       | `'disc'`      | text-panel layout: list marker for the string entries of `panel_items`: `disc` / `check` / `dash` / `arrow`. Colour via the `--section-panel-marker-color` slot. Paired rows never show a marker |
+
+### Content panel (`text-panel` layout)
+
+`panel_items` entries are EITHER plain strings (bulleted list items) OR paired-row objects `{ label, value }` rendered as a two-part row (label left, value right) — for a spec sheet, pricing summary, stat readout, or config list. String and paired-row entries mix in one list. A paired row may carry a per-row `style` map setting the item_eligible `--section-panel-text` slot to emphasise/de-emphasise that one row. Set `--section-panel-font` to `var(--font-mono)` for a monospace panel. A monospace data panel (spec sheet, config readout, stat summary) is a composition of these generic parts (mono font + paired rows + dark `--section-panel-bg` + per-row accent), not a named mode. Full grammar and worked examples: `ai-instructions/composition.md`.
 
 ## Variants
 

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -98,7 +98,12 @@
       "type": "array",
       "required": false,
       "default": [],
-      "description": "text-panel layout only: array of plain-text strings rendered as a bulleted list inside the panel. Non-string or empty entries are skipped."
+      "description": "text-panel layout only: array of panel list entries. Each entry is EITHER a plain-text string (rendered as a bulleted list item, unchanged) OR a paired-row object { label, value } (rendered as a two-part row: label on the left, value on the right — for a spec sheet, pricing summary, stat readout, or config list). Both label and value are plain text, escaped like the string form; an entry with neither renders nothing. String and paired-row entries may be mixed in one array. A paired-row entry may carry an optional per-row `style` map (see items.style) to emphasise or de-emphasise that one row. Non-scalar or empty entries are skipped.",
+      "items": {
+        "label": { "type": "string", "required": false, "description": "Paired-row entry: the left-hand label (e.g. 'Plan', 'Uptime'). Plain text, escaped." },
+        "value": { "type": "string", "required": false, "description": "Paired-row entry: the right-hand value (e.g. 'Pro', '99.9%'). Plain text, escaped." },
+        "style": { "type": "object", "required": false, "description": "Optional per-row style overrides for THIS paired row only. Accepts ONLY the row-scoped style slots flagged item_eligible in styling.style_slots (today: --section-panel-text, the panel text colour), letting one row read in a different colour to emphasise or de-emphasise it against its siblings. No new colour grammar and no semantic enum — the same shared style engine validates it exactly like a component-level style (unknown or section-scoped slot names and invalid values are rejected). Rendered as inline custom properties on this row, so a per-row slot overrides the panel-level value by cascade proximity. Set via the composition (update_component / update_composition / create_page), not style_component (which is component-scoped). String entries do not take a style map." }
+      }
     },
     "panel_cta_text": {
       "type": "string",
@@ -124,7 +129,7 @@
       "values": ["disc", "check", "dash", "arrow"],
       "required": false,
       "default": "disc",
-      "description": "text-panel layout only: list marker for panel_items. 'disc' (default) is the plain bulleted list, unchanged. 'check' renders a check mark, 'dash' an en dash, 'arrow' a rightwards arrow. The marker colour is authorable via the --section-panel-marker-color style slot (defaults to the site accent), so a check-list on a dark panel can be re-coloured. Just a marker choice — not a distinct list type."
+      "description": "text-panel layout only: list marker for the string entries of panel_items. 'disc' (default) is the plain bulleted list, unchanged. 'check' renders a check mark, 'dash' an en dash, 'arrow' a rightwards arrow. The marker colour is authorable via the --section-panel-marker-color style slot (defaults to the site accent), so a check-list on a dark panel can be re-coloured. Just a marker choice — not a distinct list type. Paired-row entries ({ label, value }) are not list bullets and never render a marker, regardless of this value."
     },
     "body_marker": {
       "type": "enum",
@@ -167,7 +172,8 @@
       "--section-panel-border-width": { "type": "length", "default": "0", "description": "text-panel layout: border width of the content panel" },
       "--section-panel-radius": { "type": "length", "default": "var(--radius)", "description": "text-panel layout: corner radius of the content panel" },
       "--section-panel-padding": { "type": "length", "default": "var(--space-lg)", "description": "text-panel layout: inner padding of the content panel" },
-      "--section-panel-text": { "type": "color", "default": "var(--color-text)", "description": "text-panel layout: text color inside the content panel (heading, body, and list) — set a light value for a dark panel" },
+      "--section-panel-text": { "item_eligible": true, "type": "color", "default": "var(--color-text)", "description": "text-panel layout: text color inside the content panel (heading, body, list, and paired rows) — set a light value for a dark panel. item_eligible: also settable per paired-row via panel_items[].style, where it recolours that single row to emphasise or de-emphasise it against its siblings." },
+      "--section-panel-font": { "type": "font-family", "default": "inherit", "description": "text-panel layout: font family of the content panel. Defaults to inherit (the panel uses the page font, unchanged). Set to var(--font-mono) for a monospace panel (spec sheets, config/stat readouts), or any comma-separated font stack." },
       "--section-panel-marker-color": { "type": "color", "default": "var(--color-accent)", "description": "text-panel layout: marker (glyph) color of the panel list when panel_items_marker is check/dash/arrow. Mirrors grid's --grid-bullet-color. Set a light value for a check-list on a dark panel. Ignored while panel_items_marker is 'disc'." },
       "--section-body-marker-color": { "type": "color", "default": "var(--color-accent)", "description": "Marker (glyph) color of body lists when body_marker is check/dash/arrow. Ignored while body_marker is 'disc'." }
     },

--- a/components/section/section.php
+++ b/components/section/section.php
@@ -32,10 +32,23 @@ $panel_cta_variant  = $props['panel_cta_variant']  ?? 'primary';
 $panel_items_marker = $props['panel_items_marker'] ?? 'disc';
 $body_marker        = $props['body_marker']        ?? 'disc';
 
-// Only string, non-empty list entries render (mirrors grid bullets).
+// A panel entry is EITHER a plain string (a bullet, unchanged) OR a paired-row
+// object { label, value, style? } (issue 334). Keep non-empty strings and any
+// array that carries a scalar label or value; drop everything else (empty
+// strings, numbers, and shapeless arrays) exactly as the string-only form did.
 $panel_items = array_values(array_filter(
     $panel_items,
-    static fn ($item) => is_string($item) && $item !== ''
+    static function ($item) {
+        if (is_string($item)) {
+            return $item !== '';
+        }
+        if (is_array($item)) {
+            $has_label = isset($item['label']) && is_scalar($item['label']) && (string) $item['label'] !== '';
+            $has_value = isset($item['value']) && is_scalar($item['value']) && (string) $item['value'] !== '';
+            return $has_label || $has_value;
+        }
+        return false;
+    }
 ));
 
 $allowed_panel_cta_variants = ['primary', 'secondary', 'outline', 'ghost'];
@@ -180,7 +193,25 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                     <?php if (!empty($panel_items)) : ?>
                         <ul class="section__panel-list<?php echo esc_attr($panel_list_marker_class); ?>">
                             <?php foreach ($panel_items as $panel_item) : ?>
-                                <li class="section__panel-item"><?php echo esc_html($panel_item); ?></li>
+                                <?php if (is_array($panel_item)) : ?>
+                                    <?php
+                                    // Paired-row entry (issue 334): label/value, not a bullet.
+                                    // Optional per-row style routes through the SAME shared
+                                    // engine + slots as grid's per-card style (issue 306); the
+                                    // renderer only echoes item_eligible slots (issue 323).
+                                    $row_label      = isset($panel_item['label']) && is_scalar($panel_item['label']) ? (string) $panel_item['label'] : '';
+                                    $row_value      = isset($panel_item['value']) && is_scalar($panel_item['value']) ? (string) $panel_item['value'] : '';
+                                    $row_style      = is_array($panel_item['style'] ?? null) ? $panel_item['style'] : [];
+                                    $row_style_vars = pp_render_style_vars($row_style, 'section');
+                                    $row_style_attr = $row_style_vars ? ' style="' . $row_style_vars . ';"' : '';
+                                    ?>
+                                    <li class="section__panel-row"<?php echo $row_style_attr; ?>>
+                                        <span class="section__panel-row-label"><?php echo esc_html($row_label); ?></span>
+                                        <span class="section__panel-row-value"><?php echo esc_html($row_value); ?></span>
+                                    </li>
+                                <?php else : ?>
+                                    <li class="section__panel-item"><?php echo esc_html($panel_item); ?></li>
+                                <?php endif; ?>
                             <?php endforeach; ?>
                         </ul>
                     <?php endif; ?>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.121');
+define('PP_VERSION', '0.16.122');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -268,7 +268,7 @@ function pp_migrate_legacy_variant_keys(array $items): array {
  * per-item use by carrying `item_eligible` in its style_slots definition. When the
  * per-item path ($item_index !== null) validates a component that declares at least
  * one item_eligible slot, a real-but-ineligible slot is rejected with the same
- * `invalid_style_slot` code, naming the card and pointing at grid-level style. The
+ * `invalid_style_slot` code, naming the item and pointing at component-level style. The
  * gate is opt-in by presence: a component whose slots carry no item_eligible flag
  * keeps the pre-323 behavior (any declared slot accepted), so this shared engine
  * never over-rejects an un-annotated component.
@@ -329,7 +329,7 @@ function _pp_validate_style_slot_map(array $style, array $available_slots, strin
             return new WP_Error(
                 'invalid_style_slot',
                 sprintf(
-                    '%s style slot "%s" is section-scoped and has no effect on a single card; set it on the grid-level "style" instead. Card-scoped slots: %s',
+                    '%s style slot "%s" is container-scoped and has no effect on a single item; set it on the component-level "style" instead. Item-scoped slots: %s',
                     $where,
                     $slot_name,
                     $available ?: '(none)'

--- a/lib/ai-context.php
+++ b/lib/ai-context.php
@@ -103,7 +103,7 @@ function pp_ai_system_prompt(): string {
                         $eligible_list = $item_eligible
                             ? implode(', ', $item_eligible)
                             : 'the same style slots';
-                        $parts[] = "  Per-item style: {$prop_name}[].style accepts only the card-scoped slots per card (e.g. one dark panel or terminal card in a row): {$eligible_list}. Container/heading slots are rejected — set those on the grid-level style. Set via the composition (update_component), not style_component.";
+                        $parts[] = "  Per-item style: {$prop_name}[].style accepts only the item-scoped slots for one entry (a distinct look for a single item in the set): {$eligible_list}. Container/heading slots are rejected — set those on the component-level style. Set via the composition (update_component), not style_component.";
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.121",
+  "version": "0.16.122",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.121
+Stable tag: 0.16.122
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.121
+Version:          0.16.122
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -246,7 +246,7 @@ class SchemaValidationTest extends TestCase
     {
         $expected = [
             'hero'    => 38,
-            'section' => 31,
+            'section' => 32,
             'grid'    => 30,
             'cta'     => 27,
         ];
@@ -331,7 +331,7 @@ class SchemaValidationTest extends TestCase
     public function testStyleSlotStructure(): void
     {
         $components = ['hero', 'section', 'grid', 'cta'];
-        $validTypes = ['color', 'length', 'number', 'shadow', 'gradient', 'position', 'ratio'];
+        $validTypes = ['color', 'length', 'number', 'shadow', 'gradient', 'position', 'ratio', 'font-family'];
 
         foreach ($components as $component) {
             $schemaFile = $this->themeRoot . "/components/{$component}/schema.json";
@@ -796,7 +796,7 @@ class SchemaValidationTest extends TestCase
         );
         $this->assertSame('invalid_style_slot', $result->get_error_code());
         $this->assertStringContainsString('item 1', $result->get_error_message(), 'The error must name the offending card index.');
-        $this->assertStringContainsString('grid-level', $result->get_error_message(), 'The error must point the operator at grid-level style.');
+        $this->assertStringContainsString('component-level', $result->get_error_message(), 'The error must point the operator at component-level style.');
         // The suggested "Card-scoped slots" list must NOT advertise the rejected
         // container slot as available.
         $this->assertStringNotContainsString($slot . ',', $result->get_error_message());

--- a/tests/SectionTextPanelTest.php
+++ b/tests/SectionTextPanelTest.php
@@ -517,4 +517,223 @@ class SectionTextPanelTest extends TestCase
         $this->assertStringContainsString('content: "\2013"', $css);
         $this->assertStringContainsString('content: "\2192"', $css);
     }
+
+    // ── 5. Paired label/value rows (issue 334) ────────────────────────────
+    //
+    // panel_items entries may be a plain string (a bullet, unchanged) OR a
+    // { label, value, style? } object rendered as a two-part row. String and
+    // paired-row entries mix in one <ul>. Rows are not bullets: they carry
+    // list-style:none and their marker glyph is suppressed. A row's optional
+    // per-row style routes through the SAME shared engine + item_eligible slots
+    // as grid's per-card style (issue 306/323) — no second validator, no new
+    // colour grammar. The rendered PAINT (mono font, row colour) is pinned in
+    // tests/e2e/style-render.spec.ts; these are the markup/validation/CSS pins.
+
+    public function testPanelPairedRowRendersLabelAndValue(): void
+    {
+        $html = $this->render($this->fullPanelProps([
+            'panel_items' => [['label' => 'Uptime', 'value' => '99.9%']],
+        ]));
+        $this->assertStringContainsString('<li class="section__panel-row"', $html);
+        $this->assertStringContainsString('<span class="section__panel-row-label">Uptime</span>', $html);
+        $this->assertStringContainsString('<span class="section__panel-row-value">99.9%</span>', $html);
+        // A row is NOT a bullet — it does not get the plain bullet item class.
+        $this->assertStringNotContainsString('<li class="section__panel-item">Uptime', $html);
+    }
+
+    public function testExistingStringFormRendersByteIdentical(): void
+    {
+        // Backward-compat: an all-string panel_items array must render exactly
+        // the pre-334 markup — one <ul> of section__panel-item bullets, no rows.
+        $html = $this->render($this->fullPanelProps([
+            'panel_items' => ['Freelancers', 'Small agencies'],
+        ]));
+        // The list container and each bullet <li> are unchanged from pre-334, and
+        // no paired-row markup appears when every entry is a string.
+        $this->assertStringContainsString('<ul class="section__panel-list">', $html);
+        $this->assertStringContainsString('<li class="section__panel-item">Freelancers</li>', $html);
+        $this->assertStringContainsString('<li class="section__panel-item">Small agencies</li>', $html);
+        $this->assertStringNotContainsString('section__panel-row', $html);
+        // No paired-row spans in the panel list when every entry is a string.
+        $this->assertStringNotContainsString('section__panel-row-label', $html);
+    }
+
+    public function testPanelMixesStringAndPairedRows(): void
+    {
+        $html = $this->render($this->fullPanelProps([
+            'panel_items' => ['Included', ['label' => 'Plan', 'value' => 'Pro']],
+        ]));
+        // Both shapes render, in one list, in order.
+        $this->assertStringContainsString('<li class="section__panel-item">Included</li>', $html);
+        $this->assertStringContainsString('<li class="section__panel-row"', $html);
+        $this->assertMatchesRegularExpression('/Included.*section__panel-row/s', $html);
+    }
+
+    public function testPanelPairedRowLabelAndValueAreEscaped(): void
+    {
+        $html = $this->render($this->fullPanelProps([
+            'panel_items' => [['label' => 'A & B', 'value' => '<x>']],
+        ]));
+        $this->assertStringContainsString('A &amp; B', $html);
+        $this->assertStringContainsString('&lt;x&gt;', $html);
+        $this->assertStringNotContainsString('<x>', $html);
+    }
+
+    public function testPanelPairedRowAcceptsLabelOnlyOrValueOnly(): void
+    {
+        // A partial row still renders authored content rather than silently
+        // dropping it (mirrors the panel's other never-drop-content rules); the
+        // absent side renders as an empty span.
+        $labelOnly = $this->render($this->fullPanelProps([
+            'panel_items' => [['label' => 'Solo']],
+        ]));
+        $this->assertStringContainsString('<span class="section__panel-row-label">Solo</span>', $labelOnly);
+        $this->assertStringContainsString('<span class="section__panel-row-value"></span>', $labelOnly);
+
+        $valueOnly = $this->render($this->fullPanelProps([
+            'panel_items' => [['value' => '42']],
+        ]));
+        $this->assertStringContainsString('<span class="section__panel-row-value">42</span>', $valueOnly);
+    }
+
+    public function testPanelSkipsShapelessArrayAndNonScalarEntries(): void
+    {
+        // An array with neither label nor value, and non-scalar label/value, are
+        // dropped (same posture as the string form's skip rule).
+        $html = $this->render($this->fullPanelProps([
+            'panel_items' => [
+                ['nested' => 'x'],
+                ['label' => ['not', 'scalar']],
+                ['label' => '', 'value' => ''],
+                ['label' => 'Kept', 'value' => 'Yes'],
+            ],
+        ]));
+        $this->assertSame(1, substr_count($html, 'section__panel-row"'));
+        $this->assertStringContainsString('Kept', $html);
+    }
+
+    public function testPanelPairedRowPerRowStyleRendersInline(): void
+    {
+        // A per-row style map (issue 306 mechanism) emits inline custom
+        // properties on the row element only.
+        $html = $this->render($this->fullPanelProps([
+            'panel_items' => [
+                ['label' => 'Plan', 'value' => 'Free'],
+                ['label' => 'Plan', 'value' => 'Pro', 'style' => ['--section-panel-text' => '#22d3ee']],
+            ],
+        ]));
+        $this->assertMatchesRegularExpression(
+            '/<li class="section__panel-row" style="--section-panel-text: #22d3ee;">/',
+            $html
+        );
+        // The un-styled row carries no inline style attribute.
+        $this->assertMatchesRegularExpression('/<li class="section__panel-row">\s*<span class="section__panel-row-label">Plan<\/span>\s*<span class="section__panel-row-value">Free/', $html);
+    }
+
+    // Validation — through the shared engine only (no second validator).
+
+    public function testPanelPairedRowStructuredFormPassesValidation(): void
+    {
+        $composition = [[
+            'component' => 'section',
+            'props'     => $this->fullPanelProps([
+                'panel_items' => ['A string bullet', ['label' => 'WordPress', 'value' => '6.7.1']],
+            ]),
+        ]];
+        $this->assertTrue(
+            pp_validate_composition($composition),
+            'A mixed string + paired-row panel_items array must validate.'
+        );
+    }
+
+    public function testPanelPairedRowStyleMapValidates(): void
+    {
+        $composition = [[
+            'component' => 'section',
+            'props'     => $this->fullPanelProps([
+                'panel_items' => [['label' => 'X', 'value' => 'Y', 'style' => ['--section-panel-text' => '#f8fafc']]],
+            ]),
+        ]];
+        $this->assertTrue(
+            pp_validate_composition($composition),
+            'A per-row style setting the item_eligible --section-panel-text slot must validate.'
+        );
+    }
+
+    public function testPanelPairedRowRejectsIneligibleSlot(): void
+    {
+        // --section-padding-top is a real section slot but is section-scoped, not
+        // item_eligible, so it renders nothing on a single row — the issue-323
+        // gate rejects it (reported-success-without-effect class).
+        $composition = [[
+            'component' => 'section',
+            'props'     => $this->fullPanelProps([
+                'panel_items' => [['label' => 'X', 'value' => 'Y', 'style' => ['--section-padding-top' => '4rem']]],
+            ]),
+        ]];
+        $result = pp_validate_composition($composition);
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('invalid_style_slot', $result->get_error_code());
+    }
+
+    public function testPanelPairedRowRejectsInvalidStyleValue(): void
+    {
+        $composition = [[
+            'component' => 'section',
+            'props'     => $this->fullPanelProps([
+                'panel_items' => [['label' => 'X', 'value' => 'Y', 'style' => ['--section-panel-text' => 'notacolor']]],
+            ]),
+        ]];
+        $result = pp_validate_composition($composition);
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('invalid_style_value', $result->get_error_code());
+    }
+
+    public function testPanelFontSlotValidatesWithMonoToken(): void
+    {
+        $composition = [[
+            'component' => 'section',
+            'props'     => ['body' => '<p>x</p>', 'layout' => 'text-panel', 'panel_heading' => 'H'],
+            'style'     => ['--section-panel-font' => 'var(--font-mono)'],
+        ]];
+        $this->assertTrue(
+            pp_validate_composition($composition),
+            '--section-panel-font must accept the --font-mono token via the shared engine.'
+        );
+    }
+
+    // CSS contract (structure pins; the rendered paint lives in the E2E spec).
+
+    public function testPanelFontSlotConsumedInSectionBlock(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/\.section__panel\s*\{[^}]*font-family:\s*var\(--section-panel-font,\s*inherit\)/s',
+            $this->sectionBlock(),
+            '--section-panel-font must be consumed as font-family: var(--section-panel-font, inherit) so an unset panel inherits the page font byte-identically.'
+        );
+    }
+
+    public function testPanelRowColorRoutesThroughPanelTextSlot(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/\.section__panel-row\s*\{[^}]*color:\s*var\(--section-panel-text,/s',
+            $this->sectionBlock(),
+            'A paired row must take its colour from the item_eligible --section-panel-text slot so a per-row override recolours it.'
+        );
+    }
+
+    public function testPanelRowMarkerGlyphIsSuppressed(): void
+    {
+        // A row is not a bullet: its ::before marker box is neutralised so a
+        // marker on the <ul> paints only the string bullets, not the rows.
+        $this->assertMatchesRegularExpression(
+            '/\.section__panel-list > \.section__panel-row::before\s*\{\s*content:\s*none/s',
+            $this->sectionBlock(),
+            'The shared issue-339 marker glyph must be suppressed on paired rows.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/\.section__panel-row\s*\{[^}]*list-style:\s*none/s',
+            $this->sectionBlock()
+        );
+    }
 }

--- a/tests/StyleSlotContractTest.php
+++ b/tests/StyleSlotContractTest.php
@@ -675,7 +675,7 @@ class StyleSlotContractTest extends TestCase
      * root (all 12 carry data-pp-component) and the per-card .grid__item of issue 306.
      * These are what the immunity baseline must cover.
      */
-    private const BORDER_IMMUNITY_SELECTORS = ['[data-pp-component]', '.grid__item'];
+    private const BORDER_IMMUNITY_SELECTORS = ['[data-pp-component]', '.grid__item', '.section__panel-row'];
 
     /**
      * The baseline must DECLARE these longhands with these VALUES. Asserting the value —
@@ -761,7 +761,8 @@ class StyleSlotContractTest extends TestCase
                 }
                 $emitted++;
                 $covered = str_contains($line, 'data-pp-component=')
-                    || preg_match('/class="[^"]*\bgrid__item\b/', $line) === 1;
+                    || preg_match('/class="[^"]*\bgrid__item\b/', $line) === 1
+                    || preg_match('/class="[^"]*\bsection__panel-row\b/', $line) === 1;
 
                 $this->assertTrue(
                     $covered,
@@ -776,11 +777,12 @@ class StyleSlotContractTest extends TestCase
         }
 
         // Fail-closed: 7 styled components render a root style attr, grid renders a
-        // per-card one too. If the scan finds nothing, the loop above proved nothing.
+        // per-card one, and section renders a per-row one (issue 334). If the scan
+        // finds nothing, the loop above proved nothing.
         $this->assertGreaterThanOrEqual(
-            8,
+            9,
             $emitted,
-            'Found fewer inline slot surfaces than the 8 known today — the template scan is broken.'
+            'Found fewer inline slot surfaces than the 9 known today — the template scan is broken.'
         );
 
         // Every pp_render_style_vars() call must reach an emit site the loop above actually
@@ -835,11 +837,12 @@ class StyleSlotContractTest extends TestCase
             )
         );
 
-        // The real shape passes.
+        // The real shape passes (all three inline-slot surfaces covered: roots,
+        // grid card, and the issue-334 panel row).
         $this->assertSame(
             [],
             $this->immunityGaps(
-                "[data-pp-component],\n.grid__item { border-style: none; border-width: 0; }\n"
+                "[data-pp-component],\n.grid__item,\n.section__panel-row { border-style: none; border-width: 0; }\n"
                 . "/* COMPONENT: nav */\n.nav { color: red; }"
             )
         );
@@ -852,6 +855,7 @@ class StyleSlotContractTest extends TestCase
             $this->immunityGaps(
                 "[data-pp-component] { border-style: none; border-width: 0; }\n"
                 . ".grid__item { border-style: none; border-width: 0; }\n"
+                . ".section__panel-row { border-style: none; border-width: 0; }\n"
                 . "/* COMPONENT: nav */\n.nav { color: red; }"
             )
         );
@@ -890,7 +894,7 @@ class StyleSlotContractTest extends TestCase
             [],
             $this->immunityGaps(
                 "@media (min-width: 768px) { .unrelated { color: red; } }\n"
-                . "[data-pp-component], .grid__item { border-style: none; border-width: 0; }\n"
+                . "[data-pp-component], .grid__item, .section__panel-row { border-style: none; border-width: 0; }\n"
                 . "/* COMPONENT: nav */\n.nav { color: red; }"
             )
         );

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -2287,4 +2287,65 @@ test.describe('#333 chrome site options render', () => {
     const arrow = await bodyItem.evaluate((el) => getComputedStyle(el, '::before').content);
     expect(arrow).toContain('→');
   });
+
+  test('#334 paired rows: mono font + per-row accent paint, row marker suppressed @smoke', async ({
+    page,
+  }) => {
+    // Cross-sheet PAINT proof (the #342 gap: a slot can validate yet never
+    // render). One page exercises all three parts of the capability:
+    //   - --section-panel-font: var(--font-mono) actually reaches the panel font;
+    //   - a per-row style recolours ONE row via the item_eligible --section-panel-text;
+    //   - a paired row shows NO marker glyph while a string bullet in the same
+    //     list still does (mixed list, marker on the <ul>).
+    pageId = createPage('E2E Panel Paired Rows');
+    setComposition(pageId, [
+      {
+        component: 'section',
+        props: {
+          id: 'pp-sec01',
+          layout: 'text-panel',
+          title: 'Environment',
+          body: '<p>Left.</p>',
+          panel_heading: 'Runtime',
+          panel_items_marker: 'check',
+          panel_items: [
+            'All checks passing',
+            { label: 'WordPress', value: '6.7.1' },
+            { label: 'Uptime', value: '99.9%', style: { '--section-panel-text': '#22d3ee' } },
+          ],
+        },
+        style: { '--section-panel-font': 'var(--font-mono)' },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    // 1. The mono font slot reaches the panel.
+    const panel = page.locator('.section__panel');
+    await expect(panel).toBeVisible({ timeout: 10000 });
+    const font = await panel.evaluate((el) => getComputedStyle(el).fontFamily);
+    expect(font).toContain('monospace');
+
+    // 2. The string bullet keeps its check marker; the paired rows suppress it.
+    const bulletMarker = await page
+      .locator('.section__panel-item')
+      .first()
+      .evaluate((el) => getComputedStyle(el, '::before').content);
+    expect(bulletMarker).not.toBe('none');
+    expect(bulletMarker).not.toBe('normal');
+
+    const rowMarker = await page
+      .locator('.section__panel-row')
+      .first()
+      .evaluate((el) => getComputedStyle(el, '::before').content);
+    expect(rowMarker).toBe('none');
+
+    // 3. The per-row accent recolours only the styled row (last row = Uptime).
+    const rowColor = await page
+      .locator('.section__panel-row')
+      .last()
+      .evaluate((el) => getComputedStyle(el).color);
+    expect(rowColor).toBe('rgb(34, 211, 238)');
+  });
 });

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -121,8 +121,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('hero/section/grid/cta schemas declare 126 style slots (subset of the 171 total)', () => {
-        expect(allSlots.length).toBe(126);
+    test('hero/section/grid/cta schemas declare 127 style slots (subset of the 172 total)', () => {
+        expect(allSlots.length).toBe(127);
     });
 
     allSlots.forEach(({ component, slotName }) => {


### PR DESCRIPTION
Closes #334

## Scope

`text-panel`'s `panel_items[]` accepted only plain strings, so a content panel could not express paired data (a pricing summary, spec sheet, plan comparison, stat readout, or config list). This adds a backward-compatible union item shape plus two generic styling slots, all through the existing shared engines.

- **Paired rows.** A `panel_items` entry may now be a `{ label, value }` object rendered as a two-part row (`<li class="section__panel-row">` with label/value spans), mixable with plain-string bullets in one `<ul>`. Both escaped like the string form. An entry with neither label nor value is skipped.
- **`--section-panel-font` slot** (type `font-family`, default `inherit`), consumed as `font-family: var(--section-panel-font, inherit)` on `.section__panel`. Takes `var(--font-mono)` for a monospace panel.
- **Per-row accent.** The existing `--section-panel-text` slot is now `item_eligible`, so a paired row may carry a `style` map recolouring that one row, validated through the shared issue-306 per-item engine + issue-323 item-scope gate. No new colour grammar, no second validator.
- **Marker suppression.** A paired row carries `list-style:none` and its issue-339 marker glyph is suppressed (specificity-correct), so a mixed list keeps markers on string bullets while rows stay markerless.
- **Immunity.** Per-row inline style emits on `.section__panel-row`, which is added to the issue-332 border-immunity baseline (`BORDER_IMMUNITY_SELECTORS` + `$covered` allow-list + CSS baseline + emit-count pin).

No domain vocabulary (no `terminal`/`diagnostic`/`state`/`severity`/`score`/`meter`) in schema, CSS class names, PHP, or AI docs. A monospace "spec-sheet" panel is a composition of generic parts, not a named mode.

### Acceptance criteria
- [x] Panel renders label/value rows, in a monospace font, with a per-row accent, through the documented composition surface.
- [x] Existing string form of `panel_items[]` renders byte-identically.
- [x] Unknown keys / invalid values rejected by the shared validator (issue-147 prop-key gate applies); no second validation path.
- [x] `--section-panel-font` satisfies the issue-305 slot-contract guard (live `var(--slot, <literal>)` consumer, byte-identical unset, no waiver additions).
- [x] No domain-specific vocabulary in schema, CSS class names, or AI docs.
- [x] AI docs (schema, `ai-instructions/composition.md`, `lib/ai-context.php`, plus AI_CONTEXT.md and component README) updated in the same change, generically, with more than one worked example.

## Recorded decisions applied (disclosed, not asked — no 7A question was raised)
- **Mixing** string + structured entries in one array is **supported** (the issue body delegated this: "decide during implementation and document it").
- **Per-row accent reuses the existing `--section-panel-text` slot** (made `item_eligible`) rather than a new slot, per the body's "existing-style-slot-driven accent... no new colour grammar."
- **Partial rows** (label-only or value-only) render the present side rather than being dropped, matching the panel's other never-drop-authored-content rules.
- Non-string scalar label/value are coerced to their string form via an `is_scalar` guard (consistent with grid's untyped item fields; escaped, harmless).

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` — **1802 passed** (0 failures; 15 new tests). Warnings/deprecations identical to base tree (3 warnings, 2 deprecations — pre-existing).
- `npm test` (vitest) — **554 passed** (0 failures).
- `bash scripts/package.sh` — version consistency OK across all five files; the built zip was deleted (releases are CI-built from tags).
- E2E (`tests/e2e/style-render.spec.ts`) runs in CI post-merge (WordPress 7.0): pins the rendered mono font, per-row accent paint, and row marker suppression.
- Reviews (this session, on this exact diff): `/plan-eng-review` CLEAR, `/review` clean, Codex adversarial pass — all findings verified as grid-parity false positives or accepted-consistent behavior.

## Accepted limitations
- Unknown *nested* item sub-keys (e.g. `{ label, value, foo }`) are ignored by the renderer rather than rejected — consistent with existing grid item behavior and the "no second validation path" constraint (the issue-147 gate governs top-level props). Top-level unknown props are still rejected.
- No tag/release/deploy performed (CI builds release zips from tags; maintainer handles those).
