### PR TITLE
v1.4.5 fix: symmetric section-band rhythm (#430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.5] — 2026-07-19 — stacked section bands are now vertically symmetric, so pages stop looking top-cramped and bottom-heavy (#430)
+
+**Every section-level band that followed another band used to render with a tight ~32px top and a much larger ~77px bottom on desktop — a lopsided block. On pages where backgrounds alternate (a dark stats band, an inverted CTA, a tinted section — the normal marketing pattern), the heading hugged the top edge while a large empty gap sat under the last element. Now a band's top padding equals its bottom padding: every stacked band reads as a centered block at every breakpoint, with no per-section `--*-padding-*` tuning. This is the companion retune to v1.4.4's shared spacing model.**
+
+This is a deliberate change to unstyled output: the default top padding of any band that follows another band grows to match its bottom, so contrasting-background bands stop looking off-balance. Two bands that share a background now show more combined space between them, which is the accepted trade for symmetry that can't paint a lopsided edge onto a contrasting band. Nothing about how you configure pages changed — the per-component `--section|grid|cta|stats|faq|testimonials-padding-top/bottom` slots you already use are untouched and still win on every edge and breakpoint, including a band's adjacent top edge. The hero keeps its own larger, already-symmetric page-opening rhythm when it leads the page (its own padding is not retuned); like any band, a component placed after another band takes the shared symmetric top. `data-pp-spacing` compact and spacious stay symmetric.
+
+### Fixed
+- A section-level band (section, grid, cta, stats, faq, testimonials) that follows another band now renders equal top and bottom padding by default at every breakpoint, instead of the old tight-top / heavy-bottom shape. Pages with alternating backgrounds no longer look top-cramped and bottom-heavy, and no per-section padding override is needed to balance them (#430).
+
+### Tests
+- `tests/js/css-lint.test.js` now pins the adjacent-top rhythm to the band's own padding (the symmetry guarantee) and asserts the mobile block no longer carries a separate adjacent-top value. `tests/e2e/style-render.spec.ts` gains computed-rhythm coverage: every stacked band reports exactly equal top and bottom padding at 1280 and 375, `data-pp-spacing` compact/spacious stay symmetric, and a webfiable-shaped sequence (hero → stats → grid → cta → grid → section → cta) shows no band with the old 32px-top / 77px-bottom shape; the core symmetry scenario and the webfiable-shape scenario are tagged `@smoke` (#430).
+
 ## [v1.4.4] — 2026-07-19 — every stacked section now shares one spacing model, so bands stop disagreeing about their own padding (#431)
 
 **The six section-level components — section, grid, CTA, stats, FAQ, and testimonials — used to each carry their own copy of the vertical-padding values, and the copies had drifted apart. Stats and testimonials bands rendered shorter than their neighbors on desktop, a CTA's bottom padding didn't match the plain sections next to it on mobile, and a testimonials band that followed another band ignored a `--testimonials-padding-top` you set on it. Now all six read their default rhythm from a single shared definition, so an unstyled stack lines up: every band agrees on its top and bottom padding at every breakpoint, and every band's padding slot is live on every edge. Setting `--testimonials-padding-top` on an adjacent testimonials band now works, the same as it already did for the other components.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.4-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.5-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -84,20 +84,27 @@
    literals. Internal (not authored via update_design_token, so kept out of the
    first :root token block above); a whole-site rhythm retune changes only these.
 
-   Two-tier for now: a band that follows another band gets a tighter top
-   (--pp-band-padding-adjacent-top) than its own edges (--pp-band-padding); the
-   mobile override collapses both to one uniform value. issue 430 retunes these
-   values (symmetric top/bottom) WITHOUT touching any consuming rule.
+   Symmetric rhythm: a band's top and bottom padding are equal, and a band that
+   follows another band gets that SAME top, so every stacked band reads as a
+   centered block regardless of background alternation (issue 430). The
+   adjacent-top tier is kept as a live custom property so the per-component
+   adjacent-top slot still routes through it (slot contract preserved), but its
+   value is pinned to --pp-band-padding so it can never diverge from the band's
+   own edges. The mobile override changes only --pp-band-padding; adjacent-top
+   tracks it automatically. Consuming rules in components.css are untouched.
+
+   Hero opts OUT of this shared rhythm on purpose: it carries its own larger,
+   already-symmetric page-opening rhythm (--space-xl / --space-2xl, 64/112px)
+   via the --hero-padding-* slots, so it is not retuned here.
    ========================================================================== */
 :root {
   --pp-band-padding:              clamp(4.25rem, 6vw, 5rem);
-  --pp-band-padding-adjacent-top: var(--space-lg);
+  --pp-band-padding-adjacent-top: var(--pp-band-padding);
 }
 
 @media (max-width: 767px) {
   :root {
-    --pp-band-padding:              3.35rem;
-    --pp-band-padding-adjacent-top: 3.35rem;
+    --pp-band-padding: 3.35rem;
   }
 }
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2813,12 +2813,14 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 
 /* ==========================================================================
    SHARED: Adjacent-Sibling Rhythm
-   Tightens vertical padding between consecutive section-level components
+   Sets the top padding of a section-level component that follows another one
    inside <main>. First component keeps its own padding naturally (the `+`
    combinator skips it). Desktop only — mobile spacing stays uniform.
-   Routes through the shared --pp-band-padding-adjacent-top so this generic
-   catch-all (components with no padding slot: hero, table, logos, embed)
-   stays on the one rhythm definition instead of a bare literal (issue 431).
+   Routes through the shared --pp-band-padding-adjacent-top, which is pinned to
+   --pp-band-padding (issue 430), so this adjacent top equals the band's own
+   edges (symmetric) instead of a tighter tier. This generic catch-all also
+   covers components with no padding slot (hero, table, logos, embed), keeping
+   them on the one shared rhythm definition instead of a bare literal (issue 431).
    ========================================================================== */
 
 @media (min-width: 768px) {
@@ -3418,10 +3420,12 @@ main .btn:focus-visible {
 
 /* Adjacent-sibling rhythm, restored (issue 302). This premium rule used to flatten
    the vertical rhythm to a uniform clamp() at ALL widths, outranking the base
-   two-tier rule (SHARED: Adjacent-Sibling Rhythm, ~line 2124: 32px = var(--space-lg)
-   between stacked components on desktop) AND defeating every --*-padding-top slot on
-   an adjacent component. Drop the flat override; the base rule restores the
-   two-tier default for component types with no padding slot (hero/...).
+   adjacent-sibling rule (SHARED: Adjacent-Sibling Rhythm) AND defeating every
+   --*-padding-top slot on an adjacent component. The shared adjacent-top tier is
+   now --pp-band-padding-adjacent-top, pinned to --pp-band-padding so the adjacent
+   top equals the band's own edges (symmetric, issue 430; formerly the tighter
+   var(--space-lg) two-tier value). Drop the flat override; the base rule carries
+   the shared default for component types with no padding slot (hero/...).
    For the slot-bearing components, route the adjacent top-padding through the slot
    with the shared --pp-band-padding-adjacent-top as the fallback so the slot
    controls adjacent spacing too AND every band consumes the one rhythm definition

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.4');
+define('PP_VERSION', '1.4.5');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.4
+Stable tag: 1.4.5
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.4
+Version:          1.4.5
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -3264,4 +3264,151 @@ test.describe('Shared section-band rhythm (#431)', () => {
       expect(top, `${band} adjacent-top did not follow --pp-band-padding-adjacent-top`).toBe('7px');
     }
   });
+
+  // ── issue 430: symmetric band rhythm ──────────────────────────────────────
+  //
+  // #431 (above) proved all six bands AGREE on a single top tier and a single
+  // bottom tier, but deliberately left the VALUES to this issue, so those tests
+  // pass even on the old 32px-top / 76.8px-bottom shape. issue 430 pins the
+  // adjacent-top tier to --pp-band-padding, so a band that follows another band
+  // gets the SAME top as its own bottom: every stacked band is a centered block,
+  // never top-cramped / bottom-heavy, at every breakpoint and under any background
+  // alternation. Because both edges now resolve to the identical custom property,
+  // the check is EXACT equality (top === bottom), stronger than the issue's stated
+  // 10% tolerance — a re-split of the tier would fail here by tens of px.
+
+  // Core scenario: every band that follows another band is vertically symmetric.
+  // Hero leads so all six bands render in the adjacent-top position (the edge the
+  // old 32px tier used to shave). faq stays last (its trailing JSON-LD <script>
+  // breaks the `+` adjacency of any band after it — pre-existing bug 432).
+  test('#430 every stacked band is vertically symmetric (top === bottom) at 1280 and 375 @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Band Rhythm Symmetry');
+    setComposition(pageId, STACK);
+
+    for (const width of [1280, 375]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator('main > .testimonials')).toBeVisible({ timeout: 10000 });
+
+      for (const band of BANDS) {
+        const { top, bottom } = await bandPadding(page, band);
+        // Non-trivial (a 0px collapse would make symmetry vacuously pass).
+        expect(top && top !== '0px', `${band} top vacuous @${width}: ${top}`).toBe(true);
+        // The deliberate visual change: adjacent-top no longer shaved to 32px.
+        expect(top, `${band} not symmetric @${width}: top=${top} bottom=${bottom}`).toBe(bottom);
+      }
+    }
+  });
+
+  // data-pp-spacing overrides (compact / spacious) must stay symmetric too — they
+  // set both edges to one scale step, so a band carrying either attribute reads as
+  // a centered block (compact = --space-lg; spacious = --space-2xl mobile /
+  // --space-3xl desktop). Only hero.php emits data-pp-spacing, and a hero normally
+  // leads the page, so each spacing variant is seeded as the SOLE component (own
+  // position) — that isolates the data-pp-spacing rule from the generic
+  // adjacent-sibling band rhythm. (A data-pp-spacing hero placed AFTER another band
+  // hits a pre-existing mobile-only interaction where the adjacent rule shaves the
+  // top; that narrow corner is unchanged by issue 430 and out of its scope.)
+  test('#430 data-pp-spacing compact/spacious stay symmetric at 1280 and 375', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Spacing Attr Symmetry');
+
+    for (const spacing of ['compact', 'spacious']) {
+      setComposition(pageId, [
+        { component: 'hero', props: { id: 'pp-hero-spacing', title: 'Spacing', spacing } },
+      ]);
+
+      for (const width of [1280, 375]) {
+        await page.setViewportSize({ width, height: 900 });
+        await page.goto(`/?page_id=${pageId}`);
+        const hero = page.locator('#pp-hero-spacing');
+        await expect(hero).toBeVisible({ timeout: 10000 });
+
+        const { top, bottom } = await hero.evaluate((el: Element) => {
+          const cs = getComputedStyle(el);
+          return { top: cs.paddingTop, bottom: cs.paddingBottom };
+        });
+        expect(top && top !== '0px', `${spacing} top vacuous @${width}: ${top}`).toBe(true);
+        expect(top, `${spacing} not symmetric @${width}: top=${top} bottom=${bottom}`).toBe(bottom);
+      }
+    }
+  });
+
+  // The measured webfiable.com defect sequence (issue 430 body): hero → stats →
+  // grid → cta → grid → section → cta, alternating inverted/plain backgrounds.
+  // Every band after the hero used to render 32px top / 76.8px bottom. After the
+  // fix none may: each is symmetric, and NO band shows the old shape. No faq in
+  // this sequence, so bug 432 cannot interfere.
+  test('#430 webfiable-shaped stack shows no 32/77 band; every band symmetric @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Webfiable Rhythm Shape');
+    setComposition(pageId, [
+      { component: 'hero', props: { id: 'pp-hero01', title: 'Lead' } },
+      { component: 'stats', props: { id: 'pp-stats01', theme: 'dark', items: [{ number: '10', label: 'Ten' }] } },
+      { component: 'grid', props: { id: 'pp-grid01', title: 'Grid', items: [{ title: 'One', text: 'A' }] } },
+      { component: 'cta', props: { id: 'pp-cta01', theme: 'dark', title: 'CTA', button_text: 'Go', button_url: '/go' } },
+      { component: 'grid', props: { id: 'pp-grid02', title: 'Grid Two', items: [{ title: 'Two', text: 'B' }] } },
+      { component: 'section', props: { id: 'pp-sec01', body: '<p>Section body.</p>' } },
+      { component: 'cta', props: { id: 'pp-cta02', theme: 'dark', title: 'Closing', button_text: 'Go', button_url: '/go' } },
+    ]);
+
+    // Every band-level component after the leading hero, by id (grid/cta appear twice).
+    const bandIds = ['pp-stats01', 'pp-grid01', 'pp-cta01', 'pp-grid02', 'pp-sec01', 'pp-cta02'];
+
+    for (const width of [1280, 375]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator('#pp-cta02')).toBeVisible({ timeout: 10000 });
+
+      for (const id of bandIds) {
+        const { top, bottom } = await page.locator(`#${id}`).evaluate((el: Element) => {
+          const cs = getComputedStyle(el);
+          return { top: cs.paddingTop, bottom: cs.paddingBottom };
+        });
+        // Symmetric at both breakpoints (the load-bearing #430 proof).
+        expect(top, `${id} not symmetric @${width}: top=${top} bottom=${bottom}`).toBe(bottom);
+        // The old shaved adjacent-top was 32px (var(--space-lg)) on DESKTOP only —
+        // mobile adjacent-top was already 3.35rem, so a 32px check there is vacuous.
+        if (width === 1280) {
+          expect(top, `${id} still shows the old 32px adjacent-top`).not.toBe('32px');
+        }
+      }
+    }
+  });
+
+  // Slot contract under symmetry (issue 430 acceptance criterion): a per-component
+  // --*-padding-top set on a band in the ADJACENT position must still win over the
+  // now-symmetric shared fallback, at both breakpoints. The pinned adjacent-top tier
+  // is only a FALLBACK — an author's explicit slot value still governs. A section
+  // leads so the cta renders in the adjacent-top position; 5px resolves from no
+  // token, so a fallback leak (symmetric ~76.8px/53.6px) would fail loudly.
+  test('#430 --cta-padding-top wins on an adjacent cta band at 1280 and 375', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Adjacent Slot Beats Symmetric Fallback');
+    setComposition(pageId, [
+      { component: 'section', props: { id: 'pp-sec01', body: '<p>Body.</p>' } },
+      { component: 'cta', props: { id: 'pp-cta01', title: 'CTA', button_text: 'Go', button_url: '/go' } },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    // component_index 1 = the cta band (index 0 is the leading section).
+    const res = await styleComponent(page, pageId, { '--cta-padding-top': '5px' }, undefined, 1);
+    expect(res.success).toBe(true);
+
+    for (const width of [1280, 375]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      const cta = page.locator('main > .cta');
+      await expect(cta).toBeVisible({ timeout: 10000 });
+      const paddingTop = await cta.evaluate((el) => getComputedStyle(el).paddingTop);
+      expect(paddingTop, `adjacent-top slot override @${width}`).toBe('5px');
+    }
+  });
 });

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -1567,8 +1567,9 @@ describe('CSS lint: hero flex rows declare their justification', () => {
  * --grid-heading-size, or --section-body-width validated, reported success, and
  * changed nothing. The fix routes every premium re-declaration through
  * var(--slot, <literal>) with the literal as the fallback (unset output
- * unchanged), and restores the base two-tier adjacent-sibling rhythm that the
- * premium layer had flattened to a uniform clamp().
+ * unchanged), and restores the base adjacent-sibling rhythm (now the shared
+ * --pp-band-padding-adjacent-top tier) that the premium layer had flattened to
+ * a uniform clamp().
  *
  * These pins mirror the #226/#292 guards: assert every declaration of the
  * property on the target selector routes through the slot, plus a presence guard
@@ -1665,10 +1666,11 @@ describe('CSS lint: premium layer honors padding/type/width slots (#302)', () =>
     //  in #412: those ID-scoped closers no longer ship, so the generic `.cta` slot
     //  rules above are now the whole padding surface.)
 
-    // ---- Two-tier adjacent-sibling rhythm restored ----
+    // ---- Adjacent-sibling rhythm routes through the shared def ----
     // The flat premium override was DELETED; the remaining rules for this exact
-    // selector are the base (var(--space-lg), desktop) and the uniform mobile
-    // literal. Neither may re-introduce the flattening clamp().
+    // selector route their top through --pp-band-padding-adjacent-top (issue 431),
+    // which is itself pinned to --pp-band-padding (issue 430 symmetry). Neither
+    // may re-introduce the flattening clamp() literal in components.css.
     test('adjacent-sibling rhythm no longer flattened by a bare clamp()', () => {
         const bodies = bodiesForExactSelector('main > [data-pp-component] + [data-pp-component]');
         expect(bodies.length).toBeGreaterThanOrEqual(2);
@@ -1680,10 +1682,11 @@ describe('CSS lint: premium layer honors padding/type/width slots (#302)', () =>
     // Each slot-bearing component's adjacent rule exists at BOTH breakpoints, and
     // BOTH fall back to the ONE shared adjacent-top definition (issue 431). The old
     // per-breakpoint literals (desktop var(--space-lg), mobile 3.35rem) collapsed
-    // into --pp-band-padding-adjacent-top, whose value is redefined per breakpoint
-    // at :root — so there is now a single fallback token, not two literals. Every
-    // declaration must still route through the component slot (slot wins), and
-    // testimonials must be present (its adjacent rule was missing before issue 431).
+    // into --pp-band-padding-adjacent-top, now pinned to --pp-band-padding (issue
+    // 430) so the adjacent-top tracks the band's own edges per breakpoint — a
+    // single fallback token, not two literals. Every declaration must still route
+    // through the component slot (slot wins), and testimonials must be present
+    // (its adjacent rule was missing before issue 431).
     test.each([
         ['main > [data-pp-component] + .section', '--section-padding-top'],
         ['main > [data-pp-component] + .grid', '--grid-padding-top'],
@@ -1813,14 +1816,32 @@ describe('CSS lint: section-level bands share one rhythm definition (#431)', () 
     //    breaks the pins loudly instead of silently no-op'ing.
     test('base.css defines the shared rhythm props with a mobile override', () => {
         const base = stripComments(BASE_CSS);
-        // Desktop definitions (own = clamp tier, adjacent-top = tighter).
+        // The band's own top/bottom rhythm on desktop.
         expect(base).toMatch(/--pp-band-padding\s*:\s*clamp\(\s*4\.25rem\s*,\s*6vw\s*,\s*5rem\s*\)/);
-        expect(base).toMatch(/--pp-band-padding-adjacent-top\s*:\s*var\(\s*--space-lg\s*\)/);
-        // A mobile @media block redefines both to the uniform mobile tier.
+        // A mobile @media block redefines --pp-band-padding to the uniform mobile
+        // tier. It does NOT redefine adjacent-top — that tracks --pp-band-padding
+        // automatically (issue 430 symmetry), so a stray mobile adjacent-top
+        // literal that could reintroduce asymmetry must not exist.
         const mobileRoot = base.match(/@media\s*\(\s*max-width:\s*767px\s*\)\s*\{\s*:root\s*\{([^}]*)\}/);
         expect(mobileRoot, 'expected a @media (max-width: 767px) :root override in base.css').not.toBeNull();
         expect(mobileRoot[1]).toMatch(/--pp-band-padding\s*:\s*3\.35rem/);
-        expect(mobileRoot[1]).toMatch(/--pp-band-padding-adjacent-top\s*:\s*3\.35rem/);
+        expect(mobileRoot[1]).not.toMatch(/--pp-band-padding-adjacent-top/);
+    });
+
+    // 5. Symmetry pin (issue 430): the adjacent-top tier is pinned to the band's
+    //    own padding, so a band that follows another band gets the SAME top as
+    //    its bottom — every stacked band is a centered block, never top-cramped /
+    //    bottom-heavy. This is a TEXT guarantee (the fallback token IS
+    //    --pp-band-padding); the E2E computed-rhythm spec proves the cascade
+    //    actually resolves top == bottom. A future edit that re-splits the tier
+    //    (e.g. back to var(--space-lg)) fails here loudly.
+    test('the adjacent-top tier is pinned to --pp-band-padding (symmetric bands)', () => {
+        const base = stripComments(BASE_CSS);
+        expect(base).toMatch(/--pp-band-padding-adjacent-top\s*:\s*var\(\s*--pp-band-padding\s*\)/);
+        // And nowhere in base.css does adjacent-top get a bare rhythm literal or
+        // the old tighter --space-lg tier that made bands asymmetric.
+        expect(base).not.toMatch(/--pp-band-padding-adjacent-top\s*:\s*var\(\s*--space-lg\s*\)/);
+        expect(base).not.toMatch(/--pp-band-padding-adjacent-top\s*:\s*\d/);
     });
 });
 


### PR DESCRIPTION
Closes #430

## Scope
Companion retune to #431's shared band-rhythm model. Makes every stacked section-level band vertically symmetric (top == bottom) so alternating-background pages stop looking top-cramped and bottom-heavy.

- `assets/css/base.css`: pin `--pp-band-padding-adjacent-top: var(--pp-band-padding)` so a band that follows another band gets a top equal to its own bottom (desktop was 32px top / ~77px bottom). Drop the now-redundant mobile adjacent-top override (it tracks `--pp-band-padding` automatically).
- Consuming rules in `components.css` are untouched (slot contract preserved); only their stale comments were updated.
- Hero keeps its own independent, already-symmetric page-opening rhythm (`--space-xl`/`--space-2xl`), documented in-code and in the CHANGELOG.
- Version bumped 1.4.4 -> 1.4.5 in the five synced files + CHANGELOG (deliberate visual change called out).

## Recorded decision applied
Symmetric via `adjacent-top = own padding` (the issue's likely shape; simple symmetric solution preferred over inventing a CSS-only same-background detector). Hero decision documented, not silently regressed. PATCH bump.

## Validation
- JS (vitest): **641 passed** (css-lint 293 incl. new symmetry pins).
- PHP (phpunit): **2043 passed** (warnings/deprecations unchanged from base; no PHP in diff).
- E2E (Playwright on wp-env): the #430 + #431 rhythm specs all green — per-band `top===bottom` at 1280 & 375, `data-pp-spacing` symmetry, webfiable-shaped sequence (hero -> stats -> grid -> cta -> grid -> section -> cta) with no 32/77 band, and an adjacent-edge `--cta-padding-top` slot override still winning. Core symmetry + webfiable scenarios tagged `@smoke`.

## Reviews
`/plan-eng-review` (+ Codex outside voice) and `/review` (testing + maintainability specialists, Claude + Codex adversarial) both ran this session on this exact diff and returned clean — no correctness findings. Comment-accuracy and test-precision findings were applied.

## Follow-up filed
- #434 — pre-existing mobile-only asymmetry when a `data-pp-spacing` hero follows another band (out of scope for #430; the adjacent generic rule shaves its top-only at mobile). Surfaced by the new symmetry E2E; not caused by this change.
