### PR TITLE
v0.16.126 fix: center body copy in section layout:centered (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.126] — 2026-07-14 — a centered section now centers its body copy under its heading, not just the heading (#354)
+
+**A `section` with `layout: centered` centered its heading but left the body copy pinned to the left, so the paragraph sat about 112px off-center from the title above it. Now the body block centers under the heading, the way a centered layout is meant to read. Only the `centered` layout is touched: `text-only`, `image-left`, `image-right`, and `text-panel` render exactly as before, down to the byte.**
+
+The centered layout centers an outer wrapper (`.section__body`, capped at the wider 56rem centered measure) but its inner body-copy wrapper (`.section__content`, capped at the narrower 42rem prose measure) had no horizontal centering of its own, so it hugged the left edge of the wider centered block while the title was explicitly centered. The two lines of a "centered" section therefore disagreed with each other. The fix gives the inner wrapper auto side-margins in the centered layout only, so the narrower body column sits centered under the heading. The text inside was already centered; this centers the block it lives in.
+
+### Fixed
+
+- On `section` with `layout: centered`, the body copy block now centers under the heading instead of pinning to the left of the wider centered wrapper. Scoped to the centered layout only; the other four section layouts keep their left-aligned body copy and render byte-identically.
+
+### Tests
+
+- `tests/e2e/style-render.spec.ts` gains a rendered-geometry pin asserting that in a `layout: centered` section the `.section__content` box shares its center-x with the centered `.section__body` (with real free space between them, so the match is a genuine reposition, not a fill artifact), while a `text-only` section in the same page keeps its body copy left-pinned with zero side-margins. Proven red→green: with the fix reverted the centered assertion fails by the ~112px offset.
+
 ## [v0.16.125] — 2026-07-14 — a grid card's own text color now holds on mobile, even when the card also carries a meta/kicker role (#349)
 
 **Setting a per-card text color (`--grid-item-text-color`) on a grid card that also used a `meta` or `kicker` typography role worked on desktop but silently reverted to the role's preset color below 768px. The color you authored simply vanished on phones. Now an explicit `--grid-item-text-color` wins over the role's preset at every breakpoint, so the card text renders in the color you set no matter the screen width. Leave the slot unset and every page renders exactly as before, down to the byte, at both breakpoints.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.125-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.126-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2711,6 +2711,19 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
   text-align: center;
 }
 
+/* The centered layout centers the OUTER .section__body (max-width --measure-centered,
+   56rem) but its inner .section__content carries a NARROWER cap (--section-body-width,
+   42rem) with no auto margins, so the body copy left-pinned inside the wider centered
+   wrapper while the title sat centered — a visible ~112px asymmetry (issue 354). Give
+   the inner wrapper auto side-margins so the measure centers under the heading. Scoped
+   to .section--centered only: text-only / image-left / image-right / text-panel keep
+   .section__content left-pinned (byte-identical). Text is already centered here via the
+   inherited text-align:center on .section--centered .section__body. */
+.section--centered .section__content {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 /* ==========================================================================
    SHARED: Pagination
    Renders under the post grid on the blog index / archives (issue 126).

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.125');
+define('PP_VERSION', '0.16.126');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.125",
+  "version": "0.16.126",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.125
+Stable tag: 0.16.126
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.125
+Version:          0.16.126
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -2482,4 +2482,98 @@ test.describe('#333 chrome site options render', () => {
       .evaluate((el) => getComputedStyle(el).color);
     expect(rowColor).toBe('rgb(34, 211, 238)');
   });
+
+  // #354 — a section with layout:centered centered its heading but LEFT-PINNED its body
+  // copy. The outer .section__body centers itself (max-width --measure-centered = 56rem,
+  // margin auto) but the inner .section__content carried a narrower cap (42rem) with NO
+  // auto margins, so it left-pinned inside the wider centered wrapper: title center-x 640,
+  // paragraph center-x ~528, a visible ~112px asymmetry. This is invisible at the
+  // declaration level — the bug is the ABSENCE of a margin rule, exactly how it shipped —
+  // so only a rendered box under the full cascade proves the fix. The mirror-image guard
+  // (a text-only section in the same page stays left-pinned) proves the fix is scoped to
+  // .section--centered and did not leak into the other four layouts.
+  test('#354 centered layout centers the body copy under its heading (scoped) @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Centered Body Alignment');
+    setComposition(pageId, [
+      {
+        component: 'section',
+        props: {
+          id: 'pp-sec-centered',
+          layout: 'centered',
+          title: 'Especificaciones',
+          body: '<p>The body copy of a centered section must sit centered under its heading, not pinned to the left edge of the wider centered wrapper.</p>',
+        },
+      },
+      {
+        component: 'section',
+        props: {
+          id: 'pp-sec-textonly',
+          layout: 'text-only',
+          title: 'Plain section',
+          body: '<p>A non-centered section keeps its body copy pinned to the left; the centered fix must not reach it.</p>',
+        },
+      },
+    ]);
+
+    // 1280px: the container caps at 72rem (1152px), so the centered body reaches its full
+    // 56rem (896px) and the inner content its 42rem (672px) — ~224px of real free space
+    // for the auto margins to redistribute. Without that free space the center-x equality
+    // would be vacuous (a box that fills its parent is trivially "centered" in it).
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const centeredBody = page.locator('#pp-sec-centered .section__body');
+    await expect(centeredBody).toBeVisible({ timeout: 10000 });
+
+    const centered = await page.evaluate(() => {
+      const body = document.querySelector('#pp-sec-centered .section__body') as HTMLElement;
+      const content = document.querySelector('#pp-sec-centered .section__content') as HTMLElement;
+      const b = body.getBoundingClientRect();
+      const c = content.getBoundingClientRect();
+      const cs = getComputedStyle(content);
+      return {
+        bodyWidth: b.width,
+        contentWidth: c.width,
+        bodyCenterX: b.left + b.width / 2,
+        contentCenterX: c.left + c.width / 2,
+        marginLeft: cs.marginLeft,
+        marginRight: cs.marginRight,
+      };
+    });
+
+    // Free space is real: the content wrapper is meaningfully narrower than its centered
+    // body, so a centered center-x is a genuine reposition, not a fill artifact.
+    expect(centered.bodyWidth - centered.contentWidth).toBeGreaterThan(150);
+    // The FIX: the content block centers under the (already centered) heading. Tolerance
+    // 2px absorbs sub-pixel rounding / device-scale jitter; the broken state is ~112px off,
+    // far above it, so the mutation sensitivity is unaffected.
+    expect(Math.abs(centered.contentCenterX - centered.bodyCenterX)).toBeLessThanOrEqual(2);
+    // Auto margins resolved to real, symmetric, non-zero pixels (the ~112px each side).
+    // Without the #354 rule this computes to '0px' and the center-x assertion above fails.
+    expect(centered.marginLeft).not.toBe('0px');
+    expect(centered.marginLeft).toBe(centered.marginRight);
+
+    // Mirror-image guard: the text-only section is unchanged. Its .section__content fills
+    // its wrapper (no free space) and stays left-pinned, and the rule does not attach —
+    // computed side-margins stay 0px. This proves the fix is scoped to .section--centered
+    // and did not leak into the other layouts.
+    const textOnly = await page.evaluate(() => {
+      const body = document.querySelector('#pp-sec-textonly .section__body') as HTMLElement;
+      const content = document.querySelector('#pp-sec-textonly .section__content') as HTMLElement;
+      const b = body.getBoundingClientRect();
+      const c = content.getBoundingClientRect();
+      const cs = getComputedStyle(content);
+      return {
+        bodyLeft: b.left,
+        contentLeft: c.left,
+        marginLeft: cs.marginLeft,
+        marginRight: cs.marginRight,
+      };
+    });
+    expect(textOnly.marginLeft).toBe('0px');
+    expect(textOnly.marginRight).toBe('0px');
+    expect(Math.abs(textOnly.contentLeft - textOnly.bodyLeft)).toBeLessThanOrEqual(2);
+  });
 });


### PR DESCRIPTION
Closes #354

## Scope

`section` with `layout: centered` centered its heading but rendered the body copy left-of-center — a visible ~112px asymmetry (measured at 1280px: title center-x 640, paragraph center-x 528). Root cause: `.section--centered .section__body` centers itself at the 56rem measure, but its child `.section__content` carried the narrower 42rem prose cap with no auto margins, so it left-pinned inside the wider centered block.

Fix (recorded direction in #354): add `.section--centered .section__content { margin-left: auto; margin-right: auto; }` so the body column centers under the heading. Scoped to the centered layout only. `text-only` / `image-left` / `image-right` / `text-panel` all still render `.section__content` left-pinned and are byte-identical.

CSS-only alignment fix. No schema, prop, validator, or AI-doc change (the doc surfaces already describe `centered` as "center-aligned text in a narrower centered column" — the fix makes that claim true).

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → 1807 tests, 6898 assertions green (3 warnings / 2 deprecations — identical to a clean-tree baseline, pre-existing).
- JS: `npm test` (vitest) → 556 tests green.
- E2E: new rendered pin `#354 centered layout centers the body copy under its heading (scoped)` in `tests/e2e/style-render.spec.ts` passes under wp-env Playwright. Mutation-verified red→green: with the CSS rule reverted the centered center-x assertion fails by 112px (the exact issue-reported offset). The pin asserts real free space (body−content width > 150px) so the center-x match is a genuine reposition, and a `text-only` section in the same page stays left-pinned with zero side-margins, proving the fix is scoped and did not leak.

## Accepted limitations

- The non-centered "unchanged" guard uses `text-only`, where `.section__content` fills its wrapper (no free space), so the definitive non-leak guarantee is the selector scoping; the rendered guard confirms the rule doesn't attach. Documented in the test comment.

## Reviews (this session, on this exact diff)

- `/plan-eng-review` — clean, zero architecture/quality/perf findings. Codex outside voice flagged one test-design risk (a vacuous non-leak assertion), folded in before implementation.
- `/review` + Codex adversarial — no blocking findings. One mechanical hardening applied (center-x tolerance 1px → 2px; broken state is 112px, so mutation sensitivity is unaffected). All other Codex points verified against the repo as pre-existing accepted patterns (the sibling `.section--centered .section__title` uses the same descendant scoping) or out of scope.

No version-drift check (repo has no VERSION file; five synced version files bumped by hand and validated by `scripts/package.sh`).