### PR TITLE
v1.4.2 fix: mobile nav menu opens as a panel below the header instead of squeezing into the header row (#426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.2] — 2026-07-19 — the mobile menu opens as a real panel below the header instead of crushing itself into the header row (#426)
+
+**On a phone, tapping the hamburger used to break the header instead of showing a menu: the menu tried to squeeze in beside the logo and toggle, rendered as a ~94px sliver jammed against the right edge, and stretched the sticky header from 65px to 229px so it covered the page. The toggle also gave no sign it could close anything. Now the menu drops down as a full-width, left-aligned panel below the header row, the logo and toggle stay exactly where they were whether the menu is open or closed, and the hamburger swaps to an X while open so it reads as the close button. Tap outside, tap a link, press Escape, or rotate/resize back to a wide screen and the menu closes cleanly. Desktop navigation and the dropdown submenus are untouched.**
+
+The menu had been a third item in the header's flex row, so opening it competed for space with the logo and toggle. Pulling it out of that row (it now sits below as its own panel) means opening it can never reflow the logo/toggle row or grow the sticky header. The panel matches your header colors (it follows the same `pp_header_bg` you set for the header). Without JavaScript the menu still shows, now as that same panel rather than a broken row. This is layout and behavior only: the header stays theme-owned chrome, so nothing about how you customize it changed (logo, header colors, and menus work exactly as before).
+
+### Fixed
+- The mobile navigation menu now opens as a full-width panel below the header instead of squeezing into the header's flex row. Opening it leaves the logo/toggle row byte-identical and no longer distorts the sticky header, and the toggle shows a close (X) icon while open. Closes on toggle re-click, Escape (focus returns to the toggle), link click, and tap outside; resizing or rotating across the tablet breakpoint resets it to closed. Desktop navigation and the submenu dropdowns are unchanged (#426).
+
+### Tests
+- New `tests/js/main-nav-toggle.test.js` unit suite covers every open/close path, `aria-expanded` truthfulness, focus return, and the breakpoint state reset. `tests/js/css-lint.test.js` pins the panel layout mechanism and the icon swap so a refactor can't silently regress to the in-row squeeze. A new `tests/e2e/nav-mobile.spec.ts` proves the open-vs-closed row geometry, every close path, and the desktop-unaffected + submenu behavior in a real browser, with the core geometry scenario tagged `@smoke` (#426).
+
 ## [v1.4.1] — 2026-07-19 — the nightly full E2E suite is green again: two non-smoke specs caught up to shipped contracts (#423)
 
 **The scheduled nightly E2E run executes the FULL Playwright suite, but PR and push CI run only the `@smoke` subset, so two non-smoke specs that had drifted from already-shipped behavior went red on the nightly without any gating check ever seeing them. Both were test drift, not product regressions: the runtime contracts they pin are correct as landed. This release realigns the tests to those contracts and quiets a stream of expected-absence teardown noise that was burying real failures in the nightly log. Nothing in the shipped theme changed — this is a test-only fix, verified by running the affected specs to green against a live WordPress 7.0 and a full-suite manual run.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.1-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.2-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -159,7 +159,7 @@ Components are plain PHP partials that render semantic HTML with CSS custom prop
 | `base.css` | 9 KB | Design tokens — CSS custom properties |
 | `components.css` | 84 KB | All 12 component styles, CSS variables only |
 | `utilities.css` | 3 KB | Layout helpers |
-| `main.js` | 7.8 KB | Hamburger nav toggle, dropdown-submenu disclosures, and sticky-header height measurement — one IIFE, zero dependencies |
+| `main.js` | 9.5 KB | Hamburger nav toggle (disclosure panel + close-icon swap), dropdown-submenu disclosures, and sticky-header height measurement — one IIFE, zero dependencies |
 
 No build step. No transpilation. No bundler. What you write is what ships.
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -224,6 +224,23 @@
   color: var(--color-accent);
 }
 
+/* Open-state affordance (issue 426): the toggle swaps hamburger <-> close (X)
+   purely from its own aria-expanded, so the same button visibly communicates
+   state and is the obvious close control. main.js keeps aria-expanded truthful;
+   these rules own the icon swap. The toggle is display:none at >=768px, so this
+   is inert on desktop (rendered output there is byte-identical). */
+.nav__toggle-icon--close {
+  display: none;
+}
+
+.nav__toggle[aria-expanded="true"] .nav__toggle-icon--open {
+  display: none;
+}
+
+.nav__toggle[aria-expanded="true"] .nav__toggle-icon--close {
+  display: flex;
+}
+
 /* Nav menu — visible without JS (progressive enhancement); JS adds/removes hidden. */
 .nav__menu {
   width: 100%;
@@ -274,6 +291,37 @@
 .nav__menu ul li a[aria-current="page"] {
   font-weight: 700;
   color: var(--header-link-color, var(--color-accent));
+}
+
+/* Mobile (issue 426): the nav menu is a DISCLOSURE PANEL below the header row,
+   not a third item in the header's flex row. Before this, .nav__menu (width:100%)
+   joined the nowrap flex row when un-hidden and was crushed into a ~94px column at
+   the right edge while the sticky header grew 65px -> 229px. Taking the menu OUT of
+   the flex flow (position:absolute) means opening it never reflows the logo/toggle
+   row (byte-identical open vs closed) and never grows the sticky header. The panel
+   is anchored to .nav__container (position:relative) so its left edge lines up under
+   the logo via the existing container padding; top:100% drops it just under the row.
+   It paints above page content because the whole .site-header is a z-index:100 sticky
+   stacking context — this z-index only orders the panel within that context, adding
+   no new stacking context of its own. Scoped to max-width:767px so the >=768px desktop
+   nav is entirely untouched. Short panel -> no body scroll-lock (see main.js). The
+   panel background routes the --header-bg chrome slot so a themed header carries into
+   the panel too (issue 333/426). */
+@media (max-width: 767px) {
+  .nav__container {
+    position: relative;
+  }
+
+  .nav__menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 99;
+    background: var(--header-bg, var(--color-bg));
+    border-bottom: 1px solid var(--color-border);
+    box-shadow: 0 8px 24px rgba(16, 24, 40, 0.12);
+  }
 }
 
 /* Desktop: hamburger hidden, menu always visible */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -26,40 +26,74 @@
   if (toggle && menu) {
 
     // JS is running — take ownership of the menu visibility.
-    // Without JS, the menu is visible (progressive enhancement).
+    // Without JS, the menu is visible (progressive enhancement); the CSS
+    // presents it as an absolutely-positioned panel below the header row so
+    // the JS-less state does not distort the header either (issue 426).
     menu.hidden = true;
 
-    toggle.addEventListener('click', function () {
-      var expanded = toggle.getAttribute('aria-expanded') === 'true';
-      toggle.setAttribute('aria-expanded', String(!expanded));
-      menu.hidden = expanded;
+    // Single source of truth for open/closed. Every path (toggle, Escape,
+    // link click, outside click, breakpoint reset) routes through here so
+    // aria-expanded and `hidden` can never drift (issue 426). The open menu
+    // is an out-of-flow panel, so it does NOT grow the sticky header — but we
+    // keep --header-height in sync anyway (cheap, and robust if header content
+    // ever changes on open). A short dropdown panel, so no body scroll-lock.
+    function setMenuOpen(open) {
+      menu.hidden = !open;
+      toggle.setAttribute('aria-expanded', String(open));
       setHeaderHeightVar();
+    }
+
+    toggle.addEventListener('click', function () {
+      setMenuOpen(menu.hidden);
     });
 
     // ── 2. Escape key closes the menu ──────────────────────────────────────
     document.addEventListener('keydown', function (e) {
       if (e.key === 'Escape' && !menu.hidden) {
-        menu.hidden = true;
-        toggle.setAttribute('aria-expanded', 'false');
+        setMenuOpen(false);
         toggle.focus();
-        setHeaderHeightVar();
       }
     });
 
     // ── 3. Close the menu on link click ────────────────────────────────────
-    // Without this, an in-page anchor link clicked while the mobile menu is
-    // expanded would scroll while the sticky header is still in its taller,
-    // menu-open state — the exact scenario --header-height can't correct
-    // for after the fact (issue 63). Runs before the browser's default
-    // anchor-scroll for the same click, so --header-height is already
-    // updated to the collapsed height by the time the scroll happens.
+    // A disclosure closes when the user navigates. Runs before the browser's
+    // default anchor-scroll for the same click, so the menu is already closed
+    // (and --header-height already resynced) by the time the scroll to a
+    // #section-id happens — keeping the issue-63 anchor offset correct.
     menu.addEventListener('click', function (e) {
       if (e.target.tagName === 'A') {
-        menu.hidden = true;
-        toggle.setAttribute('aria-expanded', 'false');
-        setHeaderHeightVar();
+        setMenuOpen(false);
       }
     });
+
+    // ── 4. Click/tap outside the header closes the menu ────────────────────
+    // Mirrors the #381 submenu outside-close below. The toggle and menu both
+    // live inside .site-header, so a click on either is "inside" and never
+    // self-closes here; only a click on page content collapses the panel.
+    document.addEventListener('click', function (e) {
+      if (!menu.hidden && header && !header.contains(e.target)) {
+        setMenuOpen(false);
+      }
+    });
+
+    // ── 5. Reset state across the 768px breakpoint ─────────────────────────
+    // At >=768px the CSS shows the desktop nav row and hides the hamburger, so
+    // an open mobile panel must not leave a lingering open state (aria-expanded
+    // / ✕ icon). Collapse on entering desktop; returning to mobile then lands
+    // closed. matchMedia is absent in some test/older environments, so guard it.
+    if (window.matchMedia) {
+      var desktopQuery = window.matchMedia('(min-width: 768px)');
+      var resetOnDesktop = function (e) {
+        if (e.matches && !menu.hidden) {
+          setMenuOpen(false);
+        }
+      };
+      if (desktopQuery.addEventListener) {
+        desktopQuery.addEventListener('change', resetOnDesktop);
+      } else if (desktopQuery.addListener) {
+        desktopQuery.addListener(resetOnDesktop); // Safari <14 / older engines
+      }
+    }
 
   }
 

--- a/components/nav/nav.php
+++ b/components/nav/nav.php
@@ -50,11 +50,21 @@ $style_attr = pp_chrome_style_attr([
                 aria-controls="pp-nav-menu"
                 type="button"
             >
-                <span class="nav__toggle-icon" aria-hidden="true">
+                <?php // Two icons, swapped purely by CSS on the button's aria-expanded
+                      // state (components.css): hamburger when closed, ✕ when open —
+                      // so the same button is the obvious close affordance (issue 426).
+                      // JS never touches these; it owns aria-expanded, CSS owns the swap. ?>
+                <span class="nav__toggle-icon nav__toggle-icon--open" aria-hidden="true">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <line x1="3" y1="6"  x2="21" y2="6"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                         <line x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                         <line x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                </span>
+                <span class="nav__toggle-icon nav__toggle-icon--close" aria-hidden="true">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <line x1="6" y1="6"  x2="18" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                        <line x1="18" y1="6" x2="6"  y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                     </svg>
                 </span>
                 <span class="sr-only">Menu</span>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.1');
+define('PP_VERSION', '1.4.2');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.1
+Version:          1.4.2
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/nav-mobile.spec.ts
+++ b/tests/e2e/nav-mobile.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect } from '@playwright/test';
+import { execSync } from 'child_process';
+
+/**
+ * Rendered-proof E2E for the mobile nav disclosure (issue 426).
+ *
+ * The shipped bug: opening the mobile menu made `.nav__menu` a third item in the
+ * header's nowrap flex row, crushing it into a ~94px column at x≈283 (375px vp) and
+ * growing the sticky header 65px -> 229px. The static css-lint pin proves the CSS
+ * declares `position: absolute` at max-width:767px; only a real browser proves the
+ * open menu leaves the logo/toggle row byte-identical and renders as a full-width
+ * left-aligned panel below it. Desktop (>=768px) must be untouched, including the
+ * #381 submenu disclosure. Resize across the breakpoint must reset an open menu.
+ */
+
+const cli = (cmd: string) =>
+  execSync(`npx wp-env run cli wp ${cmd}`, { cwd: process.cwd(), encoding: 'utf-8' }).trim();
+
+let menuId = 0;
+let parentItemId = 0;
+let pageId = 0;
+
+function createPage(title: string): number {
+  const id = parseInt(
+    cli(`post create --post_type=page --post_status=publish --post_author=1 --post_title="${title}" --porcelain`),
+    10,
+  );
+  cli(`post meta update ${id} _wp_page_template composition.php`);
+  cli(
+    `post meta update ${id} _pp_composition '${JSON.stringify([
+      { component: 'section', props: { id: 'pp-sec01', title: 'Body', body: '<p>Content below the header.</p>' } },
+    ])}'`,
+  );
+  return id;
+}
+
+test.describe('Mobile nav disclosure (issue 426)', () => {
+  test.beforeAll(() => {
+    // A primary menu with a top-level item, an in-page-anchor item (so a link click
+    // doesn't navigate away mid-test), and a parent+child pair for the #381 dropdown.
+    menuId = parseInt(cli('menu create "E2E Nav 426" --porcelain'), 10);
+    cli(`menu item add-custom ${menuId} "Home" "#home" --porcelain`);
+    cli(`menu item add-custom ${menuId} "About" "#about" --porcelain`);
+    parentItemId = parseInt(cli(`menu item add-custom ${menuId} "Services" "#services" --porcelain`), 10);
+    cli(`menu item add-custom ${menuId} "Cloud" "#cloud" --parent-id=${parentItemId} --porcelain`);
+    cli(`menu location assign ${menuId} primary`);
+    pageId = createPage('E2E Nav 426 Host');
+  });
+
+  test.afterAll(() => {
+    try { if (pageId) cli(`post delete ${pageId} --force`); } catch { /* noop */ }
+    // Unassign the `primary` location first (explicit, so the theme mod is left in
+    // its pre-test/unassigned state), then delete the menu. Deleting alone also
+    // unassigns, but doing it explicitly documents the no-residue intent.
+    try { if (menuId) cli(`menu location remove ${menuId} primary`); } catch { /* noop */ }
+    try { if (menuId) cli(`menu delete ${menuId}`); } catch { /* noop */ }
+  });
+
+  // Box helpers.
+  const box = (page: any, sel: string) => page.locator(sel).first().boundingBox();
+  const near = (a: number, b: number, eps = 0.75) => Math.abs(a - b) < eps;
+
+  // @smoke — the core geometry proof: opening the menu must NOT move the logo/toggle
+  // row or grow the header, and the menu must render as a full-width left-aligned
+  // panel below. Tagged @smoke so PR CI (which runs only @smoke) watches it — the
+  // #423 lesson: a geometry regression must not be nightly-only.
+  test('open menu leaves the logo/toggle row byte-identical and panels below @smoke', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const toggle = page.locator('.nav__toggle');
+    const menu = page.locator('#pp-nav-menu');
+    await expect(toggle).toBeVisible();
+
+    // Closed state: capture the row geometry + header height.
+    await expect(menu).toBeHidden();
+    const logoClosed = (await box(page, '.nav__logo'))!;
+    const toggleClosed = (await box(page, '.nav__toggle'))!;
+    const headerClosed = (await box(page, '.site-header'))!;
+    expect(await toggle.getAttribute('aria-expanded')).toBe('false');
+
+    // Open.
+    await toggle.click();
+    await expect(menu).toBeVisible();
+    expect(await toggle.getAttribute('aria-expanded')).toBe('true');
+
+    // The logo/toggle row is byte-identical (this is THE acceptance criterion).
+    const logoOpen = (await box(page, '.nav__logo'))!;
+    const toggleOpen = (await box(page, '.nav__toggle'))!;
+    const headerOpen = (await box(page, '.site-header'))!;
+    for (const k of ['x', 'y', 'width', 'height'] as const) {
+      expect(near(logoOpen[k], logoClosed[k]), `logo ${k}`).toBe(true);
+      expect(near(toggleOpen[k], toggleClosed[k]), `toggle ${k}`).toBe(true);
+    }
+    // The sticky header row height does not grow (the 65 -> 229 symptom).
+    expect(near(headerOpen.height, headerClosed.height, 1)).toBe(true);
+
+    // The menu is a full-width, left-aligned panel BELOW the row.
+    const container = (await box(page, '.nav__container'))!;
+    const firstLink = (await box(page, '#pp-nav-menu a'))!;
+    expect(firstLink.y).toBeGreaterThan(toggleOpen.y + toggleOpen.height - 1); // below the row
+    expect(firstLink.x).toBeLessThan(container.x + 24); // left-aligned, not a 94px right column
+    expect(firstLink.width).toBeGreaterThan(container.width * 0.8); // spans the container
+
+    // The toggle now shows the close (X) affordance, not the hamburger.
+    const iconDisplay = await toggle.evaluate((el) => ({
+      open: getComputedStyle(el.querySelector('.nav__toggle-icon--open')!).display,
+      close: getComputedStyle(el.querySelector('.nav__toggle-icon--close')!).display,
+    }));
+    expect(iconDisplay.open).toBe('none');
+    expect(iconDisplay.close).not.toBe('none');
+
+    // Re-click closes.
+    await toggle.click();
+    await expect(menu).toBeHidden();
+    expect(await toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('closes via Escape, outside click, and link click', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const toggle = page.locator('.nav__toggle');
+    const menu = page.locator('#pp-nav-menu');
+
+    // Escape (returns focus to the toggle).
+    await toggle.click();
+    await expect(menu).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(menu).toBeHidden();
+    expect(await toggle.evaluate((el) => el === document.activeElement)).toBe(true);
+
+    // Outside click: a raw coordinate click well BELOW the open panel (the panel
+    // overlays the top of the content, so a click there would land inside it). This
+    // is bare page content outside .site-header, so the menu collapses.
+    await toggle.click();
+    await expect(menu).toBeVisible();
+    await page.mouse.click(187, 650);
+    await expect(menu).toBeHidden();
+    expect(await toggle.getAttribute('aria-expanded')).toBe('false');
+
+    // Link click (an in-page anchor, so it does not navigate away).
+    await toggle.click();
+    await expect(menu).toBeVisible();
+    await page.locator('#pp-nav-menu a', { hasText: 'Home' }).click();
+    await expect(menu).toBeHidden();
+    expect(await toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('desktop is unaffected and an open mobile menu resets on resize', async ({ page }) => {
+    // Desktop: hamburger hidden, menu horizontal, #381 dropdown still discloses.
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    await expect(page.locator('.nav__toggle')).toBeHidden();
+    await expect(page.locator('#pp-nav-menu')).toBeVisible();
+    const listDir = await page.locator('#pp-nav-menu > ul').evaluate((el) => getComputedStyle(el).flexDirection);
+    expect(listDir).toBe('row');
+
+    // #381 submenu disclosure: main.js injects a .nav__submenu-toggle; clicking it
+    // opens the group (is-open + the sub-menu renders). Proves #381 is untouched.
+    const subToggle = page.locator('.nav__submenu-toggle').first();
+    await expect(subToggle).toHaveCount(1);
+    const parentLi = page.locator('li.pp-has-dropdown').first();
+    expect(await parentLi.evaluate((el) => el.classList.contains('is-open'))).toBe(false);
+    await subToggle.click();
+    expect(await parentLi.evaluate((el) => el.classList.contains('is-open'))).toBe(true);
+    expect(await subToggle.getAttribute('aria-expanded')).toBe('true');
+
+    // Resize reset (addendum #1): open the menu at mobile, then grow past 768px.
+    await page.setViewportSize({ width: 375, height: 812 });
+    const toggle = page.locator('.nav__toggle');
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+    await expect(page.locator('#pp-nav-menu')).toBeVisible();
+    expect(await toggle.getAttribute('aria-expanded')).toBe('true');
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    // Back on desktop: no lingering open state, hamburger hidden again.
+    await expect(page.locator('.nav__toggle')).toBeHidden();
+    expect(await toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+});

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -124,6 +124,103 @@ describe('CSS lint: #355 active header link honors --header-link-color', () => {
     });
 });
 
+/**
+ * Mobile nav menu is an out-of-flow PANEL, not a squeezed flex item (#426).
+ *
+ * The shipped bug: `.nav__menu` (width:100%) was a THIRD item in the header's
+ * nowrap flex row on mobile, so opening it crushed the menu into a ~94px column
+ * at the right edge and grew the sticky header 65px -> 229px. The fix takes the
+ * menu OUT of flex flow at mobile (position:absolute below the header row), so the
+ * logo/toggle row is byte-identical open vs closed. This pin locks that MECHANISM:
+ * a refactor that drops `position: absolute` from the mobile `.nav__menu` rule (or
+ * moves it back into the flow) must fail here, not just in a nightly E2E. It also
+ * pins the panel background to the --header-bg chrome slot (so a themed header
+ * carries into the panel) and the aria-expanded-driven icon swap (the close
+ * affordance). The layout rule lives in a max-width:767px block, so the media
+ * context is part of its identity (a desktop-scoped copy would not satisfy this).
+ */
+describe('CSS lint: mobile nav menu is an out-of-flow panel (#426)', () => {
+    // Body of the FIRST `.nav__menu { ... }` rule declared inside a
+    // `@media (max-width: 767px)` block, brace-matched so nested rules don't
+    // truncate it. Returns null when no such rule exists (a vacuous-pass guard).
+    function mobileNavMenuBody(css) {
+        const stripped = stripComments(css);
+        const opener = /@media\s*\(max-width:\s*767px\)\s*\{/g;
+        let m;
+        while ((m = opener.exec(stripped)) !== null) {
+            // Brace-match the media block.
+            let depth = 1;
+            let i = opener.lastIndex;
+            while (i < stripped.length && depth > 0) {
+                if (stripped[i] === '{') depth++;
+                else if (stripped[i] === '}') depth--;
+                i++;
+            }
+            const block = stripped.slice(opener.lastIndex, i - 1);
+            // `.nav__menu {` as a whole-class rule (not `.nav__menu ul`, `.nav__menu[...]`).
+            const rule = /(?:^|[}{])\s*\.nav__menu\s*\{([^}]*)\}/.exec(block);
+            if (rule) return rule[1];
+        }
+        return null;
+    }
+
+    const body = mobileNavMenuBody(COMPONENTS_CSS);
+
+    test('a mobile-scoped `.nav__menu` rule exists (guards against a vacuous pass)', () => {
+        expect(body).not.toBeNull();
+    });
+
+    test('the mobile `.nav__menu` is taken out of flex flow (position: absolute)', () => {
+        expect(body).toMatch(/position\s*:\s*absolute/);
+    });
+
+    test('the panel background routes the --header-bg chrome slot', () => {
+        expect(body).toMatch(/background\s*:\s*var\(\s*--header-bg\b/);
+    });
+
+    // Detection proof: the mechanism pin must CATCH an in-flow regression and PASS
+    // the out-of-flow panel — so a parser drift can't make the scan vacuous.
+    test('detector flags an in-flow mobile menu but passes an absolute panel', () => {
+        const inFlow =
+            '@media (max-width: 767px) { .nav__menu { width: 100%; } }';
+        const panel =
+            '@media (max-width: 767px) { .nav__menu { position: absolute; top: 100%; ' +
+            'background: var(--header-bg, var(--color-bg)); } }';
+        expect(/position\s*:\s*absolute/.test(mobileNavMenuBody(inFlow) || '')).toBe(false);
+        expect(/position\s*:\s*absolute/.test(mobileNavMenuBody(panel) || '')).toBe(true);
+    });
+
+    // The open-state affordance (#426): the same toggle button swaps hamburger <-> X,
+    // driven purely off its aria-expanded. Pin all three rules so a refactor can't
+    // silently drop the close icon (leaving the "no way to close" symptom).
+    describe('toggle icon swaps on aria-expanded', () => {
+        const stripped = stripComments(COMPONENTS_CSS).replace(/\s+/g, ' ');
+
+        function ruleBody(selector) {
+            const re = new RegExp(
+                '(?:^|[}{])\\s*' + selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\{([^}]*)\\}'
+            );
+            const m = re.exec(stripped);
+            return m ? m[1] : null;
+        }
+
+        test('the close icon is hidden by default', () => {
+            const b = ruleBody('.nav__toggle-icon--close');
+            expect(b).not.toBeNull();
+            expect(b).toMatch(/display\s*:\s*none/);
+        });
+
+        test('an open toggle hides the hamburger and shows the close icon', () => {
+            const openHidden = ruleBody('.nav__toggle[aria-expanded="true"] .nav__toggle-icon--open');
+            const closeShown = ruleBody('.nav__toggle[aria-expanded="true"] .nav__toggle-icon--close');
+            expect(openHidden).not.toBeNull();
+            expect(openHidden).toMatch(/display\s*:\s*none/);
+            expect(closeShown).not.toBeNull();
+            expect(closeShown).toMatch(/display\s*:\s*(flex|block|inline-flex)/);
+        });
+    });
+});
+
 describe('CSS lint: no modern CSS features', () => {
     const MODERN_FEATURES = [
         // color-mix() intentionally allowed — used for token-adaptive button shadows/focus rings.

--- a/tests/js/main-nav-toggle.test.js
+++ b/tests/js/main-nav-toggle.test.js
@@ -1,0 +1,233 @@
+/**
+ * Tests for assets/js/main.js's top-level hamburger disclosure (issue 426).
+ *
+ * The mobile menu is a WAI-ARIA *disclosure* (button + aria-expanded/aria-controls,
+ * no role="menu"), mirroring the #381 submenu precedent. main.js owns the toggle:
+ * it hides the menu on load (progressive enhancement — visible without JS), then
+ * opens/closes it and keeps aria-expanded truthful across every path (toggle click,
+ * Escape, link click, outside click, and a reset when the viewport crosses to the
+ * >=768px desktop breakpoint). The open-state ICON swap (hamburger <-> X) is CSS-only
+ * (driven off aria-expanded), pinned in tests/js/css-lint.test.js and the E2E render,
+ * so these unit tests assert state/aria/focus, not computed icon visibility.
+ *
+ * No transitions are added by this change (the panel appears/disappears via the
+ * `hidden` attribute), so there is no reduced-motion guard to exercise here.
+ *
+ *   setMenuOpen(open) is the single source of truth:
+ *
+ *     closed ──click / (was hidden)──▶ open ──click / Esc / link / outside / >=768px──▶ closed
+ *        aria-expanded=false                       aria-expanded=true  ──▶  aria-expanded=false
+ */
+
+const { JSDOM } = require('jsdom');
+
+/**
+ * Build the nav DOM and eval main.js against it.
+ *
+ * `matchMedia` is a controllable stub: jsdom ships none, and main.js guards its
+ * use, but the resize-reset path needs a fake MediaQueryList whose registered
+ * `change` listener the test can fire. The stub records the listener on
+ * `dom.window.__mql` so a test can dispatch a breakpoint crossing.
+ */
+function setup(menuHtml) {
+    const dom = new JSDOM('<!DOCTYPE html><html><body>' +
+        '<header class="site-header">' +
+        '  <nav class="nav">' +
+        '    <div class="container nav__container">' +
+        '      <a class="nav__logo" href="/">Logo</a>' +
+        '      <button class="nav__toggle" aria-expanded="false" aria-controls="pp-nav-menu" type="button">' +
+        '        <span class="nav__toggle-icon nav__toggle-icon--open" aria-hidden="true"></span>' +
+        '        <span class="nav__toggle-icon nav__toggle-icon--close" aria-hidden="true"></span>' +
+        '        <span class="sr-only">Menu</span>' +
+        '      </button>' +
+        '      <div id="pp-nav-menu" class="nav__menu">' + menuHtml + '</div>' +
+        '    </div>' +
+        '  </nav>' +
+        '</header>' +
+        '<main><p>Page content outside the header</p></main>' +
+        '</body></html>', { url: 'http://localhost', runScripts: 'outside-only' });
+
+    // Controllable matchMedia stub (jsdom has none). Records the change listener so
+    // the resize-reset test can simulate crossing the 768px breakpoint.
+    const mql = {
+        matches: false,
+        _listeners: [],
+        addEventListener(_evt, cb) { this._listeners.push(cb); },
+        removeEventListener(_evt, cb) { this._listeners = this._listeners.filter(l => l !== cb); },
+        dispatch(matches) {
+            this.matches = matches;
+            this._listeners.forEach(cb => cb({ matches: matches }));
+        },
+    };
+    dom.window.matchMedia = function () { return mql; };
+    dom.window.__mql = mql;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+
+    delete require.cache[require.resolve('../../assets/js/main.js')];
+    const script = require('fs').readFileSync(require.resolve('../../assets/js/main.js'), 'utf8');
+    dom.window.eval(script);
+
+    return dom;
+}
+
+const FLAT_MENU =
+    '<ul class="menu">' +
+    '  <li class="menu-item"><a href="/">Inicio</a></li>' +
+    '  <li class="menu-item"><a href="/about">About</a></li>' +
+    '</ul>';
+
+describe('nav hamburger disclosure (issue 426)', function () {
+    afterEach(function () {
+        delete global.window;
+        delete global.document;
+    });
+
+    function els(dom) {
+        return {
+            toggle: dom.window.document.querySelector('.nav__toggle'),
+            menu: dom.window.document.getElementById('pp-nav-menu'),
+        };
+    }
+
+    test('initial state: JS hides the menu and aria-expanded is false', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+        expect(menu.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('clicking the toggle opens the menu (hidden cleared, aria-expanded true)', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+
+        toggle.click();
+        expect(menu.hidden).toBe(false);
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    test('clicking the toggle again closes the menu', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+
+        toggle.click();
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+
+        toggle.click();
+        expect(menu.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('Escape closes the menu and returns focus to the toggle', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+
+        toggle.click();
+        expect(menu.hidden).toBe(false);
+
+        dom.window.document.dispatchEvent(
+            new dom.window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+        );
+
+        expect(menu.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(dom.window.document.activeElement).toBe(toggle);
+    });
+
+    test('Escape while already closed is a no-op (aria stays false)', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+
+        dom.window.document.dispatchEvent(
+            new dom.window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+        );
+
+        expect(menu.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('clicking a menu link closes the menu', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+
+        toggle.click();
+        expect(menu.hidden).toBe(false);
+
+        const link = menu.querySelector('a');
+        link.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        expect(menu.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('a click outside the header closes the open menu', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+
+        toggle.click();
+        expect(menu.hidden).toBe(false);
+
+        // A click on page content (outside .site-header).
+        dom.window.document.querySelector('main p')
+            .dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        expect(menu.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('a click INSIDE the panel does not close the menu', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+
+        toggle.click();
+        expect(menu.hidden).toBe(false);
+
+        // Click a non-link spot inside the menu container (still inside the header).
+        menu.querySelector('ul')
+            .dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        expect(menu.hidden).toBe(false);
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    test('crossing to the >=768px breakpoint resets an open menu to closed', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+
+        toggle.click();
+        expect(menu.hidden).toBe(false);
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+
+        // Simulate the viewport growing past 768px (matchMedia change → matches:true).
+        dom.window.__mql.dispatch(true);
+
+        expect(menu.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('a breakpoint change back to mobile (matches:false) does not reopen the menu', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+
+        // Start closed; a matches:false event must not open anything.
+        dom.window.__mql.dispatch(false);
+
+        expect(menu.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('a stale open state does not survive a breakpoint crossing (no lingering aria-expanded)', function () {
+        const dom = setup(FLAT_MENU);
+        const { toggle, menu } = els(dom);
+
+        toggle.click();
+        dom.window.__mql.dispatch(true);   // → desktop, reset to closed
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+        // Returning to mobile leaves it closed until the user acts.
+        dom.window.__mql.dispatch(false);
+        expect(menu.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+});


### PR DESCRIPTION
Closes #426

## What & why
On mobile, opening the hamburger menu broke the header instead of showing a menu: `.nav__menu` (`width:100%`) joined the header's `nowrap` flex row as a third item, so it rendered as a ~94px column crushed against the right edge, and the sticky header grew 65px → 229px and overlaid page content. The toggle also had no close affordance.

The menu is now a disclosure **panel** below the header row. Scoped to `@media (max-width: 767px)`, `.nav__menu` is `position: absolute` (out of flex flow), so opening it leaves the logo/toggle row byte-identical and never grows the sticky header. The header/nav stays theme-owned chrome (#223) — layout/behavior code only, no new composition surface or options.

## Approach (recorded decision = issue body + binding addendum)
- **Absolute panel** below the header row (implementer's choice within the issue's constraints). Anchored to `.nav__container` (`position: relative`), overlays content via the header's existing `z-index:100` sticky stacking context (no new stacking context). Panel background routes the `--header-bg` chrome slot.
- **Close affordance:** hamburger ↔ ✕ icon swap driven purely by the toggle's `aria-expanded` (CSS only). Inert on desktop (toggle is `display:none` there).
- **Close paths:** toggle re-click, Escape (focus returns to the toggle), link click, and outside click. All route through one `setMenuOpen()` helper so `aria-expanded` is always truthful.
- **Addendum #1 — resize/orientation reset:** a `matchMedia('(min-width: 768px)')` listener collapses an open menu when crossing to desktop, so no lingering `is-open`/icon state and returning to mobile lands closed.
- **Addendum #2 — scroll-lock:** none. This is a short dropdown panel, not a full-screen overlay (disclosed per the addendum).
- No-JS: the menu shows as the same panel below the header (undistorted row). WAI-ARIA disclosure preserved (no `role=menu`, no focus trap). #381 submenu behavior and the #63 `--header-height`/anchor-scroll contract are unchanged.

## Acceptance criteria
- 375px open vs closed: logo/toggle row geometry byte-identical; menu is a full-width left-aligned panel below — **verified in E2E** (bounding boxes + link x/width).
- Toggle shows a distinct open state and closes on re-click — verified.
- Escape (+ focus return), link click, outside click, `aria-expanded` truthful in every path — verified (unit + E2E).
- Desktop ≥768px byte-identical (hamburger hidden, horizontal menu, #381 dropdown works) — verified.
- No-JS mobile: header row undistorted with the panel visible — held by the same `max-width:767px` mechanism.

## Validation
- `npm test` (vitest): **618 passed** (incl. new `tests/js/main-nav-toggle.test.js` = 11 tests, and the css-lint mechanism pin; #381 dropdown suite unchanged).
- `./vendor/bin/phpunit`: **2028 passed** (3 warnings / 2 deprecations = pre-existing baseline, confirmed against a stashed clean tree).
- E2E `tests/e2e/nav-mobile.spec.ts` run locally against wp-env (WordPress): **4/4 passed** (geometry @smoke, all close paths, desktop-unaffected + #381 dropdown + resize reset). No environment residue (menu/page/location cleaned).
- `bash scripts/package.sh`: version consistency OK across the five synced files; built zip deleted (releases are CI-built from tags).

## gstack workflows
plan-eng-review (clean), /review + adversarial subagent (no CRITICAL; 1 informational applied — E2E location cleanup; 2 declined with rationale), /document-generate (README main.js size 7.8→9.5 KB refreshed; AI-grammar/option docs unchanged since no accepted grammar changed).

## Accepted limitations
- Focus is not re-homed on resize-reset by design (desktop keeps the menu inline/visible, and the toggle is `display:none` there).
- The 767/768px breakpoint split matches the theme-wide convention (a fractional-width seam exists across the whole theme, not introduced here).

## 7A questions
None — the recorded decision (issue body + addendum) resolved every choice; no accepted behavior or public surface was extended.

No tag/release/deploy performed (CI builds the release zip from tags; maintainer handles that separately).
