### PR TITLE
v1.0.2 test: add unit coverage for the WP-CLI gate stack fail-closed branches (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.0.2] — 2026-07-17 — unit coverage for the WP-CLI gate stack fail-closed branches (#390)
+
+**The WP-CLI gate stack is load-bearing safety logic, but the composed fail-closed decisions in its wrappers (`_pp_cli_require_run_id`, `_pp_cli_require_preflight_for_action`, `_pp_cli_require_preflight_covers`, `_pp_cli_require_composition_fresh`) had no direct unit coverage, because each wrapper calls `WP_CLI::error()` — a process exit — inline with its branch logic. That left the safety decisions both unshared and untested. This change extracts the decision of each gate into a pure predicate (a message-or-null return, or a discriminated result for the freshness gate) and adds `tests/CliGateTest.php`, which pins every fail-closed branch at both the predicate and the wrapper level. The wrappers stay thin emit shims; every user-facing message, return value, and branch ordering is byte-identical to before, so no CLI behavior changed.**
+
+This is the second item of the v1.0.1 executor-level safety-hardening gate (#141, Part 1.5) from the 2026-07-16 fragile-complexity audit. Pinning the composition first means later gate-stack refactors (the operate-patch unification in #391) can move this logic without silently changing a fail-closed decision. Coverage spans the eight branches the issue names: missing and invalid run ID, missing preflight coverage, unrecognized action scope, a page/section action without `post_id`, a site action carrying `post_id`, a missing composition-freshness baseline, and a stale composition marker — plus the accept and no-op paths. The composition-precondition branch (#358) is deliberately excluded: #387 relocates it into the shared validator, so pinning it here as CLI behavior would churn when that lands. The new test defines a `WP_CLI` stub whose `error()` throws a catchable exception in place of `exit(1)`, faithfully modeling the fail-closed semantics without a live WP-CLI runtime.
+
+### Tests
+
+- `tests/CliGateTest.php` (new, 30 tests) covers the WP-CLI gate composition without relying on interactive `WP_CLI::error()` exits: each fail-closed branch is asserted on its exact user-facing message, and each accept/no-op path on its exact return value, at both the extracted pure predicate and the thin wrapper. Full suite: 1889 PHP tests green (up from 1859), 575 JS tests green.
+
+### Fixed
+
+- The four WP-CLI gate wrappers in `lib/cli.php` now delegate their fail-closed decision to a pure, testable predicate (`_pp_cli_run_id_error`, `_pp_cli_preflight_target_error`, `_pp_cli_preflight_coverage_error`, `_pp_cli_composition_fresh_decision`), so the composed safety logic is unit-testable instead of trapped behind `WP_CLI::error()`. Behavior, messages, and ordering are unchanged; the `composition_required` precondition (#358) is untouched.
+
 ## [v1.0.1] — 2026-07-17 — classify operating-loop gates and correct the stale chat-CAS claim (#389)
 
 **The operating-loop safety docs claimed every agent-driven or editor-driven composition write opts into the write-time compare-and-swap (CAS). The code is narrower than that: only the WP-CLI operate loop and the dashboard editor's save/publish AJAX thread `expected_version` into the write. The chat AI path (`wp_ajax_pp_ai_chat` → `pp_execute_action()`) does not, so a chat-driven composition write is not CAS-protected. This documentation-only patch corrects that over-claim in both `docs/operating-loop-safety.md` and `docs/reference-apply-cli.md`, and adds an explicit classification of the current gates into loop-discipline (run-token ordering, INSPECT/PREFLIGHT/HANDOFF choreography — legitimately CLI-specific) versus data-safety invariants (preconditions, freshness, CAS, rollback — which belong at shared choke points or must be named as caller-specific gaps). No runtime behavior changed.**

--- a/README.md
+++ b/README.md
@@ -419,9 +419,9 @@ npm run env:stop
 
 PromptingPress is in active development by a single developer. It is not yet packaged for broad distribution. The current focus is making the AI-agent workflow reliable and the composition model complete.
 
-See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.0.1.
+See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.0.2.
 
-**What exists today (v1.0.1):**
+**What exists today (v1.0.2):**
 - 12 components with schema contracts and 194 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.0.1-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.0.2-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.0.1');
+define('PP_VERSION', '1.0.2');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -30,18 +30,35 @@ function _pp_cli_preflight_record_failed(array $result, string $message): void {
 }
 
 /**
+ * Pure decision for the --run-id gate (#390): returns the fail-closed error
+ * message, or null when the arg is present and a valid UUID v4. Split out of
+ * _pp_cli_require_run_id() so the two rejection branches (missing, invalid) are
+ * unit-testable without going through WP_CLI::error()'s process exit. The
+ * wrapper below owns the emit; this owns the decision and the message text.
+ *
+ * @param array $assoc_args The CLI assoc args (expects a 'run-id' key).
+ * @return string|null  The user-facing error, or null to accept.
+ */
+function _pp_cli_run_id_error(array $assoc_args): ?string {
+    if (empty($assoc_args['run-id'])) {
+        return '--run-id is required. Run `wp pp operate inspect` first to get a run token.';
+    }
+    if (!pp_operate_valid_run_id($assoc_args['run-id'])) {
+        return '--run-id must be a valid UUID v4. Got: "' . $assoc_args['run-id'] . '"';
+    }
+    return null;
+}
+
+/**
  * Validates and returns the --run-id from CLI args.
  * Halts with WP_CLI::error if missing or not a valid UUID v4.
  */
 function _pp_cli_require_run_id(array $assoc_args): string {
-    if (empty($assoc_args['run-id'])) {
-        WP_CLI::error('--run-id is required. Run `wp pp operate inspect` first to get a run token.');
+    $error = _pp_cli_run_id_error($assoc_args);
+    if ($error !== null) {
+        WP_CLI::error($error);
     }
-    $run_id = $assoc_args['run-id'];
-    if (!pp_operate_valid_run_id($run_id)) {
-        WP_CLI::error('--run-id must be a valid UUID v4. Got: "' . $run_id . '"');
-    }
-    return $run_id;
+    return $assoc_args['run-id'];
 }
 
 /**
@@ -50,15 +67,33 @@ function _pp_cli_require_run_id(array $assoc_args): string {
  * specific $post_id for page/section mutations, or the site grain when $post_id
  * is null. Shared by `action execute` and `operate patch`.
  */
-function _pp_cli_require_preflight_covers(string $run_id, ?int $post_id): void {
+/**
+ * Pure decision for the preflight-coverage gate (#96/#390): returns the
+ * fail-closed error message when the run has no completed PREFLIGHT covering the
+ * intended target, or null when coverage exists. Split out of
+ * _pp_cli_require_preflight_covers() so the uncovered branch and its actionable
+ * message are unit-testable without WP_CLI::error()'s exit.
+ *
+ * @param string   $run_id  The run token UUID.
+ * @param int|null $post_id The mutation target post, or null for site-scoped.
+ * @return string|null  The user-facing error, or null to accept.
+ */
+function _pp_cli_preflight_coverage_error(string $run_id, ?int $post_id): ?string {
     if (pp_operate_preflight_covers($run_id, $post_id)) {
-        return;
+        return null;
     }
     $target = $post_id !== null ? 'post ' . $post_id : 'site-scoped changes';
     $hint   = 'wp pp apply preflight --run-id=' . $run_id
             . ($post_id !== null ? ' --post_id=' . $post_id : '');
-    WP_CLI::error('Run token "' . $run_id . '" has no completed PREFLIGHT covering ' . $target
-        . '. Mutating actions require a successful preflight first. Run `' . $hint . '`.');
+    return 'Run token "' . $run_id . '" has no completed PREFLIGHT covering ' . $target
+        . '. Mutating actions require a successful preflight first. Run `' . $hint . '`.';
+}
+
+function _pp_cli_require_preflight_covers(string $run_id, ?int $post_id): void {
+    $error = _pp_cli_preflight_coverage_error($run_id, $post_id);
+    if ($error !== null) {
+        WP_CLI::error($error);
+    }
 }
 
 /**
@@ -67,28 +102,54 @@ function _pp_cli_require_preflight_covers(string $run_id, ?int $post_id): void {
  * carry none), asserts that the action's declared scope is consistent with that
  * presence so a misdeclared action can't be mis-gated, then enforces coverage.
  */
-function _pp_cli_require_preflight_for_action(string $run_id, array $action, array $params): void {
-    $scope   = $action['scope'] ?? 'unknown';
-    $post_id = isset($params['post_id']) ? (int) $params['post_id'] : null;
+/**
+ * Pure decision for the scope-consistency guardrail (#390) that resolves an
+ * action's preflight target from its declared scope and the presence of a
+ * post_id. Returns the fail-closed error message for the three misdeclaration
+ * branches, or null when scope and post_id are mutually consistent:
+ *   - unrecognized scope (not page/section/site);
+ *   - a page/section action with no post_id;
+ *   - a site action carrying a post_id.
+ * Split out of _pp_cli_require_preflight_for_action() so those branches are
+ * unit-testable without WP_CLI::error()'s exit. It does NOT enforce coverage or
+ * the #358 composition precondition — those stay in the wrapper below.
+ *
+ * @param array    $action  The registered action (expects 'scope', 'name').
+ * @param int|null $post_id The resolved target post, or null for site scope.
+ * @return string|null  The user-facing error, or null to accept.
+ */
+function _pp_cli_preflight_target_error(array $action, ?int $post_id): ?string {
+    $scope = $action['scope'] ?? 'unknown';
 
     // Fail closed on an unrecognized scope. The page/site assertions below only
     // hold for the known scopes; a missing or mistyped scope would otherwise fall
     // through to post_id-presence keying, letting a misdeclared page action be
     // unlocked by a site-grain preflight. Refuse rather than guess the target.
     if (!in_array($scope, ['page', 'section', 'site'], true)) {
-        WP_CLI::error('Action "' . ($action['name'] ?? '?') . '" has an unrecognized scope "'
-            . $scope . '"; refusing to resolve a preflight target. This is an action-registration bug.');
+        return 'Action "' . ($action['name'] ?? '?') . '" has an unrecognized scope "'
+            . $scope . '"; refusing to resolve a preflight target. This is an action-registration bug.';
     }
 
     // Scope-consistency guardrail: page/section MUST carry post_id; site MUST NOT.
     $is_page_scope = in_array($scope, ['page', 'section'], true);
     if ($is_page_scope && $post_id === null) {
-        WP_CLI::error('Action "' . ($action['name'] ?? '?') . '" is ' . $scope
-            . '-scoped but no post_id was provided; cannot resolve a preflight target.');
+        return 'Action "' . ($action['name'] ?? '?') . '" is ' . $scope
+            . '-scoped but no post_id was provided; cannot resolve a preflight target.';
     }
     if ($scope === 'site' && $post_id !== null) {
-        WP_CLI::error('Action "' . ($action['name'] ?? '?') . '" is site-scoped but a post_id '
-            . 'was provided; site actions are not page-targeted.');
+        return 'Action "' . ($action['name'] ?? '?') . '" is site-scoped but a post_id '
+            . 'was provided; site actions are not page-targeted.';
+    }
+
+    return null;
+}
+
+function _pp_cli_require_preflight_for_action(string $run_id, array $action, array $params): void {
+    $post_id = isset($params['post_id']) ? (int) $params['post_id'] : null;
+
+    $target_error = _pp_cli_preflight_target_error($action, $post_id);
+    if ($target_error !== null) {
+        WP_CLI::error($target_error);
     }
 
     _pp_cli_require_preflight_covers($run_id, $post_id);
@@ -125,27 +186,52 @@ function _pp_cli_require_preflight_for_action(string $run_id, array $action, arr
  *
  * @return int|null  The baseline version to use as expected_version, or null (no CAS).
  */
-function _pp_cli_require_composition_fresh(string $run_id, array $action, ?int $post_id): ?int {
+/**
+ * Pure decision for the preflight-freshness gate (#113/#390). Reads the recorded
+ * and live composition markers and resolves the gate to one of:
+ *   ['status' => 'ok',    'version' => int|null]  — accept; version is the CAS
+ *        baseline to thread as expected_version, or null for the no-op cases
+ *        (non-composition-mutating action, or site-scoped/no post_id);
+ *   ['status' => 'error', 'message' => string]    — fail-closed, with the exact
+ *        user-facing message for the missing-baseline or stale-marker branch.
+ * Split out of _pp_cli_require_composition_fresh() so both rejection branches are
+ * unit-testable without WP_CLI::error()'s exit. The single snapshot read here is
+ * also reused for the returned version, so the wrapper below never re-reads.
+ *
+ * @param string   $run_id  The run token UUID.
+ * @param array    $action  The registered action (checks 'mutates_composition').
+ * @param int|null $post_id The mutation target post, or null.
+ * @return array  A discriminated result: {status:'ok', version:int|null} or {status:'error', message:string}.
+ */
+function _pp_cli_composition_fresh_decision(string $run_id, array $action, ?int $post_id): array {
     if (empty($action['mutates_composition']) || $post_id === null) {
-        return null;
+        return ['status' => 'ok', 'version' => null];
     }
 
     $recorded = pp_operate_get_composition_snapshot($run_id, $post_id);
     if ($recorded === null) {
-        WP_CLI::error('Run token "' . $run_id . '" recorded no composition freshness baseline for post '
-            . $post_id . '. Re-run `wp pp apply preflight --run-id=' . $run_id . ' --post_id=' . $post_id . '`.');
+        return ['status' => 'error', 'message' => 'Run token "' . $run_id . '" recorded no composition freshness baseline for post '
+            . $post_id . '. Re-run `wp pp apply preflight --run-id=' . $run_id . ' --post_id=' . $post_id . '`.'];
     }
 
     $live = pp_get_composition_marker($post_id);
     if (!pp_composition_marker_matches($recorded, $live)) {
-        WP_CLI::error('Stale preflight for post ' . $post_id . ': the composition changed since preflight '
+        return ['status' => 'error', 'message' => 'Stale preflight for post ' . $post_id . ': the composition changed since preflight '
             . '(preflight version ' . (int) $recorded['version'] . ', live version ' . (int) $live['version'] . '). '
             . 'Another path (a CLI action, the dashboard editor, or publish flow) modified it. '
             . 'Re-inspect and re-run `wp pp apply preflight --run-id=' . $run_id . ' --post_id=' . $post_id
-            . '` before executing. [composition_conflict]');
+            . '` before executing. [composition_conflict]'];
     }
 
-    return (int) $recorded['version'];
+    return ['status' => 'ok', 'version' => (int) $recorded['version']];
+}
+
+function _pp_cli_require_composition_fresh(string $run_id, array $action, ?int $post_id): ?int {
+    $decision = _pp_cli_composition_fresh_decision($run_id, $action, $post_id);
+    if ($decision['status'] === 'error') {
+        WP_CLI::error($decision['message']);
+    }
+    return $decision['version'];
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.0.1
+Version:          1.0.2
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/CliGateTest.php
+++ b/tests/CliGateTest.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * tests/CliGateTest.php — Fail-closed coverage for the WP-CLI gate stack (#390).
+ *
+ * The gate composition in lib/cli.php (run-id validation, preflight coverage,
+ * scope-consistency, composition freshness) was load-bearing but untested,
+ * because each wrapper called WP_CLI::error() directly — a process exit that is
+ * hostile to unit testing. #390 extracts the decision of each gate into a pure
+ * predicate (message-or-null, or a discriminated result for freshness) so every
+ * fail-closed branch is assertable without the exit. This file pins:
+ *
+ *   1. the pure predicates directly (the decision), and
+ *   2. the thin WP_CLI wrappers (the composition), via a WP_CLI stub whose
+ *      error() throws a catchable exception in place of exit(1) — proving the
+ *      wrappers still fail closed and still emit the exact user-facing messages.
+ *
+ * Deliberately OUT OF SCOPE (per #390): the #358 composition-precondition branch
+ * inside _pp_cli_require_preflight_for_action(). #387 relocates that check into
+ * the shared validator, so every fail-closed branch tested here short-circuits
+ * BEFORE the precondition call is reached.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+// ── Minimal WP-CLI stubs so lib/cli.php loads outside a real WP-CLI runtime ──
+// error() throws instead of exiting, so a wrapper's fail-closed branch is
+// observable as a catchable exception carrying the exact user-facing message.
+if (!class_exists('WpCliExitException')) {
+    class WpCliExitException extends \RuntimeException {}
+}
+if (!class_exists('WP_CLI_Command')) {
+    class WP_CLI_Command {}
+}
+if (!class_exists('WP_CLI')) {
+    class WP_CLI {
+        public static function error($message, $exit = true): void { throw new WpCliExitException((string) $message); }
+        public static function add_command($name, $handler, $args = []): void {}
+        public static function line($message = ''): void {}
+        public static function warning($message = ''): void {}
+        public static function success($message = ''): void {}
+        public static function debug($message = '', $group = false): void {}
+        public static function log($message = ''): void {}
+    }
+}
+
+require_once dirname(__DIR__) . '/lib/cli.php';
+
+class CliGateTest extends TestCase
+{
+    /** @var string[] Run tokens created during a test, cleaned up in tearDown. */
+    private array $runs = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Stable site identity so a run created and read within one test matches.
+        $GLOBALS['_pp_test_store']['options']['siteurl'] = 'https://example.com';
+        $GLOBALS['_pp_test_store']['post_meta'] = [];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->runs as $run_id) {
+            pp_operate_cleanup_run($run_id);
+        }
+        $this->runs = [];
+        $GLOBALS['_pp_test_store']['post_meta'] = [];
+        parent::tearDown();
+    }
+
+    /** Creates a run token and registers it for cleanup. */
+    private function newRun(): string
+    {
+        $run_id = pp_operate_create_run();
+        $this->assertIsString($run_id, 'run token created');
+        $this->runs[] = $run_id;
+        return $run_id;
+    }
+
+    /** Sets the live composition marker (what pp_get_composition_marker reads). */
+    private function setLiveMarker(int $post_id, int $version, string $hash): void
+    {
+        update_post_meta($post_id, '_pp_composition_version', $version);
+        update_post_meta($post_id, '_pp_composition_hash', $hash);
+    }
+
+    // ── Gate 1: run-id validation ────────────────────────────────────────────
+
+    public function testRunIdErrorMissing(): void
+    {
+        $error = _pp_cli_run_id_error([]);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('--run-id is required', $error);
+    }
+
+    public function testRunIdErrorEmptyString(): void
+    {
+        // empty('') is true — the missing branch, not the invalid branch.
+        $error = _pp_cli_run_id_error(['run-id' => '']);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('--run-id is required', $error);
+    }
+
+    public function testRunIdErrorInvalidUuid(): void
+    {
+        $error = _pp_cli_run_id_error(['run-id' => 'not-a-uuid']);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('valid UUID v4', $error);
+        $this->assertStringContainsString('not-a-uuid', $error, 'echoes the offending value');
+    }
+
+    public function testRunIdErrorValidReturnsNull(): void
+    {
+        $this->assertNull(_pp_cli_run_id_error(['run-id' => '123e4567-e89b-42d3-a456-426614174000']));
+    }
+
+    public function testRequireRunIdThrowsOnMissing(): void
+    {
+        $this->expectException(WpCliExitException::class);
+        $this->expectExceptionMessage('--run-id is required');
+        _pp_cli_require_run_id([]);
+    }
+
+    public function testRequireRunIdThrowsOnInvalid(): void
+    {
+        $this->expectException(WpCliExitException::class);
+        $this->expectExceptionMessage('valid UUID v4');
+        _pp_cli_require_run_id(['run-id' => 'garbage']);
+    }
+
+    public function testRequireRunIdReturnsValidToken(): void
+    {
+        $uuid = '123e4567-e89b-42d3-a456-426614174000';
+        $this->assertSame($uuid, _pp_cli_require_run_id(['run-id' => $uuid]));
+    }
+
+    // ── Gate 2: scope-consistency / preflight target resolution ──────────────
+
+    public function testPreflightTargetErrorUnrecognizedScope(): void
+    {
+        $error = _pp_cli_preflight_target_error(['name' => 'weird_action', 'scope' => 'galaxy'], 5);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('unrecognized scope "galaxy"', $error);
+        $this->assertStringContainsString('weird_action', $error);
+    }
+
+    public function testPreflightTargetErrorMissingScopeKeyIsUnrecognized(): void
+    {
+        // No 'scope' key defaults to 'unknown', which is not page/section/site.
+        $error = _pp_cli_preflight_target_error(['name' => 'no_scope'], null);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('unrecognized scope "unknown"', $error);
+    }
+
+    public function testPreflightTargetErrorPageWithoutPostId(): void
+    {
+        $error = _pp_cli_preflight_target_error(['name' => 'set_prop', 'scope' => 'page'], null);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('page-scoped but no post_id was provided', $error);
+    }
+
+    public function testPreflightTargetErrorSectionWithoutPostId(): void
+    {
+        $error = _pp_cli_preflight_target_error(['name' => 'edit_section', 'scope' => 'section'], null);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('section-scoped but no post_id was provided', $error);
+    }
+
+    public function testPreflightTargetErrorSiteWithPostId(): void
+    {
+        $error = _pp_cli_preflight_target_error(['name' => 'set_logo', 'scope' => 'site'], 5);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('site-scoped but a post_id', $error);
+    }
+
+    public function testPreflightTargetErrorValidPageReturnsNull(): void
+    {
+        $this->assertNull(_pp_cli_preflight_target_error(['name' => 'set_prop', 'scope' => 'page'], 5));
+    }
+
+    public function testPreflightTargetErrorValidSiteReturnsNull(): void
+    {
+        $this->assertNull(_pp_cli_preflight_target_error(['name' => 'set_logo', 'scope' => 'site'], null));
+    }
+
+    // ── Gate 3: preflight coverage ───────────────────────────────────────────
+
+    public function testPreflightCoverageErrorWhenNotCovered(): void
+    {
+        // A fresh run has INSPECT only — no PREFLIGHT recorded for post 42.
+        $run_id = $this->newRun();
+        $error = _pp_cli_preflight_coverage_error($run_id, 42);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('no completed PREFLIGHT covering post 42', $error);
+        $this->assertStringContainsString('--post_id=42', $error, 'hint targets the post');
+    }
+
+    public function testPreflightCoverageErrorSiteScopeWording(): void
+    {
+        $run_id = $this->newRun();
+        $error = _pp_cli_preflight_coverage_error($run_id, null);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('no completed PREFLIGHT covering site-scoped changes', $error);
+    }
+
+    public function testPreflightCoverageErrorNullWhenCovered(): void
+    {
+        $run_id = $this->newRun();
+        $this->assertTrue(pp_operate_record_preflight($run_id, 42, [], ['version' => 1, 'hash' => 'h'], []));
+        $this->assertNull(_pp_cli_preflight_coverage_error($run_id, 42));
+    }
+
+    // ── Gate 2+3 composition, via the wrapper (fail-closed, pre-#358) ─────────
+
+    public function testRequirePreflightForActionThrowsOnUnrecognizedScope(): void
+    {
+        $this->expectException(WpCliExitException::class);
+        $this->expectExceptionMessage('unrecognized scope');
+        _pp_cli_require_preflight_for_action(
+            '123e4567-e89b-42d3-a456-426614174000',
+            ['name' => 'weird', 'scope' => 'galaxy'],
+            ['post_id' => 5]
+        );
+    }
+
+    public function testRequirePreflightForActionThrowsOnPageWithoutPostId(): void
+    {
+        $this->expectException(WpCliExitException::class);
+        $this->expectExceptionMessage('no post_id was provided');
+        _pp_cli_require_preflight_for_action(
+            '123e4567-e89b-42d3-a456-426614174000',
+            ['name' => 'set_prop', 'scope' => 'page'],
+            []
+        );
+    }
+
+    public function testRequirePreflightForActionThrowsOnSiteWithPostId(): void
+    {
+        $this->expectException(WpCliExitException::class);
+        $this->expectExceptionMessage('site-scoped but a post_id');
+        _pp_cli_require_preflight_for_action(
+            '123e4567-e89b-42d3-a456-426614174000',
+            ['name' => 'set_logo', 'scope' => 'site'],
+            ['post_id' => 5]
+        );
+    }
+
+    public function testRequirePreflightForActionThrowsOnMissingCoverage(): void
+    {
+        // Scope is consistent, so the target gate passes; coverage then fails
+        // (no PREFLIGHT recorded) — reached BEFORE the #358 precondition.
+        $run_id = $this->newRun();
+        $this->expectException(WpCliExitException::class);
+        $this->expectExceptionMessage('no completed PREFLIGHT covering post 77');
+        _pp_cli_require_preflight_for_action(
+            $run_id,
+            ['name' => 'set_prop', 'scope' => 'page'],
+            ['post_id' => 77]
+        );
+    }
+
+    // ── Gate 4: composition freshness ────────────────────────────────────────
+
+    public function testFreshnessDecisionNoOpForNonMutatingAction(): void
+    {
+        $decision = _pp_cli_composition_fresh_decision('123e4567-e89b-42d3-a456-426614174000', ['name' => 'set_title', 'scope' => 'page'], 5);
+        $this->assertSame(['status' => 'ok', 'version' => null], $decision);
+    }
+
+    public function testFreshnessDecisionNoOpForSiteScope(): void
+    {
+        // Even a composition-mutating action with no post_id (site grain) is a no-op.
+        $decision = _pp_cli_composition_fresh_decision('123e4567-e89b-42d3-a456-426614174000', ['name' => 'x', 'scope' => 'site', 'mutates_composition' => true], null);
+        $this->assertSame(['status' => 'ok', 'version' => null], $decision);
+    }
+
+    public function testFreshnessDecisionErrorOnMissingBaseline(): void
+    {
+        // Mutating action, valid run, but no snapshot recorded for post 7.
+        $run_id = $this->newRun();
+        $decision = _pp_cli_composition_fresh_decision($run_id, ['name' => 'set_prop', 'scope' => 'page', 'mutates_composition' => true], 7);
+        $this->assertSame('error', $decision['status']);
+        $this->assertStringContainsString('no composition freshness baseline for post 7', $decision['message']);
+    }
+
+    public function testFreshnessDecisionErrorOnStaleMarker(): void
+    {
+        // Recorded marker v1/a; live marker v2/b — the composition moved under us.
+        $run_id = $this->newRun();
+        $this->assertTrue(pp_operate_record_preflight($run_id, 9, [], ['version' => 1, 'hash' => 'a'], []));
+        $this->setLiveMarker(9, 2, 'b');
+        $decision = _pp_cli_composition_fresh_decision($run_id, ['name' => 'set_prop', 'scope' => 'page', 'mutates_composition' => true], 9);
+        $this->assertSame('error', $decision['status']);
+        $this->assertStringContainsString('[composition_conflict]', $decision['message']);
+        $this->assertStringContainsString('preflight version 1, live version 2', $decision['message']);
+    }
+
+    public function testFreshnessDecisionOkReturnsBaselineVersion(): void
+    {
+        // Recorded marker matches the live marker → accept, returning the CAS baseline.
+        $run_id = $this->newRun();
+        $this->assertTrue(pp_operate_record_preflight($run_id, 11, [], ['version' => 3, 'hash' => 'match'], []));
+        $this->setLiveMarker(11, 3, 'match');
+        $decision = _pp_cli_composition_fresh_decision($run_id, ['name' => 'set_prop', 'scope' => 'page', 'mutates_composition' => true], 11);
+        $this->assertSame(['status' => 'ok', 'version' => 3], $decision);
+    }
+
+    public function testRequireCompositionFreshThrowsOnMissingBaseline(): void
+    {
+        $run_id = $this->newRun();
+        $this->expectException(WpCliExitException::class);
+        $this->expectExceptionMessage('no composition freshness baseline for post 7');
+        _pp_cli_require_composition_fresh($run_id, ['name' => 'set_prop', 'scope' => 'page', 'mutates_composition' => true], 7);
+    }
+
+    public function testRequireCompositionFreshThrowsOnStaleMarker(): void
+    {
+        $run_id = $this->newRun();
+        $this->assertTrue(pp_operate_record_preflight($run_id, 9, [], ['version' => 1, 'hash' => 'a'], []));
+        $this->setLiveMarker(9, 2, 'b');
+        $this->expectException(WpCliExitException::class);
+        $this->expectExceptionMessage('[composition_conflict]');
+        _pp_cli_require_composition_fresh($run_id, ['name' => 'set_prop', 'scope' => 'page', 'mutates_composition' => true], 9);
+    }
+
+    public function testRequireCompositionFreshReturnsVersionWhenFresh(): void
+    {
+        $run_id = $this->newRun();
+        $this->assertTrue(pp_operate_record_preflight($run_id, 11, [], ['version' => 3, 'hash' => 'match'], []));
+        $this->setLiveMarker(11, 3, 'match');
+        $version = _pp_cli_require_composition_fresh($run_id, ['name' => 'set_prop', 'scope' => 'page', 'mutates_composition' => true], 11);
+        $this->assertSame(3, $version);
+    }
+
+    public function testRequireCompositionFreshReturnsNullForNoOp(): void
+    {
+        // Non-mutating action → no CAS baseline applies.
+        $version = _pp_cli_require_composition_fresh('123e4567-e89b-42d3-a456-426614174000', ['name' => 'set_title', 'scope' => 'page'], 5);
+        $this->assertNull($version);
+    }
+}


### PR DESCRIPTION
Closes #390

## Scope

The WP-CLI gate stack is load-bearing safety logic whose composed fail-closed decisions had no direct unit coverage — each wrapper calls `WP_CLI::error()` (a process exit) inline with its branch logic, which is hostile to unit testing.

This change:
1. Extracts the decision of each gate in `lib/cli.php` into a pure predicate — `_pp_cli_run_id_error`, `_pp_cli_preflight_target_error`, `_pp_cli_preflight_coverage_error` (message-or-null), and `_pp_cli_composition_fresh_decision` (a discriminated `{status, version|message}` result). The four `_pp_cli_require_*` wrappers become thin emit shims.
2. Adds `tests/CliGateTest.php` (30 tests) pinning every fail-closed branch at both the pure-predicate and the wrapper level.

**Behavior preservation:** every user-facing message string, return value, and branch ordering is byte-identical to the merge-base original. The `#358` composition-precondition block in `_pp_cli_require_preflight_for_action` is untouched.

## Acceptance criteria

- [x] Unit tests cover the CLI gate composition without relying on interactive `WP_CLI::error()` exits — the test defines a `WP_CLI` stub whose `error()` throws a catchable exception in place of `exit(1)`.
- [x] Existing CLI behavior remains unchanged — messages/returns/ordering byte-identical (verified against `origin/main`).
- [x] Tests in place before the operate-patch gate-stack refactor (#391).

Branches covered (per the issue): missing run ID, invalid run ID, missing preflight coverage, unrecognized action scope, page/section action without `post_id`, site action carrying `post_id`, missing composition-freshness baseline, stale composition marker — plus accept and no-op paths.

**Deliberately excluded** (per the issue body): the `composition_required` (#358) precondition branch. #387 relocates it into the shared validator, so pinning it here as CLI behavior would churn when that lands.

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → **1889 passed** (up from 1859; +30 new). Warnings 3 / Deprecations 2 are pre-existing (verified identical against an unmodified tree).
- JS: `npm test` → **575 passed**.
- Version sync: `bash scripts/package.sh` → "Version consistency: OK" (five files at 1.0.2); build zip deleted (CI builds releases from tags).

Reviews (this session, on this diff): `/plan-eng-review` (clean), `/review` critical pass + testing + adversarial subagents (clean — faithful behavior-preserving extraction, coverage complete).

## Accepted limitations

- `tests/CliGateTest.php` declares a `class WP_CLI` process-wide (guarded with `class_exists`). No current test relies on `class_exists('WP_CLI')` being false, and full-suite green confirms no conflict; a future test that needs WP_CLI *absent* would become order-dependent. Noted, no action needed now.
- `_pp_cli_require_preflight_covers` is exercised transitively (through the composite action wrapper) rather than called directly — it is a one-line delegate.

Version: 1.0.2 (PATCH). Do not squash — the two commits (feature+tests / version+changelog) are bisectable.