### PR TITLE
v1.4.9 fix: data-pp-spacing hero after another band — mobile adjacent rule shaved top-only (#434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.9] — 2026-07-20 — a compact or spacious hero placed after another band renders even top and bottom padding on mobile again (#434)
+
+**A hero carrying `spacing: compact` or `spacing: spacious` is supposed to read as a centered block: the same padding on top as on the bottom. That held on desktop, but on phones (viewports up to 767px) it broke whenever the hero followed another band. The top edge got shaved down to the normal between-band rhythm while the bottom kept the full spacing value, so a spacious hero rendered about 54px on top and 112px on the bottom — visibly bottom-heavy. Now the explicit spacing override wins both edges at every breakpoint, exactly as it always did on desktop, so a spaced hero is symmetric no matter where it sits on the page.**
+
+The desktop stylesheet already restated the spacing override at higher specificity so it beat the between-band rhythm; the mobile stylesheet never did, so the generic mobile rhythm rule won the top edge alone. The fix mirrors the desktop restatement into the mobile breakpoint, setting both edges to the mobile spacing tier (compact stays 32px, spacious stays 112px). Nothing about how you configure pages changed: only a `compact`/`spacious` hero placed after another band on mobile is affected, and only its top edge moves — up, to match its own bottom.
+
+### Fixed
+- On mobile (≤767px), a hero with `spacing: compact` or `spacing: spacious` placed after another band-level component now renders equal top and bottom padding instead of a shaved top edge, matching desktop behavior and the symmetric intent of the spacing override (#434).
+
+### Tests
+- `tests/e2e/style-render.spec.ts` adds a rendered-symmetry case for a spaced hero in the adjacent (after-another-band) position, asserting exact per-breakpoint padding values (compact 32px, spacious 112px at 375px / 160px at 1280px) so a "both edges wrong" regression can't pass on symmetry alone. `tests/js/css-lint.test.js` pins the mobile spacing restatement inside the `max-width:767px` block, after the adjacent-rhythm rule, on the correct per-breakpoint tier (#434).
+
 ## [v1.4.8] — 2026-07-20 — the last three band components join the shared spacing contract, so table, logos, and embed bands stop rendering lopsided (#438)
 
 **Three band-level components — the data `table`, the `logos` strip, and the `embed` block — were the last holdouts that hardcoded their own 64px vertical padding instead of consuming the theme's shared band rhythm. So while every other band rendered as a symmetric, centered block, a table/logos/embed placed after another band rendered top-heavy (about 77px on top, 64px on the bottom at desktop) — the exact lopsided shape v1.4.5 removed everywhere else. They were also the only bands an AI couldn't tune through the documented `--*-padding-*` slots, because they had none. Now all nine band components share one spacing model and one styling surface: table, logos, and embed render symmetric padding by default, gain authorable padding and heading-color style slots, and are covered by the same structural and rendered-rhythm test suites as the other six, so this exclusion can't quietly return.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.8-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.9-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -3614,6 +3614,25 @@ main .btn {
     padding-top: var(--embed-padding-top, var(--pp-band-padding-adjacent-top));
   }
 
+  /* An explicit data-pp-spacing override (only hero emits it) must govern BOTH
+     edges symmetrically at mobile, exactly as the desktop restatement does (the
+     min-width:768px block by the base spacing rules). Without this restatement the
+     generic adjacent rule above [0,2,1] out-orders the base [data-pp-spacing] rules
+     [0,2,0] and shaves ONLY the top edge of a spaced hero placed after another band,
+     leaving top=band-rhythm / bottom=spacing value — a compact/spacious hero reads
+     bottom-heavy instead of centered (issue 434). Same [0,2,1] specificity as the
+     adjacent rule, placed after it so source order wins both edges. Values mirror the
+     mobile BASE rules (compact --space-lg, spacious --space-2xl), NOT the larger
+     desktop tier, so mobile spacing is unchanged except the top edge is restored. */
+  main > [data-pp-component][data-pp-spacing="compact"] {
+    padding-top: var(--space-lg);
+    padding-bottom: var(--space-lg);
+  }
+  main > [data-pp-component][data-pp-spacing="spacious"] {
+    padding-top: var(--space-2xl);
+    padding-bottom: var(--space-2xl);
+  }
+
   /* Own mobile padding, routed through the padding slots so a declared
      --*-padding-top/bottom takes effect at mobile too (issue 302). faq now routes
      through --faq-padding-top/bottom too (issue 304). Fallbacks route through the

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.8');
+define('PP_VERSION', '1.4.9');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.8
+Stable tag: 1.4.9
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.8
+Version:          1.4.9
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -3323,9 +3323,9 @@ test.describe('Shared section-band rhythm (#431)', () => {
   // --space-3xl desktop). Only hero.php emits data-pp-spacing, and a hero normally
   // leads the page, so each spacing variant is seeded as the SOLE component (own
   // position) — that isolates the data-pp-spacing rule from the generic
-  // adjacent-sibling band rhythm. (A data-pp-spacing hero placed AFTER another band
-  // hits a pre-existing mobile-only interaction where the adjacent rule shaves the
-  // top; that narrow corner is unchanged by issue 430 and out of its scope.)
+  // adjacent-sibling band rhythm. (The AFTER-another-band corner — where the mobile
+  // adjacent rule used to shave only the top edge — is issue 434's fix and is proven
+  // by the adjacent-position test immediately below.)
   test('#430 data-pp-spacing compact/spacious stay symmetric at 1280 and 375', async ({
     page,
   }) => {
@@ -3348,6 +3348,58 @@ test.describe('Shared section-band rhythm (#431)', () => {
         });
         expect(top && top !== '0px', `${spacing} top vacuous @${width}: ${top}`).toBe(true);
         expect(top, `${spacing} not symmetric @${width}: top=${top} bottom=${bottom}`).toBe(bottom);
+      }
+    }
+  });
+
+  // Issue 434: the narrow corner the test above isolates AWAY. A data-pp-spacing hero
+  // placed AFTER another band used to be shaved on mobile only: the generic mobile
+  // adjacent rule `main > [data-pp-component] + [data-pp-component]` [0,2,1] out-ordered
+  // the base [data-pp-spacing] rules [0,2,0] and won padding-top alone, so a spacious
+  // hero measured top=53.6px (band rhythm) / bottom=112px (--space-2xl) — bottom-heavy,
+  // not centered. Desktop was already correct (its min-width:768px restatement out-orders
+  // the desktop adjacent rule). The fix adds the mirror-image mobile restatement so an
+  // explicit spacing override wins BOTH edges at every breakpoint.
+  //
+  // A leading section puts the spaced hero in the adjacent (second) position — the exact
+  // shape the sole-component test above cannot reach. Assertions are EXACT expected values
+  // per breakpoint, not just top===bottom: a "both edges wrong" regression (e.g. both
+  // collapsing to the band rhythm) would satisfy symmetry alone, so symmetry is necessary
+  // but not sufficient. compact = --space-lg (32px) at both breakpoints; spacious =
+  // --space-2xl (112px) mobile / --space-3xl (160px) desktop.
+  const SPACING_ADJ_EXPECTED: Record<string, Record<number, string>> = {
+    compact: { 375: '32px', 1280: '32px' },
+    spacious: { 375: '112px', 1280: '160px' },
+  };
+  test('#434 data-pp-spacing hero AFTER another band stays symmetric + exact at 1280 and 375', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Spacing Attr Adjacent Symmetry');
+
+    for (const spacing of ['compact', 'spacious']) {
+      // Section leads; the spaced hero renders SECOND (adjacent position) so the mobile
+      // adjacent rule is in play against the data-pp-spacing override.
+      setComposition(pageId, [
+        { component: 'section', props: { id: 'pp-sec-lead', title: 'Lead', body: 'Lead band.' } },
+        { component: 'hero', props: { id: 'pp-hero-adj', title: 'Spacing', spacing } },
+      ]);
+
+      for (const width of [1280, 375]) {
+        await page.setViewportSize({ width, height: 900 });
+        await page.goto(`/?page_id=${pageId}`);
+        const hero = page.locator('#pp-hero-adj');
+        await expect(hero).toBeVisible({ timeout: 10000 });
+
+        const { top, bottom } = await hero.evaluate((el: Element) => {
+          const cs = getComputedStyle(el);
+          return { top: cs.paddingTop, bottom: cs.paddingBottom };
+        });
+        const expected = SPACING_ADJ_EXPECTED[spacing][width];
+        // Symmetric AND at the explicit override value — the top edge is no longer shaved
+        // to the adjacent band rhythm (the pre-fix mobile bug).
+        expect(top, `adjacent ${spacing} not symmetric @${width}: top=${top} bottom=${bottom}`).toBe(bottom);
+        expect(top, `adjacent ${spacing} top not at override value @${width}: ${top}`).toBe(expected);
+        expect(bottom, `adjacent ${spacing} bottom not at override value @${width}: ${bottom}`).toBe(expected);
       }
     }
   });

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -1706,6 +1706,87 @@ describe('CSS lint: premium layer honors padding/type/width slots (#302)', () =>
             expect(d).toMatch(new RegExp('var\\(\\s*' + slot + '\\s*,\\s*var\\(\\s*--pp-band-padding-adjacent-top\\s*\\)'));
         });
     });
+
+    // An explicit data-pp-spacing override (hero only) must win BOTH edges at EVERY
+    // breakpoint (#434). The desktop restatement `main > [data-pp-component]
+    // [data-pp-spacing="…"]` [0,2,1] out-orders the desktop adjacent rule; before #434
+    // the mobile @media block had no such restatement, so the generic mobile adjacent
+    // rule [0,2,1] shaved a spaced hero's top edge alone (top=band rhythm / bottom=
+    // spacing value) when the hero followed another band. The fix mirrors the desktop
+    // restatement into the mobile block.
+    //
+    // This pin is breakpoint- AND source-order-aware, not just "a rule with this selector
+    // exists somewhere" (which two duplicated DESKTOP bodies would satisfy). It asserts,
+    // per breakpoint media block: (1) the restatement lives INSIDE that block, (2) at
+    // mobile it appears AFTER the generic adjacent rule so source order wins both edges,
+    // (3) both edges resolve to the SAME token (symmetry), and (4) the token is the tier
+    // intended for that breakpoint. Tier is asserted by token NAME, not px value, so a
+    // retune of the --space-* scale in base.css doesn't churn this pin — only a deliberate
+    // mis-mapping (e.g. mobile spacious regressing to the desktop --space-3xl tier) fails.
+    function mediaBlocks(css, queryRe) {
+        const stripped = stripComments(css);
+        const opener = new RegExp('@media\\s*\\(' + queryRe + '\\)\\s*\\{', 'g');
+        const blocks = [];
+        let m;
+        while ((m = opener.exec(stripped)) !== null) {
+            let depth = 1;
+            let i = opener.lastIndex;
+            while (i < stripped.length && depth > 0) {
+                if (stripped[i] === '{') depth++;
+                else if (stripped[i] === '}') depth--;
+                i++;
+            }
+            blocks.push(stripped.slice(opener.lastIndex, i - 1));
+        }
+        return blocks;
+    }
+    // Returns the body of the restatement rule for `spacing` inside `block`, or null.
+    function spacingRuleBody(block, spacing) {
+        const re = new RegExp(
+            '(?:^|[}{;])\\s*main\\s*>\\s*\\[data-pp-component\\]\\[data-pp-spacing="' +
+            spacing + '"\\]\\s*\\{([^}]*)\\}'
+        );
+        const m = re.exec(block);
+        return m ? m[1] : null;
+    }
+    function assertSymmetricTier(body, selectorLabel, expectedToken) {
+        expect(body, `${selectorLabel} restatement missing`).not.toBeNull();
+        const top = body.match(/padding-top\s*:\s*var\(\s*(--space-[a-z0-9]+)\s*\)/);
+        const bot = body.match(/padding-bottom\s*:\s*var\(\s*(--space-[a-z0-9]+)\s*\)/);
+        expect(top, `${selectorLabel} must set padding-top to a --space-* token`).not.toBeNull();
+        expect(bot, `${selectorLabel} must set padding-bottom to a --space-* token`).not.toBeNull();
+        // Symmetry: both edges resolve to the same scale step (never shaved).
+        expect(top[1], `${selectorLabel} not symmetric: top=${top[1]} bottom=${bot[1]}`).toBe(bot[1]);
+        // Tier: the token intended for this breakpoint.
+        expect(top[1], `${selectorLabel} on wrong tier`).toBe(expectedToken);
+    }
+
+    test('#434 mobile block restates data-pp-spacing AFTER the adjacent rule, both edges, correct tier', () => {
+        // The one max-width:767px block that carries the restatement.
+        const mobile = mediaBlocks(COMPONENTS_CSS, 'max-width:\\s*767px').find(b => spacingRuleBody(b, 'compact') !== null);
+        expect(mobile, 'expected a max-width:767px block containing the spacing restatement').toBeTruthy();
+        // Source order: the generic adjacent rule must precede BOTH restatements so the
+        // equal-specificity [0,2,1] restatements win padding-top on a spaced adjacent hero.
+        const adjIdx = mobile.indexOf('[data-pp-component] + [data-pp-component]');
+        const compactIdx = mobile.search(/main\s*>\s*\[data-pp-component\]\[data-pp-spacing="compact"\]/);
+        const spaciousIdx = mobile.search(/main\s*>\s*\[data-pp-component\]\[data-pp-spacing="spacious"\]/);
+        expect(adjIdx, 'mobile generic adjacent rule missing').toBeGreaterThanOrEqual(0);
+        expect(compactIdx, 'mobile compact restatement must follow the adjacent rule').toBeGreaterThan(adjIdx);
+        expect(spaciousIdx, 'mobile spacious restatement must follow the adjacent rule').toBeGreaterThan(adjIdx);
+        // Mobile tier: compact=--space-lg, spacious=--space-2xl (NOT the desktop --space-3xl).
+        assertSymmetricTier(spacingRuleBody(mobile, 'compact'), 'mobile compact', '--space-lg');
+        assertSymmetricTier(spacingRuleBody(mobile, 'spacious'), 'mobile spacious', '--space-2xl');
+    });
+
+    test('#434 desktop restatement still present, both edges, correct tier', () => {
+        // The min-width:768px block that carries the restatement (unchanged by #434, pinned
+        // so a mobile-focused edit can't silently drop the desktop side it mirrors).
+        const desktop = mediaBlocks(COMPONENTS_CSS, 'min-width:\\s*768px').find(b => spacingRuleBody(b, 'compact') !== null);
+        expect(desktop, 'expected a min-width:768px block containing the spacing restatement').toBeTruthy();
+        // Desktop tier: compact=--space-lg, spacious=--space-3xl (the larger open-air tier).
+        assertSymmetricTier(spacingRuleBody(desktop, 'compact'), 'desktop compact', '--space-lg');
+        assertSymmetricTier(spacingRuleBody(desktop, 'spacious'), 'desktop spacious', '--space-3xl');
+    });
 });
 
 /**


### PR DESCRIPTION
Closes #434

## Summary
A hero carrying `data-pp-spacing="compact"` or `"spacious"`, placed **after another band-level component**, rendered asymmetric top/bottom padding at mobile (≤767px): the top edge was shaved to the between-band rhythm while the bottom kept the spacing value (measured on the issue: spacious hero → top 53.6px / bottom 112px). Desktop was already correct.

## Root cause
The mobile `@media (max-width: 767px)` block had **no** `main > [data-pp-component][data-pp-spacing="…"]` restatement. The generic mobile adjacent rule `main > [data-pp-component] + [data-pp-component]` (specificity 0,2,1) therefore out-ordered the base `[data-pp-spacing]` rules (0,2,0) and won `padding-top` alone. The desktop `@media (min-width: 768px)` block already had this restatement, which is why desktop stayed symmetric.

## Fix
Mirror the desktop restatement into the mobile block, placed **after** the generic adjacent rule so equal-specificity source order wins **both** edges. Values use the mobile base tier (`compact` = `--space-lg` / 32px, `spacious` = `--space-2xl` / 112px), not the larger desktop `--space-3xl` tier, so mobile spacing is unchanged except that the top edge is restored to match the bottom. Only a `compact`/`spacious` hero in the adjacent position on mobile is affected. `default` heroes emit no attribute and are untouched.

## Scope
- Acceptance criterion (issue #434): an explicit `data-pp-spacing` override governs BOTH edges symmetrically regardless of position, at every breakpoint — met.
- No accepted-grammar or attribute-emission change; no AI-facing doc claims invalidated (`/document-generate` found none).
- No 7A questions raised — implemented the issue's recorded fix exactly.

## Validation
- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → 2057 passing (3 warnings / 2 deprecations pre-existing, no PHP touched).
- JS: `npm test` → 736 passing (includes the new breakpoint/tier-aware css-lint pin).
- E2E: `npm run test:e2e -- --grep "data-pp-spacing|#434"` → 3 passing on wp-env; the new #434 case fails without the CSS fix (proven load-bearing) and the css-lint pin fails on a tier regression (proven non-vacuous).

## Files
- `assets/css/components.css` — mobile `data-pp-spacing` compact/spacious restatement.
- `tests/e2e/style-render.spec.ts` — #434 adjacent-position symmetry + exact-value test; updated #430 isolation note.
- `tests/js/css-lint.test.js` — breakpoint- and tier-aware mobile-restatement pin.

## Reviews (this session)
- `/plan-eng-review` — clean, no architectural blockers; stayed strict to the recorded decision.
- `/review` + adversarial (Claude subagent + Codex, diff inlined) — cascade fix correct on every axis; one convergent within-decision finding (lint-pin vacuity) fixed by strengthening the pin. Other findings refuted with evidence.

Per gate policy: not tagged/released/deployed — the maintainer does that separately (release zip is CI-built from the tag).