### PR TITLE
v1.4.11 fix: inverted-band links meet WCAG AA via on-inverted accent token (#437)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -361,7 +361,8 @@ To change a token: use `pp_execute_apply('update_design_token', ['token' => '...
 ```
 Colors:     --color-bg, --color-surface, --color-text, --color-muted,
             --color-border, --color-accent, --color-accent-hover, --color-bg-inverted
-Derived:    --color-text-secondary, --color-accent-strong, --color-border-accent, --color-surface-accent
+Derived:    --color-text-secondary, --color-accent-strong, --color-border-accent, --color-surface-accent,
+            --color-accent-on-inverted, --color-accent-on-inverted-hover
 Spacing:    --space-xs, --space-sm, --space-md, --space-lg, --space-xl, --space-2xl, --space-3xl
 Typography: --font-body, --font-heading, --font-weight-heading, --line-height-body, --line-height-heading,
             --font-mono
@@ -377,7 +378,7 @@ Text roles: --text-kicker-color, --text-kicker-size, --text-kicker-weight, --tex
 > Source of truth: the `:root` block in `assets/css/base.css`, parsed by `pp_design_tokens()`.
 > Every token above is overridable via `update_design_token`. Regenerate this list from `base.css` rather than editing it by hand — `--breakpoint-*` live in a comment and are **not** overridable.
 
-**Token families:** Changing a base token (`--color-accent` or `--color-text`) auto-derives related tokens (hover, strong, border-accent, surface-accent, text-secondary) when they have no existing override. Existing overrides are always preserved — a base change never touches them (#386). Because a preserved override keeps winning in the rendered CSS, a base change can succeed (`ok:true`) yet not be visible where that override applies. To surface this, the apply returns a `stale_warnings` entry for any preserved derived override that DIVERGES from the value the new base would derive (equal-to-derivable overrides are coherent and not flagged), and the same condition is reported at INSPECT as a `masked_derived_override` token smell. `pp_masked_derived_overrides()` is the one shared engine behind both surfaces.
+**Token families:** Changing a base token (`--color-accent` or `--color-text`) auto-derives related tokens (hover, strong, border-accent, surface-accent, on-inverted + on-inverted-hover, text-secondary) when they have no existing override. Existing overrides are always preserved — a base change never touches them (#386). Because a preserved override keeps winning in the rendered CSS, a base change can succeed (`ok:true`) yet not be visible where that override applies. To surface this, the apply returns a `stale_warnings` entry for any preserved derived override that DIVERGES from the value the new base would derive (equal-to-derivable overrides are coherent and not flagged), and the same condition is reported at INSPECT as a `masked_derived_override` token smell. `pp_masked_derived_overrides()` is the one shared engine behind both surfaces.
 
 Token overrides survive theme updates — `base.css` is overwritten on update, but overrides persist in the database. See `ai-instructions/retheme.md` for the full retheme workflow.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.11] — 2026-07-20 — links on inverted (dark) bands now meet WCAG AA by default (#437)
+
+**The default accent color is tuned for light surfaces, where it clears the WCAG AA contrast bar. On the dark "inverted" band it did not: a link in an inverted section or embed rendered at about 3.2:1 against the dark background, below the 4.5:1 minimum for body text, and inverted stats numbers looked dim for the same reason. The theme now carries a surface-paired accent — a lighter accent tint used only on inverted bands, where it measures about 8.3:1. Links in inverted sections and embeds, and inverted stats numbers, pick it up automatically. Links that sit on the light cards inside an inverted band (grid cards, FAQ panels) keep the normal accent, which is already AA on those light surfaces, so nothing there changes.**
+
+The new color is a derived token, `--color-accent-on-inverted` (plus a brighter `--color-accent-on-inverted-hover`), computed from `--color-accent` the same way the other accent-family tints are. Change your accent and the on-inverted tint re-derives with it; pin it to a custom value and, like every other derived token, you get a divergence warning if a later accent change would no longer reach it. Existing per-band color slots still win when set, and default light-band output is byte-identical.
+
+### Fixed
+- Body links inside inverted `section` and `embed` bands, and the accent-colored numbers in an inverted `stats` band, now route through a light on-inverted accent tint that meets WCAG AA against the dark band background (4.5:1 for text, well above the 3:1 large-text bar for the stats numbers) instead of the light-surface accent that measured only 3.23:1 there. Links on the light cards of an inverted grid, FAQ, or testimonials band are unchanged — the accent is already AA on those light surfaces (#437).
+
+### Added
+- `--color-accent-on-inverted` and `--color-accent-on-inverted-hover` design tokens: a surface-paired accent for the dark inverted band, auto-derived from `--color-accent` and participating in the derived-token divergence warnings. Retheme contract: if you change `--color-accent` or `--color-bg-inverted`, keep `--color-accent-on-inverted` at ≥ 4.5:1 on the inverted background (#437).
+
+### Docs
+- `ai-instructions/retheme.md` documents the surface-paired accent and its ≥ 4.5:1 pairing contract; the auto-derived accent-family count (four → six) is updated in `retheme.md` and `AI_CONTEXT.md` (#437).
+
+### Tests
+- `tests/e2e/style-render.spec.ts` seeds a body link in every inverted band that renders one and asserts the computed WCAG contrast against the link's real rendered background at 375px and 1280px: dark-band links (section, embed) clear 4.5:1, inverted stats numbers clear 3:1, and light-card links (grid, FAQ) stay on the accent and remain AA. `tests/js/css-lint.test.js` pins that each dark-band inverted variant routes its link color through the on-inverted role, and `tests/ApplyTest.php` proves the two new tokens are registered derived colors that auto-derive from `--color-accent` and surface in the masked-derived-override machinery (#437).
+
 ## [v1.4.10] — 2026-07-20 — a band placed right after an FAQ picks up the normal between-band spacing again (#432)
 
 **Every band-level component that follows another band gets a tighter, tuned top edge so stacked sections read as evenly spaced blocks. One placement quietly missed out: a band placed immediately after an FAQ. The FAQ component emits an invisible FAQPage structured-data `<script>` tag for search engines, and it was being written just after the FAQ section rather than inside it. That stray tag sat between the FAQ and the next band, and the between-band spacing rule only reaches a band whose immediate previous neighbor is another band — so the band after an FAQ fell back to its own larger top padding. The script now lives inside the FAQ section, so the FAQ is once again the next band's immediate neighbor and the spacing rule applies. Search-engine output is unchanged: the same FAQ rich-result markup is still emitted, just one line earlier in the document, which Google reads identically.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.10-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.11-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/retheme.md
+++ b/ai-instructions/retheme.md
@@ -24,7 +24,7 @@ double as the reference for what each token does.
 These are the theme's shipped color defaults. For a SITE, set these values via
 `update_design_token` instead (see the programmatic path below) — editing `base.css`
 here changes the product default and is overwritten on update. When using the
-programmatic path, changing `--color-accent` auto-derives the four accent variants and
+programmatic path, changing `--color-accent` auto-derives the six accent variants and
 changing `--color-text` auto-derives `--color-text-secondary`:
 
 ```css
@@ -40,6 +40,18 @@ changing `--color-text` auto-derives `--color-text-secondary`:
 
 **WCAG AA requirement:** `--color-accent` on `--color-bg` must have contrast ratio ≥ 4.5:1.
 Check at https://webaim.org/resources/contrastchecker/
+
+**Surface-paired accent (the inverted band).** `--color-accent` is tuned for light
+surfaces; on the dark `--color-bg-inverted` it drops to ~3.2:1 and fails AA for body
+text. Links (and dim accent text like inverted stats numbers) on inverted bands
+therefore route through `--color-accent-on-inverted` (default `#9dafee`, 8.33:1 on the
+default inverted bg) with `--color-accent-on-inverted-hover` for hover. **Pairing
+contract:** if you change `--color-accent` OR `--color-bg-inverted`, keep
+`--color-accent-on-inverted` at ≥ 4.5:1 against `--color-bg-inverted`. The programmatic
+path auto-derives it (a lightened accent tint) when you change `--color-accent` and
+leave it unpinned; a pinned on-inverted override that diverges from that derivation is
+surfaced by the same `stale_warnings` / `masked_derived_override` machinery as every
+other derived token (see below), so you are told when a base change may not reach it.
 
 Example retheme — warm neutral:
 ```css
@@ -163,4 +175,4 @@ Or from PHP: `pp_execute_apply('update_design_token', ['token' => '--color-accen
 
 The apply layer validates token names, enforces type-specific value constraints, and verifies the write via database read-back. Use this path when rethemeing programmatically (e.g. from an AI interface).
 
-**Token family derivation:** When you change `--color-accent`, four derived tokens (`--color-accent-hover`, `--color-accent-strong`, `--color-border-accent`, `--color-surface-accent`) are auto-filled if they have no existing override. Changing `--color-text` auto-derives `--color-text-secondary`. **A base-token change never touches an existing derived override** — a deliberately pinned derived value survives. That is safe for pins, but it means a base change can succeed (`ok:true`) yet have no visible effect where a stale derived override still wins (e.g. you set `--color-accent` blue but an old orange `--color-accent-strong` keeps the CTA orange). To make that visible, the apply returns a `stale_warnings` entry for any preserved derived override that **diverges** from the value the new base would derive, naming the masking token so you can decide whether to update it. A coherent override (one that already equals the derivable value) is not flagged. The same divergence is reported at INSPECT as a `masked_derived_override` token smell (see `token_smells` in `wp pp operate inspect`), so you catch it before making a change, not only after. This issue makes the state visible; it never recomputes or clobbers your derived overrides.
+**Token family derivation:** When you change `--color-accent`, six derived tokens (`--color-accent-hover`, `--color-accent-strong`, `--color-border-accent`, `--color-surface-accent`, `--color-accent-on-inverted`, `--color-accent-on-inverted-hover`) are auto-filled if they have no existing override. Changing `--color-text` auto-derives `--color-text-secondary`. **A base-token change never touches an existing derived override** — a deliberately pinned derived value survives. That is safe for pins, but it means a base change can succeed (`ok:true`) yet have no visible effect where a stale derived override still wins (e.g. you set `--color-accent` blue but an old orange `--color-accent-strong` keeps the CTA orange). To make that visible, the apply returns a `stale_warnings` entry for any preserved derived override that **diverges** from the value the new base would derive, naming the masking token so you can decide whether to update it. A coherent override (one that already equals the derivable value) is not flagged. The same divergence is reported at INSPECT as a `masked_derived_override` token smell (see `token_smells` in `wp pp operate inspect`), so you catch it before making a change, not only after. This issue makes the state visible; it never recomputes or clobbers your derived overrides.

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -25,6 +25,8 @@
   --color-accent-strong:    #2744b7;  /* color: Button gradient dark stop, strong accent borders */
   --color-border-accent:    #9dafee;  /* color: Accent-tinted borders for featured elements */
   --color-surface-accent:   #e8ecfe;  /* color: Accent-washed backgrounds, eyebrows */
+  --color-accent-on-inverted:       #9dafee;  /* color: Link/accent on the inverted (dark) band — light accent tint, 8.33:1 on --color-bg-inverted (--color-accent's 3.23:1 fails AA there) */
+  --color-accent-on-inverted-hover: #c1cdfc;  /* color: Hover state for on-inverted links — brighter tint, 11.4:1 on --color-bg-inverted */
 
   /* Spacing — the layout scale */
   --space-xs:  0.25rem;   /* length: 4px */

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1189,7 +1189,14 @@
 }
 
 .pp-section--inverted a {
-  color: var(--section-accent, var(--color-accent));
+  /* On the dark band the light-surface accent fails WCAG AA (3.23:1), so links
+     fall back to the on-inverted accent role (issue 437). An explicit
+     --section-accent slot still wins. */
+  color: var(--section-accent, var(--color-accent-on-inverted));
+}
+
+.pp-section--inverted a:hover {
+  color: var(--section-accent-hover, var(--color-accent-on-inverted-hover));
 }
 
 /* Section with background image. The dark overlay below makes this a dark surface,
@@ -2127,6 +2134,11 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   color: var(--cta-body-color, var(--color-bg));
   opacity: 0.85;
 }
+/* No .cta--inverted a link remap (issue 437): cta__body is esc_html, so an inverted
+   cta renders no body-link `a` — the only anchor is the CTA button, whose color is
+   owned by the premium `main .btn` cascade, not a link-color role. Adding a link
+   remap here would be dead CSS and, per the #61 dark-surface-slot contract, would
+   force a speculative --cta-link-color slot for a link that cannot exist. */
 
 /* CTA with background image */
 /* Same dark-overlay surface as .section--has-bg-image — same theme text default
@@ -2447,7 +2459,11 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 }
 
 .stats--inverted .stats__number {
-  color: var(--stats-number-color, var(--color-accent));
+  /* Accent-colored large text on the dark band: the light-surface accent is only
+     3.23:1 here (dim). Route the fallback through the on-inverted accent role so
+     the default clears the 3:1 large-text bar (8.33:1); an explicit
+     --stats-number-color slot still wins (issue 437). */
+  color: var(--stats-number-color, var(--color-accent-on-inverted));
 }
 
 .stats--inverted .stats__label {
@@ -2613,7 +2629,12 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 }
 
 .embed--inverted a {
-  color: var(--color-accent);
+  /* Dark-band body link → on-inverted accent role for AA (issue 437). */
+  color: var(--color-accent-on-inverted);
+}
+
+.embed--inverted a:hover {
+  color: var(--color-accent-on-inverted-hover);
 }
 
 /* ==========================================================================
@@ -2840,6 +2861,9 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 .testimonials--inverted.testimonials--stack .testimonials__author {
   color: var(--testimonials-author-color, var(--color-bg));
 }
+/* No inverted testimonials link remap (issue 437): the quote is esc_html plain text
+   and testimonials declares no link/anchor prop in either layout, so no body-link
+   `a` is ever rendered — there is no dark-band link surface to bring to AA here. */
 
 /* ==========================================================================
    SHARED: Adjacent-Sibling Rhythm

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.10');
+define('PP_VERSION', '1.4.11');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -2052,6 +2052,14 @@ function pp_token_families(): array {
             '--color-accent-strong'  => ['mix' => 'black', 'ratio' => 0.30],
             '--color-border-accent'  => ['mix' => 'white', 'ratio' => 0.55],
             '--color-surface-accent' => ['mix' => 'white', 'ratio' => 0.88],
+            // On-inverted accent roles (#437): the light-surface accent fails AA on
+            // the dark inverted band (3.23:1), so links there route through a
+            // lightened accent tint instead. Derived by mixing accent toward white
+            // so a retheme's new accent auto-produces a matching on-inverted tint;
+            // registered here so a pinned override that DIVERGES surfaces in the
+            // #386 stale-warning / masked-derived machinery like any other derived.
+            '--color-accent-on-inverted'       => ['mix' => 'white', 'ratio' => 0.55],
+            '--color-accent-on-inverted-hover' => ['mix' => 'white', 'ratio' => 0.70],
         ],
         '--color-text' => [
             '--color-text-secondary' => ['mix' => 'white', 'ratio' => 0.20],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.10
+Stable tag: 1.4.11
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.10
+Version:          1.4.11
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ApplyTest.php
+++ b/tests/ApplyTest.php
@@ -711,8 +711,9 @@ class ApplyTest extends TestCase
         $this->assertTrue($result['ok']);
         $this->assertEquals('update_design_token', $result['apply']);
         $this->assertEquals('design', $result['domain']);
-        // 1 base change + 4 derived accent family tokens auto-updated
-        $this->assertCount(5, $result['changes']);
+        // 1 base change + 6 derived accent family tokens auto-updated (#437 added
+        // --color-accent-on-inverted + --color-accent-on-inverted-hover)
+        $this->assertCount(7, $result['changes']);
         $this->assertEquals('#3157f4', $result['changes'][0]['from']);
         $this->assertEquals('#b45309', $result['changes'][0]['to']);
 
@@ -723,6 +724,8 @@ class ApplyTest extends TestCase
         $this->assertArrayHasKey('--color-accent-strong', $overrides);
         $this->assertArrayHasKey('--color-border-accent', $overrides);
         $this->assertArrayHasKey('--color-surface-accent', $overrides);
+        $this->assertArrayHasKey('--color-accent-on-inverted', $overrides);
+        $this->assertArrayHasKey('--color-accent-on-inverted-hover', $overrides);
     }
 
     public function testAccentFamilyDerivation(): void
@@ -748,6 +751,37 @@ class ApplyTest extends TestCase
 
         // Surface-accent should be very light
         $this->assertGreaterThan(200, $surface[0], 'Surface-accent should be very light');
+    }
+
+    public function testOnInvertedAccentIsRegisteredDerivedColor(): void
+    {
+        // #437: the on-inverted accent roles must be REGISTERED derived colors so
+        // (a) a retheme's new accent auto-produces matching on-inverted tints, and
+        // (b) a pinned on-inverted override that diverges surfaces in the #386
+        // masked-derived / stale-warning machinery like every other derived token.
+
+        // Registered in the --color-accent family (the divergence-detection surface).
+        $family = pp_token_families()['--color-accent'];
+        $this->assertArrayHasKey('--color-accent-on-inverted', $family);
+        $this->assertArrayHasKey('--color-accent-on-inverted-hover', $family);
+
+        // Auto-derived as a lightened accent tint when the base changes (unpinned).
+        $derived = pp_derive_family_tokens('--color-accent', '#7a4f2e');
+        $this->assertArrayHasKey('--color-accent-on-inverted', $derived);
+        $this->assertArrayHasKey('--color-accent-on-inverted-hover', $derived);
+        // "Lightened toward white" — each channel brighter than the base accent.
+        $base = _pp_hex_to_rgb('#7a4f2e');
+        $onInv = _pp_hex_to_rgb($derived['--color-accent-on-inverted']);
+        $onInvHover = _pp_hex_to_rgb($derived['--color-accent-on-inverted-hover']);
+        $this->assertGreaterThan($base[0], $onInv[0], 'on-inverted is a light tint');
+        $this->assertGreaterThan($onInv[0], $onInvHover[0], 'hover is brighter still');
+
+        // Participates in divergence detection: a pinned on-inverted override that
+        // no longer matches what the new base derives is reported as masking (#386).
+        pp_set_token_override('--color-accent-on-inverted', '#123456');
+        $masking = pp_masked_derived_overrides('--color-accent', '#7a4f2e');
+        $this->assertContains('--color-accent-on-inverted', array_column($masking, 'token'),
+            'A divergent on-inverted override must surface in the #386 masking machinery');
     }
 
     public function testTextFamilyDerivation(): void
@@ -794,8 +828,9 @@ class ApplyTest extends TestCase
         // Changes should NOT include --color-accent-strong (it was skipped)
         $changed_tokens = array_column($result['changes'], 'token');
         $this->assertNotContains('--color-accent-strong', $changed_tokens);
-        // But should include the other 3 derived + 1 base = 4 changes
-        $this->assertCount(4, $result['changes']);
+        // But should include the other 5 derived + 1 base = 6 changes (#437 grew
+        // the accent family from 4 to 6 derived tokens)
+        $this->assertCount(6, $result['changes']);
     }
 
     public function testDivergentDerivedOverrideReturnsStaleWarnings(): void
@@ -1080,13 +1115,14 @@ class ApplyTest extends TestCase
 
     public function testResetAllDesignTokensClearsAll(): void
     {
-        // Setting --color-accent also auto-derives 4 family tokens (5 total + 1 for --color-bg = 6)
+        // Setting --color-accent also auto-derives 6 family tokens (#437 grew the
+        // accent family from 4 to 6): 7 total + 1 for --color-bg = 8
         pp_execute_apply('update_design_token', ['token' => '--color-accent', 'value' => '#b45309']);
         pp_execute_apply('update_design_token', ['token' => '--color-bg', 'value' => '#000000']);
 
         $result = pp_execute_apply('reset_all_design_tokens', []);
         $this->assertTrue($result['ok']);
-        $this->assertCount(6, $result['changes']);
+        $this->assertCount(8, $result['changes']);
         $this->assertSame([], pp_get_token_overrides());
     }
 

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -3804,3 +3804,219 @@ test.describe('Band heading scale (#436)', () => {
     expect(new Set(sizes).size, `band heading drift on webfiable shape @375: ${JSON.stringify(sizes)}`).toBe(1);
   });
 });
+
+/**
+ * #437 — inverted-band link contrast (rendered proof).
+ *
+ * The default light-surface accent (--color-accent #3157f4) measures only 3.23:1
+ * on the dark inverted band (--color-bg-inverted #0f172a) and fails WCAG AA for
+ * body text. This suite seeds a real link in every inverted variant that can render
+ * one and asserts the COMPUTED contrast of the link against its actual rendered
+ * background — the stronger, surface-aware check the css-lint structural test can't
+ * make. Two truths must both hold, at 375 (mobile) and 1280 (desktop):
+ *
+ *   - Dark-band body links (section body, embed content) route through
+ *     --color-accent-on-inverted (#9dafee, ~8.3:1) → AA (>= 4.5:1).
+ *   - Light-card links (grid card link, faq answer on the light .faq__item) STAY on
+ *     --color-accent (unchanged) → still AA on the light card (~4.7:1). A naive
+ *     "remap every inverted variant" would have dropped these to ~2:1; this proves
+ *     the surface-aware scope did not touch them.
+ *
+ *   - Inverted stats numbers (large accent text on the dark band) clear the 3:1
+ *     large-text bar with the new default.
+ *
+ * Not seedable, documented: cta (cta__body is esc_html; the only anchor is the CTA
+ * button, owned by the premium `main .btn` cascade) and testimonials (quote is
+ * plain esc_html, no anchor in either grid or stack layout). Their structural
+ * remaps are pinned by tests/js/css-lint.test.js instead.
+ */
+test.describe('#437 inverted link contrast (rendered)', () => {
+  let pageId = 0;
+
+  test.afterEach(async () => {
+    if (pageId) {
+      try {
+        deletePage(pageId);
+      } catch {
+        /* already cleaned */
+      }
+      pageId = 0;
+    }
+  });
+
+  // Two assertion modes:
+  //  - 'contrast': compute the WCAG ratio against the link's rendered background and
+  //    require >= minRatio. Used where the surface is a solid painted color the probe
+  //    can read (the dark band; faq's solid light panel).
+  //  - 'staysAccent': assert the link keeps the light-surface accent (rgb(49,87,244)),
+  //    proving the surface-aware scope did NOT remap it. Used for grid, whose card
+  //    background is a subtle GRADIENT (main > .grid:not(.grid--steps) .grid__item) —
+  //    its computed background-color is transparent, so a color-vs-background probe
+  //    can't see the light card and would misread the dark band behind it. Accent on
+  //    the light card is a documented-AA pairing (~4.7:1); the regression risk this
+  //    guards is the link being remapped to the light on-inverted tint (~2:1), which a
+  //    color-identity check catches exactly.
+  type Case = {
+    name: string;
+    composition: unknown[];
+    linkSelector: string;
+    mode: 'contrast' | 'staysAccent';
+    minRatio?: number;
+    openDetails?: boolean;
+  };
+  const ACCENT_RGB = [49, 87, 244]; // --color-accent #3157f4, default palette
+
+  const cases: Case[] = [
+    {
+      name: 'section body link on the dark band → on-inverted (AA)',
+      composition: [
+        {
+          component: 'section',
+          props: {
+            id: 'pp-sec01',
+            theme: 'inverted',
+            title: 'Inverted section',
+            body: '<p>Body copy with an inline <a href="/somewhere">text link</a> to prove contrast.</p>',
+          },
+        },
+      ],
+      linkSelector: '.pp-section--inverted .section__content a',
+      mode: 'contrast',
+      minRatio: 4.5,
+    },
+    {
+      name: 'embed content link on the dark band → on-inverted (AA)',
+      composition: [
+        {
+          component: 'embed',
+          props: {
+            id: 'pp-embed01',
+            theme: 'inverted',
+            heading: 'Inverted embed',
+            content: '<p>Embedded copy with an <a href="/somewhere">embed link</a>.</p>',
+          },
+        },
+      ],
+      linkSelector: '.embed--inverted a',
+      mode: 'contrast',
+      minRatio: 4.5,
+    },
+    {
+      name: 'grid card link stays on --color-accent (light card, AA)',
+      composition: [
+        {
+          component: 'grid',
+          props: {
+            id: 'pp-grid01',
+            theme: 'inverted',
+            title: 'Inverted grid',
+            items: [
+              { title: 'Card', text: 'Card body', link_url: '/somewhere', link_text: 'card link' },
+            ],
+          },
+        },
+      ],
+      linkSelector: '.grid--inverted .grid__item-link',
+      mode: 'staysAccent',
+    },
+    {
+      name: 'faq answer link stays on --color-accent (light panel, AA)',
+      composition: [
+        {
+          component: 'faq',
+          props: {
+            id: 'pp-faq01',
+            theme: 'inverted',
+            title: 'Inverted faq',
+            items: [
+              { question: 'Question?', answer: '<p>Answer with a <a href="/somewhere">faq link</a>.</p>' },
+            ],
+          },
+        },
+      ],
+      linkSelector: '.faq--inverted .faq__answer a',
+      mode: 'contrast',
+      minRatio: 4.5,
+      openDetails: true,
+    },
+    {
+      name: 'stats number on the dark band clears the 3:1 large-text bar',
+      composition: [
+        {
+          component: 'stats',
+          props: {
+            id: 'pp-stats01',
+            theme: 'inverted',
+            title: 'Inverted stats',
+            items: [{ number: '42', label: 'Metric' }],
+          },
+        },
+      ],
+      linkSelector: '.stats--inverted .stats__number',
+      mode: 'contrast',
+      minRatio: 3.0,
+    },
+  ];
+
+  for (const c of cases) {
+    test(`${c.name} @375 + @1280`, async ({ page }) => {
+      pageId = createPage(`E2E 437 ${c.name}`);
+      setComposition(pageId, c.composition);
+
+      for (const width of [375, 1280]) {
+        await page.setViewportSize({ width, height: 900 });
+        await page.goto(`/?page_id=${pageId}`);
+        if (c.openDetails) {
+          await page.locator('.faq__item').first().evaluate((el: HTMLDetailsElement) => {
+            el.open = true;
+          });
+        }
+        await expect(page.locator(c.linkSelector).first()).toBeVisible({ timeout: 10000 });
+        // WCAG relative-luminance contrast of the link's computed text color against
+        // its EFFECTIVE background — walk ancestors past transparent links/wrappers to
+        // the first painted surface (the dark band or the light card).
+        const res = await page.evaluate((selector) => {
+          const parseRgb = (s: string): number[] => (s.match(/[\d.]+/g) || []).map(Number);
+          const lum = (rgb: number[]): number => {
+            const f = (v: number) => {
+              v /= 255;
+              return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+            };
+            return 0.2126 * f(rgb[0]) + 0.7152 * f(rgb[1]) + 0.0722 * f(rgb[2]);
+          };
+          const el = document.querySelector(selector);
+          if (!el) return { found: false, fg: [] as number[], bg: [] as number[], ratio: 0 };
+          const fg = parseRgb(getComputedStyle(el).color);
+          let node: Element | null = el;
+          let bg: number[] | null = null;
+          while (node) {
+            const p = parseRgb(getComputedStyle(node).backgroundColor);
+            // Opaque enough to be the painted surface (alpha undefined => opaque).
+            if (p.length >= 3 && (p.length < 4 || p[3] > 0.5)) {
+              bg = p;
+              break;
+            }
+            node = node.parentElement;
+          }
+          if (!bg) bg = [255, 255, 255];
+          const L1 = lum(fg);
+          const L2 = lum(bg);
+          const ratio = (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+          return { found: true, fg, bg, ratio };
+        }, c.linkSelector);
+        expect(res.found, `${c.linkSelector} not found @${width}`).toBe(true);
+        if (c.mode === 'staysAccent') {
+          expect(
+            res.fg,
+            `${c.name} @${width}: link color ${JSON.stringify(res.fg)} was remapped off --color-accent ${JSON.stringify(ACCENT_RGB)} (light-card link must stay accent)`,
+          ).toEqual(ACCENT_RGB);
+        } else {
+          expect(
+            res.ratio,
+            `${c.name} @${width}: fg=${JSON.stringify(res.fg)} bg=${JSON.stringify(res.bg)} ratio=${res.ratio?.toFixed(2)} (need >= ${c.minRatio})`,
+          ).toBeGreaterThanOrEqual(c.minRatio as number);
+        }
+      }
+    });
+  }
+});

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -2386,3 +2386,68 @@ describe('CSS lint: no ID selectors in shipped stylesheets (#412)', () => {
             .toEqual(['#home-hero .btn']);
     });
 });
+
+describe('CSS lint: inverted dark-band links route through the on-inverted accent role (#437)', () => {
+    // The light-surface accent (--color-accent) measures only 3.23:1 on the dark
+    // inverted band and fails WCAG AA for body text. Every inverted variant whose
+    // links sit DIRECTLY on the dark band must remap `a` color to the
+    // --color-accent-on-inverted role (hover → --color-accent-on-inverted-hover).
+    //
+    // Deliberately NOT enumerated here:
+    //  - Light card/panel inverted variants (grid, faq, testimonials-grid) keep their
+    //    light `.grid__item`/`.faq__item`/`.testimonials__item` background, so links
+    //    there stay on --color-accent (already AA on a light card). Routing them
+    //    through the light on-inverted tint would drop them to ~2:1. The
+    //    rendered-contrast E2E covers those directly.
+    //  - cta and testimonials render NO body-link `a` at all: cta__body and the
+    //    testimonials quote are esc_html, and neither declares a link/anchor prop.
+    //    The only inverted-cta anchor is the CTA button, owned by the premium
+    //    `main .btn` cascade. There is no dark-band link surface to remap on either.
+    const css = stripComments(COMPONENTS_CSS);
+
+    // The dark-band inverted variants that actually render body-link markup
+    // (wp_kses_post body/content): the link color routes through the on-inverted role
+    // (hover → on-inverted-hover). Buttons (.btn) are never affected — the premium
+    // `main .btn` cascade out-orders these (0,1,1) rules.
+    const DARK_BAND_LINK_VARIANTS = [
+        '.pp-section--inverted a',
+        '.embed--inverted a',
+    ];
+
+    function ruleBody(selector) {
+        const esc = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        // `a\s*\{` so the color rule is matched, never the sibling `a:hover {`.
+        const m = css.match(new RegExp(esc + '\\s*\\{([^}]*)\\}'));
+        return m ? m[1] : null;
+    }
+
+    DARK_BAND_LINK_VARIANTS.forEach(selector => {
+        test(`${selector} remaps link color to --color-accent-on-inverted`, () => {
+            const body = ruleBody(selector);
+            expect(body).not.toBeNull();
+            expect(body).toMatch(/color:\s*var\([^;]*--color-accent-on-inverted\b/);
+            // Must NOT fall back to the bare light-surface accent as the default.
+            expect(body).not.toMatch(/var\(\s*--color-accent\s*[,)]/);
+        });
+
+        test(`${selector} defines a hover routed through --color-accent-on-inverted-hover`, () => {
+            const hoverBody = ruleBody(`${selector}:hover`);
+            expect(hoverBody).not.toBeNull();
+            expect(hoverBody).toMatch(/--color-accent-on-inverted-hover\b/);
+        });
+    });
+
+    test('inverted stats numbers route the fallback through --color-accent-on-inverted', () => {
+        const esc = '.stats--inverted .stats__number'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const m = css.match(new RegExp(esc + '\\s*\\{([^}]*)\\}'));
+        expect(m).not.toBeNull();
+        // Slot still wins; the DEFAULT (fallback) is the on-inverted role, not the
+        // failing --color-accent.
+        expect(m[1]).toMatch(/var\(\s*--stats-number-color\s*,\s*var\([^;]*--color-accent-on-inverted\b/);
+    });
+
+    test('the on-inverted accent tokens are defined in base.css :root', () => {
+        expect(BASE_CSS).toMatch(/--color-accent-on-inverted:\s*#[0-9a-fA-F]{6}/);
+        expect(BASE_CSS).toMatch(/--color-accent-on-inverted-hover:\s*#[0-9a-fA-F]{6}/);
+    });
+});


### PR DESCRIPTION
Closes #437

## Scope
The default accent `#3157f4` fails WCAG AA on the dark inverted band (`--color-bg-inverted` #0f172a): links there measured **3.23:1** (< 4.5:1), and inverted stats numbers rendered dim. This adds a **surface-paired** accent and routes the dark-band link/number roles through it, applying the recorded Option B decision (surface-aware, AA per real surface).

### Implemented (per acceptance criteria)
- **Derived on-inverted accent token** — `--color-accent-on-inverted` (default `#9dafee`, **8.33:1** on the inverted bg, the value the issue named) + `--color-accent-on-inverted-hover` (`#c1cdfc`, 11.4:1). Both registered in the `--color-accent` family (`pp_token_families()`), so they auto-derive on an accent change and participate in the issue-386 divergence / stale-warning machinery like every other derived token.
- **Dark-band link remap** — `.pp-section--inverted a` (via the existing `--section-accent` slot fallback) and `.embed--inverted a`, plus hovers, now resolve to the on-inverted role. `.stats--inverted .stats__number` routes its fallback through the on-inverted role (slot still wins).
- **Light-card variants unchanged** — grid cards, FAQ panels, and testimonials grid cards keep `--color-accent` (already AA on their light `--color-bg` surface). Routing them to the light on-inverted tint would have dropped them to ~2:1.
- **Existing slots keep winning**; **light-band output byte-identical**.
- **Docs** — `ai-instructions/retheme.md` documents the ≥4.5:1 pairing contract (change `--color-accent` or `--color-bg-inverted` → keep on-inverted ≥4.5:1); derived-family count 4→6 in retheme.md + AI_CONTEXT.md.

### Recorded-decision refinement (disclosed)
The recorded decision enumerated `cta` and `testimonials--stack` as dark-band remap targets. Both were dropped: `cta__body` is `esc_html` (no body-link surface; its only anchor is the CTA button, owned by the premium `main .btn` cascade), and testimonials renders no anchor in either layout (quote is `esc_html`, no link prop). A `.cta--inverted a` rule would also be dead CSS that the #61 dark-surface-slot contract forces through a speculative `--cta-link-color` slot. This is faithful execution of the binding "AA per real surface" principle (no link surface → no remap), narrowing the css-lint enumeration to the two variants that actually render body links (section, embed).

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` — **2059 passed** (3 warnings / 2 PHPUnit deprecations = baseline, unchanged).
- `npm test` (vitest) — **19 files, 742 passed**.
- `npx playwright test -g "#437 inverted link contrast"` on wp-env — **6 passed**: section/embed dark-band links ≥4.5:1, inverted stats numbers ≥3:1, grid card link stays accent, faq answer link AA on the light panel, at 375 and 1280.
- Version sync validated via `scripts/package.sh` (built zip deleted; releases are CI-built from tags).

## Tests added
- `tests/ApplyTest.php` — token-contract: the two new tokens are registered derived colors, auto-derive as light tints from `--color-accent`, and a divergent pin surfaces in `pp_masked_derived_overrides` (#386). Updated the accent-family count assertions (4→6 derived).
- `tests/js/css-lint.test.js` — structural: each dark-band inverted variant routes `a` color through the on-inverted role (+ hover), stats number routes its fallback, and the tokens exist in base.css `:root`.
- `tests/e2e/style-render.spec.ts` — computed WCAG contrast per inverted variant against each link's real rendered background, at 375 and 1280.

## Not done / deliberately out of scope
- `.section--has-bg-image a` / `.cta--has-bg-image` share the failing pattern but sit on an overlay-over-image surface (not `--color-bg-inverted`), so the ≥4.5:1-on-inverted contract doesn't bind — left untouched (candidate follow-up).
- No tag / release / deploy (CI builds release zips from tags; maintainer handles separately).

gstack workflows: /plan-eng-review (CLEARED, surface-aware plan), /review (clean, no code changes), /document-generate (no additional doc changes needed). Codex outside-voice passes skipped — Codex sandbox cannot run git on this container.