### PR TITLE
v1.4.16 feat: add --stats-radius / --stats-max-width slots for a contained stats card (#383)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -388,7 +388,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**209 style slots** across 10 components: hero (41), grid (36), section (36), cta (31), testimonials (26), faq (17), stats (10), embed (4), logos (4), table (4).
+**211 style slots** across 10 components: hero (41), grid (36), section (36), cta (31), testimonials (26), faq (17), stats (12), embed (4), logos (4), table (4).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.16] — 2026-07-20 — a `stats` band can now be a contained, rounded metrics card (#383)
+
+**The `stats` component rendered only as a full-width band. It exposed color, padding, and typography slots but no way to round its corners or cap its width, so the common marketing treatment of a contained, rounded metrics card (a rounded navy panel inset from the page edges) was inexpressible. Two new style slots fix that: `--stats-radius` rounds the band and `--stats-max-width` caps and centers it. Set both and the band becomes a card; leave them unset and the band renders exactly as before.**
+
+Both slots follow the namespaced `*-radius` pattern the hero, section, and cta bands already use, and both are length-typed and validated by the shared style engine. Their defaults are inert: `--stats-radius` defaults to `0` and `--stats-max-width` to `none`, and the centering `margin-inline: auto` collapses to zero at full width, so an unset `stats` band is byte-identical to the previous full-bleed render. To widen a capped band back out, set `--stats-max-width` to `100%`.
+
+### Added
+- `--stats-radius` (length, default `0`) and `--stats-max-width` (length, default `none`) style slots on the `stats` component, settable via `style_component` or a composition `style` block. Together they turn a full-width stats band into a contained, rounded metrics card: `--stats-max-width` caps the band and centers it with automatic side margins, and `--stats-radius` rounds its background. Unset, the band spans full width with square corners unchanged (#383).
+
+### Docs
+- `ai-instructions/style-component.md` documents the two new slots and how to combine them for a contained card (and that `--stats-max-width: 100%` is how to remove the cap, since the type has no `none` input). `AI_CONTEXT.md` and `README.md` now report 211 style slots (stats: 12) (#383).
+
+### Tests
+- `tests/e2e/style-render.spec.ts` adds rendered-proof coverage: `--stats-radius` reaches the band at 375px and 1280px, `--stats-max-width` caps and centers the band at 1280px with equal side gutters, an unset band computes `border-radius: 0px` / `max-width: none` at full width, and a 640px cap never overflows at 375px. `tests/js/css-lint.test.js` pins that both declarations route through their slots with the exact `0` / `none` fallbacks. The schema entries are auto-picked up by the keystone `StyleSlotContractTest` (#383).
+
 ## [v1.4.15] — 2026-07-20 — a `split` hero with no image no longer reserves an empty half-band (#440)
 
 **A `hero` with `layout: "split"` but no image and no `proof` used to keep the two-column split grid, squeezing the headline into the left half with dead whitespace across the rest of the band. That is a common authoring state — split chosen before media is imported, or an image prop dropped in an edit. Now that state degrades to the single-column `left` layout so the text uses the full content width and no empty column is reserved, and `wp pp check page` surfaces a `hero_split_no_media` advisory so the author knows to add media (or switch layouts). A `split` hero with an image, or with `proof` filling the second column, renders exactly as before.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.15-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.16-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-209 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+211 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.4.0.
 
 **What exists today (v1.4.0):**
-- 12 components with schema contracts and 209 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 211 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/ai-instructions/style-component.md
+++ b/ai-instructions/style-component.md
@@ -106,6 +106,15 @@ or a single-layer `box-shadow` (2-4 px/rem lengths plus an rgb/rgba/hsl/hsla col
 cta, and testimonials (card) components each expose namespaced `*-border-color`,
 `*-border-width`, `*-radius`, and `*-shadow` slots.
 
+The `stats` band exposes two of these framing slots — `--stats-radius` (length,
+default `0`) and `--stats-max-width` (length, default `none`) — for a **contained,
+rounded metrics card** (#383). Set both together: `--stats-max-width` caps the band
+and centers it with auto side margins, and `--stats-radius` rounds the band's
+background. Unset, the band spans full width with square corners exactly as before.
+To "remove" the max-width, set `100%` (the type has no `none` input) — the slot's
+`none` default is the built-in full-bleed. Stats does not expose `*-border-*` or
+`*-shadow` slots.
+
 The grid's **featured first-card treatment** (accent top bar, texture stripe, blue
 glow on card 1 of a cards-layout grid) is slot-controllable (#293):
 `--grid-card-bar-color`/`--grid-card-bar-height` pin one top bar on EVERY card

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2410,6 +2410,14 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   padding-top: var(--stats-padding-top, var(--pp-band-padding));
   padding-bottom: var(--stats-padding-bottom, var(--pp-band-padding));
   background: var(--stats-bg, transparent);
+  /* Contained rounded metrics card (issue 383). max-width caps the band and the
+     auto side-margins center it; the radius rounds the band's own background box.
+     Defaults ('none' / '0') are inert — with max-width: none the block fills its
+     container, so margin-inline: auto computes to 0, and an unset band renders
+     byte-identically to the pre-383 full-bleed. */
+  max-width: var(--stats-max-width, none);
+  margin-inline: auto;
+  border-radius: var(--stats-radius, 0);
 }
 
 .stats__heading {

--- a/components/stats/schema.json
+++ b/components/stats/schema.json
@@ -57,7 +57,9 @@
       "--stats-number-color": { "type": "color", "default": "var(--color-accent)", "description": "Stat number (large metric value) text color" },
       "--stats-number-size": { "type": "length", "default": "2.5rem", "description": "Stat number (large metric value) font size" },
       "--stats-label-color": { "type": "color", "default": "var(--color-muted)", "description": "Stat label text color" },
-      "--stats-bg-position": { "type": "position", "default": "center", "description": "background_image focal point" }
+      "--stats-bg-position": { "type": "position", "default": "center", "description": "background_image focal point" },
+      "--stats-radius": { "type": "length", "default": "0", "description": "Border radius of the stats band. Pair with --stats-max-width for a contained, rounded metrics card." },
+      "--stats-max-width": { "type": "length", "default": "none", "description": "Maximum width of the stats band. When set, the band is capped to this width and centered (auto side margins), producing a contained card; the default 'none' spans full width unchanged." }
     }
   },
   "safe_to_edit": ["stats.php", "../../assets/css/components.css (COMPONENT: stats section)"],

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.15');
+define('PP_VERSION', '1.4.16');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.15
+Stable tag: 1.4.16
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.15
+Version:          1.4.16
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -2275,6 +2275,160 @@ test.describe('Safe-surface rendered proof', () => {
 });
 
 /**
+ * #383 — stats contained rounded metrics card, rendered proof.
+ *
+ * The static StyleSlotContractTest proves `--stats-radius` / `--stats-max-width`
+ * are CONSUMED as var() on a length-compatible property; only a real browser proves
+ * they WIN once the cascade resolves (the #302 dead-slot class the issue calls out).
+ * These pins assert: (1) unset renders full-bleed + square, byte-identical to pre-383;
+ * (2) the radius reaches the rendered band at 375 AND 1280; (3) max-width caps and
+ * centers the band at 1280 and never overflows at 375.
+ */
+test.describe('#383 stats contained rounded card renders', () => {
+  let pageId: number;
+
+  test.afterEach(async () => {
+    if (pageId) {
+      try {
+        deletePage(pageId);
+      } catch {
+        /* already cleaned */
+      }
+      pageId = 0;
+    }
+  });
+
+  test('#383 unset stats band is full-bleed and square (byte-identical) @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Stats Card Defaults');
+    setComposition(pageId, [
+      {
+        component: 'stats',
+        props: { id: 'pp-stats01', items: [{ number: '98%', label: 'Uptime' }] },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const band = page.locator('.stats');
+    await expect(band).toBeVisible({ timeout: 10000 });
+
+    // Defaults are inert: max-width: none, border-radius: 0 — the pre-383 render.
+    const metrics = await band.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return {
+        radius: cs.borderTopLeftRadius,
+        maxWidth: cs.maxWidth,
+        docScroll: document.documentElement.scrollWidth,
+        docClient: document.documentElement.clientWidth,
+      };
+    });
+    expect(metrics.radius).toBe('0px');
+    expect(metrics.maxWidth).toBe('none');
+    // No horizontal overflow at the default full-bleed width.
+    expect(metrics.docScroll).toBeLessThanOrEqual(metrics.docClient + 1);
+  });
+
+  test('#383 --stats-radius rounds the band at 375 and 1280 @smoke', async ({ page }) => {
+    pageId = createPage('E2E Stats Card Radius');
+    setComposition(pageId, [
+      {
+        component: 'stats',
+        props: { id: 'pp-stats01', items: [{ number: '98%', label: 'Uptime' }] },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+    const res = await styleComponent(page, pageId, { '--stats-radius': '24px' });
+    expect(res.success).toBe(true);
+
+    for (const width of [375, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      const band = page.locator('.stats');
+      await expect(band).toBeVisible({ timeout: 10000 });
+      const radius = await band.evaluate((el) => getComputedStyle(el).borderTopLeftRadius);
+      expect(radius).toBe('24px');
+    }
+  });
+
+  test('#383 --stats-max-width caps and centers the band at 1280 @smoke', async ({ page }) => {
+    pageId = createPage('E2E Stats Card Max Width');
+    setComposition(pageId, [
+      {
+        component: 'stats',
+        props: { id: 'pp-stats01', items: [{ number: '98%', label: 'Uptime' }] },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+    const res = await styleComponent(page, pageId, { '--stats-max-width': '640px' });
+    expect(res.success).toBe(true);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+    const band = page.locator('.stats');
+    await expect(band).toBeVisible({ timeout: 10000 });
+
+    const geo = await band.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      return {
+        maxWidth: getComputedStyle(el).maxWidth,
+        width: rect.width,
+        left: rect.left,
+        right: document.documentElement.clientWidth - rect.right,
+      };
+    });
+    // The slot reaches the band, the band is capped to 640, and auto side-margins
+    // center it (equal gutters within a rounding tolerance) — a contained card, not
+    // a full-bleed band pinned to the left edge.
+    expect(geo.maxWidth).toBe('640px');
+    expect(geo.width).toBeLessThanOrEqual(641);
+    expect(geo.width).toBeGreaterThan(600);
+    expect(Math.abs(geo.left - geo.right)).toBeLessThanOrEqual(2);
+    expect(geo.left).toBeGreaterThan(100); // real gutters exist (not left-pinned)
+  });
+
+  test('#383 --stats-max-width never overflows at 375 @smoke', async ({ page }) => {
+    pageId = createPage('E2E Stats Card Max Width Mobile');
+    setComposition(pageId, [
+      {
+        component: 'stats',
+        props: {
+          id: 'pp-stats01',
+          items: [
+            { number: '98%', label: 'Uptime' },
+            { number: '+30', label: 'Years' },
+          ],
+        },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+    // 640px cap is wider than the 375px viewport, so the band must fall back to the
+    // viewport width with no horizontal scroll (acceptance: no overflow at 375px).
+    const res = await styleComponent(page, pageId, { '--stats-max-width': '640px' });
+    expect(res.success).toBe(true);
+
+    await page.setViewportSize({ width: 375, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+    const band = page.locator('.stats');
+    await expect(band).toBeVisible({ timeout: 10000 });
+
+    const overflow = await page.evaluate(() => ({
+      scroll: document.documentElement.scrollWidth,
+      client: document.documentElement.clientWidth,
+    }));
+    expect(overflow.scroll).toBeLessThanOrEqual(overflow.client + 1);
+  });
+});
+
+/**
  * #333 — header/footer chrome, rendered proof.
  *
  * The header and footer are template-owned chrome, so their styling surface is the

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -1716,6 +1716,29 @@ describe('CSS lint: premium layer honors padding/type/width slots (#302)', () =>
         });
     });
 
+    // ---- Stats contained-card slots (issue 383) ----
+    // The band's radius + max-width must route through the slots with byte-identical
+    // unset fallbacks ('0' / 'none'), so an unset stats band stays full-bleed with
+    // square corners exactly as before 383. The rendered proof lives in style-render.spec.ts.
+    test('.stats radius + max-width route through --stats-radius / --stats-max-width', () => {
+        const bodies = bodiesForExactSelector('.stats');
+        expect(bodies.length).toBeGreaterThanOrEqual(1);
+        const radiusBodies = bodies.filter(b => /border-radius\s*:/.test(b));
+        const widthBodies = bodies.filter(b => /max-width\s*:/.test(b));
+        expect(radiusBodies.length).toBeGreaterThanOrEqual(1);
+        expect(widthBodies.length).toBeGreaterThanOrEqual(1);
+        radiusBodies.forEach(body => {
+            (body.match(/border-radius\s*:[^;}]+/g) || []).forEach(d => {
+                expect(d).toMatch(/border-radius\s*:\s*var\(\s*--stats-radius\s*,\s*0\s*\)/);
+            });
+        });
+        widthBodies.forEach(body => {
+            (body.match(/max-width\s*:[^;}]+/g) || []).forEach(d => {
+                expect(d).toMatch(/max-width\s*:\s*var\(\s*--stats-max-width\s*,\s*none\s*\)/);
+            });
+        });
+    });
+
     // ---- Own section/grid/cta padding (desktop + mobile) ----
     test('every .section padding declaration routes through --section-padding-*', () => {
         assertPropRoutesThroughSlot('.section', 'padding-top', '--section-padding-top', 2);


### PR DESCRIPTION
Closes #383

## Summary
Adds two length-typed style slots to the `stats` component so a contained, rounded metrics card is expressible (the treatment the neocompute.com dogfood, 2026-07-14, found inexpressible):

- `--stats-radius` (default `0`) — rounds the band's own background box.
- `--stats-max-width` (default `none`) — caps the band and centers it via `margin-inline: auto`, producing a contained card.

Both follow the existing namespaced `*-radius` slot pattern (hero/section/cta) and are validated by the shared style engine. Defaults are inert, so an unset `stats` band renders byte-identically to the pre-383 full-bleed.

## Acceptance criteria
- ✅ Both slots schema-declared, settable via `style_component` / composition `style`, and **rendered** (proven in the browser — no #302-class dead slot).
- ✅ Unset pages render pixel-identical to today (computed `border-radius: 0px` / `max-width: none`, full-bleed, no overflow — pinned by E2E).
- ✅ With `max-width` set the band centers (equal side gutters) and the radius clips the band background; mobile verified — no overflow at 375px.
- ✅ `style-component.md` slot inventory updated.

## Design decisions
- `--stats-max-width` caps and centers the **band** (not a text-column), per the recorded decision ("centering the band, auto side margins"). The existing `-content-width` / `-body-width` slots cap text columns, a different concept, so the issue's distinct `--stats-max-width` name is used.
- Radius follows the exact `--cta-radius` / `--section-radius` idiom (`border-radius: var(--stats-radius, 0)`, no `overflow: hidden`). This clips the band's own background — the solid-card case that motivates the issue.

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` — 2123 tests, 0 failures (warnings/deprecations match the unmodified tree).
- `npm test` (vitest) — 757 tests, 0 failures (includes the new css-lint slot pin).
- New E2E in `tests/e2e/style-render.spec.ts` — ran locally against wp-env: 5/5 passing (radius wins at 375+1280, max-width caps+centers at 1280, unset full-bleed defaults, no overflow at 375). Full E2E suite also runs on post-merge main CI (WordPress 7.0).
- Keystone `StyleSlotContractTest` auto-discovers the two new slots (consumption + type-compat checks); neither name trips the #332 WP-core border-trigger regex, so no immunity baseline is needed.
- `scripts/package.sh` validates the five-file version sync at 1.4.16 (built zip deleted; releases are CI-built from tags).

## Accepted limitation
When `--stats-radius` is combined with a `background_image`, the radius rounds the band background but the separately-positioned dark-scrim overlay keeps square corners (no `overflow: hidden`, matching the cta/section radius precedent). Purely cosmetic, unusual slot combination; candidate follow-up.

## Not in scope
Stats layout variants (horizontal/vertical) and number-counting animation (per the issue).

## 7A decisions
None — the max-width band-cap semantics are the issue's recorded decision, implemented as written; no accepted-behavior/public-surface question arose.

## gstack workflows
plan-eng-review, /review + Claude adversarial subagent, /document-generate, /ship — all clean on this diff.
