### PR TITLE
v1.3.0 chore: release v1.3.0 (version bump + doc freshness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.3.0] — 2026-07-18 — first post-1.0 feature release: grid columns, icon image treatment, dropdown menus (#141)
+
+**This is a gate rollup marker: the three features of this release shipped in working versions 1.2.1–1.2.3 below, and this entry carries no new code beyond the five-file version bump and doc freshness. What 1.3.0 marks is the close of the feature gate (#141, Part 1.75) — the capability gaps that most limited fidelity in the neocompute.com benchmark dogfood, implemented as generic capabilities per the detects-not-specifies rule: an explicit grid `columns` control (1–4, opt-in, auto grain byte-identical when unset, #379); a grid `image_treatment` option rendering item images at icon scale via the `--grid-item-icon-size` slot instead of the 16:9 banner, with the icon following `--grid-item-text-align` (#380); and hierarchical menus — `set_menu` accepts `children`, rendered as WAI-ARIA disclosure dropdowns with full keyboard support and progressive enhancement (#381). The release bar was a rendered-evidence dogfood of all three capabilities on dev at both viewports (see #141), passed on RC v1.2.3.**
+
+This release bumps the version across the five synced files from 1.2.3 to 1.3.0 and updates README.md's project-status strings. No behavior changed in this entry itself.
+
+### Docs
+
+- README.md's project-status section now reads v1.3.0 in the release-history range and the "What exists today" heading. readme.txt gains its `= 1.3.0 =` rollup entry.
+
 ## [v1.2.3] — 2026-07-18 — navigation menus can have one-level dropdown submenus (#381)
 
 **Menus were flat: `set_menu` built a single row of links with no way to nest, so a "Servicios" item with a dropdown of sub-links was inexpressible through the operator surface. Each `set_menu` item now accepts an optional `children` array of the same `{page_id}` or `{url, label}` shape, and the theme renders a nested group as an accessible dropdown: hover-or-keyboard on desktop, expand-in-place in the mobile menu. Nesting is one level deep — a child with its own `children` is rejected loudly. Leave `children` off and nothing changes: a flat menu renders byte-identical. This is the third and final item of the v1.3.0 feature gate (#141, Part 1.75); the gate-close/tag is a separate release.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.2.3-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.3.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -419,9 +419,9 @@ npm run env:stop
 
 PromptingPress is in active development by a single developer. It is not yet packaged for broad distribution. The current focus is making the AI-agent workflow reliable and the composition model complete.
 
-See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.2.0.
+See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.3.0.
 
-**What exists today (v1.2.0):**
+**What exists today (v1.3.0):**
 - 12 components with schema contracts and 195 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.2.3');
+define('PP_VERSION', '1.3.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.2.3
+Stable tag: 1.3.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -19,6 +19,10 @@ An AI-first WordPress theme built for clarity. PromptingPress uses a component-b
 4. Activate the theme.
 
 == Changelog ==
+
+= 1.3.0 =
+* First post-1.0 feature release: explicit grid column-count control (1-4, auto grain unchanged when unset), icon-scale grid item images via a new image treatment option and size slot, and hierarchical dropdown menus (set_menu children) rendered as accessible WAI-ARIA disclosures with keyboard support
+* Verified by a rendered-evidence dogfood of all three capabilities at desktop and mobile viewports
 
 = 1.2.0 =
 * AI chat composition writes are now protected by the write-time compare-and-swap: proposals carry a page baseline captured when the AI read the page, stale writes are rejected with a clear conflict card and a Re-read & re-preview retry, and multi-step proposals chain baselines server-side so they never conflict with their own changes

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.2.3
+Version:          1.3.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Closes the **v1.3.0 feature gate** (#141 Part 1.75, milestone v1.3.0: #379/#380/#381, 0 open). Gate content shipped in working versions 1.2.1–1.2.3 (PRs #408, #410, #411); this PR carries **no new code** — five-file bump to 1.3.0, CHANGELOG rollup, readme.txt rollup line, README project-status freshness.

**Release bar met before this PR:** rendered-evidence dogfood of all three capabilities on dev under RC v1.2.3, both viewports (see the evidence comment on #141) — forced 2-column grid vs auto grain, 48px icon image treatment, and ARIA disclosure dropdowns with keyboard close, plus mobile expand-in-place and preserved single-column grain.

**Validation on this branch:** 1983 PHP / 612 JS green; `scripts/package.sh` five-file consistency OK at 1.3.0 (zip deleted; release zip is CI-built from the tag). Merge commit, do not squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)