### PR TITLE
v1.4.8 fix: table/logos/embed join the band-padding contract (#438)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -387,7 +387,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**200 style slots** across 10 components: hero (41), grid (36), section (36), cta (31), testimonials (26), faq (17), stats (10), embed (1), logos (1), table (1).
+**209 style slots** across 10 components: hero (41), grid (36), section (36), cta (31), testimonials (26), faq (17), stats (10), embed (4), logos (4), table (4).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.8] — 2026-07-20 — the last three band components join the shared spacing contract, so table, logos, and embed bands stop rendering lopsided (#438)
+
+**Three band-level components — the data `table`, the `logos` strip, and the `embed` block — were the last holdouts that hardcoded their own 64px vertical padding instead of consuming the theme's shared band rhythm. So while every other band rendered as a symmetric, centered block, a table/logos/embed placed after another band rendered top-heavy (about 77px on top, 64px on the bottom at desktop) — the exact lopsided shape v1.4.5 removed everywhere else. They were also the only bands an AI couldn't tune through the documented `--*-padding-*` slots, because they had none. Now all nine band components share one spacing model and one styling surface: table, logos, and embed render symmetric padding by default, gain authorable padding and heading-color style slots, and are covered by the same structural and rendered-rhythm test suites as the other six, so this exclusion can't quietly return.**
+
+This is a deliberate change to unstyled output, the same trade v1.4.4/v1.4.5 made for the other six bands: the default vertical padding of an unstyled table, logos, or embed band grows from a flat 64px to the shared symmetric tier (roughly 68–80px on desktop, ~54px on mobile), so these bands line up with their neighbors instead of sitting shorter and off-balance. Nothing about how you configure pages changed — the new slots are all optional and default to the shared rhythm. Table, logos, and embed now expose `--table-section-padding-top/bottom`, `--logos-padding-top/bottom`, and `--embed-padding-top/bottom` to set a band's own edges, each of which also governs the band's adjacent-top edge, plus `--table-section-heading-color`, `--logos-heading-color`, and `--embed-heading-color` to recolor the band heading. (The table component's slots follow its root class `.table-section`, matching the `--table-section-heading-size` slot the component already shipped.) Unset, every one of these resolves to exactly the previous color and to the shared rhythm, so a page that sets none of them changes only in the deliberate padding retune above.
+
+### Fixed
+- The `table`, `logos`, and `embed` bands now take their default vertical rhythm from the shared band-padding definition instead of a hardcoded 64px literal, so an unstyled table/logos/embed placed after another band renders equal top and bottom padding at every breakpoint instead of the old top-heavy shape. All nine band components now share one spacing model (#438).
+
+### Added
+- Authorable `--table-section-padding-top/bottom`, `--logos-padding-top/bottom`, and `--embed-padding-top/bottom` style slots, so the vertical padding of the table, logos, and embed bands can be set per instance (own edges and adjacent-top edge) like the other six band components. Authorable `--table-section-heading-color`, `--logos-heading-color`, and `--embed-heading-color` slots recolor each band's heading, defaulting to the theme text color (and to the inverted-background text color on the `dark`/`inverted` variants) so unset output is unchanged. Total per-instance style slots: 209 across 10 components (#438).
+
+### Docs
+- `AI_CONTEXT.md` and `README.md` updated to the new 209-slot / 10-component totals (#438).
+
+### Tests
+- `tests/js/css-lint.test.js` widens the shared-band-rhythm structural suite from six to nine components (own-edge and adjacent-top routing for table, logos, embed), adds a schema-token truthfulness pin (every token a schema documents resolves to a consumed CSS variable), and pins the base and inverted-variant heading-color routing for the three components. `tests/e2e/style-render.spec.ts` widens the computed symmetry and cross-component equality suites to all nine bands at 1280 and 375, and adds render proof that `--table-section-padding-top`, `--logos-padding-top`, and `--embed-padding-top` each win on the adjacent-top edge at both breakpoints (#438).
+
 ## [v1.4.7] — 2026-07-20 — band headings share one responsive scale, so section/grid/CTA titles stop collapsing to body size on mobile (#436)
 
 **Below 768px the theme had no working default size for band headings: section, grid, and CTA titles rendered at 16px — exactly body size — on every default page, and CTA titles were body-sized at every breakpoint. The `font-size: var(--slot, inherit)` pattern behind those headings had no base value, so with no per-page override the heading silently inherited body text and the visual hierarchy vanished on phones. Now every band title (section, grid, cta, faq, stats, table, testimonials, logos, embed) draws its default size from one shared, fluid scale defined once in `base.css`, so headings scale down on small screens but never collapse into body copy, and headings at the same structural level render as peers.**

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-200 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+209 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.4.0.
 
 **What exists today (v1.4.0):**
-- 12 components with schema contracts and 200 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 209 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.7-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.8-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1838,16 +1838,25 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
    ========================================================================== */
 
 .table-section {
-  padding-top: var(--space-xl);
-  padding-bottom: var(--space-xl);
+  /* Band padding joins the shared symmetric rhythm (issue 438): route each edge
+     through the component's own slot, falling back to --pp-band-padding so this
+     band agrees with every other band's own edges at every breakpoint instead of
+     hardcoding var(--space-xl) (64px), which rendered it 76.8/64 asymmetric when
+     adjacent. The adjacent-top edge routes through --pp-band-padding-adjacent-top
+     in the shared cascade below. */
+  padding-top: var(--table-section-padding-top, var(--pp-band-padding));
+  padding-bottom: var(--table-section-padding-bottom, var(--pp-band-padding));
 }
 
 .table-section__heading {
   /* Band heading joins the shared responsive scale (issue 436): route font-size
      through the component's own size slot, falling back to --pp-band-heading-size
      so this heading agrees with every other band title at every viewport instead
-     of inheriting the flat h2 element rule (30px). */
+     of inheriting the flat h2 element rule (30px). The color slot (issue 438)
+     completes the minimal band-heading surface, falling back to the h2 default
+     var(--color-text) so unset output is unchanged. */
   font-size: var(--table-section-heading-size, var(--pp-band-heading-size));
+  color: var(--table-section-heading-color, var(--color-text));
   margin-bottom: var(--space-lg);
 }
 
@@ -2485,13 +2494,16 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
    ========================================================================== */
 
 .logos {
-  padding-top: var(--space-xl);
-  padding-bottom: var(--space-xl);
+  /* Band padding joins the shared symmetric rhythm (issue 438); see .table-section. */
+  padding-top: var(--logos-padding-top, var(--pp-band-padding));
+  padding-bottom: var(--logos-padding-bottom, var(--pp-band-padding));
 }
 
 .logos__heading {
-  /* Band heading joins the shared responsive scale (issue 436). */
+  /* Band heading joins the shared responsive scale (issue 436); color slot (issue
+     438) falls back to the h2 default var(--color-text) so unset output is unchanged. */
   font-size: var(--logos-heading-size, var(--pp-band-heading-size));
+  color: var(--logos-heading-color, var(--color-text));
   margin-bottom: var(--space-lg);
 }
 
@@ -2546,7 +2558,9 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 }
 
 .logos--inverted .logos__heading {
-  color: var(--color-bg);
+  /* Route the inverted heading through the same slot (issue 438) so an explicit
+     --logos-heading-color still wins here; unset falls back to var(--color-bg). */
+  color: var(--logos-heading-color, var(--color-bg));
 }
 
 .logos--inverted .logos__label {
@@ -2560,13 +2574,16 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
    ========================================================================== */
 
 .embed {
-  padding-top: var(--space-xl);
-  padding-bottom: var(--space-xl);
+  /* Band padding joins the shared symmetric rhythm (issue 438); see .table-section. */
+  padding-top: var(--embed-padding-top, var(--pp-band-padding));
+  padding-bottom: var(--embed-padding-bottom, var(--pp-band-padding));
 }
 
 .embed__heading {
-  /* Band heading joins the shared responsive scale (issue 436). */
+  /* Band heading joins the shared responsive scale (issue 436); color slot (issue
+     438) falls back to the h2 default var(--color-text) so unset output is unchanged. */
   font-size: var(--embed-heading-size, var(--pp-band-heading-size));
+  color: var(--embed-heading-color, var(--color-text));
   margin-bottom: var(--space-lg);
 }
 
@@ -2586,7 +2603,9 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 }
 
 .embed--inverted .embed__heading {
-  color: var(--color-bg);
+  /* Route the inverted heading through the same slot (issue 438); unset falls back
+     to var(--color-bg). */
+  color: var(--embed-heading-color, var(--color-bg));
 }
 
 .embed--inverted .embed__content {
@@ -2830,8 +2849,10 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
    Routes through the shared --pp-band-padding-adjacent-top, which is pinned to
    --pp-band-padding (issue 430), so this adjacent top equals the band's own
    edges (symmetric) instead of a tighter tier. This generic catch-all also
-   covers components with no padding slot (hero, table, logos, embed), keeping
-   them on the one shared rhythm definition instead of a bare literal (issue 431).
+   covers components with no padding slot (hero) — table/logos/embed now carry
+   their own padding slots (issue 438) and route their adjacent-top edge through
+   the per-component rules in the cascade below, so only hero falls through here;
+   either way every band consumes the one shared rhythm definition (issue 431).
    ========================================================================== */
 
 @media (min-width: 768px) {
@@ -3479,6 +3500,18 @@ main .btn:focus-visible {
   main > [data-pp-component] + .testimonials {
     padding-top: var(--testimonials-padding-top, var(--pp-band-padding-adjacent-top));
   }
+  /* table/logos/embed join the per-component adjacent-top routing (issue 438) so
+     their adjacent-top edge tracks the same shared tier AND an explicit
+     --<comp>-padding-top wins on that edge too, not just their own base edges. */
+  main > [data-pp-component] + .table-section {
+    padding-top: var(--table-section-padding-top, var(--pp-band-padding-adjacent-top));
+  }
+  main > [data-pp-component] + .logos {
+    padding-top: var(--logos-padding-top, var(--pp-band-padding-adjacent-top));
+  }
+  main > [data-pp-component] + .embed {
+    padding-top: var(--embed-padding-top, var(--pp-band-padding-adjacent-top));
+  }
 }
 
 /* Own section padding, routed through each component's padding slots (issue 302).
@@ -3569,6 +3602,16 @@ main .btn {
   }
   main > [data-pp-component] + .testimonials {
     padding-top: var(--testimonials-padding-top, var(--pp-band-padding-adjacent-top));
+  }
+  /* table/logos/embed adjacent-top on mobile too (issue 438). */
+  main > [data-pp-component] + .table-section {
+    padding-top: var(--table-section-padding-top, var(--pp-band-padding-adjacent-top));
+  }
+  main > [data-pp-component] + .logos {
+    padding-top: var(--logos-padding-top, var(--pp-band-padding-adjacent-top));
+  }
+  main > [data-pp-component] + .embed {
+    padding-top: var(--embed-padding-top, var(--pp-band-padding-adjacent-top));
   }
 
   /* Own mobile padding, routed through the padding slots so a declared

--- a/components/embed/schema.json
+++ b/components/embed/schema.json
@@ -32,7 +32,10 @@
     "variant_classes": ["embed--dark", "embed--inverted"],
     "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted"],
     "style_slots": {
-      "--embed-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Section heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." }
+      "--embed-padding-top": { "type": "length", "default": "var(--pp-band-padding)", "description": "Top padding of the band. Defaults to the shared symmetric band rhythm (fluid ~68-80px desktop, ~54px mobile); set an explicit length to override." },
+      "--embed-padding-bottom": { "type": "length", "default": "var(--pp-band-padding)", "description": "Bottom padding of the band. Defaults to the shared symmetric band rhythm; set an explicit length to override." },
+      "--embed-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Section heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." },
+      "--embed-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading color. Defaults to the theme text color (inverted variant defaults to the inverted-background text color); set an explicit color to override." }
     }
   },
   "safe_to_edit": ["embed.php", "../../assets/css/components.css (COMPONENT: embed section)"],

--- a/components/logos/schema.json
+++ b/components/logos/schema.json
@@ -38,7 +38,10 @@
     "variant_classes": ["logos--dark", "logos--inverted"],
     "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted"],
     "style_slots": {
-      "--logos-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Section heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." }
+      "--logos-padding-top": { "type": "length", "default": "var(--pp-band-padding)", "description": "Top padding of the band. Defaults to the shared symmetric band rhythm (fluid ~68-80px desktop, ~54px mobile); set an explicit length to override." },
+      "--logos-padding-bottom": { "type": "length", "default": "var(--pp-band-padding)", "description": "Bottom padding of the band. Defaults to the shared symmetric band rhythm; set an explicit length to override." },
+      "--logos-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Section heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." },
+      "--logos-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading color. Defaults to the theme text color (inverted variant defaults to the inverted-background text color); set an explicit color to override." }
     }
   },
   "safe_to_edit": ["logos.php", "../../assets/css/components.css (COMPONENT: logos section)"],

--- a/components/table/schema.json
+++ b/components/table/schema.json
@@ -36,7 +36,10 @@
     "variant_classes": [],
     "tokens": ["--space-xl", "--space-2xl", "--color-border", "--color-surface"],
     "style_slots": {
-      "--table-section-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Section heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." }
+      "--table-section-padding-top": { "type": "length", "default": "var(--pp-band-padding)", "description": "Top padding of the band. Defaults to the shared symmetric band rhythm (fluid ~68-80px desktop, ~54px mobile); set an explicit length to override." },
+      "--table-section-padding-bottom": { "type": "length", "default": "var(--pp-band-padding)", "description": "Bottom padding of the band. Defaults to the shared symmetric band rhythm; set an explicit length to override." },
+      "--table-section-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Section heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." },
+      "--table-section-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading color. Defaults to the theme text color; set an explicit color to override." }
     }
   },
   "safe_to_edit": ["table.php", "../../assets/css/components.css (COMPONENT: table section)"],

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.7');
+define('PP_VERSION', '1.4.8');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.7
+Stable tag: 1.4.8
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.7
+Version:          1.4.8
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -3083,13 +3083,14 @@ test.describe('#369 --btn-radius rendered proof (real WP)', () => {
 /**
  * Computed-rhythm proof for the shared section-band spacing model (issue 431).
  *
- * The six band-level components (section, grid, cta, stats, faq, testimonials)
- * used to hard-code their own vertical-padding literals per component per media
- * block, so they disagreed: stats/testimonials sat at 64px while section/grid/faq
- * were 76.8px on desktop, cta stayed 68px on mobile, and testimonials was missing
- * from BOTH adjacent-sibling routing lists (its --testimonials-padding-top slot was
- * dead on the adjacent-top edge). This suite proves, at the rendered level, that all
- * six now consume ONE shared rhythm definition (--pp-band-padding for a band's own
+ * The band-level components used to hard-code their own vertical-padding literals
+ * per component per media block, so they disagreed: stats/testimonials sat at 64px
+ * while section/grid/faq were 76.8px on desktop, cta stayed 68px on mobile, and
+ * testimonials was missing from BOTH adjacent-sibling routing lists (its
+ * --testimonials-padding-top slot was dead on the adjacent-top edge). Issue 438
+ * folded the last three holdouts (table, logos, embed) into the same contract, so
+ * this suite now measures all NINE bands. It proves, at the rendered level, that all
+ * nine consume ONE shared rhythm definition (--pp-band-padding for a band's own
  * edges, --pp-band-padding-adjacent-top for a band that follows another band):
  *
  *   - every band reports identical unset padding-top AND padding-bottom (both
@@ -3108,7 +3109,15 @@ test.describe('#369 --btn-radius rendered proof (real WP)', () => {
 test.describe('Shared section-band rhythm (#431)', () => {
   let pageId: number;
 
-  const BANDS = ['section', 'grid', 'cta', 'stats', 'faq', 'testimonials'] as const;
+  // Nine bands: issue 438 folded table/logos/embed into the shared rhythm contract.
+  const BANDS = ['section', 'grid', 'cta', 'stats', 'table', 'testimonials', 'logos', 'embed', 'faq'] as const;
+
+  // Band -> root class. All map 1:1 EXCEPT table, whose root class is .table-section.
+  const BAND_CLASS: Record<string, string> = {
+    section: 'section', grid: 'grid', cta: 'cta', stats: 'stats',
+    table: 'table-section', testimonials: 'testimonials', logos: 'logos',
+    embed: 'embed', faq: 'faq',
+  };
 
   // Hero first so all six bands render in the adjacent-sibling position (their
   // top edges are then the same tier and directly comparable). Minimal valid
@@ -3130,12 +3139,15 @@ test.describe('Shared section-band rhythm (#431)', () => {
     { component: 'grid', props: { id: 'pp-grid01', title: 'Grid', items: [{ title: 'One', text: 'A' }] } },
     { component: 'cta', props: { id: 'pp-cta01', title: 'CTA', button_text: 'Go', button_url: '/go' } },
     { component: 'stats', props: { id: 'pp-stats01', items: [{ number: '10', label: 'Ten' }] } },
+    { component: 'table', props: { id: 'pp-tbl01', title: 'Table', headers: ['A', 'B'], rows: [['1', '2']] } },
     { component: 'testimonials', props: { id: 'pp-tst01', items: [{ quote: 'It works.', author: 'A' }] } },
+    { component: 'logos', props: { id: 'pp-logo01', title: 'Logos', items: [{ image_url: 'https://example.com/l.png', image_alt: 'Logo' }] } },
+    { component: 'embed', props: { id: 'pp-emb01', title: 'Embed', content: 'https://example.com/video' } },
     { component: 'faq', props: { id: 'pp-faq01', items: [{ question: 'Q?', answer: 'A.' }] } },
   ];
 
   async function bandPadding(page: any, band: string) {
-    return page.locator(`main > .${band === 'stats' ? 'stats' : band}`).evaluate((el: Element) => {
+    return page.locator(`main > .${BAND_CLASS[band]}`).evaluate((el: Element) => {
       const cs = getComputedStyle(el);
       return { top: cs.paddingTop, bottom: cs.paddingBottom };
     });
@@ -3154,7 +3166,7 @@ test.describe('Shared section-band rhythm (#431)', () => {
 
   // Core scenario: every band agrees on unset padding at BOTH breakpoints. This is
   // the heart of #431 — one spacing model, no per-component drift, testimonials in.
-  test('#431 all six bands report identical unset padding-top and padding-bottom at 1280 and 375 @smoke', async ({
+  test('#431 all nine bands report identical unset padding-top and padding-bottom at 1280 and 375 @smoke', async ({
     page,
   }) => {
     pageId = createPage('E2E Shared Band Rhythm Equality');
@@ -3163,7 +3175,7 @@ test.describe('Shared section-band rhythm (#431)', () => {
     for (const width of [1280, 375]) {
       await page.setViewportSize({ width, height: 900 });
       await page.goto(`/?page_id=${pageId}`);
-      await expect(page.locator('main > .testimonials')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('main > .faq')).toBeVisible({ timeout: 10000 });
 
       const measured: Record<string, { top: string; bottom: string }> = {};
       for (const band of BANDS) {
@@ -3177,7 +3189,7 @@ test.describe('Shared section-band rhythm (#431)', () => {
       expect(tops.every((t) => t && t !== '0px'), `tops @${width}: ${JSON.stringify(measured)}`).toBe(true);
       expect(bottoms.every((b) => b && b !== '0px'), `bottoms @${width}: ${JSON.stringify(measured)}`).toBe(true);
 
-      // The invariant: all six share one top tier and one bottom tier. Compare
+      // The invariant: all nine share one top tier and one bottom tier. Compare
       // component-to-component (not to a hardcoded px) so #430 can retune freely.
       expect(new Set(tops).size, `padding-top drift @${width}: ${JSON.stringify(measured)}`).toBe(1);
       expect(new Set(bottoms).size, `padding-bottom drift @${width}: ${JSON.stringify(measured)}`).toBe(1);
@@ -3235,7 +3247,10 @@ test.describe('Shared section-band rhythm (#431)', () => {
       { component: 'grid', props: { id: 'pp-grid01', title: 'Grid', items: [{ title: 'One', text: 'A' }] } },
       { component: 'cta', props: { id: 'pp-cta01', title: 'CTA', button_text: 'Go', button_url: '/go' } },
       { component: 'stats', props: { id: 'pp-stats01', items: [{ number: '10', label: 'Ten' }] } },
+      { component: 'table', props: { id: 'pp-tbl01', title: 'Table', headers: ['A', 'B'], rows: [['1', '2']] } },
       { component: 'testimonials', props: { id: 'pp-tst01', items: [{ quote: 'It works.', author: 'A' }] } },
+      { component: 'logos', props: { id: 'pp-logo01', title: 'Logos', items: [{ image_url: 'https://example.com/l.png', image_alt: 'Logo' }] } },
+      { component: 'embed', props: { id: 'pp-emb01', title: 'Embed', content: 'https://example.com/video' } },
       { component: 'faq', props: { id: 'pp-faq01', items: [{ question: 'Q?', answer: 'A.' }] } },
     ];
     setComposition(pageId, bandLed);
@@ -3257,8 +3272,8 @@ test.describe('Shared section-band rhythm (#431)', () => {
     expect(first.bottom, 'first band own-bottom did not follow --pp-band-padding').toBe('5px');
 
     // Every band's own bottom follows --pp-band-padding; every ADJACENT band's top
-    // follows --pp-band-padding-adjacent-top. Proves both shared props drive all six.
-    for (const band of ['grid', 'cta', 'stats', 'testimonials', 'faq']) {
+    // follows --pp-band-padding-adjacent-top. Proves both shared props drive all nine.
+    for (const band of ['grid', 'cta', 'stats', 'table', 'testimonials', 'logos', 'embed', 'faq']) {
       const { top, bottom } = await bandPadding(page, band);
       expect(bottom, `${band} own-bottom did not follow --pp-band-padding`).toBe('5px');
       expect(top, `${band} adjacent-top did not follow --pp-band-padding-adjacent-top`).toBe('7px');
@@ -3290,7 +3305,7 @@ test.describe('Shared section-band rhythm (#431)', () => {
     for (const width of [1280, 375]) {
       await page.setViewportSize({ width, height: 900 });
       await page.goto(`/?page_id=${pageId}`);
-      await expect(page.locator('main > .testimonials')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('main > .faq')).toBeVisible({ timeout: 10000 });
 
       for (const band of BANDS) {
         const { top, bottom } = await bandPadding(page, band);
@@ -3411,6 +3426,47 @@ test.describe('Shared section-band rhythm (#431)', () => {
       expect(paddingTop, `adjacent-top slot override @${width}`).toBe('5px');
     }
   });
+
+  // Issue 438: the three newly-minted band padding slots must each win on the
+  // ADJACENT-top edge (the trickiest cascade case) at both breakpoints, exactly
+  // like cta above. A section leads so the target renders in the adjacent position;
+  // a distinct px per component (no token resolves to it) catches a fallback leak
+  // or a cross-wired slot name. This is the render-level proof that the slot the
+  // schema declares reaches the DOM through pp_render_style_vars.
+  const NEW_BAND_SLOTS = [
+    { comp: 'table', sel: '.table-section', slot: '--table-section-padding-top', px: '5px',
+      props: { id: 'pp-tbl01', title: 'Table', headers: ['A', 'B'], rows: [['1', '2']] } },
+    { comp: 'logos', sel: '.logos', slot: '--logos-padding-top', px: '6px',
+      props: { id: 'pp-logo01', title: 'Logos', items: [{ image_url: 'https://example.com/l.png', image_alt: 'Logo' }] } },
+    { comp: 'embed', sel: '.embed', slot: '--embed-padding-top', px: '7px',
+      props: { id: 'pp-emb01', title: 'Embed', content: 'https://example.com/video' } },
+  ];
+
+  for (const { comp, sel, slot, px, props } of NEW_BAND_SLOTS) {
+    test(`#438 ${slot} wins on an adjacent ${comp} band at 1280 and 375`, async ({ page }) => {
+      pageId = createPage(`E2E Adjacent Slot ${comp}`);
+      setComposition(pageId, [
+        { component: 'section', props: { id: 'pp-sec01', body: '<p>Body.</p>' } },
+        { component: comp, props },
+      ]);
+
+      await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+      await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+      // component_index 1 = the target band (index 0 is the leading section).
+      const res = await styleComponent(page, pageId, { [slot]: px }, undefined, 1);
+      expect(res.success, `${slot} set: ${JSON.stringify(res)}`).toBe(true);
+
+      for (const width of [1280, 375]) {
+        await page.setViewportSize({ width, height: 900 });
+        await page.goto(`/?page_id=${pageId}`);
+        const band = page.locator(`main > ${sel}`);
+        await expect(band).toBeVisible({ timeout: 10000 });
+        const paddingTop = await band.evaluate((el) => getComputedStyle(el).paddingTop);
+        expect(paddingTop, `${slot} adjacent-top override @${width}`).toBe(px);
+      }
+    });
+  }
 });
 
 test.describe('Band heading scale (#436)', () => {

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -1732,7 +1732,21 @@ describe('CSS lint: premium layer honors padding/type/width slots (#302)', () =>
  *      so a rename breaks these pins loudly instead of silently no-op'ing.
  */
 describe('CSS lint: section-level bands share one rhythm definition (#431)', () => {
-    const BAND_COMPONENTS = ['section', 'grid', 'cta', 'stats', 'faq', 'testimonials'];
+    // Nine bands (issue 438 folded table/logos/embed into the contract). Each entry
+    // carries its root class AND slot prefix because table's class (.table-section)
+    // and slot prefix (--table-section) differ from the component name — a naive
+    // `--${comp}-` derivation would assert against a nonexistent `.table` selector.
+    const BAND_COMPONENTS = [
+        { comp: 'section', cls: '.section', slot: '--section' },
+        { comp: 'grid', cls: '.grid', slot: '--grid' },
+        { comp: 'cta', cls: '.cta', slot: '--cta' },
+        { comp: 'stats', cls: '.stats', slot: '--stats' },
+        { comp: 'faq', cls: '.faq', slot: '--faq' },
+        { comp: 'testimonials', cls: '.testimonials', slot: '--testimonials' },
+        { comp: 'table', cls: '.table-section', slot: '--table-section' },
+        { comp: 'logos', cls: '.logos', slot: '--logos' },
+        { comp: 'embed', cls: '.embed', slot: '--embed' },
+    ];
 
     // Brace-matched extraction of every rule whose selector is EXACTLY `selector`
     // (whitespace-normalized), across all media contexts. Same technique as the
@@ -1761,16 +1775,16 @@ describe('CSS lint: section-level bands share one rhythm definition (#431)', () 
 
     // 1. Own padding: every padding-top/bottom on each band's root routes through
     //    the component slot AND falls back to the shared --pp-band-padding.
-    test.each(BAND_COMPONENTS)('%s own padding routes through its slot to var(--pp-band-padding)', (comp) => {
-        const bodies = bodiesForExactSelector('.' + comp);
+    test.each(BAND_COMPONENTS)('$comp own padding routes through its slot to var(--pp-band-padding)', ({ cls, slot }) => {
+        const bodies = bodiesForExactSelector(cls);
         ['padding-top', 'padding-bottom'].forEach(prop => {
-            const slot = `--${comp}-${prop === 'padding-top' ? 'padding-top' : 'padding-bottom'}`;
+            const slotName = `${slot}-${prop}`;
             const decls = bodies.flatMap(b => b.match(new RegExp(prop + '\\s*:[^;}]+', 'g')) || []);
             // At least the base rule declares each edge — a drift to a different
             // selector can't make this vacuously pass.
             expect(decls.length).toBeGreaterThanOrEqual(1);
             decls.forEach(d => {
-                expect(d).toMatch(new RegExp(prop + '\\s*:\\s*var\\(\\s*' + slot + '\\s*,\\s*var\\(\\s*--pp-band-padding\\s*\\)'));
+                expect(d).toMatch(new RegExp(prop + '\\s*:\\s*var\\(\\s*' + slotName + '\\s*,\\s*var\\(\\s*--pp-band-padding\\s*\\)'));
             });
         });
     });
@@ -1778,13 +1792,13 @@ describe('CSS lint: section-level bands share one rhythm definition (#431)', () 
     // 2. Adjacent-top: every band (testimonials included) routes its adjacent-top
     //    edge through the slot to the shared --pp-band-padding-adjacent-top, at both
     //    breakpoints. The dead --testimonials-padding-top slot is resurrected here.
-    test.each(BAND_COMPONENTS)('adjacent %s routes top-padding to var(--pp-band-padding-adjacent-top) at both breakpoints', (comp) => {
-        const bodies = bodiesForExactSelector('main > [data-pp-component] + .' + comp);
+    test.each(BAND_COMPONENTS)('adjacent $comp routes top-padding to var(--pp-band-padding-adjacent-top) at both breakpoints', ({ cls, slot }) => {
+        const bodies = bodiesForExactSelector('main > [data-pp-component] + ' + cls);
         const decls = bodies.flatMap(b => b.match(/padding-top\s*:[^;}]+/g) || []);
         // Desktop + mobile adjacent rules both exist.
         expect(decls.length).toBeGreaterThanOrEqual(2);
         decls.forEach(d => {
-            expect(d).toMatch(new RegExp('padding-top\\s*:\\s*var\\(\\s*--' + comp + '-padding-top\\s*,\\s*var\\(\\s*--pp-band-padding-adjacent-top\\s*\\)'));
+            expect(d).toMatch(new RegExp('padding-top\\s*:\\s*var\\(\\s*' + slot + '-padding-top\\s*,\\s*var\\(\\s*--pp-band-padding-adjacent-top\\s*\\)'));
         });
     });
 
@@ -1798,9 +1812,10 @@ describe('CSS lint: section-level bands share one rhythm definition (#431)', () 
         expect(stripped).not.toContain('3.35rem');
     });
 
-    // 3b. The generic adjacent catch-all (components with no padding slot: hero,
-    //     table, logos, embed) also consumes the shared adjacent-top, not a literal,
-    //     so nothing routes rhythm outside the one definition.
+    // 3b. The generic adjacent catch-all (the only slot-less band left is hero, after
+    //     issue 438 gave table/logos/embed their own padding slots) also consumes the
+    //     shared adjacent-top, not a literal, so nothing routes rhythm outside the one
+    //     definition.
     test('the generic adjacent-sibling rule routes through --pp-band-padding-adjacent-top', () => {
         const bodies = bodiesForExactSelector('main > [data-pp-component] + [data-pp-component]');
         expect(bodies.length).toBeGreaterThanOrEqual(2); // desktop + mobile
@@ -1960,6 +1975,105 @@ describe('CSS lint: band-level headings share one responsive scale (#436)', () =
         expect(stripped).not.toMatch(/clamp\(\s*2\.25rem\s*,\s*3vw\s*,\s*2\.62rem\s*\)/);
         expect(stripped).not.toMatch(/font-size\s*:\s*var\(\s*--[a-z-]+-(?:title|heading)-size\s*,\s*1\.875rem\s*\)/);
         expect(stripped).not.toMatch(/font-size\s*:\s*var\(\s*--section-title-size\s*,\s*2\.25rem\s*\)/);
+    });
+});
+
+/**
+ * Schema/token truthfulness pin (#438). Every global token a component schema
+ * lists in `styling.tokens` must actually be CONSUMED as `var(--token …)`
+ * somewhere in the theme CSS — otherwise the schema documents a styling surface
+ * the renderer never reads. The #438 audit found logos already truthful (it lists
+ * --space-2xl/3xl, consumed by the shared data-pp-spacing rules, not its own
+ * block), so the check is a GLOBAL consumption scan across components/base/
+ * utilities CSS, not block-scoped. A schema that adds a token no rule reads, or a
+ * CSS edit that drops the last consumer of a listed token, fails here loudly.
+ */
+describe('CSS lint: schema styling.tokens resolve to a consumed var (#438)', () => {
+    const ALL_CSS = stripComments(COMPONENTS_CSS) + '\n' +
+        stripComments(BASE_CSS) + '\n' + stripComments(UTILITIES_CSS);
+
+    // Auto-discover every component schema so a new component is covered without
+    // touching this list (same posture as StyleSlotContractTest discovery).
+    const componentsDir = path.resolve(__dirname, '../../components');
+    const schemaTokens = [];
+    fs.readdirSync(componentsDir, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .forEach(d => {
+            const schemaPath = path.join(componentsDir, d.name, 'schema.json');
+            if (!fs.existsSync(schemaPath)) return;
+            const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
+            const tokens = schema.styling?.tokens || [];
+            tokens.forEach(token => schemaTokens.push({ component: d.name, token }));
+        });
+
+    // Fail-closed floor: if discovery breaks (moved dir, renamed schemas), the
+    // per-token loop would pass vacuously over an empty list.
+    test('discovery finds schema tokens to check', () => {
+        expect(schemaTokens.length).toBeGreaterThanOrEqual(10);
+    });
+
+    test.each(schemaTokens)('$component token $token is consumed as var(--…) in the theme CSS', ({ token }) => {
+        // Every token is a custom property; assert it appears in a var() consumption
+        // (var(--token) or var(--token, fallback)) somewhere in the theme CSS.
+        const re = new RegExp('var\\(\\s*' + token.replace(/[-]/g, '\\$&') + '\\s*[,)]');
+        expect(ALL_CSS).toMatch(re);
+    });
+});
+
+/**
+ * Band heading-color slot routing pin (#438). table/logos/embed gained a
+ * --<comp>-heading-color slot. The keystone StyleSlotContractTest only proves the
+ * slot is consumed SOMEWHERE in the component block (satisfied by the base rule),
+ * and the #61 dark-surface guard's variant whitelist excludes logos/embed — so a
+ * revert of the INVERTED-variant heading color to a hardcoded literal would leave
+ * every other test green while silently killing the slot on the inverted variant.
+ * This pins both the base rule (fallback var(--color-text), the h2 default, so unset
+ * output is unchanged) AND the inverted-variant rules (fallback var(--color-bg)).
+ */
+describe('CSS lint: band heading-color slots route through the slot (#438)', () => {
+    // Brace-matched extraction of every rule whose selector is EXACTLY `selector`.
+    // Same technique as the #431 suite; the `[{};,]` prefix isolates the base
+    // `.logos__heading` rule from the descendant `.logos--inverted .logos__heading`.
+    function bodiesForExactSelector(selector) {
+        const css = stripComments(COMPONENTS_CSS).replace(/\s+/g, ' ');
+        const re = new RegExp(
+            '[{};,]\\s*' + selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\{',
+            'g'
+        );
+        const bodies = [];
+        let match;
+        while ((match = re.exec(css)) !== null) {
+            let i = re.lastIndex;
+            let depth = 1;
+            const start = i;
+            while (i < css.length && depth > 0) {
+                if (css[i] === '{') depth++;
+                else if (css[i] === '}') depth--;
+                i++;
+            }
+            bodies.push(css.slice(start, i - 1));
+        }
+        return bodies;
+    }
+
+    // selector, its heading-color slot, and the fallback that preserves unset output.
+    const HEADING_COLOR_RULES = [
+        { selector: '.table-section__heading', slot: '--table-section-heading-color', fallback: '--color-text' },
+        { selector: '.logos__heading', slot: '--logos-heading-color', fallback: '--color-text' },
+        { selector: '.embed__heading', slot: '--embed-heading-color', fallback: '--color-text' },
+        { selector: '.logos--inverted .logos__heading', slot: '--logos-heading-color', fallback: '--color-bg' },
+        { selector: '.embed--inverted .embed__heading', slot: '--embed-heading-color', fallback: '--color-bg' },
+    ];
+
+    test.each(HEADING_COLOR_RULES)('$selector routes color through $slot to var($fallback)', ({ selector, slot, fallback }) => {
+        const bodies = bodiesForExactSelector(selector);
+        expect(bodies.length, `no exact rule for ${selector}`).toBeGreaterThanOrEqual(1);
+        const colorDecls = bodies.flatMap(b => b.match(/color\s*:[^;}]+/g) || [])
+            .filter(d => /^\s*color\s*:/.test(d)); // exclude background-color etc.
+        expect(colorDecls.length, `${selector} declares no color`).toBeGreaterThanOrEqual(1);
+        colorDecls.forEach(d => {
+            expect(d).toMatch(new RegExp('color\\s*:\\s*var\\(\\s*' + slot + '\\s*,\\s*var\\(\\s*' + fallback + '\\s*\\)'));
+        });
     });
 });
 


### PR DESCRIPTION
Closes #438

Third issue of the v1.5.0 default-quality gate. Brings the last three band-level components — `table` (`.table-section`), `logos`, `embed` — into the shared band-padding contract that the other six bands already consume (issues 430/431/436), so all nine band components now share one spacing model and one styling surface. The heading-**size** half shipped in #436; this completes the **padding** half plus heading-color slots and contract membership.

## Scope (vs acceptance criteria)
- **Symmetric unset padding across nine bands** — `.table-section`/`.logos`/`.embed` own edges now route `var(--<comp>-padding-top/bottom, var(--pp-band-padding))` (both breakpoints); adjacent-top routes through the slot to `var(--pp-band-padding-adjacent-top)` in both the desktop and mobile adjacent lists. Replaces the hardcoded `var(--space-xl)` (64px) that rendered them 76.8/64 asymmetric when adjacent.
- **Slot-override wins on both breakpoints incl. adjacent-top** — new `--table-section-padding-*`, `--logos-padding-*`, `--embed-padding-*` slots; proven at 375/1280 by new E2E specs.
- **Lint/E2E enumerate nine bands** — css-lint shared-rhythm suite widened 6→9 (own + adjacent routing); E2E symmetry (#430) + equality (#431) widened to nine.
- **Heading-color slots** (minimal-slot-set: padding + heading size/color) — `--table-section-heading-color`, `--logos-heading-color`, `--embed-heading-color`, fallback `var(--color-text)` (and `var(--color-bg)` on the inverted variants), byte-identical unset output.
- **Schemas + docs** — three schemas' `style_slots` updated; `AI_CONTEXT.md`/`README.md` slot totals 200→209 (table/logos/embed 1→4 each).
- **Schema/token truthfulness test** — new css-lint pin: every token in a schema `styling.tokens` resolves to a consumed `var()` in CSS.

## Slot-naming decision (recorded)
The issue's illustrative example wrote `--table-padding-*`, but table's slots are named `--table-section-padding-*` / `--table-section-heading-color`. The issue explicitly deferred this ("confirm against existing naming precedent"): all 10 components prefix slots by their `root_class`, and #436 already shipped `--table-section-heading-size`, so `--table-section-*` is the internally consistent, precedent-following name. logos/embed use `--logos-*` / `--embed-*` (class == component). The E2E acceptance test uses `--table-section-padding-top` in place of the issue's illustrative `--table-padding-top`.

## Deliberate visual change (CHANGELOG'd)
Unset padding of table/logos/embed shifts from a flat 64px to the shared symmetric tier (~68–80px desktop, ~54px mobile), the same treatment #431 gave cta/stats/testimonials. All optional slots default to the shared rhythm; unset color output is unchanged.

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` — 2057 pass (warnings/deprecations 3/2, identical to baseline). Keystone `StyleSlotContractTest` auto-discovers and enforces the new slots; `SchemaValidationTest` enforces the 209 total + breakdown.
- `npm test` (vitest) — 734 pass, incl. the widened nine-band css-lint suite, schema-token pin, and heading-color pins.
- Playwright E2E on wp-env (WordPress 7.0): band-rhythm suite 11/11 (nine-band symmetry/equality + three new slot-override specs) and heading-scale suite 4/4 pass.

## gstack workflows
- `/plan-eng-review` — CLEARED, 0 findings.
- `/review` — 0 critical; 1 informational fixed (heading-color inverted-variant routing had no guard → added a css-lint pin so a revert to a hardcoded color can't pass silently). Codex adversarial pass hung with no output; fell back to the Claude adversarial subagent per the Codex playbook (ran the real suites, APPROVE).

## Accepted limitation / follow-up (not in scope)
The six older band schemas declare `"default": "var(--space-xl)"` on their padding slots though their CSS routes through `--pp-band-padding` (pre-existing since #431); the three new slots correctly declare `var(--pp-band-padding)`. Reconciling the six older defaults is a separate follow-up.
