### PR TITLE
v0.16.127 fix: eyebrow border slots make an outlined pill authorable (#356)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -380,7 +380,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**175 style slots** across 7 components: hero (38), section (33), grid (31), cta (27), testimonials (22), faq (14), stats (10).
+**187 style slots** across 7 components: hero (40), section (35), grid (33), cta (29), testimonials (24), faq (16), stats (10).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.127] — 2026-07-14 — an eyebrow pill can now carry an outline, not just a fill (#356)
+
+**The eyebrow pill exposed text color, background, and corner radius, but no border, so an outlined pill was simply not authorable — the only way to fake one was a tinted background. This adds a per-component border to the eyebrow on all six components that render one (hero, section, faq, grid, cta, testimonials) through two style slots: `--<component>-eyebrow-border-width` and `--<component>-eyebrow-border-color`. Leave them unset and every page renders exactly as before, down to the byte: the default is a zero-width transparent border, which draws nothing.**
+
+An outlined pill is a generic capability, not a product feature, so this follows the same shape the component roots already use for their own borders (`border: var(--x-border-width, 0) solid var(--x-border-color, transparent)`) rather than inventing a new grammar. Width is a `length` slot defaulting to `0`; color is a `color` slot defaulting to `transparent`; the border style is a fixed `solid`, consistent with every other border in the theme. The two new slots surface to the site-building AI through the same runtime schema inspection that carries every style slot and the `--<component>-eyebrow-*` wildcard already documented for grid card-scope rejection, so no accepted-grammar description changed. The slot names embed `border-width`/`border-color`, which are WP-core cascade triggers (#332), but their inline custom properties render on the immunized component root, and the #332 rendered-immunity coverage was extended to all twelve new slots so the phantom-border guard stays honest.
+
+### Fixed
+
+- The eyebrow pill on `hero`, `section`, `faq`, `grid`, `cta`, and `testimonials` now takes an authorable border through `--<component>-eyebrow-border-width` and `--<component>-eyebrow-border-color`, so an outlined pill is expressible. Unset, the border is zero-width and transparent — byte-identical to before. On the four benchmark hero pages whose eyebrow re-declares `border-color` at ID specificity, that declaration now routes through the color slot so a set value still reaches the pill.
+
+### Docs
+
+- `AI_CONTEXT.md` and `README.md` slot counts updated (175 → 187). The new slots surface to the chat AI through the existing runtime slot inspection and the documented `--<component>-eyebrow-*` wildcard, so no accepted-grammar description changed.
+
+### Tests
+
+- `tests/e2e/style-render.spec.ts` gains a rendered computed-style pin proving that setting the hero eyebrow border slots renders a real 3px border in the asked-for color (on both a plain id and the ID-specificity benchmark hero, proving the routing), while an unset eyebrow stays at `0px` — byte-identical to before. The #332 `BORDER_TRIGGER_CASES` immunity set is extended to all twelve new border-trigger slots so cascade immunity stays proven. Slot-count pins in `tests/SchemaValidationTest.php`, `tests/OperateTest.php`, and `tests/js/css-lint.test.js` updated, and the two grid eyebrow border slots added to the grid card-scope-ineligible set.
+
 ## [v0.16.126] — 2026-07-14 — a centered section now centers its body copy under its heading, not just the heading (#354)
 
 **A `section` with `layout: centered` centered its heading but left the body copy pinned to the left, so the paragraph sat about 112px off-center from the title above it. Now the body block centers under the heading, the way a centered layout is meant to read. Only the `centered` layout is touched: `text-only`, `image-left`, `image-right`, and `text-panel` render exactly as before, down to the byte.**

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-175 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+187 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.16.99.
 
 **What exists today (v0.16.99):**
-- 12 components with schema contracts and 175 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 187 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.126-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.127-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -368,6 +368,7 @@
   align-self: flex-start;
   padding: 0.35rem 0.85rem;
   margin-bottom: var(--space-sm);
+  border: var(--hero-eyebrow-border-width, 0) solid var(--hero-eyebrow-border-color, transparent);
   border-radius: var(--hero-eyebrow-radius, 3px);
   font-size: 0.8125rem;
   font-weight: 600;
@@ -817,6 +818,7 @@
   display: inline-block;
   padding: 0.35rem 0.85rem;
   margin-bottom: var(--space-sm);
+  border: var(--section-eyebrow-border-width, 0) solid var(--section-eyebrow-border-color, transparent);
   border-radius: var(--section-eyebrow-radius, 3px);
   font-size: 0.8125rem;
   font-weight: 600;
@@ -1100,6 +1102,7 @@
   display: inline-block;
   padding: 0.35rem 0.85rem;
   margin-bottom: var(--space-sm);
+  border: var(--faq-eyebrow-border-width, 0) solid var(--faq-eyebrow-border-color, transparent);
   border-radius: var(--faq-eyebrow-radius, 3px);
   font-size: 0.8125rem;
   font-weight: 600;
@@ -1247,6 +1250,7 @@
   display: inline-block;
   padding: 0.35rem 0.85rem;
   margin-bottom: var(--space-sm);
+  border: var(--grid-eyebrow-border-width, 0) solid var(--grid-eyebrow-border-color, transparent);
   border-radius: var(--grid-eyebrow-radius, 3px);
   font-size: 0.8125rem;
   font-weight: 600;
@@ -1728,6 +1732,7 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
   display: inline-block;
   padding: 0.35rem 0.85rem;
   margin-bottom: var(--space-sm);
+  border: var(--cta-eyebrow-border-width, 0) solid var(--cta-eyebrow-border-color, transparent);
   border-radius: var(--cta-eyebrow-radius, 3px);
   font-size: 0.8125rem;
   font-weight: 600;
@@ -2432,6 +2437,7 @@ main > .grid:not(.grid--steps) .grid__item:first-child::before {
   display: inline-block;
   padding: 0.35rem 0.85rem;
   margin-bottom: var(--space-sm);
+  border: var(--testimonials-eyebrow-border-width, 0) solid var(--testimonials-eyebrow-border-color, transparent);
   border-radius: var(--testimonials-eyebrow-radius, 3px);
   font-size: 0.8125rem;
   font-weight: 600;
@@ -3891,7 +3897,7 @@ main .btn:focus-visible,
 #agencies-hero .hero__eyebrow,
 #implementers-hero .hero__eyebrow {
   border-radius: var(--hero-eyebrow-radius, 3px);
-  border-color: var(--color-border);
+  border-color: var(--hero-eyebrow-border-color, var(--color-border));
   background:
     linear-gradient(90deg, rgba(37, 99, 235, 0.06) 1px, transparent 1px) 0 0 / 1.4rem 100%,
     var(--hero-eyebrow-bg, var(--color-surface-accent));

--- a/components/cta/schema.json
+++ b/components/cta/schema.json
@@ -83,6 +83,8 @@
       "--cta-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
       "--cta-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
       "--cta-eyebrow-radius": { "type": "length", "default": "3px", "description": "Eyebrow pill corner radius. Set a large value (e.g. 999px) for a fully rounded pill." },
+      "--cta-eyebrow-border-width": { "type": "length", "default": "0", "description": "Eyebrow pill border width. Set a non-zero width (with --cta-eyebrow-border-color) for an outlined pill; 0 (default) renders no border." },
+      "--cta-eyebrow-border-color": { "type": "color", "default": "transparent", "description": "Eyebrow pill border color. Takes effect when --cta-eyebrow-border-width is non-zero." },
       "--cta-title-size": { "type": "length", "default": "inherit", "description": "Title font size" },
       "--cta-body-color": { "type": "color", "default": "var(--color-muted)", "description": "Body text color" },
       "--cta-body-size": { "type": "length", "default": "inherit", "description": "Body text font size" },

--- a/components/faq/schema.json
+++ b/components/faq/schema.json
@@ -55,6 +55,8 @@
       "--faq-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
       "--faq-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
       "--faq-eyebrow-radius": { "type": "length", "default": "3px", "description": "Eyebrow pill corner radius. Set a large value (e.g. 999px) for a fully rounded pill." },
+      "--faq-eyebrow-border-width": { "type": "length", "default": "0", "description": "Eyebrow pill border width. Set a non-zero width (with --faq-eyebrow-border-color) for an outlined pill; 0 (default) renders no border." },
+      "--faq-eyebrow-border-color": { "type": "color", "default": "transparent", "description": "Eyebrow pill border color. Takes effect when --faq-eyebrow-border-width is non-zero." },
       "--faq-heading-size": { "type": "length", "default": "1.875rem", "description": "Section heading font size" },
       "--faq-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading text color" },
       "--faq-heading-accent-color": { "type": "color", "default": "var(--color-accent)", "description": "Color of the title_accent substring within the heading, if set" },

--- a/components/grid/schema.json
+++ b/components/grid/schema.json
@@ -84,6 +84,8 @@
       "--grid-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
       "--grid-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
       "--grid-eyebrow-radius": { "type": "length", "default": "3px", "description": "Eyebrow pill corner radius. Set a large value (e.g. 999px) for a fully rounded pill." },
+      "--grid-eyebrow-border-width": { "type": "length", "default": "0", "description": "Eyebrow pill border width. Set a non-zero width (with --grid-eyebrow-border-color) for an outlined pill; 0 (default) renders no border." },
+      "--grid-eyebrow-border-color": { "type": "color", "default": "transparent", "description": "Eyebrow pill border color. Takes effect when --grid-eyebrow-border-width is non-zero." },
       "--grid-subheading-color": { "type": "color", "default": "var(--color-muted)", "description": "Subheading text color" },
       "--grid-subheading-margin-bottom": { "type": "length", "default": "var(--space-lg)", "description": "Space between the subheading and the content below it" },
       "--grid-heading-margin-bottom": { "type": "length", "default": "var(--space-lg)", "description": "Space between the heading and the subheading below it" },

--- a/components/hero/schema.json
+++ b/components/hero/schema.json
@@ -142,6 +142,8 @@
       "--hero-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
       "--hero-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
       "--hero-eyebrow-radius": { "type": "length", "default": "3px", "description": "Eyebrow pill corner radius. Set a large value (e.g. 999px) for a fully rounded pill." },
+      "--hero-eyebrow-border-width": { "type": "length", "default": "0", "description": "Eyebrow pill border width. Set a non-zero width (with --hero-eyebrow-border-color) for an outlined pill; 0 (default) renders no border." },
+      "--hero-eyebrow-border-color": { "type": "color", "default": "transparent", "description": "Eyebrow pill border color. Takes effect when --hero-eyebrow-border-width is non-zero." },
       "--hero-accent": { "type": "color", "default": "var(--color-accent)", "description": "Button background and border color" },
       "--hero-accent-hover": { "type": "color", "default": "var(--color-accent-hover)", "description": "Button hover background color" },
       "--hero-cta2-bg": { "type": "color", "default": "(varies by cta2_variant)", "description": "Second CTA button background color, independent of the primary button. Applies whatever cta2_variant is set to." },

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -155,6 +155,8 @@
       "--section-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
       "--section-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
       "--section-eyebrow-radius": { "type": "length", "default": "3px", "description": "Eyebrow pill corner radius. Set a large value (e.g. 999px) for a fully rounded pill." },
+      "--section-eyebrow-border-width": { "type": "length", "default": "0", "description": "Eyebrow pill border width. Set a non-zero width (with --section-eyebrow-border-color) for an outlined pill; 0 (default) renders no border." },
+      "--section-eyebrow-border-color": { "type": "color", "default": "transparent", "description": "Eyebrow pill border color. Takes effect when --section-eyebrow-border-width is non-zero." },
       "--section-subheading-color": { "type": "color", "default": "var(--color-muted)", "description": "Subheading text color" },
       "--section-subheading-margin-bottom": { "type": "length", "default": "var(--space-md)", "description": "Space between the subheading and the content below it" },
       "--section-title-margin-bottom": { "type": "length", "default": "var(--space-md)", "description": "Space between the title and the subheading below it" },

--- a/components/testimonials/schema.json
+++ b/components/testimonials/schema.json
@@ -80,6 +80,8 @@
       "--testimonials-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },
       "--testimonials-eyebrow-bg": { "type": "color", "default": "var(--color-surface-accent)", "description": "Eyebrow pill background color" },
       "--testimonials-eyebrow-radius": { "type": "length", "default": "3px", "description": "Eyebrow pill corner radius. Set a large value (e.g. 999px) for a fully rounded pill." },
+      "--testimonials-eyebrow-border-width": { "type": "length", "default": "0", "description": "Eyebrow pill border width. Set a non-zero width (with --testimonials-eyebrow-border-color) for an outlined pill; 0 (default) renders no border." },
+      "--testimonials-eyebrow-border-color": { "type": "color", "default": "transparent", "description": "Eyebrow pill border color. Takes effect when --testimonials-eyebrow-border-width is non-zero." },
       "--testimonials-subheading-color": { "type": "color", "default": "var(--color-muted)", "description": "Subheading text color" },
       "--testimonials-subheading-margin-bottom": { "type": "length", "default": "var(--space-lg)", "description": "Space between the subheading and the content below it" },
       "--testimonials-heading-margin-bottom": { "type": "length", "default": "var(--space-lg)", "description": "Space between the heading and the subheading below it" },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.126');
+define('PP_VERSION', '0.16.127');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.126",
+  "version": "0.16.127",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.126
+Stable tag: 0.16.127
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.126
+Version:          0.16.127
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/OperateTest.php
+++ b/tests/OperateTest.php
@@ -1960,7 +1960,7 @@ class OperateTest extends TestCase
         $result = pp_inspect_composition($post_id);
         $this->assertCount(1, $result);
         $this->assertArrayHasKey('style_slots', $result[0]);
-        $this->assertCount(38, $result[0]['style_slots']); // hero has 38 slots (37 + --hero-eyebrow-radius, issue 336)
+        $this->assertCount(40, $result[0]['style_slots']); // hero has 40 slots (38 + eyebrow border width/color, issue 356)
 
         // Verify slot structure.
         $first_slot = $result[0]['style_slots'][0];

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -245,10 +245,10 @@ class SchemaValidationTest extends TestCase
     public function testStyleSlotsExistForV1Components(): void
     {
         $expected = [
-            'hero'    => 38,
-            'section' => 33,
-            'grid'    => 31,
-            'cta'     => 27,
+            'hero'    => 40,
+            'section' => 35,
+            'grid'    => 33,
+            'cta'     => 29,
         ];
 
         foreach ($expected as $component => $count) {
@@ -920,7 +920,9 @@ class SchemaValidationTest extends TestCase
             [
                 '--grid-padding-top', '--grid-padding-bottom', '--grid-bg',
                 '--grid-heading-color', '--grid-heading-accent-color', '--grid-eyebrow-color',
-                '--grid-eyebrow-bg', '--grid-eyebrow-radius', '--grid-subheading-color',
+                '--grid-eyebrow-bg', '--grid-eyebrow-radius',
+                '--grid-eyebrow-border-width', '--grid-eyebrow-border-color',
+                '--grid-subheading-color',
                 '--grid-subheading-margin-bottom', '--grid-heading-margin-bottom',
                 '--grid-heading-size', '--grid-heading-max-width', '--grid-gap',
             ],

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -1210,22 +1210,39 @@ test.describe('Safe-surface rendered proof', () => {
     {
       component: 'grid',
       props: { id: 'pp-grid01', items: [{ title: 'One', text: 'First' }] },
-      slots: { '--grid-card-border-width': '0px' },
+      slots: {
+        '--grid-card-border-width': '0px',
+        '--grid-eyebrow-border-width': '0px',
+        '--grid-eyebrow-border-color': 'transparent',
+      },
     },
     {
       component: 'faq',
       props: { id: 'pp-faq01', items: [{ question: 'Q?', answer: 'A.' }] },
-      slots: { '--faq-border-color': '#ff0080' },
+      slots: {
+        '--faq-border-color': '#ff0080',
+        '--faq-eyebrow-border-width': '0px',
+        '--faq-eyebrow-border-color': 'transparent',
+      },
     },
     {
       component: 'testimonials',
       props: { id: 'pp-tst01', items: [{ quote: 'It works.', author: 'A' }] },
-      slots: { '--testimonials-card-border-width': '0px' },
+      slots: {
+        '--testimonials-card-border-width': '0px',
+        '--testimonials-eyebrow-border-width': '0px',
+        '--testimonials-eyebrow-border-color': 'transparent',
+      },
     },
     {
       component: 'cta',
       props: { id: 'pp-cta01', button_text: 'Go', button_url: '/go' },
-      slots: { '--cta-border-width': '0px', '--cta-border-color': 'transparent' },
+      slots: {
+        '--cta-border-width': '0px',
+        '--cta-border-color': 'transparent',
+        '--cta-eyebrow-border-width': '0px',
+        '--cta-eyebrow-border-color': 'transparent',
+      },
     },
     {
       component: 'section',
@@ -1235,6 +1252,8 @@ test.describe('Safe-surface rendered proof', () => {
         '--section-border-color': 'transparent',
         '--section-panel-border-width': '0px',
         '--section-panel-border-color': 'transparent',
+        '--section-eyebrow-border-width': '0px',
+        '--section-eyebrow-border-color': 'transparent',
       },
     },
     {
@@ -1245,6 +1264,8 @@ test.describe('Safe-surface rendered proof', () => {
         '--hero-border-color': 'transparent',
         '--hero-surface-border-width': '0px',
         '--hero-surface-border-color': 'transparent',
+        '--hero-eyebrow-border-width': '0px',
+        '--hero-eyebrow-border-color': 'transparent',
       },
     },
   ];
@@ -2021,6 +2042,54 @@ test.describe('Safe-surface rendered proof', () => {
         .locator('.hero__eyebrow')
         .evaluate((el) => getComputedStyle(el).borderRadius);
       expect(rounded).toBe('999px');
+    });
+  }
+
+  // #356: the eyebrow pill had color/bg/radius slots but no border slot, so an
+  // OUTLINED pill was inexpressible. Border width/color slots make it authorable.
+  //
+  // Both ids are load-bearing, exactly as in the #336 radius strand above: the
+  // `#home-hero, #how-hero, #agencies-hero, #implementers-hero .hero__eyebrow`
+  // block re-declares `border-color` at ID specificity (1,1,0). If that literal
+  // were left unrouted it would clobber --hero-eyebrow-border-color on those four
+  // benchmark heroes, and a non-matching id (pp-hero01) could not catch it.
+  for (const heroId of ['pp-hero01', 'home-hero']) {
+    test(`#356 hero eyebrow border is slot-driven and defaults to no border (#${heroId}) @smoke`, async ({
+      page,
+    }) => {
+      pageId = createPage(`E2E Hero Eyebrow Border Slot ${heroId}`);
+      setComposition(pageId, [
+        { component: 'hero', props: { id: heroId, eyebrow: 'Kicker', title: 'Border' } },
+      ]);
+
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+
+      const eyebrow = page.locator('.hero__eyebrow');
+      await expect(eyebrow).toBeVisible({ timeout: 10000 });
+
+      // Unset output stays byte-identical to pre-#356: the default pill has no
+      // visible border (0-width), the slot adds capability, not opinion.
+      expect(await eyebrow.evaluate((el) => getComputedStyle(el).borderTopWidth)).toBe('0px');
+
+      await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+      await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+      const res = await styleComponent(page, pageId, {
+        '--hero-eyebrow-border-width': '3px',
+        '--hero-eyebrow-border-color': '#ff0080',
+      });
+      expect(res.success).toBe(true);
+
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      const outlined = await page.locator('.hero__eyebrow').evaluate((el) => {
+        const s = getComputedStyle(el);
+        return { width: s.borderTopWidth, color: s.borderTopColor };
+      });
+      // The outlined pill now renders: a real 3px border in the asked-for color,
+      // reaching even the ID-specificity benchmark heroes (routing proven).
+      expect(outlined.width).toBe('3px');
+      expect(outlined.color).toBe('rgb(255, 0, 128)');
     });
   }
 

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -121,8 +121,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('hero/section/grid/cta schemas declare 129 style slots (subset of the 175 total)', () => {
-        expect(allSlots.length).toBe(129);
+    test('hero/section/grid/cta schemas declare 137 style slots (subset of the 187 total)', () => {
+        expect(allSlots.length).toBe(137);
     });
 
     allSlots.forEach(({ component, slotName }) => {


### PR DESCRIPTION
Closes #356

## What & why
The eyebrow pill exposed `--<component>-eyebrow-color`, `-eyebrow-bg`, and `-eyebrow-radius` on all six eyebrow-bearing components but **no border slot**, so an *outlined* pill (as on the reference webfiable.com) was inexpressible — only fakeable with a tinted background. This adds a generic eyebrow border capability. Straight mirror of the #336 eyebrow-radius pattern.

## Approach (recorded decision from the issue)
The issue explicitly permitted either a `--<component>-eyebrow-border` shorthand OR `border-color/width/style` slots. Split slots is the shape chosen because it is:
- the **repo-native root-border idiom** (`.hero { border: var(--hero-border-width, 0) solid var(--hero-border-color, transparent) }`), and
- the **only shape expressible through the allowed style-slot types** (`SchemaValidationTest.php` whitelist: `color`, `length`, …) **without adding a validator or broadening the type whitelist** — a single shorthand would need `raw` (not an allowed style-slot type) or a new `border` type. This satisfies the standing "shared engines only, no second validator" constraint.

Per component (hero, section, faq, grid, cta, testimonials):
- `--<component>-eyebrow-border-width` — `length`, default `0`
- `--<component>-eyebrow-border-color` — `color`, default `transparent`
- CSS: `border: var(--x-eyebrow-border-width, 0) solid var(--x-eyebrow-border-color, transparent)`; style fixed `solid` (consistent with every other border in the theme).

**Default = zero-width transparent border = byte-identical unset output.**

## Acceptance criteria
- [x] Generic eyebrow border authorable on all six eyebrow components (outlined pill now expressible).
- [x] Default keeps today's borderless pill; unset output byte-identical.
- [x] Slots registered in each `schema.json`; AI docs wired (runtime `lib/ai-context.php` auto-emits every schema style slot; `--<component>-eyebrow-*` wildcard already documented; AI_CONTEXT.md + README counts updated 175 → 187).
- [x] No named/benchmark-specific variants; no color/size opinion baked.

## #332 (WP-core phantom border) handling
The new slot names embed `border-width`/`border-color`, WP-core `[style*=…]` triggers. Their inline custom properties render on the **immunized component root** (`data-pp-component`), not the eyebrow span, so `StyleSlotContractTest` check 7 stays green. The rendered `#332 BORDER_TRIGGER_CASES` immunity set was extended to all twelve new slots (set-equality guard). The benchmark hero ID block that re-declares `border-color` at ID specificity now routes through the color slot, so a set value reaches those four pages (pinned in the e2e test).

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` → **1809 passed** (3 warnings / 2 deprecations = unmodified-tree baseline).
- `npm test` (vitest) → **564 passed**.
- `bash scripts/package.sh` → version consistency OK across all five files; built zip deleted (CI builds release zips).
- E2E (`tests/e2e/style-render.spec.ts`): added a red→green computed-style pin (visible 3px colored border when set on both a plain and an ID-specificity hero; `0px` when unset). Runs on post-merge CI (WordPress 7.0); wp-env unavailable locally.
- Slot-contract guard (#305), cross-sheet guard (#342), and #332 immunity all green; ledgers are shrink-only / count-updated.

## gstack workflows
/plan-eng-review (0 issues), /review (0 findings, quality 10/10), /document-generate (no doc changes beyond count sync). Codex outside-voice not run — Codex sandbox cannot run git on this container.

## Accepted limitations
`border-style` is fixed `solid` (matches every other repo border; no component exposes border-style). No per-side eyebrow borders. Both are out of scope for #356 and not requested.

## No 7A question
The split-vs-shorthand choice was settled by the recorded decision (issue explicitly allowed border-width/color slots) plus the forced-by-constraints rule (only shape expressible through existing allowed types with no new validator). No accepted-behavior/public-surface question arose.
