### PR TITLE
v1.4.7 fix: shared responsive band-heading scale (#436)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -387,7 +387,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**196 style slots** across 7 components: hero (41), grid (36), section (36), cta (31), testimonials (25), faq (17), stats (10).
+**200 style slots** across 10 components: hero (41), grid (36), section (36), cta (31), testimonials (26), faq (17), stats (10), embed (1), logos (1), table (1).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.7] — 2026-07-20 — band headings share one responsive scale, so section/grid/CTA titles stop collapsing to body size on mobile (#436)
+
+**Below 768px the theme had no working default size for band headings: section, grid, and CTA titles rendered at 16px — exactly body size — on every default page, and CTA titles were body-sized at every breakpoint. The `font-size: var(--slot, inherit)` pattern behind those headings had no base value, so with no per-page override the heading silently inherited body text and the visual hierarchy vanished on phones. Now every band title (section, grid, cta, faq, stats, table, testimonials, logos, embed) draws its default size from one shared, fluid scale defined once in `base.css`, so headings scale down on small screens but never collapse into body copy, and headings at the same structural level render as peers.**
+
+The scale is a single `clamp()` from a ~28px mobile floor to the ~42px ceiling of the prior desktop-only rule, consumed as the fallback of each component's existing `--*-title-size` / `--*-heading-size` slot. This is a deliberate change to unstyled output, and it moves default sizes in three ways: (1) on mobile, section/grid/cta titles rise from 16px to ~28px and CTA rises at every width — the core fix; (2) on desktop, stats, table, testimonials, logos, and embed headings grow from a flat 30px to the shared step (up to ~38–42px), joining the same tier as section/grid/faq; (3) for section/grid/faq specifically, the desktop size is preserved at the 1280px breakpoint (~38.4px) and at the ceiling, but softens by ~3.5px across the 768–1071px tablet band (the old rule was floored flat at 36px there; the fluid scale ramps ~32.5px→36px), the deliberate cost of putting all bands on one fluid scale. Per-page intent is untouched: every `--*-title-size` / `--*-heading-size` slot still wins at every breakpoint, and `--cta-title-size: 60px` overrides the scale exactly as before. Table, logos, embed, and testimonials headings gain a `--*-heading-size` slot so their size is now authorable too, matching the other band components.
+
+### Fixed
+- Band-level headings (section, grid, cta, faq, stats, table, testimonials, logos, embed) now have a real default size at every viewport instead of collapsing to body size below 768px. Section, grid, and CTA titles no longer render at 16px on mobile, and CTA titles are no longer body-sized on desktop. All band titles at the same structural level now compute the same size per breakpoint, so stacked sections read as peers (#436).
+- The `font-size: var(--slot, inherit)` anti-pattern is removed from every band heading; each now falls back to the shared `--pp-band-heading-size` scale, which is fluid at every viewport and never resolves to the body font size (#436).
+
+### Added
+- Authorable `--table-section-heading-size`, `--logos-heading-size`, `--embed-heading-size`, and `--testimonials-heading-size` style slots, so the heading size of the table, logos, embed, and testimonials components can be set per instance like the other band components. Total per-instance style slots: 200 across 10 components (#436).
+
+### Docs
+- `AI_CONTEXT.md` and `README.md` updated to the new 200-slot / 10-component totals; `ai-instructions/add-component.md` documents routing a new band heading's `font-size` through its size slot to the shared `--pp-band-heading-size` scale (never `inherit`, never a literal) (#436).
+
+### Tests
+- `tests/js/css-lint.test.js` gains a structural suite pinning that every band heading `font-size` routes through its slot and falls back to the shared scale, that `inherit` never appears as a heading font-size fallback, and that the shared clamp is defined with a floor ≥1.5rem and the prior ceiling. `tests/e2e/style-render.spec.ts` gains viewport-typography coverage: at 375/768/1280 every band heading is an `<h2>`, computes the same size per breakpoint, clears the 1.5rem mobile floor, and never equals the body font size, plus render proof that the existing and newly-minted heading-size slots override the scale at mobile and desktop; the core and webfiable-shape scenarios are tagged `@smoke`. `tests/AiContextTest.php` pins that the newly styleable band components surface their heading-size slot in the AI prompt (#436).
+
 ## [v1.4.6] — 2026-07-20 — the "no raw hex" guard stops tripping on issue references written in CSS comments (#289)
 
 **The check that keeps hardcoded hex colors out of `components.css` used to flag a GitHub issue reference like `(#226)` written inside a `/* ... */` comment, because `#226` reads as a three-digit hex string. That forced an awkward "write `issue 226`, never `(#226)`" convention in CSS comments and had already broken two builds. Now both the local test guard and the CI check strip `/* ... */` comments before scanning, so a comment can cite `(#226)` freely while a real hardcoded color in a declaration (`color: #226;` or `color: #ff0000;`) still fails exactly as before. The two guards now run the same code, so a comment that passes locally can't fail CI or the reverse.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.6-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.7-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-196 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+200 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.4.0.
 
 **What exists today (v1.4.0):**
-- 12 components with schema contracts and 196 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 200 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/ai-instructions/add-component.md
+++ b/ai-instructions/add-component.md
@@ -151,6 +151,12 @@ Open `/assets/css/components.css` and add a labeled section at the bottom:
 }
 
 .mycomponent__title {
+  /* A band-level title shares ONE responsive heading scale with every other band
+     title (issue 436). Route its font-size through the component's own size slot,
+     falling back to the shared --pp-band-heading-size, so it never collapses to
+     body size on mobile and reads as a peer of adjacent band titles. Never fall
+     back to `inherit` (that silently discards the scale) or a bare literal. */
+  font-size: var(--mycomponent-heading-size, var(--pp-band-heading-size));
   margin-bottom: var(--space-md);
 }
 
@@ -163,7 +169,10 @@ Open `/assets/css/components.css` and add a labeled section at the bottom:
 each component's own authorable slots (`--mycomponent-padding-*`) falling back to
 `base.css` tokens. Band-level components take their default vertical rhythm from
 `--pp-band-padding` (never a per-component literal), so all sections share one
-spacing model.
+spacing model. Band titles do the same on the typography axis: their `font-size`
+falls back to `--pp-band-heading-size` (never `inherit`, never a per-component
+literal), so every band heading shares one responsive scale and never collapses
+to body size on mobile.
 
 ---
 

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -96,10 +96,25 @@
    Hero opts OUT of this shared rhythm on purpose: it carries its own larger,
    already-symmetric page-opening rhythm (--space-xl / --space-2xl, 64/112px)
    via the --hero-padding-* slots, so it is not retuned here.
+
+   Band heading scale — the typography analog of the rhythm above (issue 436).
+   Every band title (section, grid, cta, faq, stats, table, testimonials, logos,
+   embed) routes its font-size fallback through --pp-band-heading-size, so the
+   default heading step is defined ONCE and fluid at EVERY viewport instead of
+   collapsing to body size below 768px (the old `font-size: var(--slot, inherit)`
+   trap) or drifting per component. The clamp runs from a ~28px mobile floor
+   (never body-size) to the ~42px ceiling of the prior desktop-only clamp; at
+   1280px it resolves to ~38.4px, matching the previous desktop output for
+   section/grid/faq. Internal like the rhythm props (not authored via
+   update_design_token, kept out of the first :root token block); a whole-site
+   heading-scale retune changes only this line. Hero keeps its own larger clamp
+   (out of scope). Per-component --*-title-size / --*-heading-size slots still
+   win at every breakpoint — this is only the fallback.
    ========================================================================== */
 :root {
   --pp-band-padding:              clamp(4.25rem, 6vw, 5rem);
   --pp-band-padding-adjacent-top: var(--pp-band-padding);
+  --pp-band-heading-size:         clamp(1.75rem, 1.48rem + 1.15vw, 2.62rem);
 }
 
 @media (max-width: 767px) {

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -973,7 +973,7 @@
 }
 
 .section__title {
-  font-size: var(--section-title-size, inherit);
+  font-size: var(--section-title-size, var(--pp-band-heading-size));
   color: var(--section-title-color, var(--section-title-theme-color, var(--color-text)));
   /* Top-side header rhythm (title -> subheading gap). issue 336 made the subheading's
      BOTTOM margin authorable; this routes the title's own bottom margin through a
@@ -1261,7 +1261,7 @@
      widths below the desktop premium typography breakpoint, where the heading
      renders at the h2 base size (base.css); the desktop clamp is routed through
      the same slot below. Fallback keeps unset output byte-identical. */
-  font-size: var(--faq-heading-size, 1.875rem);
+  font-size: var(--faq-heading-size, var(--pp-band-heading-size));
   margin-bottom: var(--space-lg);
   color: var(--faq-heading-color, var(--faq-heading-theme-color, var(--color-text)));
 }
@@ -1406,7 +1406,7 @@
 
 .grid__heading {
   color: var(--grid-heading-color, var(--grid-heading-theme-color, var(--color-text)));
-  font-size: var(--grid-heading-size, inherit);
+  font-size: var(--grid-heading-size, var(--pp-band-heading-size));
   max-width: var(--grid-heading-max-width, 40rem);
   /* Top-side header rhythm (heading -> subheading gap), mirror of the issue 336
      subheading BOTTOM slot on the adjacent property (issue 343). The heading is
@@ -1843,6 +1843,11 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 }
 
 .table-section__heading {
+  /* Band heading joins the shared responsive scale (issue 436): route font-size
+     through the component's own size slot, falling back to --pp-band-heading-size
+     so this heading agrees with every other band title at every viewport instead
+     of inheriting the flat h2 element rule (30px). */
+  font-size: var(--table-section-heading-size, var(--pp-band-heading-size));
   margin-bottom: var(--space-lg);
 }
 
@@ -1946,7 +1951,7 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 }
 
 .cta__title {
-  font-size: var(--cta-title-size, inherit);
+  font-size: var(--cta-title-size, var(--pp-band-heading-size));
   color: var(--cta-text, inherit);
   max-width: var(--cta-content-width, 40rem);
   margin-bottom: var(--space-xs);
@@ -2362,7 +2367,7 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   /* Route the heading size through the slot (issue 304). stats has no premium
      typography rule, so the fallback is the h2 base size (base.css) — unset
      output is byte-identical, and an operator can now tune the scale. */
-  font-size: var(--stats-title-size, 1.875rem);
+  font-size: var(--stats-title-size, var(--pp-band-heading-size));
   margin-bottom: var(--space-lg);
   /* Center the heading BOX, not just its text (issue 367 — same class as issue 354).
      The shared cap rule gives this h2 max-width: var(--cta-content-width, 40rem);
@@ -2485,6 +2490,8 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 }
 
 .logos__heading {
+  /* Band heading joins the shared responsive scale (issue 436). */
+  font-size: var(--logos-heading-size, var(--pp-band-heading-size));
   margin-bottom: var(--space-lg);
 }
 
@@ -2558,6 +2565,8 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 }
 
 .embed__heading {
+  /* Band heading joins the shared responsive scale (issue 436). */
+  font-size: var(--embed-heading-size, var(--pp-band-heading-size));
   margin-bottom: var(--space-lg);
 }
 
@@ -2622,6 +2631,8 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 }
 
 .testimonials__heading {
+  /* Band heading joins the shared responsive scale (issue 436). */
+  font-size: var(--testimonials-heading-size, var(--pp-band-heading-size));
   color: var(--testimonials-heading-color, var(--color-text));
   max-width: 40rem;
   /* Top-side header rhythm (heading -> subheading gap), mirror of the issue 336
@@ -2838,7 +2849,7 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
    ========================================================================== */
 
 .section--text-only .section__title {
-  font-size: var(--section-title-size, 2.25rem);
+  font-size: var(--section-title-size, var(--pp-band-heading-size));
 }
 
 .section--text-only .section__content {
@@ -2975,30 +2986,47 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
      to live in the shared rule above as a bare clamp(), outranking the base
      .section__title / .grid__heading rules ([0,1,0]) and silently ignoring a
      declared --section-title-size / --grid-heading-size. Route each through its
-     size slot with the clamp() as the fallback so unset output is unchanged. faq
-     now routes through --faq-heading-size too (issue 304).
+     size slot so a set slot still wins at this [0,2,1] specificity. faq routes
+     through --faq-heading-size too (issue 304). The fallback is now the shared
+     --pp-band-heading-size (issue 436) instead of a per-rule clamp(): the shared
+     clamp is already fluid at every viewport, so this desktop rule and the base
+     rule resolve to the same value when the slot is unset (~38.4px at 1280px,
+     matching the prior desktop clamp) — the rule stays only to keep the slot
+     winning at desktop specificity, not to redefine the size.
 
      margin-bottom joins the split for section/grid (issue 343): this premium rule
      hardcoded the title -> subheading gap (1.65rem here, 1.25rem in the max-width
      rule below) at [0,2,1], outranking the base [0,1,0] rules and silently ignoring
      a declared --section-title-margin-bottom / --grid-heading-margin-bottom. Route
      each through its slot with 1.65rem as the fallback so unset output is unchanged.
-     faq stays a bare literal (no faq heading-margin slot in issue 343's scope). */
+     faq stays a bare literal (no faq heading-margin slot in issue 343's scope).
+
+     issue 436 note: the font-size fallback here is now the shared --pp-band-heading-size
+     instead of this rule's old per-rule clamp(2.25rem, 3vw, 2.62rem). Because that
+     shared value is itself a fluid clamp, this desktop rule and the base rule resolve
+     to the SAME size when the slot is unset — so this rule exists only to keep a set
+     slot winning at this [0,2,1] specificity, not to redefine the size. Unset output
+     is preserved at the 1280px desktop anchor (~38.4px) and at the >=1400px ceiling
+     (2.62rem), but it is NOT byte-identical across the whole old desktop range: the
+     old clamp was floored flat at 36px for ~768-1071px, whereas the shared fluid
+     clamp ramps from ~32.5px at 768px up to 36px near 1071px. That ~3.5px tablet-band
+     softening is the deliberate cost of unifying section/grid/faq onto one fluid scale
+     (issue 436) and is called out in the CHANGELOG. */
   main > .grid .grid__heading {
     color: var(--grid-heading-color, var(--grid-heading-theme-color, var(--color-text)));
-    font-size: var(--grid-heading-size, clamp(2.25rem, 3vw, 2.62rem));
+    font-size: var(--grid-heading-size, var(--pp-band-heading-size));
     margin-bottom: var(--grid-heading-margin-bottom, 1.65rem);
   }
 
   main > .section .section__title {
     color: var(--section-title-color, var(--section-title-theme-color, var(--color-text)));
-    font-size: var(--section-title-size, clamp(2.25rem, 3vw, 2.62rem));
+    font-size: var(--section-title-size, var(--pp-band-heading-size));
     margin-bottom: var(--section-title-margin-bottom, 1.65rem);
   }
 
   main > .faq .faq__heading {
     color: var(--faq-heading-color, var(--faq-heading-theme-color, var(--color-text)));
-    font-size: var(--faq-heading-size, clamp(2.25rem, 3vw, 2.62rem));
+    font-size: var(--faq-heading-size, var(--pp-band-heading-size));
     margin-bottom: 1.65rem;
   }
 

--- a/components/embed/embed.php
+++ b/components/embed/embed.php
@@ -26,8 +26,10 @@ if (!in_array($theme, $allowed_themes, true)) {
 
 $theme_class = $theme !== 'default' ? ' embed--' . $theme : '';
 
+$slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'embed');
+$style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';
 ?>
-<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="embed<?php echo esc_attr($theme_class); ?>" data-pp-component="embed">
+<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="embed<?php echo esc_attr($theme_class); ?>" data-pp-component="embed"<?php echo $style_attr; ?>>
     <div class="container">
 
         <?php if ($title) : ?>

--- a/components/embed/schema.json
+++ b/components/embed/schema.json
@@ -30,7 +30,10 @@
   "styling": {
     "root_class": "embed",
     "variant_classes": ["embed--dark", "embed--inverted"],
-    "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted"]
+    "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted"],
+    "style_slots": {
+      "--embed-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Section heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." }
+    }
   },
   "safe_to_edit": ["embed.php", "../../assets/css/components.css (COMPONENT: embed section)"],
   "do_not_touch": ["schema.json without updating AI_CONTEXT.md"]

--- a/components/logos/logos.php
+++ b/components/logos/logos.php
@@ -21,8 +21,10 @@ if (!in_array($theme, $allowed_themes, true)) {
 
 $theme_class = $theme !== 'default' ? ' logos--' . $theme : '';
 
+$slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'logos');
+$style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';
 ?>
-<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="logos<?php echo esc_attr($theme_class); ?>" data-pp-component="logos">
+<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="logos<?php echo esc_attr($theme_class); ?>" data-pp-component="logos"<?php echo $style_attr; ?>>
     <div class="container">
 
         <?php if ($title) : ?>

--- a/components/logos/schema.json
+++ b/components/logos/schema.json
@@ -36,7 +36,10 @@
   "styling": {
     "root_class": "logos",
     "variant_classes": ["logos--dark", "logos--inverted"],
-    "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted"]
+    "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted"],
+    "style_slots": {
+      "--logos-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Section heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." }
+    }
   },
   "safe_to_edit": ["logos.php", "../../assets/css/components.css (COMPONENT: logos section)"],
   "do_not_touch": ["schema.json without updating AI_CONTEXT.md"]

--- a/components/table/schema.json
+++ b/components/table/schema.json
@@ -34,7 +34,10 @@
   "styling": {
     "root_class": "table-section",
     "variant_classes": [],
-    "tokens": ["--space-xl", "--space-2xl", "--color-border", "--color-surface"]
+    "tokens": ["--space-xl", "--space-2xl", "--color-border", "--color-surface"],
+    "style_slots": {
+      "--table-section-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Section heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." }
+    }
   },
   "safe_to_edit": ["table.php", "../../assets/css/components.css (COMPONENT: table section)"],
   "do_not_touch": ["schema.json without updating README.md"]

--- a/components/table/table.php
+++ b/components/table/table.php
@@ -13,8 +13,11 @@ $title   = $props['title']   ?? '';
 $headers = $props['headers'] ?? [];
 $rows    = $props['rows']    ?? [];
 $caption = $props['caption'] ?? '';
+
+$slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'table');
+$style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';
 ?>
-<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="table-section" data-pp-component="table">
+<section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="table-section" data-pp-component="table"<?php echo $style_attr; ?>>
     <div class="container">
 
         <?php if ($title) : ?>

--- a/components/testimonials/schema.json
+++ b/components/testimonials/schema.json
@@ -75,6 +75,7 @@
       "--testimonials-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the section" },
       "--testimonials-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the section" },
       "--testimonials-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
+      "--testimonials-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." },
       "--testimonials-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Heading text color" },
       "--testimonials-heading-accent-color": { "type": "color", "default": "var(--color-accent)", "description": "Color of the title_accent substring within the heading, if set" },
       "--testimonials-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.6');
+define('PP_VERSION', '1.4.7');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.6
+Stable tag: 1.4.7
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.6
+Version:          1.4.7
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/AiContextTest.php
+++ b/tests/AiContextTest.php
@@ -497,17 +497,58 @@ class AiContextTest extends TestCase
         $this->assertStringContainsString('Recipes:', $prompt);
     }
 
-    public function testSystemPromptOmitsStyleSlotsForUnstyled(): void
+    public function testSystemPromptOmitsStyleSlotsForComponentsWithNoSlots(): void
     {
-        // faq gained style slots in #100 — it's no longer an "unstyled" example
-        // (see testSystemPromptIncludesStyleSlotsForFaq below).
+        // faq gained style slots in #100, and table/logos/embed gained the shared
+        // band-heading size slot in #436, so no band/content component in the
+        // catalog is "unstyled" anymore (embed used to be the example here). This
+        // guard is now dynamic: any component whose schema declares zero style
+        // slots must still omit the "Style slots:" line in the prompt. It passes
+        // vacuously today (every listed component has >= 1 slot) but re-arms the
+        // moment a slotless component is added.
+        $prompt = pp_ai_system_prompt();
+        $this->assertNotEmpty($prompt);
+        $lines = explode("\n", $prompt);
+        foreach (pp_get_registered_components() as $name => $schema) {
+            if (count($schema['styling']['style_slots'] ?? []) > 0) {
+                continue;
+            }
+            foreach ($lines as $i => $line) {
+                if (str_contains($line, "**{$name}**")) {
+                    $next = $lines[$i + 1] ?? '';
+                    $this->assertStringNotContainsString(
+                        'Style slots:',
+                        $next,
+                        "Component {$name} declares no style slots but the prompt lists them."
+                    );
+                }
+            }
+        }
+    }
+
+    public function testSystemPromptIncludesHeadingSizeSlotForNewlyStyledBands(): void
+    {
+        // #436 regression pin: table/logos/embed each gained the shared band-heading
+        // size slot, so the AI-facing prompt must now surface it the same way it does
+        // faq's slots (see testSystemPromptIncludesStyleSlotsForFaq below).
         $prompt = pp_ai_system_prompt();
         $lines = explode("\n", $prompt);
-        foreach ($lines as $i => $line) {
-            if (str_contains($line, '**embed**')) {
-                $next = $lines[$i + 1] ?? '';
-                $this->assertStringNotContainsString('Style slots:', $next);
+        $expected = [
+            'embed' => '--embed-heading-size',
+            'logos' => '--logos-heading-size',
+            'table' => '--table-section-heading-size',
+        ];
+        foreach ($expected as $name => $slot) {
+            $found = false;
+            foreach ($lines as $i => $line) {
+                if (str_contains($line, "**{$name}**")) {
+                    $next = $lines[$i + 1] ?? '';
+                    $this->assertStringContainsString('Style slots:', $next);
+                    $this->assertStringContainsString($slot, $next);
+                    $found = true;
+                }
             }
+            $this->assertTrue($found, "Expected {$name} in the system prompt.");
         }
     }
 

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -3412,3 +3412,190 @@ test.describe('Shared section-band rhythm (#431)', () => {
     }
   });
 });
+
+test.describe('Band heading scale (#436)', () => {
+  let pageId: number;
+
+  // Every band-level heading is an <h2> that shares ONE responsive scale
+  // (--pp-band-heading-size) as the fallback of its own size slot. Before #436
+  // section/grid/cta collapsed to 16px body size on mobile (cta at every
+  // viewport) and the rest disagreed. Selector + size slot per band.
+  const HEADINGS: { band: string; sel: string; slot: string }[] = [
+    { band: 'section', sel: '.section__title', slot: '--section-title-size' },
+    { band: 'grid', sel: '.grid__heading', slot: '--grid-heading-size' },
+    { band: 'cta', sel: '.cta__title', slot: '--cta-title-size' },
+    { band: 'stats', sel: '.stats__heading', slot: '--stats-title-size' },
+    { band: 'table', sel: '.table-section__heading', slot: '--table-section-heading-size' },
+    { band: 'testimonials', sel: '.testimonials__heading', slot: '--testimonials-heading-size' },
+    { band: 'logos', sel: '.logos__heading', slot: '--logos-heading-size' },
+    { band: 'embed', sel: '.embed__heading', slot: '--embed-heading-size' },
+    { band: 'faq', sel: '.faq__heading', slot: '--faq-heading-size' },
+  ];
+
+  // Hero first so every band renders in-flow; faq LAST because its trailing
+  // JSON-LD <script> breaks the `+` adjacency of a following band (pre-existing
+  // bug 432). Adjacency does not affect font-size, but keeping faq last matches
+  // the #430/#431 stacks and avoids the quirk entirely. Each band carries a
+  // `title` so its <h2> renders.
+  const STACK = [
+    { component: 'hero', props: { id: 'pp-hero01', title: 'Lead' } },
+    { component: 'section', props: { id: 'pp-sec01', title: 'Section', body: '<p>Body.</p>' } },
+    { component: 'grid', props: { id: 'pp-grid01', title: 'Grid', items: [{ title: 'One', text: 'A' }] } },
+    { component: 'cta', props: { id: 'pp-cta01', title: 'CTA', button_text: 'Go', button_url: '/go' } },
+    { component: 'stats', props: { id: 'pp-stats01', title: 'Stats', items: [{ number: '10', label: 'Ten' }] } },
+    { component: 'table', props: { id: 'pp-tbl01', title: 'Table', headers: ['A', 'B'], rows: [['1', '2']] } },
+    { component: 'testimonials', props: { id: 'pp-tst01', title: 'Testimonials', items: [{ quote: 'It works.', author: 'A' }] } },
+    { component: 'logos', props: { id: 'pp-logo01', title: 'Logos', items: [{ image_url: 'https://example.com/l.png', image_alt: 'Logo' }] } },
+    { component: 'embed', props: { id: 'pp-emb01', title: 'Embed', content: 'https://example.com/video' } },
+    { component: 'faq', props: { id: 'pp-faq01', title: 'FAQ', items: [{ question: 'Q?', answer: 'A.' }] } },
+  ];
+
+  async function headingMetrics(page: any, sel: string) {
+    return page.locator(`main ${sel}`).first().evaluate((el: Element) => {
+      const cs = getComputedStyle(el);
+      return { tag: el.tagName, size: parseFloat(cs.fontSize) };
+    });
+  }
+
+  test.afterEach(async () => {
+    if (pageId) {
+      try {
+        deletePage(pageId);
+      } catch {
+        /* already cleaned */
+      }
+      pageId = 0;
+    }
+  });
+
+  // Core scenario: every band <h2> shares one computed size per breakpoint, never
+  // collapses to body size, and clears the 1.5rem mobile floor. The regression pin
+  // (no band h2 equals the body font-size at any tested viewport) lives here.
+  test('#436 all band headings share one size per breakpoint, never body-size, >=1.5rem @375 @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Band Heading Scale Equality');
+    setComposition(pageId, STACK);
+
+    for (const width of [375, 768, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator('main .faq__heading').first()).toBeVisible({ timeout: 10000 });
+
+      const bodySize = await page.evaluate(() =>
+        parseFloat(getComputedStyle(document.body).fontSize),
+      );
+      const measured: Record<string, number> = {};
+      for (const { band, sel } of HEADINGS) {
+        const m = await headingMetrics(page, sel);
+        expect(m.tag, `${band} heading is not an <h2> @${width}`).toBe('H2');
+        measured[band] = m.size;
+        // The regression that shipped the bug: a band h2 computing at body size.
+        expect(m.size, `${band} h2 collapsed to body size @${width}: ${JSON.stringify(measured)}`).not.toBe(bodySize);
+        // Mobile floor: never below 1.5rem (24px at the 16px root).
+        if (width === 375) {
+          expect(m.size, `${band} below 1.5rem floor @375: ${m.size}`).toBeGreaterThanOrEqual(24);
+        }
+      }
+      // Cross-component equality: all band h2s are peers at this breakpoint (they
+      // all resolve the same --pp-band-heading-size clamp when unset).
+      const sizes = HEADINGS.map((h) => measured[h.band]);
+      expect(new Set(sizes).size, `band heading size drift @${width}: ${JSON.stringify(measured)}`).toBe(1);
+    }
+  });
+
+  // Slot contract preserved AND every newly-minted slot works end-to-end: the
+  // existing slot (--cta-title-size) plus ALL FOUR slots first introduced by #436
+  // (--table-section-heading-size, --logos-heading-size, --embed-heading-size,
+  // --testimonials-heading-size) must each validate (styleComponent success) and
+  // win over the shared scale at mobile AND desktop. This is the only render-level
+  // proof that the fresh pp_render_style_vars wiring in table/logos/embed.php uses
+  // the correct component-name string — a typo there would validate but never
+  // reach the DOM. Pixel values no scale step resolves to, so a fallback leak is
+  // unmistakable.
+  test('#436 existing and all newly-minted heading slots override the shared scale at 375 and 1280', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Band Heading Slot Override');
+    setComposition(pageId, [
+      { component: 'cta', props: { id: 'pp-cta01', title: 'CTA', button_text: 'Go', button_url: '/go' } },
+      { component: 'table', props: { id: 'pp-tbl01', title: 'Table', headers: ['A', 'B'], rows: [['1', '2']] } },
+      { component: 'logos', props: { id: 'pp-logo01', title: 'Logos', items: [{ image_url: 'https://example.com/l.png', image_alt: 'Logo' }] } },
+      { component: 'embed', props: { id: 'pp-emb01', title: 'Embed', content: 'https://example.com/video' } },
+      { component: 'testimonials', props: { id: 'pp-tst01', title: 'Testimonials', items: [{ quote: 'It works.', author: 'A' }] } },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    // index 0 = cta (existing slot); 1..4 = the slots minted in #436. Distinct px
+    // per component so a cross-wired value would be caught.
+    const overrides = [
+      { idx: 0, slot: '--cta-title-size', px: '60px', sel: '.cta__title' },
+      { idx: 1, slot: '--table-section-heading-size', px: '61px', sel: '.table-section__heading' },
+      { idx: 2, slot: '--logos-heading-size', px: '62px', sel: '.logos__heading' },
+      { idx: 3, slot: '--embed-heading-size', px: '63px', sel: '.embed__heading' },
+      { idx: 4, slot: '--testimonials-heading-size', px: '64px', sel: '.testimonials__heading' },
+    ];
+    for (const o of overrides) {
+      const r = await styleComponent(page, pageId, { [o.slot]: o.px }, undefined, o.idx);
+      expect(r.success, `${o.slot} set: ${JSON.stringify(r)}`).toBe(true);
+    }
+
+    for (const width of [375, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      for (const o of overrides) {
+        const h = page.locator(`main ${o.sel}`).first();
+        await expect(h).toBeVisible({ timeout: 10000 });
+        expect(await h.evaluate((el) => getComputedStyle(el).fontSize), `${o.slot} @${width}`).toBe(o.px);
+      }
+    }
+  });
+
+  // Live-shape check (acceptance criterion): the measured webfiable.com defect
+  // sequence (hero -> stats -> grid -> cta -> grid -> section -> cta) renders a
+  // DISTINGUISHABLE heading hierarchy at 375w — every band h2 clearly larger than
+  // body text and all peers equal, instead of the old 16px collapse where the
+  // section and both CTA titles were indistinguishable from body copy. No faq in
+  // this sequence, so bug 432 cannot interfere.
+  test('#436 webfiable-shaped stack renders distinguishable band headings at 375 @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Band Heading Webfiable Shape');
+    setComposition(pageId, [
+      { component: 'hero', props: { id: 'pp-hero01', title: 'Lead' } },
+      { component: 'stats', props: { id: 'pp-stats01', theme: 'dark', title: 'Stats', items: [{ number: '10', label: 'Ten' }] } },
+      { component: 'grid', props: { id: 'pp-grid01', title: 'Grid', items: [{ title: 'One', text: 'A' }] } },
+      { component: 'cta', props: { id: 'pp-cta01', theme: 'dark', title: 'CTA', button_text: 'Go', button_url: '/go' } },
+      { component: 'grid', props: { id: 'pp-grid02', title: 'Grid Two', items: [{ title: 'Two', text: 'B' }] } },
+      { component: 'section', props: { id: 'pp-sec01', title: 'Section', body: '<p>Section body.</p>' } },
+      { component: 'cta', props: { id: 'pp-cta02', theme: 'dark', title: 'Closing', button_text: 'Go', button_url: '/go' } },
+    ]);
+
+    await page.setViewportSize({ width: 375, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+    await expect(page.locator('#pp-cta02 .cta__title')).toBeVisible({ timeout: 10000 });
+
+    const bodySize = await page.evaluate(() => parseFloat(getComputedStyle(document.body).fontSize));
+    // The band titles that used to collapse to 16px on this exact sequence.
+    const titleSelectors = [
+      '#pp-stats01 .stats__heading',
+      '#pp-grid01 .grid__heading',
+      '#pp-cta01 .cta__title',
+      '#pp-grid02 .grid__heading',
+      '#pp-sec01 .section__title',
+      '#pp-cta02 .cta__title',
+    ];
+    const sizes: number[] = [];
+    for (const sel of titleSelectors) {
+      const size = await page.locator(sel).evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+      // Distinguishable from body copy (the bug rendered these AT body size).
+      expect(size, `${sel} not distinguishable from body @375: ${size}`).toBeGreaterThan(bodySize);
+      expect(size, `${sel} below 1.5rem floor @375: ${size}`).toBeGreaterThanOrEqual(24);
+      sizes.push(size);
+    }
+    // Peers: all band h2s at the same structural level share one step.
+    expect(new Set(sizes).size, `band heading drift on webfiable shape @375: ${JSON.stringify(sizes)}`).toBe(1);
+  });
+});

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -1845,6 +1845,124 @@ describe('CSS lint: section-level bands share one rhythm definition (#431)', () 
     });
 });
 
+/**
+ * Structural pin: every band-level heading shares ONE responsive scale (#436),
+ * the typography analog of the #431 rhythm pin above.
+ *
+ * Before #436, band titles had no working default size below 768px: section /
+ * grid / cta used `font-size: var(--slot, inherit)` (collapses to 16px body size
+ * on mobile; cta collapsed at every viewport), while faq / stats / table / logos /
+ * embed / testimonials used divergent literals (1.875rem or the flat h2 element
+ * rule). The fix defines the scale once in base.css — `--pp-band-heading-size`
+ * (a fluid clamp from a ~28px mobile floor to the ~42px desktop ceiling) — and
+ * routes every band heading's font-size fallback through it.
+ *
+ * These pins enforce that model structurally so a heading can't re-introduce the
+ * collapse by pasting a literal or falling back to `inherit`:
+ *   1. every band-heading font-size declaration routes var(--<comp>-*-size,
+ *      var(--pp-band-heading-size)) — slot still wins, shared scale is the floor;
+ *   2. `inherit` never appears as a heading font-size fallback (the exact
+ *      regression that shipped the 16px collapse);
+ *   3. the shared prop is actually defined in base.css as a fluid clamp, so the
+ *      routing resolves and a rename breaks these pins loudly.
+ */
+describe('CSS lint: band-level headings share one responsive scale (#436)', () => {
+    // Brace-matched extraction of every rule whose selector is EXACTLY `selector`
+    // (whitespace-normalized), across all media contexts. Same technique as the
+    // #431 helper; re-declared here so this suite is self-contained.
+    function bodiesForExactSelector(selector) {
+        const css = stripComments(COMPONENTS_CSS).replace(/\s+/g, ' ');
+        const re = new RegExp(
+            '[{};,]\\s*' + selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\{',
+            'g'
+        );
+        const bodies = [];
+        let match;
+        while ((match = re.exec(css)) !== null) {
+            let i = re.lastIndex;
+            let depth = 1;
+            const start = i;
+            while (i < css.length && depth > 0) {
+                if (css[i] === '{') depth++;
+                else if (css[i] === '}') depth--;
+                i++;
+            }
+            bodies.push(css.slice(start, i - 1));
+        }
+        return bodies;
+    }
+
+    // Each band heading: its exact selector(s) and the size slot the font-size
+    // must route through. section/grid/faq carry BOTH a base rule and a desktop
+    // premium rule ([0,2,1]); both must route the slot to the shared scale, so a
+    // multi-selector entry pins every declaration site.
+    const BAND_HEADINGS = [
+        { selectors: ['.section__title', '.section--text-only .section__title', 'main > .section .section__title'], slot: '--section-title-size' },
+        { selectors: ['.grid__heading', 'main > .grid .grid__heading'], slot: '--grid-heading-size' },
+        { selectors: ['.cta__title'], slot: '--cta-title-size' },
+        { selectors: ['.faq__heading', 'main > .faq .faq__heading'], slot: '--faq-heading-size' },
+        { selectors: ['.stats__heading'], slot: '--stats-title-size' },
+        { selectors: ['.table-section__heading'], slot: '--table-section-heading-size' },
+        { selectors: ['.logos__heading'], slot: '--logos-heading-size' },
+        { selectors: ['.embed__heading'], slot: '--embed-heading-size' },
+        { selectors: ['.testimonials__heading'], slot: '--testimonials-heading-size' },
+    ];
+
+    // 1. Every band-heading font-size routes through its slot AND falls back to the
+    //    shared --pp-band-heading-size — at every declaration site (base + premium).
+    test.each(BAND_HEADINGS)('$slot heading routes font-size through its slot to var(--pp-band-heading-size)', ({ selectors, slot }) => {
+        // Per-selector (not summed): EACH listed selector must carry at least one
+        // font-size declaration AND every such declaration must route the slot to
+        // the shared scale. A summed count would let one selector's two decls mask
+        // another selector that dropped its font-size entirely.
+        selectors.forEach(sel => {
+            const decls = bodiesForExactSelector(sel).flatMap(b => b.match(/font-size\s*:[^;}]+/g) || []);
+            expect(decls.length, `${sel} has no font-size declaration`).toBeGreaterThanOrEqual(1);
+            decls.forEach(d => {
+                expect(d).toMatch(new RegExp('font-size\\s*:\\s*var\\(\\s*' + slot + '\\s*,\\s*var\\(\\s*--pp-band-heading-size\\s*\\)'));
+            });
+        });
+    });
+
+    // 2. `inherit` never appears as a heading font-size fallback anywhere in
+    //    components.css — this is the exact regression that shipped the 16px
+    //    collapse. Body-copy slots (e.g. --cta-body-size) may still inherit;
+    //    this pin is scoped to the band-heading slots above.
+    test('no band-heading font-size falls back to inherit', () => {
+        const stripped = stripComments(COMPONENTS_CSS);
+        const headingSlots = BAND_HEADINGS.map(h => h.slot);
+        headingSlots.forEach(slot => {
+            const re = new RegExp('font-size\\s*:\\s*var\\(\\s*' + slot + '\\s*,\\s*inherit\\s*\\)');
+            expect(stripped).not.toMatch(re);
+        });
+    });
+
+    // 3. The shared scale is actually defined in base.css as a fluid clamp with a
+    //    mobile floor >= 1.5rem (never body size) and the prior desktop ceiling,
+    //    so the routing resolves and a rename breaks these pins loudly.
+    test('base.css defines --pp-band-heading-size as a fluid clamp', () => {
+        const base = stripComments(BASE_CSS);
+        const m = base.match(/--pp-band-heading-size\s*:\s*clamp\(\s*([0-9.]+)rem\s*,[^,]+,\s*([0-9.]+)rem\s*\)/);
+        expect(m, 'expected --pp-band-heading-size: clamp(floor, preferred, ceiling) in base.css').not.toBeNull();
+        // Mobile floor never collapses into body size.
+        expect(parseFloat(m[1])).toBeGreaterThanOrEqual(1.5);
+        // Ceiling stays at the prior desktop-clamp ceiling.
+        expect(parseFloat(m[2])).toBeCloseTo(2.62, 2);
+    });
+
+    // 4. The former per-component heading literals are gone from components.css —
+    //    a heading that pastes a literal instead of consuming the shared scale
+    //    fails this pin. (2.25rem lived on section text-only + the desktop clamp
+    //    floor; 1.875rem on faq/stats.) The clamp(2.25rem,3vw,2.62rem) desktop
+    //    fallback is likewise fully replaced by the shared prop.
+    test('former per-heading size literals no longer appear in components.css', () => {
+        const stripped = stripComments(COMPONENTS_CSS);
+        expect(stripped).not.toMatch(/clamp\(\s*2\.25rem\s*,\s*3vw\s*,\s*2\.62rem\s*\)/);
+        expect(stripped).not.toMatch(/font-size\s*:\s*var\(\s*--[a-z-]+-(?:title|heading)-size\s*,\s*1\.875rem\s*\)/);
+        expect(stripped).not.toMatch(/font-size\s*:\s*var\(\s*--section-title-size\s*,\s*2\.25rem\s*\)/);
+    });
+});
+
 describe('CSS lint: no raw hex in components.css', () => {
     test('components.css has no raw hex color values', () => {
         const stripped = stripComments(COMPONENTS_CSS);


### PR DESCRIPTION
Closes #436

## Summary
Band headings had no working default size below 768px: section/grid/CTA titles collapsed to 16px body size on mobile (CTA at every breakpoint) because `font-size: var(--slot, inherit)` had no base value. This defines one fluid scale `--pp-band-heading-size: clamp(1.75rem, 1.48rem + 1.15vw, 2.62rem)` once in `base.css` (the issue-431 shared-property pattern) and routes every band heading's font-size fallback through its size slot to it, eliminating the `inherit` fallback.

## Scope vs acceptance criteria
- Every band h2 (section, grid, cta, faq, stats, table, testimonials, logos, embed) computes >= 1.5rem at 375w and the SAME value per breakpoint — E2E pinned at 375/768/1280.
- CTA title >= the shared step at 375/768/1280 (was 16px at all widths). CTA joins the shared step, not a smaller one — the recorded-decision default; no 7A was needed.
- `--cta-title-size: 60px` and every sibling slot still win at mobile and desktop — E2E render proof.
- No `font-size: var(--*, inherit)` remains on any heading (css-lint pins this).
- Regression pin: no band h2 equals the body font size at any tested viewport.
- New authorable `--table-section-heading-size` / `--logos-heading-size` / `--embed-heading-size` / `--testimonials-heading-size` slots (schema + `pp_render_style_vars` wired into the three previously slot-less templates), so those band headings are size-authorable like the others. Total per-instance slots: 200 across 10 components.

## Intended visual changes (CHANGELOG'd)
- Mobile: section/grid/cta titles 16px -> ~28px; CTA rises at every width. Core fix.
- Desktop: stats/table/testimonials/logos/embed headings 30px -> shared step (~38-42px), joining section/grid/faq's tier.
- section/grid/faq desktop preserved at 1280px (~38.4px) and at the ceiling, but softens ~3.5px across the 768-1071px tablet band (old rule was floored flat at 36px there; the fluid scale ramps ~32.5px -> 36px). Deliberate cost of one fluid scale, disclosed in the CHANGELOG and the in-code comment.

## Accepted limitations / decisions
- Tablet-band softening above: preserving the two specified anchors (375 floor, 1280 = current desktop) was prioritized over the old flat 36px tablet floor; both plan-eng-review and the adversarial pass flagged it and it is disclosed rather than silently shipped.
- Hero's own clamp scale is out of scope (untouched).

## Validation
- PHP: `./vendor/bin/phpunit` — 2057 tests, 0 failures (warnings match baseline).
- JS: `npm test` — 653 tests pass (includes the new css-lint band-heading suite).
- E2E: `style-render.spec.ts` full run — 95 pass, 0 failures (includes 4 new #436 tests; existing #305/#431/#430 green).
- `scripts/package.sh` — 5-file version sync OK; build zip deleted.

## Reviews (this session, on this diff)
- /plan-eng-review: CLEARED.
- /review: security specialist clean; testing specialist findings (slot-override coverage + per-selector lint) applied; adversarial pass found no correctness/cascade/escaping/count bug (only the disclosed tablet-band note).