### PR TITLE
v0.16.133 fix: center stats heading instead of left-pinning its capped box (#367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
-## [v0.16.132] — 2026-07-14 — a grid card's link/button now follows --grid-item-text-align, so a centered card is fully centered (#361)
+## [v0.16.133] — 2026-07-15 — a stats heading with a long title now centers on the page instead of sitting left of center (#367)
+
+**A `stats` component's heading rendered left of page center on desktop. `.stats__heading` carries `text-align: center` and the shared `max-width: var(--cta-content-width, 40rem)` cap, but shipped with no auto side-margins. A block `<h2>` fills to that 40rem cap inside the wider centered `.container`, so the heading box pinned to the container's left edge (measured x 96-736 in a 1280px viewport, where the centered position is ~288-928) and `text-align: center` only centered the text inside that left-pinned box. The heading sat left of page center for any title long enough to reach the cap. This adds auto side-margins so the heading box centers under the already-centered stats row.**
+
+Same class of bug as #354, on the stats component. The fix is `margin-left: auto; margin-right: auto` on `.stats__heading`, mirroring #354's `.section--centered .section__content` fix and the file's centering convention. Both sides auto, so the box centers regardless of writing direction and collapses to zero margin when the heading is as wide as the container (narrow viewports), introducing no band. The stats component is already centered end to end (`.stats__list` uses `justify-content: center`, `.stats__item` uses `align-items: center`), so centering the heading is consistent with the rest of the component. A pure alignment fix: no prop, schema, style slot, validator, or AI-facing behavior changes.
+
+### Fixed
+
+- A `stats` heading now centers within its container on desktop instead of pinning to the left edge. Previously a long stats title sat left of page center because the 40rem-capped heading box was left-aligned with only its text centered inside it. A heading narrower than the cap and narrow-viewport rendering are unaffected.
+
+### Tests
+
+- `tests/e2e/style-render.spec.ts` adds a rendered-geometry pin: at 1280px the stats heading box center-x equals its containing `.container` center-x (and the centered `.stats__list` beneath it), with real free space between them so the equality is a genuine reposition, not a fill artifact. Proven red→green: reverting the CSS left-pins the box and fails the assertion by ~224px. `tests/js/css-lint.test.js` adds a declaration-level guard that aggregates per selector and asserts any centered, max-width-capped content-block selector (`__heading`/`__title`/`__body`/`__content`) also declares an auto inline margin, plus targeted pins for `.stats__heading` (#367) and `.section--centered .section__content` (#354).
+
+
 
 **#357 made a grid card's TEXT content (title, text, bullets) alignable through the `align`-typed `--grid-item-text-align` slot, but the `Read more` link stayed pinned left. `.grid__item-link` is a content-width flex item placed by `align-self: flex-start`, and per the #338 flex trap `text-align` cannot move a flex item's box — so a centered contact card (the webfiable use case #357 cites) centered its emoji/label but left the link flush left, only half-expressible. This makes the link follow the same slot: the operator still sets ONE value and both the text and the link align together, so a centered card is fully centered and a right-aligned card is fully right-aligned.**
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.132-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.133-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2231,6 +2231,20 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
      output is byte-identical, and an operator can now tune the scale. */
   font-size: var(--stats-title-size, 1.875rem);
   margin-bottom: var(--space-lg);
+  /* Center the heading BOX, not just its text (issue 367 — same class as issue 354).
+     The shared cap rule gives this h2 max-width: var(--cta-content-width, 40rem);
+     a block h2 fills to that cap inside the wider .container, so without auto
+     inline margins the 40rem box pins to the container's left edge (measured
+     x 96-736 at 1280px) and text-align: center only centers WITHIN that
+     left-pinned box — the heading sits left of page center for any title.
+     Auto side-margins center the box under the already-centered stats list
+     (.stats__list is justify-content: center, spanning the full container).
+     Both sides auto so it centers regardless of writing direction; collapses to
+     0 when the heading is as wide as the container (narrow viewports), so no
+     band is introduced. Physical margins mirror the landed issue-354 fix
+     (.section--centered .section__content) and the file's centering convention. */
+  margin-left: auto;
+  margin-right: auto;
   text-align: center;
   color: var(--stats-title-color, var(--color-text));
 }

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.132');
+define('PP_VERSION', '0.16.133');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.132",
+  "version": "0.16.133",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.132
+Stable tag: 0.16.133
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.132
+Version:          0.16.133
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -2957,6 +2957,82 @@ test.describe('#333 chrome site options render', () => {
     expect(textOnly.marginRight).toBe('0px');
     expect(Math.abs(textOnly.contentLeft - textOnly.bodyLeft)).toBeLessThanOrEqual(2);
   });
+
+  // #367 — same class as #354, on the stats component. `.stats__heading` is a block <h2>
+  // that carries `max-width: var(--cta-content-width, 40rem)` (the shared cap rule) and
+  // `text-align: center`, but shipped with NO auto inline margins. A block h2 fills to its
+  // max-width cap inside the wider .container, so the 40rem box pinned to the container's
+  // LEFT edge (measured x 96-736 at 1280px; the container content center is ~x 288-928) and
+  // text-align:center only centered the text WITHIN that left-pinned box — the heading sat
+  // left of page center for ANY title length, not just long ones. The bug is the ABSENCE of
+  // a margin rule (exactly how it shipped), invisible at the declaration level, so only a
+  // rendered box under the full cascade proves the fix. We compare the heading box center-x
+  // to its actual containing block (the .container), the parent margin-inline:auto centers it
+  // in — not a sibling proxy — with real free space between them so the equality is a genuine
+  // reposition, not a fill artifact. Mutation-verified: reverting the CSS left-pins the box
+  // and fails the center-x assertion by ~224px ((container 1088 - cap 640) / 2).
+  test('#367 stats heading centers in its container, not pinned left @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Stats Heading Centering');
+    setComposition(pageId, [
+      {
+        component: 'stats',
+        props: {
+          id: 'pp-stats-centered',
+          title: 'The numbers behind our platform performance and reliability',
+          items: [
+            { number: '99.9%', label: 'Uptime' },
+            { number: '2.4M', label: 'Requests / day' },
+            { number: '<50ms', label: 'Median latency' },
+          ],
+        },
+      },
+    ]);
+
+    // 1280px: the container caps at 72rem (1152px), leaving the heading's 40rem (640px) cap
+    // well inside the container content width (~1088px after padding) — ~448px of real free
+    // space for the auto margins to redistribute. Without that free space the center-x
+    // equality would be vacuous (a box that fills its parent is trivially "centered" in it).
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const heading = page.locator('#pp-stats-centered .stats__heading');
+    await expect(heading).toBeVisible({ timeout: 10000 });
+
+    const geom = await page.evaluate(() => {
+      const h = document.querySelector('#pp-stats-centered .stats__heading') as HTMLElement;
+      const container = h.parentElement as HTMLElement; // the .stats .container the heading centers in
+      const list = document.querySelector('#pp-stats-centered .stats__list') as HTMLElement;
+      const hb = h.getBoundingClientRect();
+      const cb = container.getBoundingClientRect();
+      const lb = list.getBoundingClientRect();
+      const cs = getComputedStyle(h);
+      return {
+        headingWidth: hb.width,
+        containerWidth: cb.width,
+        headingCenterX: hb.left + hb.width / 2,
+        containerCenterX: cb.left + cb.width / 2,
+        listCenterX: lb.left + lb.width / 2,
+        marginLeft: cs.marginLeft,
+        marginRight: cs.marginRight,
+      };
+    });
+
+    // Free space is real: the capped heading is meaningfully narrower than its container,
+    // so a centered center-x is a genuine reposition, not a fill artifact.
+    expect(geom.containerWidth - geom.headingWidth).toBeGreaterThan(150);
+    // THE FIX: the heading box centers within the containing block that actually matters
+    // (its parent .container). Tolerance 2px absorbs sub-pixel rounding; the broken state is
+    // ~224px off, far above it, so mutation sensitivity is unaffected.
+    expect(Math.abs(geom.headingCenterX - geom.containerCenterX)).toBeLessThanOrEqual(2);
+    // ...and it lines up with the already-centered stats list beneath it (the visual band).
+    expect(Math.abs(geom.headingCenterX - geom.listCenterX)).toBeLessThanOrEqual(2);
+    // Auto margins resolved to real, symmetric, non-zero pixels (~224px each side). Without
+    // the #367 rule these compute to '0px' and the center-x assertions above fail.
+    expect(geom.marginLeft).not.toBe('0px');
+    expect(geom.marginLeft).toBe(geom.marginRight);
+  });
 });
 
 /**

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -1560,3 +1560,114 @@ describe('CSS lint: no raw hex in components.css', () => {
         expect(hexInValues).toEqual([]);
     });
 });
+
+/**
+ * Centered content blocks carry auto inline margins (#367, class of #354).
+ *
+ * A block-level content element (a heading/title/body/content wrapper) that
+ * carries BOTH `text-align: center` AND a `max-width` cap but NO auto inline
+ * margins is falsely centered: the block fills to its cap and pins to its
+ * container's LEFT edge, and text-align only centers the text WITHIN that
+ * left-pinned box. That is exactly how `.stats__heading` shipped (#367).
+ *
+ * This is a DECLARATION-LEVEL backstop, not a cascade-aware layout engine. It
+ * aggregates per exact selector string and is blind to specificity, source
+ * order, media context, and INHERITED (undeclared) text-align. The authoritative
+ * proof lives in the rendered e2e pins (#354, #367 in style-render.spec.ts),
+ * which measure real boxes under the full cascade. What this adds cheaply: the
+ * next centered heading that declares a cap + center on one selector but forgets
+ * its auto margins fails here before it reaches a browser.
+ *
+ * Coverage note (why #354 needs its OWN targeted pin below, not the class scan):
+ * the class scan only fires when cap AND center land on the SAME selector key.
+ * `.stats__heading` does (cap @ the shared rule, center @ its own rule), so the
+ * scan catches #367. The #354 selector `.section--centered .section__content`
+ * does NOT — its centering is INHERITED from `.section--centered .section__body`,
+ * never declared on `.section__content`, so declaration aggregation can never
+ * mark it center=true. It is pinned directly instead.
+ *
+ * Scope is the content-block naming (trailing `__heading` / `__title` /
+ * `__body` / `__content` element), which is the surface this defect lives on.
+ * Controls are deliberately out: `main .btn` also matches text-align:center +
+ * max-width, but its box is positioned by its flex parent (display:inline-flex,
+ * justify-content:center) and text-align centers its own LABEL — auto margins
+ * are neither the mechanism nor expected there. Excluding it by name (a button
+ * is not a `__heading`) is correct, not a carve-out. The known live tradeoff: a
+ * future content block centered by a flex/grid PARENT (the `.btn` mechanism
+ * under a content-block name) would be a spurious offender; whitelist it here
+ * with a comment if one ever appears.
+ */
+describe('CSS lint: centered content blocks carry auto inline margins (#367)', () => {
+    const stripped = stripComments(COMPONENTS_CSS);
+
+    // selector -> { maxWidth, center, autoMargin } aggregated across every rule.
+    const AUTO_MARGIN =
+        /margin(-inline(-start|-end)?|-left|-right)?\s*:\s*[^;}]*\bauto\b/;
+    const agg = new Map();
+    const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+    let m;
+    while ((m = ruleRe.exec(stripped)) !== null) {
+        const body = m[2];
+        const hasMax = /(max-width|max-inline-size)\s*:/.test(body);
+        const hasCenter = /text-align\s*:\s*center/.test(body);
+        const hasAuto = AUTO_MARGIN.test(body);
+        if (!hasMax && !hasCenter && !hasAuto) continue;
+        m[1].split(',').forEach(raw => {
+            const sel = raw.trim().replace(/\s+/g, ' ');
+            if (!sel || sel.startsWith('@')) return;
+            const cur = agg.get(sel) || { maxWidth: false, center: false, autoMargin: false };
+            cur.maxWidth = cur.maxWidth || hasMax;
+            cur.center = cur.center || hasCenter;
+            cur.autoMargin = cur.autoMargin || hasAuto;
+            agg.set(sel, cur);
+        });
+    }
+
+    // A content-block selector = the element it TARGETS (the trailing compound of
+    // a descendant selector) is a __heading/__title/__body/__content element. Test
+    // only the last space-separated compound so `.foo__heading .child` (targets
+    // `.child`) is NOT pulled in, while `.section--centered .section__body` (targets
+    // `.section__body`) is. Word-boundaried so `.stats__heading-accent` never matches.
+    const isContentBlock = (sel) => {
+        const target = sel.split(' ').pop();
+        return /__(heading|title|body|content)(?![\w-])/.test(target);
+    };
+
+    const centeredCapped = [...agg.entries()]
+        .filter(([sel, p]) => isContentBlock(sel) && p.maxWidth && p.center);
+
+    // Not vacuous: `.stats__heading` (cap+center on one key) MUST be a member, or a
+    // selector rename would make the offender scan below silently pass on nothing.
+    test('finds the centered, max-width-capped content blocks it governs', () => {
+        expect(centeredCapped.length).toBeGreaterThan(0);
+        expect(centeredCapped.map(([sel]) => sel)).toContain('.stats__heading');
+    });
+
+    test('every centered, capped content block also declares an auto inline margin', () => {
+        const offenders = centeredCapped
+            .filter(([, p]) => !p.autoMargin)
+            .map(([sel]) => sel);
+        expect(offenders).toEqual([]);
+    });
+
+    // Targeted regression pin for the exact #367 selector: it must keep BOTH the cap+center
+    // that make centering meaningful AND the auto margin that delivers it. Removing the
+    // auto margins (the bug) fails here even if the class scan above were ever narrowed.
+    test('.stats__heading is centered, capped, and carries an auto inline margin', () => {
+        const p = agg.get('.stats__heading');
+        expect(p).toBeDefined();
+        expect(p.maxWidth).toBe(true);
+        expect(p.center).toBe(true);
+        expect(p.autoMargin).toBe(true);
+    });
+
+    // Targeted regression pin for the landed #354 fix, which the class scan cannot see
+    // (its centering is inherited, never declared on this selector). The auto side-margins
+    // are the whole fix — if they are ever removed, the centered-layout body copy left-pins
+    // again. The #354 e2e pin proves the rendered geometry; this guards the declaration.
+    test('.section--centered .section__content carries an auto inline margin (#354)', () => {
+        const p = agg.get('.section--centered .section__content');
+        expect(p).toBeDefined();
+        expect(p.autoMargin).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes #367

## Scope
A `stats` component heading rendered left of page center on desktop. `.stats__heading` carries `text-align: center` and the shared `max-width: var(--cta-content-width, 40rem)` cap but shipped with no auto side-margins. A block `<h2>` fills to that 40rem cap inside the wider centered `.container`, so the box pinned to the container's left edge (measured x 96-736 at 1280px; centered is ~288-928) and `text-align: center` only centered the text inside that left-pinned box. The heading sat left of page center for any title long enough to reach the cap.

Fix: `margin-left: auto; margin-right: auto` on `.stats__heading` (`assets/css/components.css`) so the box centers under the already-centered stats row. Same class as the landed #354 fix (`.section--centered .section__content`); physical margins match the file's centering convention. Both sides auto → centers regardless of writing direction, collapses to 0 on narrow viewports (no band).

Audit: aggregating `max-width` + `text-align:center` + auto-margin per selector across `components.css`, `.stats__heading` was the ONE genuinely-broken content block. `main .btn` was flagged by the raw aggregate but refuted (a control: `display:inline-flex`/`justify-content:center`, `max-width` only <767px with `width:100%`, `text-align` centers its own label). No other broken instance.

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` → 1841 passed (3 warnings + 2 deprecations = pre-change baseline).
- `npm test` (vitest) → 571 passed (includes the new css-lint guard + version-sync check).
- New e2e pin `tests/e2e/style-render.spec.ts` "#367 stats heading centers…" run under wp-env at 1280px → green; mutation-verified red→green (reverting the CSS fails the center-x assertion by ~224px).
- New static guard mutation-verified red→green.
- `bash scripts/package.sh` → version consistency OK across the five synced files; built zip deleted (releases are CI-built).

## Reviews (this session)
- `/plan-eng-review` — CLEARED, no gating findings; Codex outside voice refined test design (compare heading center-x to its `.container`, not just the list; honest framing that short titles also re-center).
- `/review` — testing + maintainability specialists + Codex adversarial converged on one issue: the static guard over-claimed #354 coverage. Fixed within scope (corrected comment, added a targeted `.section--centered .section__content` pin, anchored `isContentBlock` to the trailing compound, switched to physical `margin-left/right:auto`).
- `/document-generate` — no docs invalidated (stats has no `heading_align` prop or alignment slot; pure alignment fix).

## Accepted limitations
- The css-lint guard is declaration-level (blind to specificity/source-order/inherited alignment) — documented in-file; the rendered e2e pin is the authoritative cascade-aware proof.
- The e2e pin is fixed at 1280px (mirrors #354); the bug is a desktop-only left-pin. `margin-inline`-style logical behavior is covered by both-sides-auto physical margins.
