### PR TITLE
v1.0.0 chore: release v1.0.0 (version bump + doc freshness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.0.0] — 2026-07-15 — first stable release: the v1.0.0 acceptance gate is closed (#141)
+
+**PromptingPress reaches 1.0.0. This is a milestone marker, not a feature release: every capability shipped in the 0.16.x train below, and this entry carries no new code beyond the five-file version bump and a documentation-freshness pass. What 1.0.0 marks is the close of the v1.0.0 acceptance gate (#141) — the milestone reached zero open issues, and three independent benchmark dogfoods verified the product materially credible with all trust-class defects resolved. The 0.16.x train is what earned the tag: the composition/file authority model, the shared validation engines (no surface-specific second validator), write-time compare-and-swap on composition writes (#13), composition history and restore (#133/#233), the typed action/apply layer with preview and rollback, the per-instance style-slot contract enforced by static and rendered-cascade guards, and the runtime AI action catalog. 1.0.0 does not add to that surface; it certifies it.**
+
+This release bumps the version across the five synced files (style.css, package.json, functions.php `PP_VERSION`, the README badge, and readme.txt's Stable tag) from 0.16.136 to 1.0.0, and corrects the two stale theme-version strings in README.md's project-status section (the release-history range and the "What exists today" heading) that still read v0.16.99. A full audit of the documentation surfaces (README.md, readme.txt, AI_CONTEXT.md, AI_RULES.md, docs/, ai-instructions/) found no other stale theme-version string or stale feature claim: the style-slot count (194) and its per-component breakdown are test-guarded against the schemas (`SchemaValidationTest::testDocsStyleSlotCountMatchesSchema`) and remain current, and the per-post composition-freshness version references (the #13 compare-and-swap counter) are a distinct value from the theme version and were correctly left untouched. No behavior changed.
+
+### Docs
+
+- README.md's project-status section now reads v1.0.0 instead of v0.16.99 in the release-history range and the "What exists today" heading. All other documented counts, claims, and grammars were audited and confirmed current — no other changes were needed.
+
 ## [v0.16.136] — 2026-07-15 — add_component now accepts a per-instance style, so you can add a styled component in one call instead of two (#368)
 
 **The `add_component` action took `component`, `props`, and `position` but had no `style` param. Because composition items already carry a per-instance `items[].style` map, an operator would naturally pass `style` to `add_component` too — and the action returned `ok: true` while silently dropping the styling. That is the #147 trust class: a mutating action reports success while ignoring an input that had visible intent. Per-instance styling only landed through a separate `style_component` call or a full composition write. This adds an optional `style` param to `add_component` that is written onto the new composition item and validated by the exact same shared engine as `items[].style`, so a styled component can be added in one call — and an invalid style is now rejected instead of silently accepted.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-0.16.136-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.0.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -419,9 +419,9 @@ npm run env:stop
 
 PromptingPress is in active development by a single developer. It is not yet packaged for broad distribution. The current focus is making the AI-agent workflow reliable and the composition model complete.
 
-See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v0.16.99.
+See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.0.0.
 
-**What exists today (v0.16.99):**
+**What exists today (v1.0.0):**
 - 12 components with schema contracts and 194 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '0.16.136');
+define('PP_VERSION', '1.0.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "0.16.136",
+  "version": "1.0.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 0.16.136
+Stable tag: 1.0.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -19,6 +19,10 @@ An AI-first WordPress theme built for clarity. PromptingPress uses a component-b
 4. Activate the theme.
 
 == Changelog ==
+
+= 1.0.0 =
+* First stable release: the v1.0.0 acceptance gate is closed. Every capability shipped in the 0.16.x series; 1.0.0 certifies that surface rather than adding to it, following three benchmark dogfoods that verified the product materially credible with all trust-class defects resolved
+* Version bump and a documentation-freshness pass only — no behavior changed
 
 = 0.16.48 =
 * Rollup of the 0.16 series (48 patch releases). Highlights:

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          0.16.136
+Version:          1.0.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
## What this is

The **first stable release**. The v1.0.0 acceptance gate (#141) is fully closed — the milestone reached zero open issues and three benchmark dogfoods verified the product materially credible with all trust-class defects resolved. This PR carries **no new code**: it is the version bump plus a documentation-freshness pass. Every capability shipped in the 0.16.x train; 1.0.0 certifies that surface rather than adding to it.

## Changes

**Version bump 0.16.136 → 1.0.0** across all five synced files:
- `style.css` (`Version:`)
- `package.json` (`version`)
- `functions.php` (`PP_VERSION`)
- `README.md` (version badge)
- `readme.txt` (`Stable tag`)

Validated with `bash scripts/package.sh` → `Version consistency: OK`. The built zip was deleted immediately (releases are CI-built from the tag).

**Documentation freshness:**
- `README.md` project-status section: corrected the two stale `v0.16.99` references (release-history range and the "What exists today" heading) to `v1.0.0`.
- `CHANGELOG.md`: added the `[v1.0.0]` entry in the repo's format (bold lede + explanation + `### Docs`).
- `readme.txt`: added the `= 1.0.0 =` changelog rollup entry in the existing rollup style.

**Doc-audit result (full pass over README.md, readme.txt, AI_CONTEXT.md, AI_RULES.md, docs/, ai-instructions/):** the two README strings above were the only genuinely stale theme-version references. All other counts and claims were confirmed current — the style-slot count (194) and its per-component breakdown are test-guarded against the schemas (`SchemaValidationTest::testDocsStyleSlotCountMatchesSchema`). The per-post composition-freshness version references in `docs/reference-apply-cli.md` and `AI_CONTEXT.md` are the #13 compare-and-swap counter (a distinct value from the theme version) and were correctly left untouched.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` → **1859 tests, 7208 assertions, OK** (3 warnings / 2 deprecations are pre-existing framework noise; this diff touches no PHP logic).
- `npm test` (vitest) → **575 tests passed** (includes `package.test.js` version-sync pins and `docs-lint.test.js`).
- `/review` (proportional scope + doc-accuracy pass) → **CLEAN**, 0 findings. Full adversarial fan-out not warranted for a 28-line docs+version diff.

## Not done here (maintainer's steps)

Tagging, the GitHub release, and any deploy are **not** part of this PR. Per repo invariant, release zips are CI-built from the tag and the maintainer/orchestrator tags after merge. `release.yml` enforces `tag == style.css Version`, and this PR sets that Version to exactly `1.0.0`.

No `Closes #` — this is a release chore, not an issue implementation.
