### PR TITLE
v1.2.0 chore: release v1.2.0 (version bump + doc freshness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.2.0] — 2026-07-18 — chat writes gain compare-and-swap conflict protection: the v1.2.0 gate is closed (#141)
+
+**This is a gate rollup marker: the single feature of this release — composition CAS baselines threaded through the AI chat's single and batch executors (#404, working version 1.1.1) — shipped below, and this entry carries no new code beyond the five-file version bump and doc freshness. What 1.2.0 marks is the close of the chat CAS gate (#141, Part 1.6), the two-phase gate opened by the 2026-07-16 complexity audit: #392 designed the baseline lifecycle (context-read derivation, fail-closed mandates on both chat entry points, per-page batch baseline map with server-side chaining, envelope version refresh, Re-read & re-preview conflict UX), and #404 implemented it. The release bar was rendered CONFLICT evidence, not a feature dogfood, and it was met on dev under v1.1.1: an editor-vs-chat interleaved write and a chat-vs-chat interleaved write were both rejected in the real chat UI with the conflict card and a usable Re-read & re-preview retry (the retried apply preserved both writers' changes — no lost update), and a three-step batch mutating the same page did not false-conflict against its own writes (version advanced exactly +3). The docs claim corrected in #389 — that every agent-driven write opts into the CAS — is now true for the chat surface.**
+
+This release bumps the version across the five synced files from 1.1.1 to 1.2.0 and updates README.md's project-status strings. Remaining tracked gap outside this gate: apply/token mutation reversibility outside CLI runs (#393, needs-design). No behavior changed in this entry itself.
+
+### Docs
+
+- README.md's project-status section now reads v1.2.0 in the release-history range and the "What exists today" heading. readme.txt gains its `= 1.2.0 =` rollup entry.
+
 ## [v1.1.1] — 2026-07-18 — chat composition writes gain fail-closed CAS conflict protection (#404)
 
 **Chat was the one composition writer that never threaded a version baseline, so a chat-driven write could silently clobber a concurrent editor, CLI, or chat change. It now opts into the write-time compare-and-swap (#13) — mandatorily and fail-closed — on both chat entry points, implementing the accepted v1.2.0-gate design (#392). This is the implementation phase of the v1.2.0 chat-CAS gate (#141, Part 1.6); the gate-close/tag is a separate release.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.1.1-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.2.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -419,9 +419,9 @@ npm run env:stop
 
 PromptingPress is in active development by a single developer. It is not yet packaged for broad distribution. The current focus is making the AI-agent workflow reliable and the composition model complete.
 
-See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.1.0.
+See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.2.0.
 
-**What exists today (v1.1.0):**
+**What exists today (v1.2.0):**
 - 12 components with schema contracts and 194 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.1.1');
+define('PP_VERSION', '1.2.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.1.1
+Stable tag: 1.2.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -19,6 +19,10 @@ An AI-first WordPress theme built for clarity. PromptingPress uses a component-b
 4. Activate the theme.
 
 == Changelog ==
+
+= 1.2.0 =
+* AI chat composition writes are now protected by the write-time compare-and-swap: proposals carry a page baseline captured when the AI read the page, stale writes are rejected with a clear conflict card and a Re-read & re-preview retry, and multi-step proposals chain baselines server-side so they never conflict with their own changes
+* Fail-closed: a chat write without a baseline is rejected rather than silently skipping the safety check
 
 = 1.1.0 =
 * Executor-level safety hardening (seven-issue gate from the 2026-07-16 complexity audit): data-safety invariants moved to shared choke points — the composition-presence precondition now guards every executor caller including chat, the retired variant prop is rejected at write time while stored legacy pages still migrate on read/restore/render, operate patch shares the real per-action gate and error parity with action execute, and the WP-CLI gate stack's fail-closed branches are unit-pinned

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.1.1
+Version:          1.2.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Closes the **v1.2.0 chat CAS gate** (#141 Part 1.6, milestone v1.2.0: #392 design + #404 implementation, 0 open). Gate content shipped in working version 1.1.1 (PR #406); this PR carries **no new code** — five-file bump to 1.2.0, CHANGELOG v1.2.0 rollup, readme.txt rollup line, README project-status freshness.

**Release bar met before this PR:** rendered conflict evidence on dev under v1.1.1 (see the evidence comment on #404) — editor-vs-chat and chat-vs-chat interleaved writes rejected in the real chat UI with a usable Re-read & re-preview retry, and a three-step same-page batch with zero self-false-conflict.

**Validation on this branch:** 1935 PHP / 589 JS green; `scripts/package.sh` five-file consistency OK at 1.2.0 (zip deleted; the release zip is CI-built from the tag). Merge commit, do not squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)