### PR TITLE
v1.4.12 fix: inverted/bg-image text-panel heading legible via panel-slot carve-out (#424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.12] — 2026-07-20 — the heading of a text-panel on a dark band is legible again (#424)
+
+**A `section` with `theme: inverted` (or a background image) renders a light panel box on the dark band. The panel's list items were dark and readable, but its heading came out light-on-light and effectively invisible. The dark-band styling colors every heading in the section with the band's light title color, and that rule outranked the panel's own text color — so the heading, but not the list below it, took the wrong color. The panel is a self-contained light surface with its own text color, so its heading now stays with the panel and reads in the panel's dark text, while the main on-band section title stays light exactly as before.**
+
+The panel heading and the on-band section title are now independently controllable: the panel heading follows the panel's own `--section-panel-text` (set it, and only the heading and panel body move), and the band title follows `--section-title-color` (set it, and only the title moves). Neither bleeds into the other. The same fix applies to a text-panel placed on a background-image section, which is the identical dark-surface case. Default light-band output is unchanged.
+
+### Fixed
+- The heading of a `layout: text-panel` panel on an inverted or background-image `section` now renders in the panel's own text color (`--section-panel-text`, dark by default on the light panel) instead of inheriting the dark band's light title color, so it is legible on the light panel. The on-band section title still uses `--section-title-color`, and the two color slots stay independently authorable — setting one no longer affects the other (#424).
+
+### Tests
+- `tests/e2e/style-render.spec.ts` adds a text-panel legibility suite that proves, at 375px and 1280px, the panel heading computes the panel's dark text (matching the panel list items and clearing WCAG AA against the light panel) while the on-band title stays light — for both an inverted band and a background-image band — plus slot-independence: an explicit `--section-panel-text` moves the panel heading and items together while leaving the band title, and an explicit `--section-title-color` moves only the band title. `tests/js/css-lint.test.js` pins that both dark-band heading rules (`.pp-section--inverted` and `.section--has-bg-image`) carve `.section__panel-heading` out of their bare `h2,h3` branches, and that the panel heading routes color through `--section-panel-text` (#424).
+
 ## [v1.4.11] — 2026-07-20 — links on inverted (dark) bands now meet WCAG AA by default (#437)
 
 **The default accent color is tuned for light surfaces, where it clears the WCAG AA contrast bar. On the dark "inverted" band it did not: a link in an inverted section or embed rendered at about 3.2:1 against the dark background, below the 4.5:1 minimum for body text, and inverted stats numbers looked dim for the same reason. The theme now carries a surface-paired accent — a lighter accent tint used only on inverted bands, where it measures about 8.3:1. Links in inverted sections and embeds, and inverted stats numbers, pick it up automatically. Links that sit on the light cards inside an inverted band (grid cards, FAQ panels) keep the normal accent, which is already AA on those light surfaces, so nothing there changes.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.11-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.12-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1178,9 +1178,16 @@
   --section-text-theme-color: var(--color-bg);
 }
 
+/* The text-panel is a self-contained LIGHT surface sitting on the dark band, with
+   its own --section-panel-text authority (see the .section__panel comment block).
+   Its heading is an <h3.section__panel-heading> whose own rule (0,1,0) routes color
+   through --section-panel-text, but a bare `h3` here (0,1,1) outranks it and paints
+   the panel heading in the band's light title color — light-on-light, invisible on
+   the panel. Carve the panel heading out so the panel slot wins inside the panel
+   while --section-title-color keeps governing the on-band title. (#424) */
 .pp-section--inverted .section__title,
-.pp-section--inverted h2,
-.pp-section--inverted h3 {
+.pp-section--inverted h2:not(.section__panel-heading),
+.pp-section--inverted h3:not(.section__panel-heading) {
   color: var(--section-title-color, var(--color-bg));
 }
 
@@ -1223,9 +1230,13 @@
   z-index: 1;
 }
 
+/* Same self-contained-panel carve-out as the inverted band above: a bg-image
+   section is a dark surface (overlay), so its bare `h2,h3` rule (0,1,1) would
+   clobber the light panel's own --section-panel-text heading authority (0,1,0)
+   and render the panel heading invisible on the light panel. (#424) */
 .section--has-bg-image .section__title,
-.section--has-bg-image h2,
-.section--has-bg-image h3 {
+.section--has-bg-image h2:not(.section__panel-heading),
+.section--has-bg-image h3:not(.section__panel-heading) {
   color: var(--section-title-color, var(--color-bg));
 }
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.11');
+define('PP_VERSION', '1.4.12');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.11
+Stable tag: 1.4.12
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.11
+Version:          1.4.12
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -4020,3 +4020,192 @@ test.describe('#437 inverted link contrast (rendered)', () => {
     });
   }
 });
+
+/*
+ * #424 — inverted text-panel heading legibility (rendered proof).
+ *
+ * A `theme: inverted` + `layout: text-panel` section renders a LIGHT panel box on the
+ * dark band. The panel heading is `<h3 class="section__panel-heading">`, whose own rule
+ * routes color through --section-panel-text (the panel's dark text). But the inverted
+ * band's `h3` rule (0,1,1) outranked it and painted the panel heading in the band's
+ * LIGHT title color — light-on-light, invisible on the light panel, while the panel LIST
+ * items (not headings) stayed dark and legible. The css-lint pin proves the carve-out
+ * selector shape; only getComputedStyle after the full cascade proves the browser
+ * actually renders the panel heading in the panel's dark text at BOTH breakpoints, and
+ * that the two color slots stay independently authorable.
+ */
+test.describe('#424 inverted text-panel heading legibility (rendered)', () => {
+  let pageId = 0;
+
+  test.afterEach(async () => {
+    if (pageId) {
+      try {
+        deletePage(pageId);
+      } catch {
+        /* already cleaned */
+      }
+      pageId = 0;
+    }
+  });
+
+  // One inverted text-panel section: an on-band title plus a panel with a heading and
+  // list items. Reused by every case below (styled variants restyle component 0).
+  const invertedTextPanel = (extra: Record<string, unknown> = {}) => [
+    {
+      component: 'section',
+      props: {
+        id: 'pp-sec01',
+        theme: 'inverted',
+        layout: 'text-panel',
+        title: 'Included in every plan',
+        panel_heading: 'Included, no exceptions',
+        panel_items: ['First perk', 'Second perk', 'Third perk'],
+        ...extra,
+      },
+    },
+  ];
+
+  // Computed `color` of the first match of a selector, as the browser resolves it.
+  const colorOf = (page: any, selector: string) =>
+    page.locator(selector).first().evaluate((el: Element) => getComputedStyle(el).color);
+
+  // WCAG relative-luminance contrast of an element's text color against its first
+  // painted (opaque) ancestor background — the light panel surface here.
+  const contrastOf = (page: any, selector: string) =>
+    page.evaluate((sel: string) => {
+      const parseRgb = (s: string): number[] => (s.match(/[\d.]+/g) || []).map(Number);
+      const lum = (rgb: number[]): number => {
+        const f = (v: number) => {
+          v /= 255;
+          return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+        };
+        return 0.2126 * f(rgb[0]) + 0.7152 * f(rgb[1]) + 0.0722 * f(rgb[2]);
+      };
+      const el = document.querySelector(sel);
+      if (!el) return 0;
+      const fg = parseRgb(getComputedStyle(el).color);
+      let node: Element | null = el;
+      let bg: number[] | null = null;
+      while (node) {
+        const p = parseRgb(getComputedStyle(node).backgroundColor);
+        if (p.length >= 3 && (p.length < 4 || p[3] > 0.5)) {
+          bg = p;
+          break;
+        }
+        node = node.parentElement;
+      }
+      if (!bg) bg = [255, 255, 255];
+      const L1 = lum(fg);
+      const L2 = lum(bg);
+      return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+    }, selector);
+
+  // The regression itself: panel heading must render the panel's dark text (same color
+  // as the panel list items) and NOT the light on-band title color, at both breakpoints.
+  test('panel heading takes panel dark text, band title stays light @375 + @1280', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E 424 base');
+    setComposition(pageId, invertedTextPanel());
+
+    for (const width of [375, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+
+      await expect(page.locator('.section__panel-heading')).toBeVisible({ timeout: 10000 });
+
+      const heading = await colorOf(page, '.section__panel-heading');
+      const item = await colorOf(page, '.section__panel-item');
+      const title = await colorOf(page, '.pp-section--inverted .section__title');
+      const ratio = await contrastOf(page, '.section__panel-heading');
+
+      // Heading routes through the SAME panel slot as the list items (both dark).
+      expect(heading, `@${width}: panel heading ${heading} != panel item ${item}`).toBe(item);
+      // Heading is NOT the light on-band title color (the exact pre-fix bug).
+      expect(heading, `@${width}: panel heading ${heading} must differ from band title ${title}`).not.toBe(title);
+      // And it is actually legible on the light panel.
+      expect(ratio, `@${width}: panel heading contrast ${ratio.toFixed(2)} on the light panel`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  // Slot independence, half 1: an explicit --section-panel-text moves the panel heading
+  // and must NOT bleed into the on-band title.
+  test('--section-panel-text moves the panel heading only @375 + @1280', async ({ page }) => {
+    pageId = createPage('E2E 424 panel-text slot');
+    setComposition(pageId, invertedTextPanel());
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    // A vivid color no theme token resolves to, so a leak is unmistakable.
+    const res = await styleComponent(page, pageId, { '--section-panel-text': '#ff0080' });
+    expect(res.success).toBe(true);
+
+    for (const width of [375, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator('.section__panel-heading')).toBeVisible({ timeout: 10000 });
+
+      const heading = await colorOf(page, '.section__panel-heading');
+      const item = await colorOf(page, '.section__panel-item');
+      const title = await colorOf(page, '.pp-section--inverted .section__title');
+      expect(heading, `@${width}: panel heading should honor --section-panel-text`).toBe('rgb(255, 0, 128)');
+      // The heading must move WITH the rest of the panel (the slot is the panel's,
+      // not a heading-only override), so the list items track it too.
+      expect(item, `@${width}: panel items should track the same --section-panel-text`).toBe('rgb(255, 0, 128)');
+      expect(title, `@${width}: --section-panel-text must not bleed into the band title`).not.toBe('rgb(255, 0, 128)');
+    }
+  });
+
+  // The parallel dark surface: a text-panel on a background-image section. The
+  // .section--has-bg-image class is added whenever background_image is set
+  // (independent of theme/layout), so its bare h2,h3 rule defeated the panel slot
+  // exactly like the inverted band. The image itself need not load — the class,
+  // overlay, and the panel's own opaque light surface are what drive the cascade.
+  test('bg-image text-panel: panel heading takes panel dark text, band title stays light @375 + @1280', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E 424 bg-image');
+    setComposition(pageId, invertedTextPanel({ theme: 'default', background_image: '/pp-424-probe.jpg' }));
+
+    for (const width of [375, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+
+      await expect(page.locator('.section--has-bg-image .section__panel-heading')).toBeVisible({ timeout: 10000 });
+
+      const heading = await colorOf(page, '.section--has-bg-image .section__panel-heading');
+      const item = await colorOf(page, '.section--has-bg-image .section__panel-item');
+      const title = await colorOf(page, '.section--has-bg-image .section__title');
+      const ratio = await contrastOf(page, '.section--has-bg-image .section__panel-heading');
+
+      expect(heading, `@${width}: bg-image panel heading ${heading} != panel item ${item}`).toBe(item);
+      expect(heading, `@${width}: bg-image panel heading ${heading} must differ from band title ${title}`).not.toBe(title);
+      expect(ratio, `@${width}: bg-image panel heading contrast ${ratio.toFixed(2)} on the light panel`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  // Slot independence, half 2: an explicit --section-title-color moves the on-band title
+  // and must NOT reach into the self-contained panel heading.
+  test('--section-title-color moves the band title only @375 + @1280', async ({ page }) => {
+    pageId = createPage('E2E 424 title-color slot');
+    setComposition(pageId, invertedTextPanel());
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    const res = await styleComponent(page, pageId, { '--section-title-color': '#00e5ff' });
+    expect(res.success).toBe(true);
+
+    for (const width of [375, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator('.section__panel-heading')).toBeVisible({ timeout: 10000 });
+
+      const title = await colorOf(page, '.pp-section--inverted .section__title');
+      const heading = await colorOf(page, '.section__panel-heading');
+      expect(title, `@${width}: band title should honor --section-title-color`).toBe('rgb(0, 229, 255)');
+      expect(heading, `@${width}: --section-title-color must not reach the panel heading`).not.toBe('rgb(0, 229, 255)');
+    }
+  });
+});

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -787,6 +787,76 @@ describe('CSS lint: theme variants survive the desktop typography cascade (#222)
     });
 });
 
+describe('CSS lint: dark-band heading rules carve out the self-contained panel heading (#424)', () => {
+    // A text-panel is a light surface on a DARK band (inverted, or bg-image overlay).
+    // Its heading is `<h3 class="section__panel-heading">`, whose own rule (0,1,0)
+    // routes color through --section-panel-text. The dark-band heading rules paint
+    // ALL headings via a bare `h2,h3` selector (0,1,1) that outranks the panel rule,
+    // so the panel heading rendered in the band's LIGHT title color — light-on-light,
+    // invisible on the light panel (#424). The fix scopes each bare heading branch
+    // with :not(.section__panel-heading) so the panel's slot wins inside the panel.
+    //
+    // Asserting "the :not appears somewhere" is not enough: if a band rule kept a bare
+    // `h3` branch (no exclusion), the panel heading would regress while the suite stayed
+    // green. So for each dark-band variant, pin that EVERY heading-element branch that
+    // is not the shared `.section__title` carries the exclusion.
+    const stripped = stripComments(COMPONENTS_CSS);
+
+    const rules = [];
+    const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+    let m;
+    while ((m = ruleRe.exec(stripped)) !== null) {
+        rules.push({ selector: m[1].trim(), body: m[2] });
+    }
+
+    // The two dark-band variants whose bare heading rule defeats the panel slot.
+    const DARK_BAND_VARIANTS = ['.pp-section--inverted', '.section--has-bg-image'];
+
+    DARK_BAND_VARIANTS.forEach((variant) => {
+        // The heading-color rule for this variant sets `color: var(--section-title-color, ...)`
+        // and targets the variant's headings. Find every rule that both scopes the variant
+        // and colours a heading through the title slot.
+        const headingRules = rules.filter((r) =>
+            r.selector.includes(variant) &&
+            /\bh[23]\b/.test(r.selector) &&
+            /color\s*:\s*var\(--section-title-color/.test(r.body)
+        );
+
+        test(`${variant} has a heading-color rule (guard is not vacuous)`, () => {
+            expect(headingRules.length).toBeGreaterThan(0);
+        });
+
+        // Every comma-part of that rule that targets a bare `h2`/`h3` element (i.e. not the
+        // `.section__title` class branch) must exclude `.section__panel-heading`.
+        test(`${variant} excludes .section__panel-heading from every bare h2/h3 branch`, () => {
+            const offenders = [];
+            headingRules.forEach((r) => {
+                r.selector.split(',').forEach((part) => {
+                    const p = part.trim();
+                    // Only heading-element branches are the trap; the `.section__title`
+                    // class branch legitimately has no bare element to carve out.
+                    if (!/\bh[23]\b/.test(p)) return;
+                    if (!/:not\(\.section__panel-heading\)/.test(p)) {
+                        offenders.push(p);
+                    }
+                });
+            });
+            expect(offenders).toEqual([]);
+        });
+    });
+
+    // The other half of the contract: the panel heading's OWN rule must route color
+    // through the panel slot, so once the band rule is carved out the panel heading
+    // resolves to the panel's (dark) text authority rather than an inherited light band.
+    test('.section__panel-heading colors through --section-panel-text', () => {
+        const rule = rules.find((r) =>
+            r.selector.split(',').some((s) => s.trim() === '.section__panel-heading')
+        );
+        expect(rule).toBeDefined();
+        expect(rule.body).toMatch(/color\s*:\s*var\(--section-panel-text\b/);
+    });
+});
+
 /**
  * Featured grid card honors the --grid-card-border style slot (#226).
  *


### PR DESCRIPTION
Closes #424

## Summary
A `section` with `theme: inverted` (or a background image) renders a light text-panel box on the dark band. The panel's list items were dark and readable, but its heading came out light-on-light and invisible.

Root cause: the dark-band heading-color rules color every heading via a bare `h2,h3` selector at specificity `(0,1,1)`, which outranked the panel heading's own `.section__panel-heading` rule `(0,1,0)`. The panel is a self-contained light surface with its own `--section-panel-text` authority, so its heading wrongly inherited the band's light title color. The list items are `<li>`/`<p>`, never matched the band rule — which is why the list stayed legible while the heading disappeared.

Fix: scope `.section__panel-heading` out of both dark-band heading rules (`.pp-section--inverted` and the parallel `.section--has-bg-image`) with `:not(.section__panel-heading)`, so the panel's `--section-panel-text` wins inside the panel while `--section-title-color` keeps governing the on-band title. No `!important`. The two color slots remain independently authorable.

## Scope note
The issue reports the inverted band. The identical defect exists in the parallel `.section--has-bg-image` heading rule (`background_image` and `layout` are independent props, so a text-panel on a bg-image dark surface hits the same illegibility). Both are fixed here as one theme-agnostic carve-out; this changes no accepted grammar, prop, or slot — it only makes already-intended-legible text legible.

## Validation
- `npm test` (vitest): 747 passed — includes 5 new css-lint pins for the two carve-outs and the panel-heading slot routing.
- `./vendor/bin/phpunit`: 2059 passed (3 pre-existing GET_LOCK warnings + 2 deprecations, unrelated — diff touches no PHP).
- E2E `tests/e2e/style-render.spec.ts` (wp-env, WordPress 7.0): 4 new `#424` cases pass at 375px and 1280px — panel heading computes the panel's dark text (matching the list items, clearing WCAG AA on the light panel) on both inverted and bg-image bands; `--section-panel-text` moves only the panel heading + items; `--section-title-color` moves only the band title. Verified as a real regression guard (fails on the unfixed CSS: panel heading computes `rgb(252,253,255)` instead of the panel's `rgb(16,24,40)`).
- `bash scripts/package.sh`: five-file version sync OK at 1.4.12; build zip deleted (CI builds from tags).

## Reviews (this session)
- `/plan-eng-review`: CLEAR, no findings.
- `/review` + independent adversarial subagent: no correctness defects; confirmed cascade math (`h2/h3` branch rises `0,1,1` → `0,2,1`, title branch unchanged), completeness (no other rule reaches the panel heading), and slot independence. Two test-coverage findings (bg-image rendered case; panel-item slot assertion) fixed directly. Codex was unavailable on this container (sandbox cannot run git); Claude adversarial subagent ran per the documented fallback.

## Accepted limitations
None. No 7A decision was required.
