### PR TITLE
v1.4.6 fix: raw-hex guards ignore comment issue-refs (#289)

### DIFF
--- a/.github/workflows/ai-ready-check.yml
+++ b/.github/workflows/ai-ready-check.yml
@@ -8,6 +8,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
       - name: No raw WP functions in templates
         run: |
           if grep -r --include="*.php" "get_field\|wp_nav_menu\|get_bloginfo\|get_the_title\|get_the_content\|home_url\|get_permalink\|WP_Query" templates/ components/; then
@@ -57,11 +62,10 @@ jobs:
           fi
 
       - name: No raw hex in components.css
-        run: |
-          if grep -P '#[0-9a-fA-F]{3,6}(?![0-9a-fA-F])' assets/css/components.css; then
-            echo "ERROR: Raw hex color found in components.css. Use CSS variables from base.css."
-            exit 1
-          fi
+        # Shares scripts/check-raw-hex.php with tests/InvariantTest.php so this
+        # CI guard and the local test use identical semantics (issue #289):
+        # a `/* ... */` comment ref like (#226) passes; a real hex still fails.
+        run: php scripts/check-raw-hex.php assets/css/components.css
 
       - name: All components have README.md
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.6] — 2026-07-20 — the "no raw hex" guard stops tripping on issue references written in CSS comments (#289)
+
+**The check that keeps hardcoded hex colors out of `components.css` used to flag a GitHub issue reference like `(#226)` written inside a `/* ... */` comment, because `#226` reads as a three-digit hex string. That forced an awkward "write `issue 226`, never `(#226)`" convention in CSS comments and had already broken two builds. Now both the local test guard and the CI check strip `/* ... */` comments before scanning, so a comment can cite `(#226)` freely while a real hardcoded color in a declaration (`color: #226;` or `color: #ff0000;`) still fails exactly as before. The two guards now run the same code, so a comment that passes locally can't fail CI or the reverse.**
+
+The rule itself is unchanged: component CSS must use CSS variables from `base.css`, never raw hex color values. Only the false positive on comment text is fixed. The local `tests/InvariantTest.php` guard and the CI `ai-ready` workflow now both call a single shared checker, `scripts/check-raw-hex.php`, which blanks comments (preserving line numbers and without fusing tokens across a comment boundary) and then applies the same hex pattern as before. The comment stripping is deliberately lexical, not a full CSS parser, so a `/* ... */` byte sequence inside a CSS string literal is also treated as a comment; such text is not a hardcoded color value, so exempting it does not weaken the guard.
+
+### Fixed
+- A GitHub issue reference inside a `/* ... */` comment in `assets/css/components.css` (for example `/* fixes overflow (#226) */`) no longer trips the raw-hex guard, in both the local PHPUnit test and the CI `ai-ready` check. A genuine raw hex color in a declaration still fails both. The two guards share one implementation (`scripts/check-raw-hex.php`) so they can never disagree (#289).
+
+### Tests
+- New `tests/RawHexGuardTest.php` proves both directions: real hex (`#ff0000`, `#226`) is detected, comment-context issue refs (single-line, multi-line, trailing) pass, a real hex on a line that also carries a comment is still caught, two-digit refs like `#24` stay below the pattern, line numbers stay accurate across multi-line comments and CRLF input, a comment never fuses tokens across its boundary, and the CLI exits 1 on real hex / 0 on a comment-only ref / 2 on a missing file. `tests/InvariantTest.php` now exercises the shared checker against the real `components.css` (#289).
+
 ## [v1.4.5] — 2026-07-19 — stacked section bands are now vertically symmetric, so pages stop looking top-cramped and bottom-heavy (#430)
 
 **Every section-level band that followed another band used to render with a tight ~32px top and a much larger ~77px bottom on desktop — a lopsided block. On pages where backgrounds alternate (a dark stats band, an inverted CTA, a tinted section — the normal marketing pattern), the heading hugged the top edge while a large empty gap sat under the last element. Now a band's top padding equals its bottom padding: every stacked band reads as a centered block at every breakpoint, with no per-section `--*-padding-*` tuning. This is the companion retune to v1.4.4's shared spacing model.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.5-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.6-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.5');
+define('PP_VERSION', '1.4.6');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.5
+Stable tag: 1.4.6
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/scripts/check-raw-hex.php
+++ b/scripts/check-raw-hex.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * scripts/check-raw-hex.php
+ *
+ * Single source of truth for the "no raw hex colors in components.css" guard.
+ * Both the local test (tests/InvariantTest.php) and the CI `ai-ready` workflow
+ * call THIS code, so a comment that passes locally cannot fail CI or vice versa
+ * (issue #289, acceptance criterion 3).
+ *
+ * The guard is intentionally lexical, NOT a full CSS parser: it flags `#`
+ * followed by 3-6 hex digits (and not another hex digit) anywhere OUTSIDE a
+ * `/* ... *\/` comment. Comment context is the only exemption — that is what
+ * lets an issue reference like `/* fixes overflow (#226) *\/` pass while a
+ * genuine raw hex in a declaration (`color: #226;` or `color: #ff0000;`) still
+ * fails. The regex is unchanged from the original guard on purpose; only the
+ * comment handling is new.
+ *
+ * Usage (CLI):  php scripts/check-raw-hex.php [path]   (default: assets/css/components.css)
+ *   exit 0 = clean, exit 1 = raw hex found, exit 2 = file missing/unreadable.
+ */
+
+declare(strict_types=1);
+
+if (!function_exists('pp_strip_css_comments')) {
+    /**
+     * Blank out `/* ... *\/` comment spans while preserving newlines AND byte
+     * offsets, so line numbers stay accurate and tokens on either side of a
+     * comment are never fused. Blanking to newlines ALONE would collapse
+     * `#22/* x *\/6` into `#226` and produce a false positive; replacing every
+     * non-newline comment char with a space keeps `#22` and `6` apart.
+     *
+     * An unterminated `/*` (no closing `*\/`) is left untouched by design —
+     * that is malformed CSS, and scanning it stays on the strict side.
+     */
+    function pp_strip_css_comments(string $content): string
+    {
+        return (string) preg_replace_callback(
+            '/\/\*.*?\*\//s',
+            static function (array $m): string {
+                // Keep newlines (line numbers); blank everything else to a space.
+                return (string) preg_replace('/[^\n]/', ' ', $m[0]);
+            },
+            $content
+        );
+    }
+}
+
+if (!function_exists('pp_find_raw_hex')) {
+    /**
+     * Find raw hex color literals in $content that are NOT inside a
+     * `/* ... *\/` comment. Reports the first match on each offending line
+     * (one entry per line, all lines scanned) — enough to fail the guard and
+     * point at the line; it is not an exhaustive per-line match list.
+     *
+     * The comment stripping is intentionally lexical, not CSS-aware: a
+     * `/* ... *\/` byte sequence inside a CSS string literal (e.g.
+     * `content: "/* ... *\/"`) is also treated as a comment. That is an
+     * accepted limitation of the "strip comments, keep the regex simple"
+     * approach chosen for issue #289; such a hex is text, not a hardcoded
+     * color value, so exempting it does not weaken the guard's real job.
+     *
+     * @return list<array{line:int,match:string,text:string}>
+     */
+    function pp_find_raw_hex(string $content): array
+    {
+        $stripped = pp_strip_css_comments($content);
+        $scanLines = explode("\n", $stripped);
+        $rawLines  = explode("\n", $content);
+
+        $hits = [];
+        foreach ($scanLines as $i => $line) {
+            if (preg_match('/#[0-9a-fA-F]{3,6}(?![0-9a-fA-F])/', $line, $m)) {
+                $hits[] = [
+                    'line'  => $i + 1,
+                    'match' => $m[0],
+                    // Report the ORIGINAL line (comment intact) for a useful message.
+                    'text'  => rtrim($rawLines[$i] ?? $line, "\r"),
+                ];
+            }
+        }
+
+        return $hits;
+    }
+}
+
+// ── CLI entrypoint ────────────────────────────────────────────────────────
+// Guarded so a `require`/`require_once` from PHPUnit (also PHP_SAPI 'cli')
+// does NOT run the CLI: under PHPUnit $argv[0] is the phpunit binary, so the
+// realpath comparison fails and only the function definitions above load.
+if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === __FILE__) {
+    $file = $argv[1] ?? 'assets/css/components.css';
+
+    if (!is_file($file) || !is_readable($file)) {
+        fwrite(STDERR, "check-raw-hex: cannot read file: {$file}\n");
+        exit(2);
+    }
+
+    $hits = pp_find_raw_hex((string) file_get_contents($file));
+    foreach ($hits as $hit) {
+        fwrite(STDERR, sprintf(
+            "ERROR: Raw hex color '%s' found in %s on line %d: %s\n",
+            $hit['match'],
+            $file,
+            $hit['line'],
+            trim($hit['text'])
+        ));
+    }
+
+    if ($hits !== []) {
+        fwrite(STDERR, "Use CSS variables from base.css instead.\n");
+        exit(1);
+    }
+
+    echo "OK: no raw hex colors in {$file}\n";
+    exit(0);
+}

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.5
+Version:          1.4.6
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/InvariantTest.php
+++ b/tests/InvariantTest.php
@@ -114,28 +114,23 @@ class InvariantTest extends TestCase
 
     public function testNoRawHexInComponentsCss(): void
     {
+        // Use the shared guard so this local test and the CI `ai-ready` workflow
+        // run the IDENTICAL detection logic (issue #289). The shared guard
+        // strips `/* ... */` comments before matching, so an issue reference in
+        // a comment (e.g. `(#226)`) passes while a real hex still fails.
+        require_once $this->themeRoot . '/scripts/check-raw-hex.php';
+
         $cssFile = $this->themeRoot . '/assets/css/components.css';
         $this->assertFileExists($cssFile, 'components.css not found.');
 
-        $content = file_get_contents($cssFile);
-        $lines   = explode("\n", $content);
+        $hits = \pp_find_raw_hex((string) file_get_contents($cssFile));
 
-        foreach ($lines as $lineNum => $line) {
-            // Skip comment lines
-            if (str_contains(ltrim($line), '*') || str_contains(ltrim($line), '//')) {
-                continue;
-            }
-
-            // Match hex colors that are not part of a longer hex sequence
-            if (preg_match('/#[0-9a-fA-F]{3,6}(?![0-9a-fA-F])/', $line, $matches)) {
-                $this->fail(
-                    "Raw hex color '{$matches[0]}' found in components.css on line " . ($lineNum + 1) . ": {$line}\n" .
-                    "Use CSS variables from base.css instead."
-                );
-            }
+        $message = "Raw hex colors found in components.css (use CSS variables from base.css):\n";
+        foreach ($hits as $hit) {
+            $message .= "  line {$hit['line']}: '{$hit['match']}' — " . trim($hit['text']) . "\n";
         }
 
-        $this->assertTrue(true, 'No raw hex colors found in components.css.');
+        $this->assertSame([], $hits, $message);
     }
 
     // ── All components have README.md ─────────────────────────────────────

--- a/tests/RawHexGuardTest.php
+++ b/tests/RawHexGuardTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * tests/RawHexGuardTest.php
+ *
+ * Both-directions proof for the shared raw-hex guard (issue #289):
+ *   - a genuine raw hex color still FAILS (detection not weakened),
+ *   - an issue reference inside a `/* ... *\/` comment PASSES.
+ *
+ * Covers both the in-process function (pp_find_raw_hex — used by
+ * tests/InvariantTest.php) and the CLI entrypoint (php scripts/check-raw-hex.php
+ * — used by the `ai-ready` CI workflow), so the two guards are proven aligned.
+ */
+
+declare(strict_types=1);
+
+namespace PromptingPress\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class RawHexGuardTest extends TestCase
+{
+    private string $script;
+
+    protected function setUp(): void
+    {
+        $this->script = dirname(__DIR__) . '/scripts/check-raw-hex.php';
+        require_once $this->script;
+    }
+
+    // ── Detection is NOT weakened: real raw hex still fails ────────────────
+
+    public function testDetectsSixDigitHexInDeclaration(): void
+    {
+        $hits = \pp_find_raw_hex('.a { color: #ff0000; }');
+        $this->assertCount(1, $hits);
+        $this->assertSame('#ff0000', $hits[0]['match']);
+    }
+
+    public function testDetectsThreeDigitHexInDeclaration(): void
+    {
+        // `#226` as an actual color value must still fail — only comment-context
+        // refs are exempt, per the recorded decision on #289.
+        $hits = \pp_find_raw_hex('.a { color: #226; }');
+        $this->assertCount(1, $hits);
+        $this->assertSame('#226', $hits[0]['match']);
+    }
+
+    public function testDetectsHexEvenWhenLineAlsoCarriesACommentRef(): void
+    {
+        // A real hex on a line that also has a trailing comment must still be
+        // caught. The old crude line-skip missed this class entirely.
+        $hits = \pp_find_raw_hex('.a { color: #fff; } /* tweak (#226) */');
+        $this->assertCount(1, $hits);
+        $this->assertSame('#fff', $hits[0]['match']);
+    }
+
+    // ── False-positive class fixed: comment refs pass ─────────────────────
+
+    public function testIssueRefInSingleLineCommentPasses(): void
+    {
+        $this->assertSame([], \pp_find_raw_hex('/* fixes overflow (#226) */'));
+    }
+
+    public function testIssueRefInMultiLineCommentPasses(): void
+    {
+        $css = "/*\n * Per-instance slots survive this rule (#226).\n * Also (#238), (#243).\n */\n.a { color: var(--fg); }";
+        $this->assertSame([], \pp_find_raw_hex($css));
+    }
+
+    public function testTrailingIssueRefCommentPasses(): void
+    {
+        $this->assertSame([], \pp_find_raw_hex('.a { color: var(--fg); } /* (#226) */'));
+    }
+
+    public function testTwoDigitIssueRefStaysBelowThreshold(): void
+    {
+        // e.g. `#24`, `#56` — under the {3,6} minimum, so never a match,
+        // in a comment or not. Preserves the original guard's behavior.
+        $this->assertSame([], \pp_find_raw_hex('/* noisy arrow (#56) */'));
+        $this->assertSame([], \pp_find_raw_hex('.a { width: calc(1px + 2px); } /* #24 */'));
+    }
+
+    // ── Line numbers stay accurate across comment shapes ──────────────────
+
+    public function testReportsCorrectLineNumberAfterMultiLineComment(): void
+    {
+        $css = "/*\n multi\n line (#226)\n */\n.a { color: #abc123; }";
+        $hits = \pp_find_raw_hex($css);
+        $this->assertCount(1, $hits);
+        $this->assertSame(5, $hits[0]['line']);
+        $this->assertSame('#abc123', $hits[0]['match']);
+    }
+
+    public function testCommentDoesNotFuseTokensAcrossItsBoundary(): void
+    {
+        // `#22` + comment + `6` must NOT be read as `#226`. Blanking the comment
+        // to spaces (not to nothing) keeps the tokens apart.
+        $this->assertSame([], \pp_find_raw_hex('#22/* x */6'));
+    }
+
+    public function testHandlesCrlfLineEndings(): void
+    {
+        $css = "/* ref (#226) */\r\n.a { color: #ff0000; }\r\n";
+        $hits = \pp_find_raw_hex($css);
+        $this->assertCount(1, $hits);
+        $this->assertSame('#ff0000', $hits[0]['match']);
+        $this->assertSame(2, $hits[0]['line']);
+    }
+
+    // ── CLI entrypoint (the exact command CI runs) ────────────────────────
+
+    public function testCliExitsOneOnRealHex(): void
+    {
+        [$code] = $this->runCli(".a { color: #ff0000; }\n");
+        $this->assertSame(1, $code, 'CLI must exit 1 when a real raw hex is present.');
+    }
+
+    public function testCliExitsZeroOnCommentRefOnly(): void
+    {
+        [$code, $out] = $this->runCli("/* fixes overflow (#226) */\n.a { color: var(--fg); }\n");
+        $this->assertSame(0, $code, "CLI must exit 0 for a comment-only issue ref. Output: {$out}");
+    }
+
+    public function testCliExitsTwoOnMissingFile(): void
+    {
+        $missing = sys_get_temp_dir() . '/pp-no-such-file-' . uniqid() . '.css';
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($this->script) . ' ' . escapeshellarg($missing);
+        exec($cmd . ' 2>/dev/null', $out, $code);
+        $this->assertSame(2, $code);
+    }
+
+    /**
+     * Write $css to a temp fixture, run the CLI against it, return [exitCode, output].
+     *
+     * @return array{0:int,1:string}
+     */
+    private function runCli(string $css): array
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'pp-hex-') . '.css';
+        file_put_contents($tmp, $css);
+        try {
+            $cmd = escapeshellarg(PHP_BINARY) . ' '
+                . escapeshellarg($this->script) . ' '
+                . escapeshellarg($tmp) . ' 2>&1';
+            exec($cmd, $out, $code);
+            return [$code, implode("\n", $out)];
+        } finally {
+            @unlink($tmp);
+        }
+    }
+}


### PR DESCRIPTION
Closes #289

## Summary
The raw-hex guard on `assets/css/components.css` (which enforces "use CSS variables from base.css, never raw hex") false-positived on GitHub issue references written inside `/* ... */` comments — `(#226)` reads as a 3-digit hex string. This forced an awkward "write `issue 226`, never `(#226)`" convention and had already broken two builds (comment refs `(#226)` and `(#266)`).

Both guards now strip `/* ... */` comments before applying the existing hex pattern, so comment-context issue refs pass while real raw hex in a declaration still fails.

## What changed
- **New `scripts/check-raw-hex.php`** — single source of truth. `pp_find_raw_hex()` blanks `/* ... */` comments to spaces (preserving newlines/byte offsets, so line numbers stay accurate and tokens are never fused across a comment boundary), then applies the unchanged regex `#[0-9a-fA-F]{3,6}(?![0-9a-fA-F])`. Runs as a CLI: exit 0 clean, 1 raw hex found, 2 file missing.
- **`tests/InvariantTest.php`** — now calls the shared checker instead of the old crude line-skip (which had a hole: it skipped any line containing `*`, so a real hex on a trailing-comment line escaped detection). This is now strictly stronger.
- **`.github/workflows/ai-ready-check.yml`** — the ai-ready "No raw hex" step now runs `php scripts/check-raw-hex.php`, the identical code path as the local test (adds a `shivammathur/setup-php@v2` step matching the existing `tests` job). Local and CI can no longer diverge (acceptance criterion 3).
- **`tests/RawHexGuardTest.php`** — both-directions proof (see Validation).

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` — **2056 passed** (13 new RawHexGuard cases + repurposed InvariantTest). Warnings/deprecations match the pre-change baseline (pre-existing, in `lib/apply.php` / `lib/components.php`).
- `npm test` (vitest) — **641 passed**.
- CLI verified by hand: real `components.css` exits 0; a comment-only `(#226)` exits 0; `color: #ff0000; /* (#226) */` exits 1 flagging `#ff0000`.
- Both-directions coverage: real hex (`#ff0000`, `#226`) detected; comment refs (single-line, multi-line, trailing) pass; real hex on a line that also has a comment still caught; two-digit `#24` stays below threshold; line numbers accurate across multi-line + CRLF; no token fusion across a comment boundary; CLI exit codes 1/0/2.

## Accepted limitation
The comment stripping is intentionally lexical, not a full CSS parser — the recorded decision on #289 explicitly chose "strip `/* … */`, keep the regex simple" over a CSS-aware rule. Consequently a `/* ... */` byte sequence inside a CSS string literal (e.g. `content: "/* #ff0000 */"`) is also treated as a comment. Such text is not a hardcoded color value, so exempting it does not weaken the guard's real job. No such construct exists in the current `components.css`.

## Reviews (this session, on this exact diff)
- `/plan-eng-review` — clean; single-source-of-truth shared checker chosen for DRY + guaranteed alignment.
- `/review` + Codex adversarial — one within-decision doc-accuracy nit fixed (docblock wording); the string-literal edge above was raised and accepted per the recorded decision.

Not tagged/released/deployed — release zip is CI-built from a tag by the maintainer.
