### PR TITLE
v0.16.125 fix: grid text_role no longer defeats --grid-item-text-color on mobile (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.125] — 2026-07-14 — a grid card's own text color now holds on mobile, even when the card also carries a meta/kicker role (#349)
+
+**Setting a per-card text color (`--grid-item-text-color`) on a grid card that also used a `meta` or `kicker` typography role worked on desktop but silently reverted to the role's preset color below 768px. The color you authored simply vanished on phones. Now an explicit `--grid-item-text-color` wins over the role's preset at every breakpoint, so the card text renders in the color you set no matter the screen width. Leave the slot unset and every page renders exactly as before, down to the byte, at both breakpoints.**
+
+The role class the card gets from `text_role` (`.text-meta` / `.text-kicker`) sets a color of its own, and because the theme's utility stylesheet loads after the component stylesheet, that role color won the tie against the card's own text-color rule on narrow screens, while a wider-screen rule out-specified it on desktop. The result was a color slot that reported success and rendered nothing on mobile. The fix out-specifies the role color at all breakpoints with the authored slot, falling back to the role's own color when the slot is unset, so nothing changes unless you explicitly set the color. Only `meta` and `kicker` carry a preset color; the `mono` and `label` roles were never affected.
+
+### Fixed
+
+- An explicit per-card `--grid-item-text-color` now overrides a `text_role: meta` or `text_role: kicker` color preset at all breakpoints, mobile included. Previously the slot was honored at ≥768px and silently defeated below it. Unset-slot output is byte-identical to before at both breakpoints; no default color changed.
+
+### Docs
+
+- The grid `text_role` note in `ai-instructions/composition.md`, `ai-instructions/style-component.md`, `components/grid/schema.json`, and `components/grid/README.md` now documents that an explicit `--grid-item-text-color` always wins over a role's preset color, and that the role's non-color typography (size, weight, letter-spacing, transform) always applies.
+
+### Tests
+
+- `tests/e2e/style-render.spec.ts` gains a rendered computed-style pin asserting the slot wins over `meta` and `kicker` at BOTH 375px and 1280px, and that unset cards stay byte-identical (role color on mobile, secondary color on desktop). Proven red→green: with the fix reverted, the mobile set-slot assertion fails. `tests/js/css-lint.test.js` widens its grid-card-text fallback allow-list to accept the role-color tokens, which are fixed global tokens never re-scoped under any theme.
+
 ## [v0.16.124] — 2026-07-14 — the header's top gap is authorable now, so "tighten this header" is fully expressible (#343)
 
 **The site-building AI could set the space *below* a component's sub-heading but not the space *above* it, so a request like "tighten this header" was only half-expressible. This adds three style slots — `--section-title-margin-bottom`, `--grid-heading-margin-bottom`, and `--testimonials-heading-margin-bottom` — that make the gap between the title and the sub-heading authorable on section, grid, and testimonials. Leave them unset and every page renders exactly as before, down to the byte: the slots add reach, not a new spacing opinion.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.124-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.125-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -201,6 +201,8 @@ Renders a checklist below the card's `text`, each line prefixed with a check mar
 
 Optional typography role for a card's `text`: `mono` (code), `meta` (captions), `label`, or `kicker` (eyebrow styling). Adds a `.text-<role>` class; invalid or absent values fall back to default body text. Set via `update_component` like any other item field.
 
+`meta` and `kicker` also carry a preset text **color** (muted / accent), but the grid's own responsive text-color rules can take precedence when the slot is unset (for example, at the desktop breakpoint card text renders in the standard secondary color). To control card text color reliably, set `--grid-item-text-color` (grid-level or per-card `style`): it always wins over a role preset at **all breakpoints**. The role's other typography (size, weight, letter-spacing, transform) always applies regardless.
+
 ```json
 { "component": "grid", "props": { "title": "Security", "items": [
   { "title": "Perimeter security", "bullets": ["HTTP security headers", "SSL/TLS validity", "Clickjacking protection"] }

--- a/ai-instructions/style-component.md
+++ b/ai-instructions/style-component.md
@@ -211,7 +211,9 @@ wp pp action execute update_component --run-id=<uuid> --params='{
 }'
 ```
 `text_role` accepts `mono`, `meta`, `label`, `kicker`. An unknown role is ignored
-(the card renders default body text).
+(the card renders default body text). `meta`/`kicker` set a preset text color; an
+explicit `--grid-item-text-color` slot overrides it at all breakpoints (the role's
+size/weight/spacing still apply).
 
 **Verify all three:** re-run `wp pp operate inspect-composition <page_id>` and load
 the page. The CTA section carries the `--cta-shadow` / `--cta-radius` inline custom

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1375,7 +1375,7 @@
   flex: 1;
 }
 
-/* Issue #349 — an explicit per-instance --grid-item-text-color must win over a
+/* Issue 349 — an explicit per-instance --grid-item-text-color must win over a
    text_role color preset at ALL breakpoints. text_role adds .text-meta / .text-kicker
    (utilities.css), each a (0,1,0) `color` rule enqueued AFTER components.css, so it
    defeats the (0,1,0) base rule on the source-order tie below the 768px premium

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1375,6 +1375,25 @@
   flex: 1;
 }
 
+/* Issue #349 — an explicit per-instance --grid-item-text-color must win over a
+   text_role color preset at ALL breakpoints. text_role adds .text-meta / .text-kicker
+   (utilities.css), each a (0,1,0) `color` rule enqueued AFTER components.css, so it
+   defeats the (0,1,0) base rule on the source-order tie below the 768px premium
+   breakpoint — the slot was honored on desktop and dead on mobile. These (0,2,0)
+   companion rules out-specify the utility regardless of enqueue order (mirroring how
+   the desktop `main > .grid .grid__item-text` premium rule already does at (0,2,1)),
+   so the slot always wins when set. The fallback is the exact role token, so an UNSET
+   slot still renders the role colour — byte-identical to today at both breakpoints
+   (desktop stays governed by the premium rule, which is strictly higher at (0,2,1)).
+   Only meta/kicker set a colour; mono/label do not, so they need no companion rule. */
+.grid__item-text.text-meta {
+  color: var(--grid-item-text-color, var(--text-meta-color));
+}
+
+.grid__item-text.text-kicker {
+  color: var(--grid-item-text-color, var(--text-kicker-color));
+}
+
 .grid__item-bullets {
   list-style: none;
   display: flex;

--- a/components/grid/README.md
+++ b/components/grid/README.md
@@ -24,7 +24,7 @@ Each item in `items`:
 | `title`     | string | No       | `''`           | Card heading (h3) |
 | `text`      | string | No       | `''`           | Card body text |
 | `bullets`   | array  | No       | —              | Checklist lines rendered below `text`, each prefixed with a check mark. Plain text only. |
-| `text_role` | enum   | No       | —              | Typography role for the card text: `mono` / `meta` / `label` / `kicker` |
+| `text_role` | enum   | No       | —              | Typography role for the card text: `mono` / `meta` / `label` / `kicker`. `meta`/`kicker` set a preset text color; an explicit `--grid-item-text-color` slot overrides it at all breakpoints. |
 | `image_url` | string | No       | `''`           | Card image URL |
 | `image_alt` | string | No       | `''`           | Alt text for the card image |
 | `link_url`  | string | No       | `''`           | Card link URL (shown only if set) |

--- a/components/grid/schema.json
+++ b/components/grid/schema.json
@@ -61,7 +61,7 @@
         "number":    { "type": "string", "required": false, "description": "Step number label (e.g. '1', '01', '1.'). Required when grid layout is 'steps'." },
         "title":     { "type": "string", "required": false },
         "text":      { "type": "string", "required": false },
-        "text_role": { "type": "enum", "values": ["mono", "meta", "label", "kicker"], "required": false, "description": "Optional typography role for the card text: 'mono' (code), 'meta' (captions), 'label', or 'kicker' (eyebrow). Adds a .text-<role> class. Invalid/absent → default body text. Set via update_component." },
+        "text_role": { "type": "enum", "values": ["mono", "meta", "label", "kicker"], "required": false, "description": "Optional typography role for the card text: 'mono' (code), 'meta' (captions), 'label', or 'kicker' (eyebrow). Adds a .text-<role> class. Invalid/absent → default body text. Set via update_component. 'meta'/'kicker' also set a preset text color; an explicit --grid-item-text-color style slot overrides that preset color at ALL breakpoints (the explicit slot always wins), while the role's size/weight/letter-spacing/transform still apply." },
         "bullets":   { "type": "array", "required": false, "description": "Optional checklist lines rendered below text, each prefixed with a check mark. Plain text only — no HTML/markdown; each line is escaped independently. Use for scannable feature/benefit lists instead of cramming items into one text sentence.", "items": { "type": "string" } },
         "image_url": { "type": "string", "required": false },
         "image_alt": { "type": "string", "required": false, "default": "", "description": "Alt text for the card image. Leave empty only if the image is purely decorative." },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.124');
+define('PP_VERSION', '0.16.125');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.124",
+  "version": "0.16.125",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.124
+Stable tag: 0.16.125
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.124
+Version:          0.16.125
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -260,6 +260,70 @@ test.describe('Safe-surface rendered proof', () => {
     expect(color).toBe('rgb(255, 0, 128)');
   });
 
+  // #349: an explicit per-instance --grid-item-text-color must win over a text_role
+  // color preset (.text-meta / .text-kicker) at BOTH breakpoints. The bug was a
+  // breakpoint split: the role utility (utilities.css, enqueued after components.css)
+  // is (0,1,0) and defeated the (0,1,0) base slot rule on the source-order tie below
+  // 768px, while the (0,2,1) desktop premium rule out-specified it — so the slot was
+  // honored on desktop and DEAD on mobile. A single-viewport pin would miss it exactly
+  // as it shipped, so this asserts at 375px (mobile) AND 1280px (desktop).
+  //
+  // Four cards prove both halves in one render (per-item `style`, the #306 per-instance
+  // path): cards 0/1 SET --grid-item-text-color and must render the slot colour at both
+  // breakpoints (the fix); cards 2/3 leave it UNSET and must render byte-identically to
+  // today — the role colour on mobile (--text-meta-color=--color-muted #5e6677 /
+  // --text-kicker-color=--color-accent #3157f4), and the premium fallback
+  // --color-text-secondary (#2d3648) on desktop, where the (0,2,1) rule still governs.
+  // The unset assertions guard that the fix changed NO default colour.
+  test('#349 explicit --grid-item-text-color beats text_role at both breakpoints @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Grid Text Role Slot Precedence');
+    const SLOT = '#ff0080'; // vivid, no token uses it — a leak or clobber is obvious
+    setComposition(pageId, [
+      {
+        component: 'grid',
+        props: {
+          id: 'pp-grid01',
+          title: 'Role vs slot',
+          items: [
+            { title: 'One', text: 'Set meta', text_role: 'meta', style: { '--grid-item-text-color': SLOT } },
+            { title: 'Two', text: 'Set kicker', text_role: 'kicker', style: { '--grid-item-text-color': SLOT } },
+            { title: 'Three', text: 'Unset meta', text_role: 'meta' },
+            { title: 'Four', text: 'Unset kicker', text_role: 'kicker' },
+          ],
+        },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    const textColor = (i: number) =>
+      page.locator('.grid__item').nth(i).locator('.grid__item-text')
+        .evaluate((el) => getComputedStyle(el).color);
+
+    for (const width of [1280, 375]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator('.grid__item')).toHaveCount(4, { timeout: 10000 });
+
+      // Set slot wins at BOTH breakpoints (mobile is the case that shipped broken).
+      expect(await textColor(0)).toBe('rgb(255, 0, 128)'); // set + meta
+      expect(await textColor(1)).toBe('rgb(255, 0, 128)'); // set + kicker
+
+      // Unset output is byte-identical to today: role colour on mobile, premium
+      // --color-text-secondary on desktop. No default colour changed.
+      if (width >= 768) {
+        expect(await textColor(2)).toBe('rgb(45, 54, 72)'); // unset meta -> --color-text-secondary
+        expect(await textColor(3)).toBe('rgb(45, 54, 72)'); // unset kicker -> --color-text-secondary
+      } else {
+        expect(await textColor(2)).toBe('rgb(94, 102, 119)'); // unset meta -> --text-meta-color (--color-muted)
+        expect(await textColor(3)).toBe('rgb(49, 87, 244)'); // unset kicker -> --text-kicker-color (--color-accent)
+      }
+    }
+  });
+
   // #24: a hero-surface slot must reach the rendered inner shell (.hero__surface only
   // renders for the split variant with proof markup).
   test('#24 hero surface honors --hero-surface-border-width', async ({ page }) => {

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -348,6 +348,12 @@ describe('CSS lint: theme variants survive the desktop typography cascade (#222)
     // Inverted grid CARDS keep a light background (`--grid-card-bg: var(--color-bg)`),
     // so their text must stay DARK. Theming it would be the inverse of #222: an
     // inverted grid would render light-on-light card text. Pin both halves of that.
+    // The fallback must be a FIXED global token (never a theme-swapped var): a bare
+    // `--color-*`, OR the `--text-meta-color` / `--text-kicker-color` role tokens used
+    // by the #349 role-vs-slot companion rules (`.grid__item-text.text-meta/.text-kicker`).
+    // Those two are aliases defined once in base.css :root (→ --color-muted / --color-accent)
+    // and are never redefined under any inverted/bg-image/theme scope, so they stay dark
+    // on a light card exactly like a bare --color-* fallback.
     test('inverted grid card text resolves to a global token, never a theme var', () => {
         const cardDecls = rules
             .filter(r => targetsElement(r.selector, '.grid__item-title') ||
@@ -356,7 +362,7 @@ describe('CSS lint: theme variants survive the desktop typography cascade (#222)
 
         expect(cardDecls.length).toBeGreaterThan(0);
         const offenders = cardDecls
-            .filter(d => !/^var\(--grid-item-(title|text)-color,\s*var\(--color-[a-z0-9-]+\)\)$/.test(d.value))
+            .filter(d => !/^var\(--grid-item-(title|text)-color,\s*var\(--(color-[a-z0-9-]+|text-(meta|kicker)-color)\)\)$/.test(d.value))
             .map(d => `${d.selector.split('\n').pop().trim()} { color: ${d.value} }`);
         expect(offenders).toEqual([]);
     });


### PR DESCRIPTION
Closes #349

## What this fixes

A per-instance grid card text color (`--grid-item-text-color`) silently died on mobile when the card also carried a `text_role: meta` or `text_role: kicker`. The role adds a `.text-meta`/`.text-kicker` utility class whose `color` is specificity (0,1,0), the same as the base `.grid__item-text` rule, and because `utilities.css` is enqueued after `components.css` (functions.php ~104 then ~111) the utility won the source-order tie below the 768px premium breakpoint. At ≥768px the premium rule `main > .grid .grid__item-text` (0,2,1) out-specified the utility, so the slot worked on desktop and was dead on mobile — the #86/#336 split-brain class, and the #302 documented-slot-with-zero-effect trust failure that reopened the v1.0.0 gate. This is the last item of #141 § 1.0-I.

## Recorded decision applied

Per the orchestrator's recorded decision on #349: the explicit per-instance slot WINS at all breakpoints. An unset slot still falls back to the role/muted color (unchanged); no default color changes; styling-only.

## Approach

Two var-routed companion rules in `components.css`, immediately after the base rule, outside any media query:

```css
.grid__item-text.text-meta   { color: var(--grid-item-text-color, var(--text-meta-color)); }
.grid__item-text.text-kicker { color: var(--grid-item-text-color, var(--text-kicker-color)); }
```

At (0,2,0) they beat the (0,1,0) utility on mobile (slot wins when set; role-token fallback preserves the unset color). On desktop the premium rule (0,2,1) is strictly higher, so desktop is entirely unchanged. Only `meta`/`kicker` set a color; `mono`/`label` do not, so they need no rule. No stylesheet enqueue reorder. `text_role` is grid-only, so no other component surface has the same clobber.

## Scope vs acceptance criteria

- Explicit `--grid-item-text-color` overrides `text_role: meta`/`kicker` at BOTH breakpoints — done (CSS fix).
- Unset output byte-identical at both breakpoints, no default color changed — done (unset E2E assertions + css-lint pins).
- Rendered computed-style pin at both breakpoints, proven red→green — done.
- AI docs updated in the same change (composition.md, style-component.md, schema.json, grid README) — done.

## Validation

- **PHPUnit** (`./vendor/bin/phpunit --configuration phpunit.xml`): 1807 tests, 6898 assertions, OK. The 3 warnings / 2 PHPUnit deprecations are pre-existing (identical on a clean `main` tree). `StyleSlotContractTest` check 8 unchanged; neither the `KNOWN_DEAD_SLOT_WAIVERS` nor `CROSS_SHEET_CLOBBER_LEDGER` grew (this opt-in utility-class path was explicitly left to #349 and is out of check-8's automatic-match scope).
- **vitest** (`npm test`): 556 passed (16 files).
- **E2E** (`tests/e2e/style-render.spec.ts`, `#349`): passes at 375px and 1280px. Mutation/negative-control: with the CSS reverted, the mobile set+meta assertion fails (`rgb(94,102,119)` instead of `rgb(255,0,128)`) while desktop passes — the breakpoint split is captured. The 20 grid-focused style-render tests (incl. #86/#293/#336) still pass.

## Accepted limitations / decided without asking

- Companion rules are unscoped and rely on the desktop premium rule (0,2,1) out-specifying them at ≥768px, mirroring the recorded implementation direction ("mirror how the premium rule does it"). A reviewer suggested scoping them inside `@media (max-width: 767px)` instead; both produce byte-identical output, and the desktop seam is guarded by the E2E desktop assertions, so I kept the directed approach.
- Corrected one doc wording issue surfaced in review: the earlier draft implied an unset slot always "keeps the role's preset color", but on desktop the premium rule renders the secondary color regardless. Wording now describes this accurately.

## Reviews (this session, on this exact diff)

- `/plan-eng-review` — plan sound, no blocking findings; Codex outside voice contributed the both-breakpoint unset-case test coverage (adopted).
- `/review` — 0 critical; specialists (testing, maintainability) + Claude adversarial + Codex adversarial all confirm the byte-identical-at-both-breakpoints requirement holds. All Codex findings verified false-positive against the real repo (same-element render at grid.php:110; non-premium desktop grids already render the role color). One informational doc-wording fix applied.

No tag / release / deploy performed (CI builds the release zip from tags; maintainer handles that separately).
