### PR TITLE
v1.4.13 fix: rename theme value dark -> muted with a renderer-level alias (#442)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -139,7 +139,7 @@ renders the header or footer twice, and the write is rejected with the error cod
 **Two consistent axes — `layout` (structure) and `theme` (color/tone).** There is no `variant` prop anywhere; the name is retired. A write carrying `props.variant` is rejected as `unknown_prop` on every write path (`create_page`, `update_composition`, `add_component`, `update_component`) — v1 accepts no alias, only `layout`/`theme` (#388). (Restoring a pre-rename snapshot still decodes a stored `variant` to `layout`/`theme` on the read/restore path; the rejection is write-time only.) Structure is always `layout`, color/tone is always `theme`, and they never overload one key:
 
 - **`layout`** (structural, changes DOM/rendering) is used by the components that have more than one structure: `hero` (`left`, `centered`, `split`, `cover`), `section` (`text-only`, `image-left`, `image-right`, `centered`, `text-panel`), `grid` (`cards`, `steps`), `cta` (`full-width`, `inline`), `testimonials` (`grid`, `stack`).
-- **`theme`** (color/tone preset, `default` | `dark` | `inverted`) is used by the section-level components that carry a background tone: `section`, `stats`, `logos`, `embed`, `grid`, `cta`, `testimonials`, `faq`.
+- **`theme`** (color/tone preset, `default` | `muted` | `inverted`) is used by the section-level components that carry a background tone: `section`, `stats`, `logos`, `embed`, `grid`, `cta`, `testimonials`, `faq`. `muted` is a light tinted surface band (`--color-surface`) with framing borders; for a genuinely **dark** band use `inverted`. (The legacy value `dark` still renders — it is a deprecated alias of `muted`, i.e. a LIGHT band — but do not use it on new pages: its name mispredicts its output.)
 - `hero` has no `theme` prop — its color comes entirely from style slots (`--hero-bg`, etc.).
 - Components with a single structure (`stats`, `logos`, `embed`) expose only `theme`, not `layout`.
 - `style_component` / recipes / style slots remain the final visual authority over any `theme` or default CSS.
@@ -436,7 +436,7 @@ Pages using the **Composition** template store their layout in `_pp_composition`
 [
   { "component": "hero", "props": { "id": "top", "title": "Welcome", "layout": "cover", "image_url": "/path/to/bg.jpg" }, "style": { "--hero-padding-top": "8rem", "--hero-bg": "#1a1a2e" } },
   { "component": "section", "props": { "id": "about", "body": "<p>Content here.</p>", "layout": "text-only" } },
-  { "component": "stats", "props": { "theme": "dark", "items": [{ "number": "50+", "label": "Clients" }] } },
+  { "component": "stats", "props": { "theme": "muted", "items": [{ "number": "50+", "label": "Clients" }] } },
   { "component": "cta", "props": { "title": "Go", "button_text": "Click", "button_url": "/", "theme": "inverted" } }
 ]
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.13] — 2026-07-20 — the surface-tint band theme is now named `muted`, and the name matches what it renders (#442)
+
+**The band `theme` value that paints a light surface-tinted band was named `dark` — a misnomer, because it renders a near-white `--color-surface` band, not a dark one. Anyone (or any AI) who asked for a "dark band" and reached for the obvious value got a pale tint; the genuinely dark band is `inverted`. On top of that, the eight band components disagreed with each other about what the value meant, so the answer depended on which schema was read last. The value is renamed to `muted` across all eight components with one identical description, and `inverted` is documented as the dark band. Pages authored before this release keep rendering exactly as they did: the old `dark` value is still accepted and renders byte-identically as a deprecated alias of `muted`.**
+
+The rename lives where it matters — the component schemas (the authoring contract the AI reads) and a single shared renderer helper, `pp_theme_class()`, so the eight components can never drift apart again. New-page guidance offers only `muted`, with a note to use `inverted` when you actually want a dark band. Stored `dark` values are never migrated or flagged: they render the same light band forever, preflight and validation leave them alone, and the composition editor preserves a legacy `dark` value on re-save instead of quietly snapping it back to the default.
+
+### Changed
+- The `theme` enum on all eight band components (`cta`, `section`, `faq`, `grid`, `embed`, `logos`, `stats`, `testimonials`) now advertises `default | muted | inverted` with a single byte-identical description across all eight. `muted` is the light `--color-surface` tinted band with framing borders (the treatment previously mis-named `dark`); `inverted` is the genuinely dark band (#442).
+
+### Fixed
+- The misnamed `dark` theme value no longer misleads authors into a light band when they wanted a dark one. It is retained as a deprecated renderer-level alias of `muted` so every existing page renders byte-identically, but it is no longer offered for new pages. The composition editor now keeps a stored legacy `dark` value selected on re-save instead of silently resetting it to `default` (#442).
+
+### Docs
+- `AI_CONTEXT.md`, `ai-instructions/composition.md`, `ai-instructions/website-building.md`, `ai-instructions/style-component.md`, and `README.md` now offer `muted` (not `dark`) for new pages and carry a "for a dark band use `inverted`" warning (#442).
+
+### Tests
+- A schema-consistency test fails if any two components that share an enum (same value set) describe it differently — the exact drift that let `theme`'s value be documented three ways. PHPUnit pins the shared `pp_theme_class()` helper and the render layer: `muted` and legacy `dark` both emit the surface-band class byte-identically, `inverted` stays inverted, and invalid values coerce to the default. A vitest test proves the editor round-trips a legacy `dark` value and refuses to reflect a malformed one. `tests/e2e/style-render.spec.ts` asserts the computed band background per theme value matches its documented meaning (#442).
+
 ## [v1.4.12] — 2026-07-20 — the heading of a text-panel on a dark band is legible again (#424)
 
 **A `section` with `theme: inverted` (or a background image) renders a light panel box on the dark band. The panel's list items were dark and readable, but its heading came out light-on-light and effectively invisible. The dark-band styling colors every heading in the section with the band's light title color, and that rule outranked the panel's own text color — so the heading, but not the list below it, took the wrong color. The panel is a self-contained light surface with its own text color, so its heading now stays with the panel and reads in the panel's dark text, while the main on-band section title stays light exactly as before.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.12-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.13-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -132,8 +132,8 @@ No blocks. No shortcodes. No visual-builder serialization. AI can read, write, d
 | Component | Purpose | Key props |
 |-----------|---------|-----------|
 | hero | Full-width headline with optional CTA, image, overlay | `title` |
-| section | Text + optional image; 4 `layout`s (text-only, image-left, image-right, centered) + `theme` (default, dark, inverted) | `body` |
-| grid | Responsive card grid; `layout` (cards, steps) + `theme` (default, dark, inverted) + `card_emphasis` (featured, uniform) + `columns` (1-4, force desktop column count) + `image_treatment` (banner, icon) | `items[]` |
+| section | Text + optional image; 4 `layout`s (text-only, image-left, image-right, centered) + `theme` (default, muted, inverted) | `body` |
+| grid | Responsive card grid; `layout` (cards, steps) + `theme` (default, muted, inverted) + `card_emphasis` (featured, uniform) + `columns` (1-4, force desktop column count) + `image_treatment` (banner, icon) | `items[]` |
 | faq | Native `details/summary` accordion, zero JavaScript | `items[]` |
 | cta | Call-to-action block with layout, color axis, and background image; `title` optional (omit for a standalone button row) | `button_text`, `button_url` |
 | stats | Large-number metrics with labels and optional background image | `items[]` |

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -69,12 +69,14 @@ Controls per-section background color/tone for visual rhythm on marketing pages.
 | Value      | Effect                                                      |
 |------------|-------------------------------------------------------------|
 | `default`  | Page background (`--color-bg`). No class added. Default.   |
-| `dark`     | Surface background (`--color-surface`). Subtle differentiation. |
-| `inverted` | Inverted background (`--color-bg-inverted`). Strong contrast. |
+| `muted`    | Light tinted surface band (`--color-surface`) with framing borders. Subtle differentiation. |
+| `inverted` | Inverted **dark** background (`--color-bg-inverted`). Strong contrast — use this for a genuinely dark band. |
+
+> `muted` is a LIGHT band, not a dark one. For a dark band use `inverted`. The legacy value `dark` still renders (it is a deprecated alias of `muted`, i.e. also LIGHT), but do not use it on new pages — its name mispredicts its output.
 
 Example — alternating section rhythm:
 ```json
-{ "component": "section", "props": { "body": "<p>...</p>", "theme": "dark" } },
+{ "component": "section", "props": { "body": "<p>...</p>", "theme": "muted" } },
 { "component": "section", "props": { "body": "<p>...</p>", "theme": "inverted" } }
 ```
 

--- a/ai-instructions/style-component.md
+++ b/ai-instructions/style-component.md
@@ -207,6 +207,14 @@ slot leaves the eyebrow byte-identically uppercase.
 | cta | `accent-framed` | Accent border with rounded corners |
 | testimonials | `dark-showcase` | Dark background with light cards |
 
+> **`dark-*` recipes vs. the `theme` prop — do not confuse them.** These `dark-*`
+> recipes DO paint a genuinely dark background (via style slots). The band-level
+> `theme` prop is different: its tinted value is `muted` (a LIGHT `--color-surface`
+> band with borders), and a `theme: "inverted"` band is the dark one. The legacy
+> `theme: "dark"` value is a deprecated alias of `muted` and also renders LIGHT — do
+> not reach for it expecting darkness. For a dark band, set `theme: "inverted"` or use
+> a `dark-*` recipe; never `theme: "dark"`.
+
 ---
 
 ## Worked example -- shadows, button variants, and text roles (v0.12.0)

--- a/ai-instructions/website-building.md
+++ b/ai-instructions/website-building.md
@@ -9,7 +9,7 @@ Every visual change maps to exactly one mutation surface. Writing to the wrong s
 | Page layout (which components, what order) | `_pp_composition` post meta | `update_composition` or `add_component` action |
 | Component content (text, images, URLs) | `_pp_composition` post meta | `update_component` action |
 | Site-wide colors, spacing, fonts | `pp_token_overrides` option (defaults in `base.css`) | `update_design_token` apply |
-| Component structure + tone (steps layout, dark/inverted theme) | `_pp_composition` post meta | `update_component` action (set `layout` or `theme` prop) |
+| Component structure + tone (steps layout, muted/inverted theme — `muted` = light tinted band, `inverted` = dark band) | `_pp_composition` post meta | `update_component` action (set `layout` or `theme` prop) |
 | Component-specific CSS (spacing, layout) | `assets/css/components.css` | Direct file edit (BEM classes, token values only) |
 | Site name, tagline | WordPress options | `update_site_option` action |
 | Site logo (header) | WordPress option (Media Library attachment) | `update_site_option` action (key `pp_logo_id`, an attachment ID) |

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1760,7 +1760,13 @@
   }
 }
 
-/* Grid theme variants */
+/* Grid theme variants.
+   NOTE (#442): the `--dark` modifier class is a MISNOMER kept for back-compat — it
+   paints the LIGHT `--color-surface` tinted band, not a dark one. The public theme
+   enum renamed this value to `muted`; the renderer maps BOTH `muted` and the
+   deprecated `dark` to this same `--dark` class (see pp_theme_class() in
+   lib/helpers.php) so existing pages render byte-identically. The genuinely dark
+   band is `--inverted`. Every band component's `--dark` variant follows this pattern. */
 .grid--dark {
   background: var(--grid-bg, var(--color-surface));
   border-top: 1px solid var(--color-border);

--- a/assets/js/pp-admin-editor.js
+++ b/assets/js/pp-admin-editor.js
@@ -186,6 +186,21 @@
 
         if (field.type === 'enum' && field.values) {
             h += '<select id="' + id + '" data-comp="' + compIdx + '" data-field="' + field.name + '">';
+            // A stored value that is no longer advertised (e.g. the deprecated
+            // theme value "dark", which the renderer still accepts as an alias of
+            // "muted", #442) is prepended as its own option so opening + re-saving
+            // an existing band round-trips it losslessly instead of silently
+            // snapping the <select> to its first option and mutating stored state.
+            // Guard the injection to a safe identifier charset: every real enum
+            // value is a lowercase slug, so legacy values still round-trip, but a
+            // malformed stored value is never reflected into the value="" attribute
+            // (esc() is text-safe but does not escape the double-quote used to close
+            // the attribute). A rejected value simply falls back to the default, which
+            // is no worse than the pre-#442 drop behavior.
+            var storedVal = (field.value === undefined || field.value === null) ? '' : String(field.value);
+            if (storedVal !== '' && field.values.indexOf(field.value) === -1 && /^[a-z0-9_-]+$/i.test(storedVal)) {
+                h += '<option value="' + esc(storedVal) + '" selected>' + esc(storedVal) + ' (legacy)</option>';
+            }
             field.values.forEach(function (v) {
                 var sel = v === field.value ? ' selected' : '';
                 h += '<option value="' + esc(v) + '"' + sel + '>' + esc(v) + '</option>';

--- a/components/cta/README.md
+++ b/components/cta/README.md
@@ -14,7 +14,7 @@ Call-to-action block. Place at the bottom of a page or between sections to drive
 | `button_text` | string | Yes      | —              | Button label |
 | `button_url`  | string | Yes      | —              | Button URL |
 | `layout`     | enum   | No       | `'full-width'` | Structural layout: `full-width` / `inline` |
-| `theme`       | enum   | No       | `'default'`    | Background color: `default` / `dark` / `inverted` (independent of `layout`) |
+| `theme`       | enum   | No       | `'default'`    | Background color: `default` / `muted` (light tinted surface band) / `inverted` (genuinely dark band) (independent of `layout`) |
 | `background_image` | string | No | `''`           | Optional background image URL with dark overlay for text readability |
 | `button_variant` | enum | No      | `'primary'`    | Button style: `primary` / `secondary` / `outline` / `ghost` |
 

--- a/components/cta/cta.php
+++ b/components/cta/cta.php
@@ -32,12 +32,8 @@ if (!in_array($button_variant, $allowed_button_variants, true)) {
 // primary is the bare .btn; other variants add a .btn--{variant} modifier.
 $button_variant_class = $button_variant !== 'primary' ? ' btn--' . $button_variant : '';
 
-$allowed_themes = ['default', 'dark', 'inverted'];
-if (!in_array($theme, $allowed_themes, true)) {
-    $theme = 'default';
-}
-
-$theme_class    = $theme !== 'default' ? ' cta--' . $theme : '';
+// theme coercion + the deprecated 'dark' -> 'muted' alias live in pp_theme_class() (#442).
+$theme_class    = pp_theme_class($theme, 'cta');
 $bg_image_class = $background_image ? ' cta--has-bg-image' : '';
 
 // Style slot overrides (per-instance visual customization).

--- a/components/cta/schema.json
+++ b/components/cta/schema.json
@@ -51,10 +51,10 @@
     },
     "theme": {
       "type": "enum",
-      "values": ["default", "dark", "inverted"],
+      "values": ["default", "muted", "inverted"],
       "required": false,
       "default": "default",
-      "description": "Color theme. 'default' = surface/page background. 'dark' = dark surface. 'inverted' = inverted background for strong contrast. Combines with layout for structure + color."
+      "description": "Background color/tone for this band. 'default' = the band's own default background (no tone override). 'muted' = light tinted surface band (renders the --color-surface background with framing top and bottom borders). 'inverted' = inverted dark background for strong contrast; use 'inverted' for a genuinely dark band."
     },
     "background_image": {
       "type": "string",

--- a/components/embed/README.md
+++ b/components/embed/README.md
@@ -11,7 +11,7 @@ This is the only sanctioned way to introduce arbitrary plugin-rendered content i
 | `id`      | string | No       | `''`    | HTML id for anchor linking |
 | `title`   | string | No       | `''`    | Optional heading above the embedded content |
 | `content` | string | Yes      | —       | WP shortcode or pre-rendered HTML |
-| `theme`   | enum   | No       | `default` | Background color/tone: `default` (page background), `dark` (surface background with borders), `inverted` (inverted background for strong contrast) |
+| `theme`   | enum   | No       | `default` | Background color/tone: `default` (page background), `muted` (light tinted surface band with borders; deprecated alias `dark`), `inverted` (inverted dark background for strong contrast) |
 
 ## Usage
 

--- a/components/embed/embed.php
+++ b/components/embed/embed.php
@@ -19,12 +19,8 @@ $title   = $props['title']   ?? '';
 $content = $props['content'] ?? '';
 $theme = $props['theme'] ?? 'default';
 
-$allowed_themes = ['default', 'dark', 'inverted'];
-if (!in_array($theme, $allowed_themes, true)) {
-    $theme = 'default';
-}
-
-$theme_class = $theme !== 'default' ? ' embed--' . $theme : '';
+// theme coercion + the deprecated 'dark' -> 'muted' alias live in pp_theme_class() (#442).
+$theme_class = pp_theme_class($theme, 'embed');
 
 $slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'embed');
 $style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';

--- a/components/embed/schema.json
+++ b/components/embed/schema.json
@@ -21,10 +21,10 @@
     },
     "theme": {
       "type": "enum",
-      "values": ["default", "dark", "inverted"],
+      "values": ["default", "muted", "inverted"],
       "required": false,
       "default": "default",
-      "description": "Background color/tone. 'default' = page background. 'dark' = surface background with borders. 'inverted' = inverted background for strong contrast."
+      "description": "Background color/tone for this band. 'default' = the band's own default background (no tone override). 'muted' = light tinted surface band (renders the --color-surface background with framing top and bottom borders). 'inverted' = inverted dark background for strong contrast; use 'inverted' for a genuinely dark band."
     }
   },
   "styling": {

--- a/components/faq/README.md
+++ b/components/faq/README.md
@@ -10,7 +10,7 @@ FAQ accordion using native HTML `<details>`/`<summary>` elements. No JavaScript 
 | `title`        | string | No       | `'Frequently Asked Questions'`   | Section heading |
 | `title_accent` | string | No       | `''`                             | Exact substring of `title` to render in an accent color |
 | `eyebrow`      | string | No       | `''`                             | Short kicker/label rendered as a pill above the title |
-| `theme`        | enum   | No       | `'default'`                      | Background tone: `default`, `dark`, or `inverted` |
+| `theme`        | enum   | No       | `'default'`                      | Background tone: `default`, `muted` (light tinted surface band), or `inverted` (genuinely dark band) |
 | `items`        | array  | Yes      | —                                | Array of `{ question, answer }` objects |
 
 Each item in `items`:

--- a/components/faq/faq.php
+++ b/components/faq/faq.php
@@ -19,11 +19,8 @@ $items = $props['items'] ?? [];
 // default surface rather than emitting an unstyled `faq--<garbage>` class
 // (mirrors section.php / grid.php — composition validation does not check
 // enum values, so the render is the actual contract).
-$allowed_themes = ['default', 'dark', 'inverted'];
-if (!in_array($theme, $allowed_themes, true)) {
-    $theme = 'default';
-}
-$theme_class = $theme !== 'default' ? ' faq--' . $theme : '';
+// theme coercion + the deprecated 'dark' -> 'muted' alias live in pp_theme_class() (#442).
+$theme_class = pp_theme_class($theme, 'faq');
 
 // Style slot overrides (per-instance visual customization).
 $slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'faq');

--- a/components/faq/schema.json
+++ b/components/faq/schema.json
@@ -28,10 +28,10 @@
     },
     "theme": {
       "type": "enum",
-      "values": ["default", "dark", "inverted"],
+      "values": ["default", "muted", "inverted"],
       "required": false,
       "default": "default",
-      "description": "Background color/tone. 'default' = surface background. 'dark' = dark surface with borders. 'inverted' = inverted background for strong contrast. Independent of content."
+      "description": "Background color/tone for this band. 'default' = the band's own default background (no tone override). 'muted' = light tinted surface band (renders the --color-surface background with framing top and bottom borders). 'inverted' = inverted dark background for strong contrast; use 'inverted' for a genuinely dark band."
     },
     "items": {
       "type": "array",

--- a/components/grid/README.md
+++ b/components/grid/README.md
@@ -13,8 +13,8 @@ Responsive card grid for discrete content objects. Use this for blog post listin
 | `subheading`    | string | No       | `''`      | Supporting line below the title |
 | `heading_align` | enum   | No       | `'start'` | Header block alignment: `start` / `center` |
 | `layout`        | enum   | No       | `'cards'`   | Structural layout: `cards` (card grid) / `steps` (numbered process cards) |
-| `card_emphasis` | enum   | No       | `'featured'` | First-card emphasis: `featured` (default — first card gets an accent bar, tinted fill, larger title, extra top padding, dark-theme lift) / `uniform` (every card identical). Use `uniform` for a symmetric/peer card row (see below). Cards-layout concept; ignored on `steps`. |
-| `theme`         | enum   | No       | `'default'` | Background color: `default` / `dark` / `inverted` (independent of `layout`) |
+| `card_emphasis` | enum   | No       | `'featured'` | First-card emphasis: `featured` (default — first card gets an accent bar, tinted fill, larger title, extra top padding, muted-theme lift) / `uniform` (every card identical). Use `uniform` for a symmetric/peer card row (see below). Cards-layout concept; ignored on `steps`. |
+| `theme`         | enum   | No       | `'default'` | Background color: `default` / `muted` (light tinted surface band) / `inverted` (genuinely dark band) (independent of `layout`) |
 | `columns`       | number | No       | —         | Explicit desktop (768px+) column count, integer `1`–`4`. Unset = auto by item count (see below). Out-of-range/non-integer values are rejected, not clamped. Cards-layout concept; ignored on `steps`. |
 | `image_treatment` | enum | No       | `'banner'` | How each card's `image_url` renders: `banner` (full-width 16:9 cover banner above the body) / `icon` (small fixed icon size, un-cropped, above the title — see below). Unset = `banner` (byte-identical). Values outside the set are rejected, not coerced. Cards-layout concept; ignored on `steps`. |
 | `items`         | array  | Yes      | —         | Array of card objects |
@@ -68,14 +68,14 @@ It works with and without `bullets` on the same card, and at every breakpoint (t
 
 ## Card emphasis (featured vs uniform)
 
-By default a `cards` grid gives its **first card** a "featured" treatment: an accent top bar, a tinted gradient fill, a larger title, extra body top-padding, and (on the `dark` theme) a slight upward lift. This draws the eye to a lead item and is the historical, unchanged default (`card_emphasis: 'featured'`).
+By default a `cards` grid gives its **first card** a "featured" treatment: an accent top bar, a tinted gradient fill, a larger title, extra body top-padding, and (on the `muted` theme, legacy alias `dark`) a slight upward lift. This draws the eye to a lead item and is the historical, unchanged default (`card_emphasis: 'featured'`).
 
 Set `card_emphasis: 'uniform'` to render **every card identically** — no featured first card. Use it whenever the cards are peers of equal weight and the featured emphasis would mislead or misalign them:
 
 - Symmetric specification/comparison rows whose checklists or bodies must line up across cards (the featured card's extra top-padding otherwise pushes its content down relative to its neighbors).
 - Equal-weight feature, benefit, or plan rows where no single card should stand out.
 
-Keep the default `featured` when one card really is the lead (a highlighted plan, a primary feature). This is a structural prop, not a style slot — set it with `create_page` / `update_component`, not `style_component`. It differs from styling one card individually (`items[].style`) or from the slot-level `uniform-cards` recipe: `uniform` cleanly drops the *entire* featured treatment (including the first-card top-padding and dark-theme lift that slot overrides cannot reach).
+Keep the default `featured` when one card really is the lead (a highlighted plan, a primary feature). This is a structural prop, not a style slot — set it with `create_page` / `update_component`, not `style_component`. It differs from styling one card individually (`items[].style`) or from the slot-level `uniform-cards` recipe: `uniform` cleanly drops the *entire* featured treatment (including the first-card top-padding and muted-theme lift that slot overrides cannot reach).
 
 ## Steps layout
 

--- a/components/grid/grid.php
+++ b/components/grid/grid.php
@@ -30,11 +30,6 @@ if (!in_array($card_emphasis, $allowed_card_emphasis, true)) {
     $card_emphasis = 'featured';
 }
 
-$allowed_themes = ['default', 'dark', 'inverted'];
-if (!in_array($theme, $allowed_themes, true)) {
-    $theme = 'default';
-}
-
 $allowed_heading_aligns = ['start', 'center'];
 if (!in_array($heading_align, $allowed_heading_aligns, true)) {
     $heading_align = 'start';
@@ -43,7 +38,7 @@ if (!in_array($heading_align, $allowed_heading_aligns, true)) {
 // Explicit desktop column-count override (issue 379). Write-time validation
 // (pp_validate_composition_errors) already rejects out-of-range/non-integer
 // values, so this is a defensive coercion for raw-written state (mirroring the
-// layout/theme/card_emphasis in_array guards above): only an integer 1-4 emits
+// layout/card_emphasis in_array guards above; theme via pp_theme_class, #442): only an integer 1-4 emits
 // the data-pp-columns attribute the CSS reads; anything else falls through to
 // the auto-by-count grain, so unset output stays byte-identical.
 // $is_steps is computed below; forward-declare the steps check here so a forced
@@ -62,7 +57,8 @@ $header_align_class = $heading_align === 'center' ? ' grid__header--center' : ''
 
 $is_steps      = $layout === 'steps';
 $layout_class  = $is_steps ? ' grid--steps' : '';
-$theme_class   = $theme !== 'default' ? ' grid--' . $theme : '';
+// theme coercion + the deprecated 'dark' -> 'muted' alias live in pp_theme_class() (#442).
+$theme_class   = pp_theme_class($theme, 'grid');
 // 'uniform' opts the first card out of the featured emphasis so every card
 // renders identically (issue 226). Default 'featured' emits no class, keeping
 // existing pages byte-identical. The featured CSS selectors carry a

--- a/components/grid/schema.json
+++ b/components/grid/schema.json
@@ -55,10 +55,10 @@
     },
     "theme": {
       "type": "enum",
-      "values": ["default", "dark", "inverted"],
+      "values": ["default", "muted", "inverted"],
       "required": false,
       "default": "default",
-      "description": "Background color/tone. Independent of layout. 'default' = page background. 'dark' = surface background with borders. 'inverted' = inverted background for strong contrast."
+      "description": "Background color/tone for this band. 'default' = the band's own default background (no tone override). 'muted' = light tinted surface band (renders the --color-surface background with framing top and bottom borders). 'inverted' = inverted dark background for strong contrast; use 'inverted' for a genuinely dark band."
     },
     "columns": {
       "type": "number",

--- a/components/logos/README.md
+++ b/components/logos/README.md
@@ -8,7 +8,7 @@ A flex-wrap image grid. Use for client logo strips (items without labels) or ico
 |---------|--------|----------|---------|-------------|
 | `id`    | string | No       | `''`    | HTML id for anchor linking |
 | `title` | string | No       | `''`    | Optional heading above the grid |
-| `theme`   | enum | No       | `default` | Background color/tone: `default` (page background), `dark` (surface background with borders), `inverted` (inverted background for strong contrast) |
+| `theme`   | enum | No       | `default` | Background color/tone: `default` (page background), `muted` (light tinted surface band with borders; deprecated alias `dark`), `inverted` (inverted dark background for strong contrast) |
 | `items` | array  | Yes      | —       | Array of image items |
 
 Each item:

--- a/components/logos/logos.php
+++ b/components/logos/logos.php
@@ -14,12 +14,8 @@ $title   = $props['title']   ?? '';
 $theme = $props['theme'] ?? 'default';
 $items   = $props['items']   ?? [];
 
-$allowed_themes = ['default', 'dark', 'inverted'];
-if (!in_array($theme, $allowed_themes, true)) {
-    $theme = 'default';
-}
-
-$theme_class = $theme !== 'default' ? ' logos--' . $theme : '';
+// theme coercion + the deprecated 'dark' -> 'muted' alias live in pp_theme_class() (#442).
+$theme_class = pp_theme_class($theme, 'logos');
 
 $slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'logos');
 $style_attr = $slot_style ? ' style="' . $slot_style . ';"' : '';

--- a/components/logos/schema.json
+++ b/components/logos/schema.json
@@ -16,10 +16,10 @@
     },
     "theme": {
       "type": "enum",
-      "values": ["default", "dark", "inverted"],
+      "values": ["default", "muted", "inverted"],
       "required": false,
       "default": "default",
-      "description": "Background color/tone. 'default' = page background. 'dark' = surface background with borders. 'inverted' = inverted background for strong contrast."
+      "description": "Background color/tone for this band. 'default' = the band's own default background (no tone override). 'muted' = light tinted surface band (renders the --color-surface background with framing top and bottom borders). 'inverted' = inverted dark background for strong contrast; use 'inverted' for a genuinely dark band."
     },
     "items": {
       "type": "array",

--- a/components/section/README.md
+++ b/components/section/README.md
@@ -17,7 +17,7 @@ Generic text + optional image section. Use this for "what is this", "how it work
 | `image_id`         | int    | No       | `0`           | Media Library attachment ID for the image. When set and it resolves, renders responsively (`srcset`/`sizes`) via `wp_get_attachment_image()`; falls back to `image_url` otherwise |
 | `image_alt`        | string | No       | `''`          | Image alt text |
 | `layout`           | enum   | No       | `'text-only'` | Structural layout: `text-only` / `image-left` / `image-right` / `centered` |
-| `theme`            | enum   | No       | `'default'`   | Background color/tone: `default` / `dark` / `inverted` |
+| `theme`            | enum   | No       | `'default'`   | Background color/tone: `default` / `muted` (light tinted surface band) / `inverted` (genuinely dark band) |
 | `background_image` | string | No       | `''`          | Optional background image URL with dark overlay for text readability |
 | `body_marker`        | enum   | No       | `'disc'`      | List marker for top-level `<ul>` lists in `body`: `disc` / `check` / `dash` / `arrow`. Colour via the `--section-body-marker-color` slot |
 | `panel_items_marker` | enum   | No       | `'disc'`      | text-panel layout: list marker for the string entries of `panel_items`: `disc` / `check` / `dash` / `arrow`. Colour via the `--section-panel-marker-color` slot. Paired rows never show a marker |

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -71,10 +71,10 @@
     },
     "theme": {
       "type": "enum",
-      "values": ["default", "dark", "inverted"],
+      "values": ["default", "muted", "inverted"],
       "required": false,
       "default": "default",
-      "description": "Background color/tone. 'default' = page background. 'dark' = dark surface. 'inverted' = inverted background for strong contrast. Controls per-section visual rhythm on marketing pages. Independent of layout."
+      "description": "Background color/tone for this band. 'default' = the band's own default background (no tone override). 'muted' = light tinted surface band (renders the --color-surface background with framing top and bottom borders). 'inverted' = inverted dark background for strong contrast; use 'inverted' for a genuinely dark band."
     },
     "background_image": {
       "type": "string",

--- a/components/section/section.php
+++ b/components/section/section.php
@@ -107,18 +107,14 @@ if ($layout === 'text-panel') {
     $layout = 'text-only';
 }
 
-$allowed_themes = ['default', 'dark', 'inverted'];
-if (!in_array($theme, $allowed_themes, true)) {
-    $theme = 'default';
-}
-
 $allowed_heading_aligns = ['start', 'center'];
 if (!in_array($heading_align, $allowed_heading_aligns, true)) {
     $heading_align = 'start';
 }
 $header_align_class = $heading_align === 'center' ? ' section__header--center' : '';
 
-$theme_class = $theme !== 'default' ? ' pp-section--' . $theme : '';
+// theme coercion + the deprecated 'dark' -> 'muted' alias live in pp_theme_class() (#442).
+$theme_class = pp_theme_class($theme, 'pp-section');
 $bg_image_class = $background_image ? ' section--has-bg-image' : '';
 
 // Style slot overrides (per-instance visual customization).

--- a/components/stats/README.md
+++ b/components/stats/README.md
@@ -9,7 +9,7 @@ A horizontal row of large-number metrics with labels. Use for quantified social 
 | `id`            | string | No       | `''`    | HTML id for anchor linking |
 | `title`         | string | No       | `''`    | Optional heading above the stats row |
 | `title_accent`  | string | No       | `''`    | Exact substring of `title` to render in an accent color |
-| `theme`         | enum   | No       | `'default'` | Background color/tone: `default` / `dark` / `inverted` |
+| `theme`         | enum   | No       | `'default'` | Background color/tone: `default` / `muted` (light tinted surface band) / `inverted` (genuinely dark band) |
 | `background_image` | string | No  | `''`    | Optional background image URL with dark overlay for text readability |
 | `items`         | array  | Yes      | —       | Array of `{ number, label }` objects |
 

--- a/components/stats/schema.json
+++ b/components/stats/schema.json
@@ -22,10 +22,10 @@
     },
     "theme": {
       "type": "enum",
-      "values": ["default", "dark", "inverted"],
+      "values": ["default", "muted", "inverted"],
       "required": false,
       "default": "default",
-      "description": "Background color/tone. 'default' = page background. 'dark' = surface background with borders. 'inverted' = inverted background for strong contrast."
+      "description": "Background color/tone for this band. 'default' = the band's own default background (no tone override). 'muted' = light tinted surface band (renders the --color-surface background with framing top and bottom borders). 'inverted' = inverted dark background for strong contrast; use 'inverted' for a genuinely dark band."
     },
     "background_image": {
       "type": "string",

--- a/components/stats/stats.php
+++ b/components/stats/stats.php
@@ -16,12 +16,8 @@ $theme            = $props['theme']            ?? 'default';
 $items            = $props['items']            ?? [];
 $background_image = $props['background_image'] ?? '';
 
-$allowed_themes = ['default', 'dark', 'inverted'];
-if (!in_array($theme, $allowed_themes, true)) {
-    $theme = 'default';
-}
-
-$theme_class    = $theme !== 'default' ? ' stats--' . $theme : '';
+// theme coercion + the deprecated 'dark' -> 'muted' alias live in pp_theme_class() (#442).
+$theme_class    = pp_theme_class($theme, 'stats');
 $bg_image_class = $background_image ? ' stats--has-bg-image' : '';
 
 // Style slot overrides (per-instance visual customization).

--- a/components/testimonials/README.md
+++ b/components/testimonials/README.md
@@ -13,7 +13,7 @@ Customer quotes with attribution, for social-proof sections. Use this instead of
 | `subheading`    | string | No       | `''`    | Supporting line below the title |
 | `heading_align` | enum   | No       | `start` | `start` or `center` |
 | `layout`       | enum   | No       | `grid`  | Layout: `grid` (card grid) or `stack` (single centered column) |
-| `theme`         | enum   | No       | `default` | Background color: `default` / `dark` / `inverted` |
+| `theme`         | enum   | No       | `default` | Background color: `default` / `muted` (light tinted surface band) / `inverted` (genuinely dark band) |
 | `items`         | array  | Yes      | —       | Array of testimonial objects |
 
 Each item in `items`:

--- a/components/testimonials/schema.json
+++ b/components/testimonials/schema.json
@@ -37,7 +37,7 @@
       "values": ["start", "center"],
       "required": false,
       "default": "start",
-      "description": "Alignment of the eyebrow/title/subheading header block. 'start' = left-aligned (default). 'center' = centered."
+      "description": "Alignment of the eyebrow/title/subheading header block. 'start' = left-aligned (default, unchanged historical behavior). 'center' = centered."
     },
     "layout": {
       "type": "enum",
@@ -48,10 +48,10 @@
     },
     "theme": {
       "type": "enum",
-      "values": ["default", "dark", "inverted"],
+      "values": ["default", "muted", "inverted"],
       "required": false,
       "default": "default",
-      "description": "Background color/tone. Independent of layout. 'default' = page background. 'dark' = surface background with borders. 'inverted' = inverted background for strong contrast."
+      "description": "Background color/tone for this band. 'default' = the band's own default background (no tone override). 'muted' = light tinted surface band (renders the --color-surface background with framing top and bottom borders). 'inverted' = inverted dark background for strong contrast; use 'inverted' for a genuinely dark band."
     },
     "items": {
       "type": "array",

--- a/components/testimonials/testimonials.php
+++ b/components/testimonials/testimonials.php
@@ -23,11 +23,6 @@ if (!in_array($layout, $allowed_layouts, true)) {
     $layout = 'grid';
 }
 
-$allowed_themes = ['default', 'dark', 'inverted'];
-if (!in_array($theme, $allowed_themes, true)) {
-    $theme = 'default';
-}
-
 $allowed_heading_aligns = ['start', 'center'];
 if (!in_array($heading_align, $allowed_heading_aligns, true)) {
     $heading_align = 'start';
@@ -36,7 +31,8 @@ $header_align_class = $heading_align === 'center' ? ' testimonials__header--cent
 
 $is_stack      = $layout === 'stack';
 $layout_class  = $is_stack ? ' testimonials--stack' : '';
-$theme_class   = $theme !== 'default' ? ' testimonials--' . $theme : '';
+// theme coercion + the deprecated 'dark' -> 'muted' alias live in pp_theme_class() (#442).
+$theme_class   = pp_theme_class($theme, 'testimonials');
 
 // Style slot overrides (per-instance visual customization).
 $slot_style = pp_render_style_vars($props['__pp_style'] ?? [], 'testimonials');

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.12');
+define('PP_VERSION', '1.4.13');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -90,3 +90,43 @@ function pp_footer_linkify_contact(string $contact): string {
 
     return nl2br($linked);
 }
+
+/**
+ * Builds the tonal `theme` modifier class for a band-level component (#442).
+ *
+ * The public `theme` enum is `default | muted | inverted`:
+ *   - `default`  — no tone override; the band keeps its own default background.
+ *   - `muted`    — the light tinted surface band: `--color-surface` (#f4f7fb, a
+ *                  pale near-white) with framing top/bottom borders.
+ *   - `inverted` — the genuinely dark band: `--color-bg-inverted` (#0f172a).
+ *
+ * `dark` is a DEPRECATED renderer-level ALIAS for `muted`, kept forever so every
+ * page authored before the rename renders byte-identically. The tinted band still
+ * ships under the LEGACY `--dark` CSS class name (renaming the class would change
+ * the emitted HTML of the installed base), so BOTH `muted` and the legacy `dark`
+ * resolve to the same `{prefix}--dark` class. Schemas advertise only `muted`; the
+ * renderer accepts both. Value name `dark` was a misnomer — it renders a LIGHT
+ * band — which is exactly why the enum migrated; `inverted` is the dark band.
+ *
+ * Any value outside the accepted set (including non-string / empty / unknown input
+ * arriving from a JSON payload) coerces to `default`, matching the historical
+ * per-component accept-and-coerce behavior for the non-strict `theme` prop.
+ *
+ * @param mixed  $theme  The raw `theme` prop value (any type; coerced defensively).
+ * @param string $prefix The component's BEM block prefix (e.g. 'cta', 'pp-section').
+ * @return string A leading-space class fragment (e.g. ' cta--dark'), or '' for the
+ *                default theme so `class="cta<?php echo $theme_class; ?>"` stays clean.
+ */
+function pp_theme_class($theme, string $prefix): string {
+    $accepted = ['default', 'muted', 'dark', 'inverted'];
+    if (!is_string($theme) || !in_array($theme, $accepted, true)) {
+        $theme = 'default';
+    }
+    if ($theme === 'default') {
+        return '';
+    }
+    // `muted` is the canonical value; `dark` is its deprecated alias. Both share the
+    // legacy `--dark` CSS class so existing pages render byte-identically forever.
+    $slug = ($theme === 'muted') ? 'dark' : $theme;
+    return ' ' . $prefix . '--' . $slug;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.12
+Stable tag: 1.4.13
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.12
+Version:          1.4.13
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1392,6 +1392,45 @@ class ComponentPropsTest extends TestCase
         $this->assertStringContainsString('class="faq"', $html);
     }
 
+    // ── #442: theme `muted` migration + deprecated `dark` alias (render layer) ──
+    // The canonical value `muted` and the deprecated legacy value `dark` must BOTH
+    // emit the legacy `--dark` surface-band class, so pages authored before the
+    // rename render byte-identically forever while new pages use `muted`. Proven
+    // at the render layer (not just the helper) so the template wiring is pinned.
+
+    public function testFaqMutedThemeEmitsLegacyDarkClass(): void
+    {
+        $html = $this->render('faq', $this->faqProps(['theme' => 'muted']));
+        $this->assertStringContainsString('class="faq faq--dark"', $html);
+    }
+
+    public function testFaqMutedAndLegacyDarkRenderByteIdentically(): void
+    {
+        $muted = $this->render('faq', $this->faqProps(['theme' => 'muted']));
+        $dark  = $this->render('faq', $this->faqProps(['theme' => 'dark']));
+        $this->assertSame($dark, $muted, 'muted must render byte-identically to the legacy dark alias');
+    }
+
+    public function testGridMutedThemeEmitsLegacyDarkClass(): void
+    {
+        $muted = $this->render('grid', ['theme' => 'muted', 'items' => [['title' => 'One', 'text' => 'a']]]);
+        $dark  = $this->render('grid', ['theme' => 'dark', 'items' => [['title' => 'One', 'text' => 'a']]]);
+        $this->assertStringContainsString('grid--dark', $muted);
+        $this->assertSame($dark, $muted);
+    }
+
+    public function testCtaMutedEmitsDarkAndInvertedStaysInverted(): void
+    {
+        $base     = ['title' => 'Go', 'button_text' => 'Click', 'button_url' => '/'];
+        $muted    = $this->render('cta', $base + ['theme' => 'muted']);
+        $dark     = $this->render('cta', $base + ['theme' => 'dark']);
+        $inverted = $this->render('cta', $base + ['theme' => 'inverted']);
+        $this->assertStringContainsString('cta--dark', $muted);
+        $this->assertSame($dark, $muted, 'cta muted must equal the legacy dark alias');
+        $this->assertStringContainsString('cta--inverted', $inverted);
+        $this->assertStringNotContainsString('cta--dark', $inverted);
+    }
+
     public function testStatsRendersAllFourSlots(): void
     {
         $overrides = [

--- a/tests/SchemaThemeConsistencyTest.php
+++ b/tests/SchemaThemeConsistencyTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Schema contract: enums SHARED across component schemas must describe every value
+ * identically. This is the test that would have caught the #442 drift, where the
+ * `theme` enum's `dark` value was documented as "dark surface" in 3 schemas and
+ * "surface background with borders" in 5 — the AI's belief depended on which schema
+ * it read last. The rule is generic (any prop name shared across 2+ components), so
+ * it also guards `layout`, `card_emphasis`, or any future shared enum.
+ *
+ * It also pins the #442 migration outcome directly: the `theme` enum advertises
+ * `default | muted | inverted` (no `dark`), byte-identical across all eight bands.
+ */
+class SchemaThemeConsistencyTest extends TestCase
+{
+    /**
+     * @return array<string, array<string, mixed>>  component name => decoded schema
+     */
+    private function loadSchemas(): array
+    {
+        $root    = dirname(__DIR__);
+        $schemas = [];
+        foreach (glob($root . '/components/*/schema.json') as $file) {
+            $name = basename(dirname($file));
+            $data = json_decode(file_get_contents($file), true);
+            $this->assertIsArray($data, "schema.json for '{$name}' is not valid JSON");
+            $schemas[$name] = $data;
+        }
+        $this->assertNotEmpty($schemas, 'no component schemas found');
+        return $schemas;
+    }
+
+    /**
+     * Components that share the SAME enum — the same prop name AND the same set of
+     * values — must describe it identically. Two enums that merely share a name but
+     * carry different value sets (e.g. `layout`, whose values differ per component)
+     * are genuinely different enums and are allowed to differ; grouping by value set
+     * lets those through while still pinning a true shared vocabulary like `theme`.
+     *
+     * This is precisely the test that fails on the #442 drift: all eight `theme`
+     * enums declared the same values ([default, dark, inverted]) yet 3 described the
+     * band as "dark surface" and 5 as "surface background with borders" — one group,
+     * divergent descriptions.
+     */
+    public function testSharedEnumPropsAreDescribedIdenticallyAcrossComponents(): void
+    {
+        $schemas = $this->loadSchemas();
+
+        // prop name => value-set-signature => [component => description]
+        $groups = [];
+        foreach ($schemas as $component => $schema) {
+            foreach (($schema['props'] ?? []) as $propName => $def) {
+                if (($def['type'] ?? null) !== 'enum') {
+                    continue;
+                }
+                $signature = json_encode($def['values'] ?? null);
+                $groups[$propName][$signature][$component] = $def['description'] ?? null;
+            }
+        }
+
+        // `theme` must be a real shared enum: same value set across 2+ components.
+        $this->assertArrayHasKey('theme', $groups, 'theme enum not found in any schema');
+        $themeSharedGroups = array_filter($groups['theme'], static fn ($comps) => count($comps) >= 2);
+        $this->assertNotEmpty($themeSharedGroups, 'theme should share one value set across components');
+
+        $checkedTheme = false;
+        foreach ($groups as $propName => $bySignature) {
+            foreach ($bySignature as $signature => $componentsToDesc) {
+                if (count($componentsToDesc) < 2) {
+                    continue; // a per-component enum (or a lone occurrence) — nothing shared to enforce
+                }
+                if ($propName === 'theme') {
+                    $checkedTheme = true;
+                }
+                $uniqueDescriptions = array_unique(array_values($componentsToDesc), SORT_REGULAR);
+                $this->assertCount(
+                    1,
+                    $uniqueDescriptions,
+                    sprintf(
+                        "Shared enum '%s' (values %s) has divergent descriptions across components (%s). "
+                        . "Components sharing the same enum must document each value identically (#442).",
+                        $propName,
+                        $signature,
+                        implode(', ', array_keys($componentsToDesc))
+                    )
+                );
+            }
+        }
+
+        $this->assertTrue($checkedTheme, 'the shared theme enum was not actually asserted');
+    }
+
+    /**
+     * Pins the #442 migration: `theme` advertises muted, not dark, everywhere.
+     */
+    public function testThemeEnumAdvertisesMutedNotDark(): void
+    {
+        $bandComponents = ['cta', 'section', 'faq', 'grid', 'embed', 'logos', 'stats', 'testimonials'];
+        $schemas        = $this->loadSchemas();
+
+        foreach ($bandComponents as $component) {
+            $this->assertArrayHasKey($component, $schemas, "missing schema for '{$component}'");
+            $theme = $schemas[$component]['props']['theme'] ?? null;
+            $this->assertIsArray($theme, "'{$component}' has no theme prop");
+            $this->assertSame(
+                ['default', 'muted', 'inverted'],
+                $theme['values'],
+                "'{$component}' theme enum must advertise default|muted|inverted (no dark) — #442"
+            );
+            $this->assertNotContains('dark', $theme['values'], "'{$component}' still advertises the deprecated 'dark'");
+            // The description must steer toward inverted for a dark band, and must not
+            // present 'dark' as an offered value.
+            $this->assertStringContainsString('muted', $theme['description']);
+            $this->assertStringContainsString('inverted', $theme['description']);
+        }
+    }
+}

--- a/tests/ThemeClassHelperTest.php
+++ b/tests/ThemeClassHelperTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit coverage for pp_theme_class() — the single source of truth for the band
+ * `theme` modifier class and the deprecated `dark` -> `muted` alias (#442).
+ *
+ * The alias must map BOTH ways to the SAME legacy `--dark` CSS class so existing
+ * pages storing `theme: "dark"` render byte-identically while new pages use `muted`.
+ * The genuinely dark band is `--inverted`. Anything unexpected coerces to default
+ * (empty string), matching the historical non-strict accept-and-coerce behavior.
+ */
+class ThemeClassHelperTest extends TestCase
+{
+    public function testDefaultEmitsNoModifier(): void
+    {
+        $this->assertSame('', pp_theme_class('default', 'cta'));
+    }
+
+    public function testMutedEmitsLegacyDarkClass(): void
+    {
+        // muted is the canonical value; it renders under the legacy `--dark` class.
+        $this->assertSame(' cta--dark', pp_theme_class('muted', 'cta'));
+    }
+
+    public function testDeprecatedDarkAliasEmitsSameClassAsMuted(): void
+    {
+        // Both values resolve to the identical class — the alias, proven both ways.
+        $this->assertSame(
+            pp_theme_class('muted', 'grid'),
+            pp_theme_class('dark', 'grid'),
+            'dark must be a byte-identical alias of muted at the class level'
+        );
+        $this->assertSame(' grid--dark', pp_theme_class('dark', 'grid'));
+    }
+
+    public function testInvertedEmitsInvertedClass(): void
+    {
+        $this->assertSame(' cta--inverted', pp_theme_class('inverted', 'cta'));
+    }
+
+    public function testPrefixIsRespected(): void
+    {
+        $this->assertSame(' pp-section--dark', pp_theme_class('muted', 'pp-section'));
+        $this->assertSame(' testimonials--inverted', pp_theme_class('inverted', 'testimonials'));
+    }
+
+    /**
+     * @dataProvider unexpectedValues
+     * @param mixed $value
+     */
+    public function testUnexpectedValuesCoerceToDefault($value): void
+    {
+        $this->assertSame('', pp_theme_class($value, 'cta'));
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unexpectedValues(): array
+    {
+        return [
+            'unknown string' => ['neon'],
+            'empty string'   => [''],
+            'null'           => [null],
+            'array'          => [['muted']],
+            'integer'        => [1],
+            'bool'           => [true],
+            'uppercase'      => ['MUTED'],
+        ];
+    }
+}

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -284,6 +284,46 @@ test.describe('Safe-surface rendered proof', () => {
     expect(color).toBe('rgb(255, 0, 128)');
   });
 
+  // #442: the `theme` enum value must PREDICT the rendered band background. The static
+  // schema/helper tests prove the class mapping; only getComputedStyle proves the CSS
+  // cascade actually paints it. Seed one band per theme value and assert the computed
+  // background-color matches the documented meaning:
+  //   default  -> transparent (page background shows through)
+  //   muted    -> --color-surface (#f4f7fb) — the LIGHT tinted band
+  //   dark     -> IDENTICAL to muted (deprecated alias; existing pages unchanged)
+  //   inverted -> --color-bg-inverted (#0f172a) — the genuinely dark band
+  test('#442 theme values render the documented band background', async ({ page }) => {
+    pageId = createPage('E2E Theme Band Backgrounds');
+    setComposition(pageId, [
+      { component: 'grid', props: { id: 'pp-theme-default', theme: 'default', items: [{ title: 'D', text: 'x' }] } },
+      { component: 'grid', props: { id: 'pp-theme-muted', theme: 'muted', items: [{ title: 'M', text: 'x' }] } },
+      { component: 'grid', props: { id: 'pp-theme-dark', theme: 'dark', items: [{ title: 'K', text: 'x' }] } },
+      { component: 'grid', props: { id: 'pp-theme-inverted', theme: 'inverted', items: [{ title: 'I', text: 'x' }] } },
+    ]);
+
+    await page.goto(`/?page_id=${pageId}`);
+
+    const bg = async (sel: string) => {
+      const el = page.locator(sel);
+      await expect(el).toBeVisible({ timeout: 10000 });
+      return el.evaluate((n) => getComputedStyle(n).backgroundColor);
+    };
+
+    const SURFACE = 'rgb(244, 247, 251)'; // --color-surface #f4f7fb
+    const INVERTED = 'rgb(15, 23, 42)';   // --color-bg-inverted #0f172a
+    const TRANSPARENT = 'rgba(0, 0, 0, 0)';
+
+    expect(await bg('#pp-theme-default')).toBe(TRANSPARENT);
+    const muted = await bg('#pp-theme-muted');
+    const dark = await bg('#pp-theme-dark');
+    expect(muted).toBe(SURFACE);
+    // The whole point of #442: `muted` is a LIGHT band, not dark.
+    expect(muted).not.toBe(INVERTED);
+    // The deprecated `dark` alias renders byte-identically to `muted`.
+    expect(dark).toBe(muted);
+    expect(await bg('#pp-theme-inverted')).toBe(INVERTED);
+  });
+
   // #349: an explicit per-instance --grid-item-text-color must win over a text_role
   // color preset (.text-meta / .text-kicker) at BOTH breakpoints. The bug was a
   // breakpoint split: the role utility (utilities.css, enqueued after components.css)

--- a/tests/js/pp-editor-enum-legacy.test.js
+++ b/tests/js/pp-editor-enum-legacy.test.js
@@ -1,0 +1,100 @@
+/**
+ * Enum <select> rendering in the accordion editor must not silently drop a stored
+ * value that is no longer advertised in the schema's `values`.
+ *
+ * This is the #442 migration hazard: the `theme` enum dropped the deprecated `dark`
+ * value from `values` (schemas now advertise `default | muted | inverted`), but the
+ * renderer still accepts `dark` as an alias of `muted`. If the editor built the
+ * <select> only from `values`, opening an existing band that stored `theme: "dark"`
+ * would leave no option selected — the browser would fall back to the first option
+ * (`default`) and RE-SAVING would silently rewrite the stored value, a visual change
+ * to an existing page. The fix (pp-admin-editor.js buildFieldHtml, ~line 187) prepends
+ * the stored value as its own option when it is not in `values`, so it round-trips.
+ *
+ * These tests mirror that render snippet (same pattern as pp-editor-dom.test.js).
+ *
+ * @vitest-environment jsdom
+ */
+
+// Faithful to the editor's real esc(): `$('<span>').text(text).html()` escapes
+// `<`, `>`, `&` but NOT the double-quote (text content serialization). The test
+// must mirror that exactly, or it would mask the shipped escaping behavior — which
+// is precisely why the injection is charset-guarded rather than escape-trusted.
+function esc(s) {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+/**
+ * Mirrors the enum branch of buildFieldHtml in pp-admin-editor.js (~lines 187-206),
+ * including the #442 legacy-value injection.
+ */
+function buildEnumSelectHtml(field) {
+    let h = '<select data-field="' + field.name + '">';
+    if (field.type === 'enum' && field.values) {
+        var storedVal = (field.value === undefined || field.value === null) ? '' : String(field.value);
+        if (storedVal !== '' && field.values.indexOf(field.value) === -1 && /^[a-z0-9_-]+$/i.test(storedVal)) {
+            h += '<option value="' + esc(storedVal) + '" selected>' + esc(storedVal) + ' (legacy)</option>';
+        }
+        field.values.forEach(function (v) {
+            var sel = v === field.value ? ' selected' : '';
+            h += '<option value="' + esc(v) + '"' + sel + '>' + esc(v) + '</option>';
+        });
+    }
+    h += '</select>';
+    return h;
+}
+
+function selectedValue(html) {
+    document.body.innerHTML = html;
+    const sel = document.querySelector('select');
+    return sel.value; // reflects the `selected` option
+}
+
+const themeValues = ['default', 'muted', 'inverted'];
+
+describe('accordion editor enum <select> — #442 legacy value round-trip', () => {
+    it('preserves a stored legacy "dark" value that is no longer advertised', () => {
+        const html = buildEnumSelectHtml({ name: 'theme', type: 'enum', values: themeValues, value: 'dark' });
+        // The stored value survives as a selected option, so re-saving keeps "dark".
+        expect(selectedValue(html)).toBe('dark');
+        expect(html).toContain('>dark (legacy)</option>');
+    });
+
+    it('selects an advertised value normally without injecting an extra option', () => {
+        const html = buildEnumSelectHtml({ name: 'theme', type: 'enum', values: themeValues, value: 'muted' });
+        expect(selectedValue(html)).toBe('muted');
+        expect(html).not.toContain('(legacy)');
+        // Exactly the three advertised options, none injected.
+        expect((html.match(/<option/g) || []).length).toBe(3);
+    });
+
+    it('does not inject a stray option when no value is stored', () => {
+        const html = buildEnumSelectHtml({ name: 'theme', type: 'enum', values: themeValues, value: undefined });
+        expect(html).not.toContain('(legacy)');
+        expect((html.match(/<option/g) || []).length).toBe(3);
+        // Browser defaults to the first option.
+        expect(selectedValue(html)).toBe('default');
+    });
+
+    it('does not reflect a malformed stored value into the value attribute (charset guard)', () => {
+        // A stored value with attribute-breaking characters must NOT be injected —
+        // esc() is text-safe but does not escape the double-quote that closes the
+        // attribute, so the charset guard is the real defense. The malformed value
+        // simply falls back to the default option.
+        const evil = 'x" onfocus=alert(1) autofocus="';
+        const html = buildEnumSelectHtml({ name: 'theme', type: 'enum', values: themeValues, value: evil });
+        expect(html).not.toContain('onfocus');
+        expect(html).not.toContain('(legacy)');
+        expect((html.match(/<option/g) || []).length).toBe(3);
+        expect(selectedValue(html)).toBe('default');
+    });
+
+    it('does not double-count when the stored value is the default', () => {
+        const html = buildEnumSelectHtml({ name: 'theme', type: 'enum', values: themeValues, value: 'default' });
+        expect((html.match(/<option/g) || []).length).toBe(3);
+        expect(selectedValue(html)).toBe('default');
+    });
+});


### PR DESCRIPTION
Closes #442

## What & why
The band `theme` enum value `dark` renders a **light** `--color-surface` tinted band, not a dark one — a misnomer that produced wrong generated output in two real dogfoods (an AI asked for a "dark band", picked `dark`, and got a near-white tint; the genuinely dark band is `inverted`). The eight band components also disagreed about what the value meant (3 schemas said "dark surface", 5 said "surface background with borders").

This migrates the value (issue Option 1): introduce the accurately-named `muted` and keep `dark` as a **renderer-level deprecated alias** so the installed base (webfiable / neocompute / poc) renders byte-identically forever.

## Scope (against acceptance criteria)
- **All eight theme descriptions identical + truthful:** all 8 `components/*/schema.json` `theme` enums advertise `default | muted | inverted` with one byte-identical description. (`default` is phrased generically-true because `faq`'s base band is already `--color-surface` while the other seven default to `transparent` — a literal "page background" would be false for faq.)
- **`muted` renders the current surface treatment; `dark` byte-identical; new-page guidance drops `dark`:** a single shared helper `pp_theme_class($theme, $prefix)` (`lib/helpers.php`) maps both `muted` (canonical) and legacy `dark` to the existing `--dark` CSS class. No CSS class is renamed, so existing pages emit identical HTML. All 8 render files call the helper. `theme` is non-strict, so write-validation and preflight never reject or warn on stored `dark`.
- **Schema-consistency test:** `tests/SchemaThemeConsistencyTest.php` fails if any two components sharing an enum (same value set) describe it differently — the exact 3-vs-5 drift. (It also surfaced a real pre-existing near-identical drift in the shared `heading_align` enum on `testimonials`, unified here so the general invariant holds.)

## Naming decision (delegated in plan-eng-review)
Chose **`muted`** over `tinted`: it matches the issue's acceptance criteria verbatim, describes a recessed/quieter surface panel (not an added hue — `tinted` wrongly implies brand-color involvement), and pairs cleanly against `inverted`.

## Docs
`AI_CONTEXT.md`, `ai-instructions/composition.md`, `ai-instructions/website-building.md`, `ai-instructions/style-component.md`, and `README.md` now offer `muted` for new pages and carry a "for a dark band use `inverted`" warning.

## Validation
- PHPUnit: **2077 passed** (`./vendor/bin/phpunit`), warnings/deprecations match the unmodified tree (3/2).
- vitest: **752 passed** (`npm test`).
- E2E on wp-env: `#442 theme values render the documented band background` **passed** — computed background per value: `default`->transparent, `muted`->`rgb(244,247,251)`, legacy `dark`->identical to `muted`, `inverted`->`rgb(15,23,42)`.
- `bash scripts/package.sh`: version consistency OK across all five files (zip deleted).

## Reviews (this session, on this diff)
- `/plan-eng-review` — clean; Codex outside voice ran clean.
- `/review` — CLEAN. Codex + Claude adversarial converged; both Codex High findings refuted with file:line (esc() is a DOM escaper + `theme` is non-strict). Two low within-scope findings fixed: a charset guard on the editor's injected option and a faithful test escaper.

## Accepted limitations
- Stored `dark` is intentionally **not** migrated on read; it renders forever via the alias, and `inspect` echoes the stored value honestly (read-only-CLI invariant). New pages use `muted`.
- The canonical `muted` value renders under the legacy `--dark` CSS class by design (byte-identical existing pages); a code comment in `components.css` and the helper docblock document this.

## 7A questions
None — all decisions were within the issue's recorded Option 1 mandate.
