### PR TITLE
v0.16.124 fix: make the title→subheading gap authorable on section/grid/testimonials (#343)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -380,7 +380,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**172 style slots** across 7 components: hero (38), section (32), grid (30), cta (27), testimonials (21), faq (14), stats (10).
+**175 style slots** across 7 components: hero (38), section (33), grid (31), cta (27), testimonials (22), faq (14), stats (10).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.124] — 2026-07-14 — the header's top gap is authorable now, so "tighten this header" is fully expressible (#343)
+
+**The site-building AI could set the space *below* a component's sub-heading but not the space *above* it, so a request like "tighten this header" was only half-expressible. This adds three style slots — `--section-title-margin-bottom`, `--grid-heading-margin-bottom`, and `--testimonials-heading-margin-bottom` — that make the gap between the title and the sub-heading authorable on section, grid, and testimonials. Leave them unset and every page renders exactly as before, down to the byte: the slots add reach, not a new spacing opinion.**
+
+This is the top-side companion to the sub-heading bottom-margin slots added in #336. The whole header rhythm on these three components is now slot-driven instead of half-hardcoded. The gap is not a single fixed value: on section and grid the responsive "premium typography" rules set it to `1.65rem` on wide screens and `1.25rem` on narrow ones, and both of those declarations now route through the slot with today's literal as the fallback, so a set value wins at every breakpoint and an unset slot changes nothing. Testimonials, which has no responsive override, keeps its `var(--space-lg)` default. The FAQ heading shares the same responsive rule but is out of scope here and keeps its literal spacing, unchanged.
+
+### Fixed
+
+- The title-to-subheading gap on `section`, `grid`, and `testimonials` is now routed through a per-component `--<component>-<title|heading>-margin-bottom` style slot instead of a bare literal, at the base rule and at both responsive breakpoints. Defaults are byte-identical to before.
+
+### Docs
+
+- `AI_CONTEXT.md` and `README.md` slot counts updated (172 → 175). The new slots surface to the chat AI through the existing runtime slot inspection and the `--grid-heading-*` wildcard already documented for grid card-scope rejection, so no accepted-grammar description changed.
+
+### Tests
+
+- `tests/e2e/style-render.spec.ts` gains rendered computed-style pins per component proving the slot's default renders unchanged (26.4px section/grid at ≥768px, 32px testimonials) and that a set value reaches the element under the real cascade, including past the premium-typography override. `tests/StyleSlotContractTest.php` auto-discovers the three new slots and confirms none is bypassed by a literal re-declaration. Slot-count pins in `tests/SchemaValidationTest.php` and `tests/js/css-lint.test.js` updated, and `--grid-heading-margin-bottom` added to the grid card-scope-ineligible set.
+
 ## [v0.16.123] — 2026-07-14 — the slot-contract guard can no longer be blindsided by a clobber in another stylesheet (#342)
 
 **`tests/StyleSlotContractTest.php` scanned only `components.css`, so a rule in `base.css` or `utilities.css` that outranks a component's slot rule was invisible to it — which is exactly how #336 hid: `base.css`'s `p:last-child { margin-bottom: 0 }` (specificity (0,1,1)) silently beat a bare `.grid__subheading` (0,1,0) on three components while every unit test stayed green. This adds check 8, a static cross-sheet tripwire that reads `base.css` and `utilities.css` and fails the build when an automatic-match rule (a bare element/pseudo-class selector, the mechanism that matches component elements by tag with no template opt-in) declares a slot-consumed property at a specificity that defeats a bare component class. Every such candidate must be acknowledged in a shrink-only ledger with a justification; a new one fails until a human accounts for it. No product CSS changed — this is guard hardening only.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.123-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.124-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-172 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+175 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.16.99.
 
 **What exists today (v0.16.99):**
-- 12 components with schema contracts and 172 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 175 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -829,7 +829,7 @@
 .section__title {
   font-size: var(--section-title-size, inherit);
   color: var(--section-title-color, var(--section-title-theme-color, var(--color-text)));
-  /* Top-side header rhythm (title -> subheading gap). #336 made the subheading's
+  /* Top-side header rhythm (title -> subheading gap). issue 336 made the subheading's
      BOTTOM margin authorable; this routes the title's own bottom margin through a
      slot so the whole header rhythm is slot-driven (issue 343). No header-scoping
      needed: the title is a heading, not the header's last child, so base.css's
@@ -1260,7 +1260,7 @@
   color: var(--grid-heading-color, var(--grid-heading-theme-color, var(--color-text)));
   font-size: var(--grid-heading-size, inherit);
   max-width: var(--grid-heading-max-width, 40rem);
-  /* Top-side header rhythm (heading -> subheading gap), mirror of the #336
+  /* Top-side header rhythm (heading -> subheading gap), mirror of the issue 336
      subheading BOTTOM slot on the adjacent property (issue 343). The heading is
      not the header's last child, so base.css's `p:last-child` reset never won
      here — a plain slot on the heading suffices. Today's literal is the fallback. */
@@ -2425,7 +2425,7 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
 .testimonials__heading {
   color: var(--testimonials-heading-color, var(--color-text));
   max-width: 40rem;
-  /* Top-side header rhythm (heading -> subheading gap), mirror of the #336
+  /* Top-side header rhythm (heading -> subheading gap), mirror of the issue 336
      subheading BOTTOM slot on the adjacent property (issue 343). The heading is
      not the header's last child, so base.css's `p:last-child` reset never won
      here — a plain slot on the heading suffices. Today's literal is the fallback. */
@@ -3281,7 +3281,7 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
      rule below) at [0,2,1], outranking the base [0,1,0] rules and silently ignoring
      a declared --section-title-margin-bottom / --grid-heading-margin-bottom. Route
      each through its slot with 1.65rem as the fallback so unset output is unchanged.
-     faq stays a bare literal (no faq heading-margin slot in #343's scope). */
+     faq stays a bare literal (no faq heading-margin slot in issue 343's scope). */
   main > .grid .grid__heading {
     color: var(--grid-heading-color, var(--grid-heading-theme-color, var(--color-text)));
     font-size: var(--grid-heading-size, clamp(2.25rem, 3vw, 2.62rem));
@@ -3382,7 +3382,7 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
 
   /* margin-bottom split per-selector so each component's heading-margin slot
      reaches the title at this breakpoint too (issue 343); fallbacks preserve
-     today's 1.25rem. faq keeps the bare literal (out of #343's scope). */
+     today's 1.25rem. faq keeps the bare literal (out of issue 343's scope). */
   main > .grid .grid__heading {
     margin-bottom: var(--grid-heading-margin-bottom, 1.25rem);
   }

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -829,7 +829,12 @@
 .section__title {
   font-size: var(--section-title-size, inherit);
   color: var(--section-title-color, var(--section-title-theme-color, var(--color-text)));
-  margin-bottom: var(--space-md);
+  /* Top-side header rhythm (title -> subheading gap). #336 made the subheading's
+     BOTTOM margin authorable; this routes the title's own bottom margin through a
+     slot so the whole header rhythm is slot-driven (issue 343). No header-scoping
+     needed: the title is a heading, not the header's last child, so base.css's
+     `p:last-child` reset never reached it. Today's literal stays the fallback. */
+  margin-bottom: var(--section-title-margin-bottom, var(--space-md));
 }
 
 .section__title-accent {
@@ -1255,7 +1260,11 @@
   color: var(--grid-heading-color, var(--grid-heading-theme-color, var(--color-text)));
   font-size: var(--grid-heading-size, inherit);
   max-width: var(--grid-heading-max-width, 40rem);
-  margin-bottom: var(--space-lg);
+  /* Top-side header rhythm (heading -> subheading gap), mirror of the #336
+     subheading BOTTOM slot on the adjacent property (issue 343). The heading is
+     not the header's last child, so base.css's `p:last-child` reset never won
+     here — a plain slot on the heading suffices. Today's literal is the fallback. */
+  margin-bottom: var(--grid-heading-margin-bottom, var(--space-lg));
 }
 
 .grid__heading-accent {
@@ -2416,7 +2425,11 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
 .testimonials__heading {
   color: var(--testimonials-heading-color, var(--color-text));
   max-width: 40rem;
-  margin-bottom: var(--space-lg);
+  /* Top-side header rhythm (heading -> subheading gap), mirror of the #336
+     subheading BOTTOM slot on the adjacent property (issue 343). The heading is
+     not the header's last child, so base.css's `p:last-child` reset never won
+     here — a plain slot on the heading suffices. Today's literal is the fallback. */
+  margin-bottom: var(--testimonials-heading-margin-bottom, var(--space-lg));
 }
 
 .testimonials__heading-accent {
@@ -3245,7 +3258,6 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
   main > .section .section__title,
   main > .grid .grid__heading,
   main > .faq .faq__heading {
-    margin-bottom: 1.65rem;
     font-weight: 560;
     line-height: 1.12;
   }
@@ -3262,20 +3274,30 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
      .section__title / .grid__heading rules ([0,1,0]) and silently ignoring a
      declared --section-title-size / --grid-heading-size. Route each through its
      size slot with the clamp() as the fallback so unset output is unchanged. faq
-     now routes through --faq-heading-size too (issue 304). */
+     now routes through --faq-heading-size too (issue 304).
+
+     margin-bottom joins the split for section/grid (issue 343): this premium rule
+     hardcoded the title -> subheading gap (1.65rem here, 1.25rem in the max-width
+     rule below) at [0,2,1], outranking the base [0,1,0] rules and silently ignoring
+     a declared --section-title-margin-bottom / --grid-heading-margin-bottom. Route
+     each through its slot with 1.65rem as the fallback so unset output is unchanged.
+     faq stays a bare literal (no faq heading-margin slot in #343's scope). */
   main > .grid .grid__heading {
     color: var(--grid-heading-color, var(--grid-heading-theme-color, var(--color-text)));
     font-size: var(--grid-heading-size, clamp(2.25rem, 3vw, 2.62rem));
+    margin-bottom: var(--grid-heading-margin-bottom, 1.65rem);
   }
 
   main > .section .section__title {
     color: var(--section-title-color, var(--section-title-theme-color, var(--color-text)));
     font-size: var(--section-title-size, clamp(2.25rem, 3vw, 2.62rem));
+    margin-bottom: var(--section-title-margin-bottom, 1.65rem);
   }
 
   main > .faq .faq__heading {
     color: var(--faq-heading-color, var(--faq-heading-theme-color, var(--color-text)));
     font-size: var(--faq-heading-size, clamp(2.25rem, 3vw, 2.62rem));
+    margin-bottom: 1.65rem;
   }
 
   main > .section .section__content,
@@ -3354,9 +3376,23 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
   main > .section .section__title,
   main > .grid .grid__heading,
   main > .faq .faq__heading {
-    margin-bottom: 1.25rem;
     font-weight: 560;
     line-height: 1.15;
+  }
+
+  /* margin-bottom split per-selector so each component's heading-margin slot
+     reaches the title at this breakpoint too (issue 343); fallbacks preserve
+     today's 1.25rem. faq keeps the bare literal (out of #343's scope). */
+  main > .grid .grid__heading {
+    margin-bottom: var(--grid-heading-margin-bottom, 1.25rem);
+  }
+
+  main > .section .section__title {
+    margin-bottom: var(--section-title-margin-bottom, 1.25rem);
+  }
+
+  main > .faq .faq__heading {
+    margin-bottom: 1.25rem;
   }
 
   main > .section .section__content,

--- a/components/grid/schema.json
+++ b/components/grid/schema.json
@@ -86,6 +86,7 @@
       "--grid-eyebrow-radius": { "type": "length", "default": "3px", "description": "Eyebrow pill corner radius. Set a large value (e.g. 999px) for a fully rounded pill." },
       "--grid-subheading-color": { "type": "color", "default": "var(--color-muted)", "description": "Subheading text color" },
       "--grid-subheading-margin-bottom": { "type": "length", "default": "var(--space-lg)", "description": "Space between the subheading and the content below it" },
+      "--grid-heading-margin-bottom": { "type": "length", "default": "var(--space-lg)", "description": "Space between the heading and the subheading below it" },
       "--grid-heading-size": { "type": "length", "default": "inherit", "description": "Heading font size" },
       "--grid-heading-max-width": { "type": "length", "default": "40rem", "description": "Heading maximum width — increase to let long headings use available horizontal space" },
       "--grid-gap": { "type": "length", "default": "var(--space-lg)", "description": "Gap between grid cards" },

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -157,6 +157,7 @@
       "--section-eyebrow-radius": { "type": "length", "default": "3px", "description": "Eyebrow pill corner radius. Set a large value (e.g. 999px) for a fully rounded pill." },
       "--section-subheading-color": { "type": "color", "default": "var(--color-muted)", "description": "Subheading text color" },
       "--section-subheading-margin-bottom": { "type": "length", "default": "var(--space-md)", "description": "Space between the subheading and the content below it" },
+      "--section-title-margin-bottom": { "type": "length", "default": "var(--space-md)", "description": "Space between the title and the subheading below it" },
       "--section-body-width": { "type": "length", "default": "42rem", "description": "Max width of the content column" },
       "--section-border-color": { "type": "color", "default": "transparent", "description": "Top and bottom border color" },
       "--section-border-width": { "type": "length", "default": "0", "description": "Top and bottom border width" },

--- a/components/testimonials/schema.json
+++ b/components/testimonials/schema.json
@@ -82,6 +82,7 @@
       "--testimonials-eyebrow-radius": { "type": "length", "default": "3px", "description": "Eyebrow pill corner radius. Set a large value (e.g. 999px) for a fully rounded pill." },
       "--testimonials-subheading-color": { "type": "color", "default": "var(--color-muted)", "description": "Subheading text color" },
       "--testimonials-subheading-margin-bottom": { "type": "length", "default": "var(--space-lg)", "description": "Space between the subheading and the content below it" },
+      "--testimonials-heading-margin-bottom": { "type": "length", "default": "var(--space-lg)", "description": "Space between the heading and the subheading below it" },
       "--testimonials-gap": { "type": "length", "default": "var(--space-lg)", "description": "Gap between testimonial cards (grid layout) or between stacked quotes (stack layout)" },
       "--testimonials-card-bg": { "type": "gradient", "default": "var(--color-surface)", "description": "Card background color or gradient" },
       "--testimonials-card-border": { "type": "color", "default": "var(--color-border)", "description": "Card border color" },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.123');
+define('PP_VERSION', '0.16.124');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.123",
+  "version": "0.16.124",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.123
+Stable tag: 0.16.124
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.123
+Version:          0.16.124
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -246,8 +246,8 @@ class SchemaValidationTest extends TestCase
     {
         $expected = [
             'hero'    => 38,
-            'section' => 32,
-            'grid'    => 30,
+            'section' => 33,
+            'grid'    => 31,
             'cta'     => 27,
         ];
 
@@ -921,8 +921,8 @@ class SchemaValidationTest extends TestCase
                 '--grid-padding-top', '--grid-padding-bottom', '--grid-bg',
                 '--grid-heading-color', '--grid-heading-accent-color', '--grid-eyebrow-color',
                 '--grid-eyebrow-bg', '--grid-eyebrow-radius', '--grid-subheading-color',
-                '--grid-subheading-margin-bottom', '--grid-heading-size',
-                '--grid-heading-max-width', '--grid-gap',
+                '--grid-subheading-margin-bottom', '--grid-heading-margin-bottom',
+                '--grid-heading-size', '--grid-heading-max-width', '--grid-gap',
             ],
             $scopes['ineligible'],
             'The container/heading-scoped set drifted from issue 323.'

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -1849,6 +1849,76 @@ test.describe('Safe-surface rendered proof', () => {
     });
   }
 
+  // ── #343: title -> subheading gap is now slot-driven ──────────────────────
+  //
+  // #336 made the subheading's BOTTOM margin authorable; the title's OWN bottom
+  // margin (the title -> subheading gap, the TOP half of the header rhythm) stayed
+  // hardcoded. This routes it through a slot so the whole header rhythm is
+  // slot-driven. The gap is NOT the simple base literal: for section/grid a shared
+  // "premium typography" rule (`main > .X .heading`, [0,2,1]) overrides the base
+  // [0,1,0] rule at every breakpoint, so the value that actually renders is 1.65rem
+  // at >=768px (this test's 1280px viewport) and 1.25rem below it. The slot is
+  // routed through the base rule AND both premium breakpoints (the #302 split), so
+  // a declaration-level assertion would not prove the slot survives the premium
+  // override — only computed style does. testimonials has no premium override, so
+  // its base var(--space-lg) (32px) is what renders. 1.65rem @ 16px root = 26.4px.
+  // Pinned twice: unset -> the real rendered default, and set -> the operator wins.
+  for (const { component, locator, slot, expected } of [
+    { component: 'section', locator: '.section__title', slot: '--section-title-margin-bottom', expected: '26.4px' },
+    { component: 'grid', locator: '.grid__heading', slot: '--grid-heading-margin-bottom', expected: '26.4px' },
+    { component: 'testimonials', locator: '.testimonials__heading', slot: '--testimonials-heading-margin-bottom', expected: '32px' },
+  ]) {
+    test(`#343 ${component} title keeps its slot-driven gap above the subheading @smoke`, async ({
+      page,
+    }) => {
+      pageId = createPage(`E2E ${component} Title Rhythm`);
+      setComposition(pageId, [
+        {
+          component,
+          props: {
+            id: 'pp-ttl01',
+            title: 'Rhythm',
+            eyebrow: 'Kicker',
+            subheading: 'The title must not collide with the sub-heading below it.',
+            // Each component's own required props (section: body, grid/testimonials: items).
+            ...(component === 'section' ? { body: '<p>Body copy.</p>' } : {}),
+            ...(component === 'grid' ? { items: [{ title: 'One', text: 'Card' }] } : {}),
+            ...(component === 'testimonials'
+              ? { items: [{ quote: 'Great.', author: 'A. Person' }] }
+              : {}),
+          },
+        },
+      ]);
+
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+
+      const title = page.locator(locator);
+      await expect(title).toBeVisible({ timeout: 10000 });
+
+      // Unset: today's literal renders (byte-identical to pre-#343). The slot adds
+      // capability, not a new default. The title is NOT the header's last child, so
+      // the `p:last-child` reset never applied here in the first place.
+      const unset = await title.evaluate((el) => getComputedStyle(el).marginBottom);
+      expect(unset).toBe(expected);
+      const isLastChild = await title.evaluate((el) => el === el.parentElement?.lastElementChild);
+      expect(isLastChild).toBe(false);
+
+      // Set: the new slot drives it. A value no token resolves to.
+      await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+      await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+      const res = await styleComponent(page, pageId, { [slot]: '61px' });
+      expect(res.success).toBe(true);
+
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      const set = await page.locator(locator).evaluate(
+        (el) => getComputedStyle(el).marginBottom
+      );
+      expect(set).toBe('61px');
+    });
+  }
+
   // Strand 1. The eyebrow had color/bg slots but no radius slot, so the pill
   // shape was unreachable.
   //

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -121,8 +121,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('hero/section/grid/cta schemas declare 127 style slots (subset of the 172 total)', () => {
-        expect(allSlots.length).toBe(127);
+    test('hero/section/grid/cta schemas declare 129 style slots (subset of the 175 total)', () => {
+        expect(allSlots.length).toBe(129);
     });
 
     allSlots.forEach(({ component, slotName }) => {


### PR DESCRIPTION
Closes #343

## Scope

The site-building AI could author the space *below* a component's sub-heading (via the #336 slots) but not the space *above* it, so "tighten this header" was only half-expressible. This adds the top-side companion: three per-component style slots that make the title→subheading gap authorable, byte-identical when unset.

- `--section-title-margin-bottom` on `.section__title` (fallback `var(--space-md)`)
- `--grid-heading-margin-bottom` on `.grid__heading` (fallback `var(--space-lg)`)
- `--testimonials-heading-margin-bottom` on `.testimonials__heading` (fallback `var(--space-lg)`)

Mirror of #336 on the adjacent property. Registered in each component's `schema.json`, routed as `var(--slot, <literal>)`.

## Notable implementation detail

The gap is not a single literal. On `section`/`grid` the shared responsive "premium typography" rules (`main > .X .heading`, specificity (0,2,1)) override the base rule and hardcode `1.65rem` at ≥768px and `1.25rem` below it. Left unrouted, those would silently bypass the slot (the #292/#302 class). So `margin-bottom` is split out of the shared rule per-selector at both breakpoints (the #302 pattern), routing `section`/`grid` through their slots with the responsive literal as the fallback. `faq` shares that rule but is out of #343's scope, so it keeps its literal (unchanged). `testimonials` has no premium override, so its base `var(--space-lg)` default renders.

Unlike #336's subheading, the title is a heading element and not the header's last child, so `base.css`'s `p:last-child { margin-bottom: 0 }` reset never reached it — no header-scoping needed, and no new cross-sheet clobber (`margin-bottom` was already a watched property; check 8's ledger is unchanged).

## Not in scope

- A `faq` heading-margin slot (faq is not one of #343's three named components; adding it would expand the recorded decision).
- Any change to default spacing — the deliverable is the authorable slot, not a new opinion.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — 1807 passing (warnings/deprecations unchanged from base).
- `npm test` (vitest) — 556 passing.
- `tests/e2e/style-render.spec.ts`: new `#343` rendered computed-style pins per component — unset default (26.4px section/grid at 1280px, 32px testimonials) and set-value-wins, proving the slot lands under the real cascade past the premium override.
- `StyleSlotContractTest` check 5 caught the premium-rule bypass before it shipped (partial routing); check 8 (cross-sheet clobber) stays green with its ledger unchanged.
- `bash scripts/package.sh`: five-file version sync OK (0.16.124); build zip deleted (CI builds releases from tags).

## Reviews (this session)

- `/plan-eng-review`: ENG CLEARED, decision-free mirror, 0 unresolved.
- `/review`: 0 findings. Adversarial + testing passes (Claude subagents; Codex unavailable in this sandbox) both returned NO FINDINGS, confirming byte-identical unset output across base + both breakpoints and correct pin values.
- `/document-generate`: no doc updates needed beyond the count bumps already in the diff.