### PR TITLE
v0.16.134 fix: register --btn-radius so button corner radius is settable without pilling cards (#369)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -358,7 +358,7 @@ Derived:    --color-text-secondary, --color-accent-strong, --color-border-accent
 Spacing:    --space-xs, --space-sm, --space-md, --space-lg, --space-xl, --space-2xl, --space-3xl
 Typography: --font-body, --font-heading, --font-weight-heading, --line-height-body, --line-height-heading,
             --font-mono
-Button:     --btn-padding-y, --btn-padding-x
+Button:     --btn-padding-y, --btn-padding-x, --btn-radius
 Shape:      --radius, --max-width, --measure-body, --measure-body-wide, --measure-centered,
             --transition, --overlay-bg
 Elevation:  --shadow-none, --shadow-sm, --shadow-md, --shadow-lg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v0.16.134] — 2026-07-15 — button corner radius is now its own design token, so you can pill a CTA without rounding every card (#369)
+
+**The button corner radius was unreachable through the design-token surface. `components.css` advertised a `--btn-radius` hook (`border-radius: var(--btn-radius, var(--radius))`), but `--btn-radius` was never a registered token, so `update_design_token --token=--btn-radius` was rejected as unregistered. The only radius lever that WAS registered, `--radius`, is global: setting it to `100px` to pill a CTA also pills every card and panel. Worse, the winning cascade rule for composed buttons (`main .btn`, the premium-CTA treatment) hardcoded `border-radius: 4px`, so the button radius never even followed `--radius` — it was a fixed 4px with no operator control at all. A pill CTA over square cards was inexpressible. This registers `--btn-radius` as a `length` design token (default `4px`, the button's actual current radius) and routes the winning rule through it, so an operator can set the button radius on its own.**
+
+`--btn-radius` is declared in `assets/css/base.css` `:root` with the same `/* length: ... */` type-comment convention every other token uses, so `pp_design_tokens()` registers it and `update_design_token` validates its value through the shared `_pp_validate_token_value` length engine (no second validator). The premium-CTA block that decides the rendered button radius now reads `border-radius: var(--btn-radius, 4px)`, so setting `--btn-radius` to `100px` pills the button while `--radius` and every card/panel that reads it stay put. The registered default is `4px` (the value composed buttons already rendered), not `var(--radius)`: because declaring the token in `:root` defines the property globally, the fallback never fires, so the default has to match today's rendered value to keep unset output byte-identical. Every composed button (cta, hero, section) renders inside `main` and was already 4px, so unset rendering is unchanged. The token surfaces to the chat AI automatically (the runtime token catalog in `lib/ai-context.php` enumerates `pp_design_tokens()`), and the static catalog and retheme guide are updated to name it. `--btn-radius` contains `radius`, not `border-width`/`border-color`, so it does not trip the #332 core-border-trigger guard.
+
+### Fixed
+
+- Button corner radius is now settable on its own via `update_design_token --token=--btn-radius` (e.g. `--value=100px` for a pill CTA). Previously the only radius token an operator could set was the global `--radius`, which rounds cards and panels too, and the composed button radius was hardcoded at 4px and ignored it entirely. Cards and panels keep reading `--radius`, so button and card radius are now independent. Unset rendering is byte-identical: composed buttons still render at 4px.
+
+### Docs
+
+- `ai-instructions/retheme.md` no longer tells the AI to use `--radius` for "pill-shaped buttons" (an impossible instruction — `--radius` is global and never reached the button). It now points at `--btn-radius` as the per-button lever and reserves `--radius` for cards, panels, and surfaces. `AI_CONTEXT.md` lists `--btn-radius` in the Button token group.
+
+### Tests
+
+- `tests/ApplyTest.php` pins that `--btn-radius` registers as a `length` token defaulting to `4px`, that `update_design_token --token=--btn-radius --value=100px` validates through the shared engine, and that a non-length value is rejected with `invalid_length`. `tests/e2e/style-render.spec.ts` adds two rendered-proof pins driving the real `update_design_token` apply: setting `--btn-radius=100px` computes the composed button's `border-radius` to `100px` while `:root`'s `--radius` stays `0.375rem` and the card stays `4px` (decoupling), and unset computes the button at `4px` (byte-identical). Both proven red→green: removing the token registration reverts the apply to "not a registered design token", and reverting the cascade route leaves the button at 4px instead of 100px.
+
 ## [v0.16.133] — 2026-07-15 — a stats heading with a long title now centers on the page instead of sitting left of center (#367)
 
 **A `stats` component's heading rendered left of page center on desktop. `.stats__heading` carries `text-align: center` and the shared `max-width: var(--cta-content-width, 40rem)` cap, but shipped with no auto side-margins. A block `<h2>` fills to that 40rem cap inside the wider centered `.container`, so the heading box pinned to the container's left edge (measured x 96-736 in a 1280px viewport, where the centered position is ~288-928) and `text-align: center` only centered the text inside that left-pinned box. The heading sat left of page center for any title long enough to reach the cap. This adds auto side-margins so the heading box centers under the already-centered stats row.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.133-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.16.134-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/retheme.md
+++ b/ai-instructions/retheme.md
@@ -107,8 +107,14 @@ For a SITE, set `--radius` via `update_design_token`. As a release default, in
 | `0`        | Sharp, geometric corners |
 | `0.375rem` | Subtle rounding (default) |
 | `0.75rem`  | Noticeable rounding |
-| `1rem`     | Rounded cards |
-| `9999px`   | Pill-shaped buttons (use only on .btn, not cards) |
+| `1rem`     | Rounded cards and surfaces |
+
+`--radius` is the GLOBAL shape token — it drives cards, panels, surfaces, and
+image corners. It does not control button corners: buttons have their own
+`--btn-radius` token (default `4px`). To pill a CTA without rounding cards, set
+`--btn-radius` (e.g. `100px`) via `update_design_token` and leave `--radius`
+alone. Setting `--radius` to a huge value to "pill buttons" is the wrong lever —
+it rounds every card and panel too, and no longer reaches the button at all.
 
 ---
 

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -45,6 +45,7 @@
   /* Button rhythm */
   --btn-padding-y: var(--space-sm);  /* length: Button vertical padding */
   --btn-padding-x: var(--space-lg);  /* length: Button horizontal padding */
+  --btn-radius: 4px;                 /* length: Button corner radius — the authorable button shape; override to pill a CTA (e.g. 100px) without rounding cards, which follow --radius */
 
   /* Shape & motion */
   --radius:     0.375rem;   /* length: 6px — increase for rounder corners */

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -3994,7 +3994,15 @@ main .btn,
 #how-cta .cta__button,
 #agencies-cta .cta__button,
 #implementers-cta .cta__button {
-  border-radius: 4px;
+  /* This premium-CTA block is the later-cascade winner for composed buttons
+     (it overrides the base `.btn { border-radius: var(--btn-radius, var(--radius)) }`
+     at equal specificity + source order), so the button radius must be routed
+     through --btn-radius HERE or the token stays inert on every rendered button
+     (issue 369). --btn-radius is registered defaulting to 4px, so unset output
+     is byte-identical to the previous hardcoded 4px; an override (e.g. 100px)
+     pills the button without touching the global --radius (or anything that
+     reads it), so the button radius is no longer chained to the card radius. */
+  border-radius: var(--btn-radius, 4px);
 }
 
 #home-cta.cta--inline .cta__inner,

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.133');
+define('PP_VERSION', '0.16.134');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.133",
+  "version": "0.16.134",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.133
+Stable tag: 0.16.134
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.133
+Version:          0.16.134
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ApplyTest.php
+++ b/tests/ApplyTest.php
@@ -1663,6 +1663,55 @@ class ApplyTest extends TestCase
         $this->assertSame('length', $tokens['--btn-padding-x']['type']);
     }
 
+    // ── --btn-radius (issue 369) ──────────────────────────────────────────
+    // components.css reads `border-radius: var(--btn-radius, var(--radius))`,
+    // but --btn-radius was never declared in :root, so update_design_token
+    // rejected it as unregistered. Worse, the WINNING cascade rule for every
+    // composed button — the premium-CTA block `main .btn { border-radius: 4px }`
+    // — hardcoded 4px and ignored the token entirely, so even a registered token
+    // was inert. The fix registers --btn-radius (defaulting to the composed
+    // button's actual current radius, 4px, so unset output is byte-identical)
+    // and routes that winning rule through var(--btn-radius, 4px). Card/panel
+    // radius still reads the GLOBAL --radius, so button radius is now settable
+    // on its own without pilling every card.
+
+    public function testBtnRadiusIsRegisteredAsLengthToken(): void
+    {
+        $tokens = pp_design_tokens();
+        $this->assertArrayHasKey('--btn-radius', $tokens);
+        $this->assertSame('length', $tokens['--btn-radius']['type']);
+    }
+
+    public function testBtnRadiusDefaultsToComposedButtonRadiusForByteIdenticalUnset(): void
+    {
+        // Registering the token in :root DEFINES the property globally, so the
+        // `var(--btn-radius, 4px)` fallback in the winning rule never fires — the
+        // declared default wins. It must therefore equal the composed button's
+        // actual current radius (4px), NOT var(--radius) (6px): a 6px default
+        // would silently restyle every existing button 4px->6px. 4px keeps unset
+        // rendering byte-identical.
+        $tokens = pp_design_tokens();
+        $this->assertSame('4px', $tokens['--btn-radius']['value']);
+    }
+
+    public function testUpdateDesignTokenAcceptsBtnRadiusLength(): void
+    {
+        // The whole point of the issue: --btn-radius must validate through the
+        // SAME shared length engine (_pp_validate_token_value) so an operator
+        // can pill a CTA (100px) without touching --radius.
+        $result = pp_validate_apply('update_design_token', ['token' => '--btn-radius', 'value' => '100px']);
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateDesignTokenRejectsInvalidBtnRadius(): void
+    {
+        // Same length grammar as every other length token — a non-length value
+        // is rejected by the shared engine, not a surface-specific validator.
+        $result = pp_validate_apply('update_design_token', ['token' => '--btn-radius', 'value' => 'rounded']);
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertEquals('invalid_length', $result->get_error_code());
+    }
+
     // ── Font apply tests ─────────────────────────────────────────────────
 
     public function testEnqueueFontValid(): void

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -3160,3 +3160,180 @@ test.describe('#355 active header link honors pp_header_link_color', () => {
     expect(weight).toBe('700');
   });
 });
+
+/**
+ * #369 — --btn-radius is a real, settable design token.
+ *
+ * components.css reads `border-radius: var(--btn-radius, var(--radius))`, but
+ * --btn-radius was never declared in :root, so update_design_token rejected it
+ * as unregistered. The only reachable lever was the GLOBAL --radius — which also
+ * rounds every card. A pill CTA over square cards was inexpressible.
+ *
+ * Registering the token is not enough on its own: the WINNING cascade rule for
+ * every composed button is the premium-CTA block `main .btn { border-radius: 4px }`
+ * (components.css), which overrode the base `.btn { var(--btn-radius, var(--radius)) }`
+ * and hardcoded 4px. So the fix ALSO routes that winning rule through
+ * `var(--btn-radius, 4px)`, and registers --btn-radius defaulting to 4px (the
+ * composed button's actual current radius). A validator-only test cannot see any
+ * of this — only a rendered box proves the two goals:
+ *   1. DECOUPLING — setting --btn-radius=100px through the REAL update_design_token
+ *      apply pills the `.btn`, while a card's radius (which reads --radius) does
+ *      NOT move. Button radius is now independent of the global radius.
+ *   2. BYTE-IDENTICAL UNSET — with no override, the composed button computes 4px,
+ *      exactly the hardcoded value it rendered before the token existed.
+ *
+ * The button is a `.cta__button.btn`; the card is a `.grid__item`
+ * (`border-radius: var(--grid-card-radius, var(--radius))`). --radius is
+ * 0.375rem = 6px at the default 16px root; the composed button default is 4px.
+ */
+test.describe('#369 --btn-radius rendered proof (real WP)', () => {
+  // wp-env wraps command output in "ℹ Starting"/"✔ Ran" banner lines (ANSI-colored).
+  function stripWpEnvNoise(raw: string): string {
+    return raw
+      .split('\n')
+      .filter((line) => {
+        const t = line.replace(/\x1b\[[0-9;]*m/g, '').trim();
+        return !(t.startsWith('ℹ Starting') || t.startsWith('✔ Ran') || t.startsWith('✖'));
+      })
+      .join('\n')
+      .trim();
+  }
+
+  function wpCli(cmd: string): string {
+    return stripWpEnvNoise(
+      execSync(`npx wp-env run cli ${cmd}`, { cwd: process.cwd(), encoding: 'utf-8' }),
+    );
+  }
+
+  // Brace-match the first balanced JSON object, skipping any wrapper/"Success:" text.
+  function parseCliJson(raw: string, what: string): Record<string, unknown> {
+    const start = raw.indexOf('{');
+    if (start === -1) throw new Error(`No JSON object in ${what}: ${raw}`);
+    let depth = 0,
+      inStr = false,
+      esc = false;
+    for (let i = start; i < raw.length; i++) {
+      const c = raw[i];
+      if (inStr) {
+        if (esc) esc = false;
+        else if (c === '\\') esc = true;
+        else if (c === '"') inStr = false;
+      } else if (c === '"') inStr = true;
+      else if (c === '{') depth++;
+      else if (c === '}' && --depth === 0) return JSON.parse(raw.slice(start, i + 1));
+    }
+    throw new Error(`Unbalanced JSON in ${what}: ${raw}`);
+  }
+
+  // Drive the SAME apply path a chat AI would: operate inspect → preflight → execute.
+  function applyToken(token: string, value: string): void {
+    const runId = parseCliJson(wpCli('wp pp operate inspect'), 'operate inspect').run_id as string;
+    if (!runId) throw new Error('operate inspect returned no run_id');
+    wpCli(`wp pp apply preflight --run-id=${runId} --apply=update_design_token`);
+    const json = JSON.stringify({ token, value }).replace(/'/g, "'\\''");
+    const out = wpCli(
+      `wp pp apply execute update_design_token --run-id=${runId} --params='${json}'`,
+    );
+    if (parseCliJson(out, 'apply execute').ok !== true) {
+      throw new Error(`update_design_token ${token}=${value} did not apply: ${out}`);
+    }
+  }
+
+  function resetToken(token: string): void {
+    try {
+      const runId = parseCliJson(wpCli('wp pp operate inspect'), 'operate inspect').run_id as string;
+      wpCli(`wp pp apply preflight --run-id=${runId} --apply=update_design_token`);
+      wpCli(`wp pp apply reset --run-id=${runId} --token=${token}`);
+    } catch {
+      /* nothing to reset */
+    }
+  }
+
+  const CTA_GRID = [
+    {
+      component: 'cta',
+      props: {
+        id: 'radius-cta',
+        title: 'Get started today',
+        text: 'Supporting copy.',
+        button_text: 'Get started',
+        button_url: '/start',
+      },
+    },
+    {
+      component: 'grid',
+      props: {
+        id: 'radius-grid',
+        title: 'Cards keep their radius',
+        items: [{ title: 'One', text: 'A card that reads --radius' }],
+      },
+    },
+  ];
+
+  let pageId = 0;
+
+  test.afterEach(async () => {
+    resetToken('--btn-radius');
+    if (pageId) {
+      deletePage(pageId);
+      pageId = 0;
+    }
+  });
+
+  test('setting --btn-radius=100px pills the button without touching --radius or the card @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E btn-radius decouples from global radius');
+    setComposition(pageId, CTA_GRID);
+
+    applyToken('--btn-radius', '100px');
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const button = page.locator('.cta__button.btn');
+    const card = page.locator('.grid__item');
+    await expect(button).toBeVisible({ timeout: 10000 });
+    await expect(card).toBeVisible({ timeout: 10000 });
+
+    const buttonRadius = await button.evaluate((el) => getComputedStyle(el).borderTopLeftRadius);
+    const cardRadius = await card.evaluate((el) => getComputedStyle(el).borderTopLeftRadius);
+    // The GLOBAL radius token itself — the ONLY lever this button had before #369.
+    const rootRadius = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--radius').trim(),
+    );
+
+    // The button follows the new per-element token — it pills.
+    expect(buttonRadius).toBe('100px');
+    // The decoupling the issue is about: setting --btn-radius touched NEITHER the
+    // global --radius (still its 0.375rem default) NOR the card, which keeps its
+    // own 4px default. Before #369 the only way to round the button was to move
+    // --radius, which would have rounded the card with it. A validator-only test
+    // cannot see that --radius and the card stayed put.
+    expect(rootRadius).toBe('0.375rem');
+    expect(cardRadius).toBe('4px');
+    expect(cardRadius).not.toBe(buttonRadius);
+  });
+
+  test('an unset --btn-radius renders the composed button at its historical 4px (byte-identical) @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E btn-radius unset is byte-identical');
+    setComposition(pageId, CTA_GRID);
+    // No applyToken: --btn-radius uses its registered 4px default.
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const button = page.locator('.cta__button.btn');
+    await expect(button).toBeVisible({ timeout: 10000 });
+
+    const buttonRadius = await button.evaluate((el) => getComputedStyle(el).borderTopLeftRadius);
+
+    // Unset, the composed button computes 4px — exactly the hardcoded value it
+    // rendered before --btn-radius existed. Registering the token defaulting to
+    // 4px and routing the winning `main .btn` rule through var(--btn-radius, 4px)
+    // changed nothing about the default rendering.
+    expect(buttonRadius).toBe('4px');
+  });
+});


### PR DESCRIPTION
Closes #369

## What & why
The button corner radius was unreachable through the design-token surface. `components.css` advertised a `--btn-radius` hook, but the token was never registered, so `update_design_token --token=--btn-radius` was rejected. The only registered radius lever, `--radius`, is global — pilling a CTA with it also pills every card/panel. This registers `--btn-radius` as a `length` design token and makes the rendered button radius follow it.

## Decision (mid-implementation, resolved with the maintainer)
The recorded fix ("register `--btn-radius` defaulting to `var(--radius)` so the button keeps following the global radius") rested on a false premise that the rendered pin exposed: **the composed button never followed `--radius`.** The winning cascade rule for every composed button — the premium-CTA block `main .btn` (components.css) — hardcoded `border-radius: 4px`, overriding the base `.btn` rule. So registering the token alone left it inert; the button stayed 4px whether or not `--btn-radius` was set.

Resolved with the maintainer: **Option A with the default corrected to `4px`.** Route the winning rule through `var(--btn-radius, 4px)` and register `--btn-radius` defaulting to `4px` (the button's actual current radius). `var(--radius)` (6px) would have been wrong two ways: declaring the token in `:root` defines the property globally so the fallback never fires, and 6px would have silently restyled every existing button 4px→6px. `4px` keeps unset rendering byte-identical.

## Scope (acceptance criteria)
- `--btn-radius` registered as a `length` token in `assets/css/base.css` `:root` (default `4px`), via the same type-comment convention `pp_design_tokens()` parses — no parallel registration path.
- `update_design_token --token=--btn-radius --value=100px` validates through the shared `_pp_validate_token_value` length engine — no second validator.
- The winning premium-CTA rule (components.css) routed `border-radius: 4px` → `var(--btn-radius, 4px)`, covering `main .btn`, hero cta-group buttons, and `#*-cta .cta__button` in one declaration.
- AI docs: runtime catalog (`lib/ai-context.php`) already enumerates `pp_design_tokens()` so the token auto-surfaces; static `AI_CONTEXT.md` catalog and `ai-instructions/retheme.md` updated in the same change (retheme.md previously told the AI to pill buttons via the global `--radius`, which is impossible).

## Accepted properties / limitations
- **Byte-identical unset (verified):** only cta/hero/section emit `.btn`, all render inside `<main>` and were already 4px; the render pin computes 4px unset. The base `.btn` rule (line 30) now resolves `var(--btn-radius, 4px)` = 4px where it previously resolved `var(--radius)` = 6px, but it is overridden by `main .btn` for every rendered button, so no rendered button changes.
- `--btn-radius` contains `radius`, not `border-width`/`border-color` — does not trip the #332 core-border-trigger guard. Restore semantics unchanged (no new write-time rule).

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` — 1845 tests OK (was 1841 on the clean tree; +4 new, zero new warnings/deprecations).
- `npm test` (vitest) — 16 files, 571 tests pass.
- `tests/e2e/style-render.spec.ts` (wp-env, real WordPress) — the two `#369` render pins pass. Mutation-verified red→green both directions: dropping the token registration reverts the apply to "not a registered design token"; reverting the cascade route leaves the button at 4px instead of 100px.
- `bash scripts/package.sh` validates the five-file version sync (exit 0); the side-effect zip was deleted (releases are CI-built).

## gstack workflows run
/plan-eng-review, /review (both on this exact diff), /document-generate (fixed the stale retheme.md claim), /ship.

Not tagged/released/deployed — those are maintainer steps.
