### PR TITLE
v1.4.17 feat: authorable faq heading->list gap via --faq-heading-margin-bottom slot (#352)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -388,7 +388,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**211 style slots** across 10 components: hero (41), grid (36), section (36), cta (31), testimonials (26), faq (17), stats (12), embed (4), logos (4), table (4).
+**212 style slots** across 10 components: hero (41), grid (36), section (36), cta (31), testimonials (26), faq (18), stats (12), embed (4), logos (4), table (4).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.17] — 2026-07-20 — the `faq` header rhythm is now fully authorable (#352)
+
+**The gap below a `faq` heading was the one band-heading rhythm the site-building AI could not touch. Every other header-bearing band (`section`, `grid`, `testimonials`) already routed its heading's bottom margin through a style slot; `faq` alone kept a bare literal, so "tighten this FAQ header" was inexpressible. A new `--faq-heading-margin-bottom` slot closes that gap. Set it to pull the accordion list closer to the heading or push it further away; leave it unset and the band renders exactly as before.**
+
+`faq` renders no subheading, so the slot governs the space between the heading and the accordion list. It follows the `--<component>-heading-margin-bottom` pattern established for `section` and `grid`, and it is length-typed and validated by the shared style engine. The slot is wired at all three places the heading's bottom margin is declared (the base rule plus the desktop and mobile premium-typography rules), each keeping today's literal as the fallback, so an unset `faq` heading computes the same margin it always has (26.4px desktop, 20px mobile). `faq` now has 18 style slots; the theme total is 212.
+
+### Added
+- `--faq-heading-margin-bottom` (length, default `var(--space-lg)`) style slot on the `faq` component, settable via `style_component` or a composition `style` block. It controls the space below the FAQ heading, before the accordion list, so the header rhythm is fully slot-driven like the other band components. Unset, the heading keeps its current bottom margin at every breakpoint (#352).
+
+### Tests
+- `tests/e2e/style-render.spec.ts` adds rendered proof: a set `--faq-heading-margin-bottom` wins on the `.faq__heading` at 375px and 1280px (both premium-typography breakpoints), while an unset `faq` heading computes the unchanged literal (26.4px desktop, 20px mobile). The schema entry and the routing of all three CSS declarations through the slot are enforced by the keystone `StyleSlotContractTest` (#352).
+
 ## [v1.4.16] — 2026-07-20 — a `stats` band can now be a contained, rounded metrics card (#383)
 
 **The `stats` component rendered only as a full-width band. It exposed color, padding, and typography slots but no way to round its corners or cap its width, so the common marketing treatment of a contained, rounded metrics card (a rounded navy panel inset from the page edges) was inexpressible. Two new style slots fix that: `--stats-radius` rounds the band and `--stats-max-width` caps and centers it. Set both and the band becomes a card; leave them unset and the band renders exactly as before.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.16-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.17-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-211 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+212 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.4.0.
 
 **What exists today (v1.4.0):**
-- 12 components with schema contracts and 211 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 212 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1280,7 +1280,14 @@
      renders at the h2 base size (base.css); the desktop clamp is routed through
      the same slot below. Fallback keeps unset output byte-identical. */
   font-size: var(--faq-heading-size, var(--pp-band-heading-size));
-  margin-bottom: var(--space-lg);
+  /* Header rhythm: the gap below the heading (before the accordion list). faq
+     renders no subheading, so this is the faq analogue of #343's title->subheading
+     slot. Route the heading's own bottom margin through a slot so faq's header
+     rhythm is slot-driven like section/grid; the desktop and mobile premium rules
+     below route the same slot. No header-scoping needed: the heading is an <h2>,
+     not the header's last child, so base.css's `p:last-child` reset never reached
+     it. Today's literal stays the fallback — unset output byte-identical (issue 352). */
+  margin-bottom: var(--faq-heading-margin-bottom, var(--space-lg));
   color: var(--faq-heading-color, var(--faq-heading-theme-color, var(--color-text)));
 }
 
@@ -3091,7 +3098,8 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
      rule below) at [0,2,1], outranking the base [0,1,0] rules and silently ignoring
      a declared --section-title-margin-bottom / --grid-heading-margin-bottom. Route
      each through its slot with 1.65rem as the fallback so unset output is unchanged.
-     faq stays a bare literal (no faq heading-margin slot in issue 343's scope).
+     faq now routes the same way through --faq-heading-margin-bottom (issue 352);
+     faq was left a bare literal in issue 343's scope and is completed here.
 
      issue 436 note: the font-size fallback here is now the shared --pp-band-heading-size
      instead of this rule's old per-rule clamp(2.25rem, 3vw, 2.62rem). Because that
@@ -3119,7 +3127,7 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   main > .faq .faq__heading {
     color: var(--faq-heading-color, var(--faq-heading-theme-color, var(--color-text)));
     font-size: var(--faq-heading-size, var(--pp-band-heading-size));
-    margin-bottom: 1.65rem;
+    margin-bottom: var(--faq-heading-margin-bottom, 1.65rem);
   }
 
   main > .section .section__content,
@@ -3204,7 +3212,8 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 
   /* margin-bottom split per-selector so each component's heading-margin slot
      reaches the title at this breakpoint too (issue 343); fallbacks preserve
-     today's 1.25rem. faq keeps the bare literal (out of issue 343's scope). */
+     today's 1.25rem. faq now routes the same way (issue 352); it was left a bare
+     literal in issue 343's scope and is completed here. */
   main > .grid .grid__heading {
     margin-bottom: var(--grid-heading-margin-bottom, 1.25rem);
   }
@@ -3214,7 +3223,7 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   }
 
   main > .faq .faq__heading {
-    margin-bottom: 1.25rem;
+    margin-bottom: var(--faq-heading-margin-bottom, 1.25rem);
   }
 
   main > .section .section__content,

--- a/components/faq/schema.json
+++ b/components/faq/schema.json
@@ -61,6 +61,7 @@
       "--faq-heading-size": { "type": "length", "default": "1.875rem", "description": "Section heading font size" },
       "--faq-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading text color" },
       "--faq-heading-accent-color": { "type": "color", "default": "var(--color-accent)", "description": "Color of the title_accent substring within the heading, if set" },
+      "--faq-heading-margin-bottom": { "type": "length", "default": "var(--space-lg)", "description": "Space below the FAQ heading, before the accordion list (header rhythm). Lower it to tighten the header, raise it for more separation." },
       "--faq-question-color": { "type": "color", "default": "var(--color-text)", "description": "Question (summary) text color" },
       "--faq-answer-color": { "type": "color", "default": "var(--color-muted)", "description": "Answer text color" },
       "--faq-border-color": { "type": "color", "default": "var(--color-border)", "description": "Accordion item border color" },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.16');
+define('PP_VERSION', '1.4.17');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.16
+Stable tag: 1.4.17
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.16
+Version:          1.4.17
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -806,6 +806,51 @@ test.describe('Safe-surface rendered proof', () => {
     expect(fontSize).toBe('41px');
   });
 
+  // Header-rhythm axis (#352): faq's heading->list gap is authorable via
+  // --faq-heading-margin-bottom, the faq analogue of #343's section/grid
+  // title->subheading slot (faq renders no subheading, so the slot governs the gap
+  // before the accordion list). faq re-declares this margin in THREE places — the
+  // base rule plus the desktop (>=768px) and mobile (<768px) premium rules — so a
+  // single-viewport pin could pass while the other breakpoint's literal still
+  // clobbered the slot (the #86/#349 mobile-hid-it lesson). Assert at 1280 (desktop
+  // rule, 1.65rem fallback) AND 375 (mobile rule, 1.25rem fallback). Two faq
+  // instances in one render prove both halves: index 0 SETS the slot and must win at
+  // both breakpoints; index 1 leaves it UNSET and must compute today's literal
+  // (26.4px desktop / 20px mobile) — the byte-identical-unset guard.
+  test('#352 faq honors --faq-heading-margin-bottom at both breakpoints, unset unchanged @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E FAQ Heading Margin Slot');
+    setComposition(pageId, [
+      { component: 'faq', props: { id: 'pp-faq01', title: 'Set gap', items: [{ question: 'Q?', answer: 'A.' }] } },
+      { component: 'faq', props: { id: 'pp-faq02', title: 'Unset gap', items: [{ question: 'Q?', answer: 'A.' }] } },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    // A pixel value no token resolves to, so a premium-rule clobber is unmistakable.
+    const res = await styleComponent(page, pageId, { '--faq-heading-margin-bottom': '48px' }, undefined, 0);
+    expect(res.success).toBe(true);
+
+    const marginBottom = (id: string) =>
+      page.locator(`#${id} .faq__heading`).evaluate((el) => getComputedStyle(el).marginBottom);
+
+    for (const width of [1280, 375]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator('#pp-faq01 .faq__heading')).toBeVisible({ timeout: 10000 });
+
+      // Set slot wins at BOTH breakpoints (mobile is the case that ships broken when a
+      // media-query literal is left un-routed through the slot).
+      expect(await marginBottom('pp-faq01')).toBe('48px');
+
+      // Unset output byte-identical to today: 1.65rem (26.4px) desktop, 1.25rem (20px)
+      // mobile. No default changed.
+      expect(await marginBottom('pp-faq02')).toBe(width >= 768 ? '26.4px' : '20px');
+    }
+  });
+
   // Card-border axis (#226/#292): the featured first card (#226) AND cards 2..N (#292)
   // each had their own bypass, fixed separately — so assert BOTH boxes render the slot.
   test('#305 grid cards honor --grid-card-border on featured AND non-featured cards @smoke', async ({


### PR DESCRIPTION
Closes #352

## Scope

`faq` was the one header-bearing band whose heading→content gap the site-building AI could not author. `section`, `grid`, and `testimonials` already route their heading's bottom margin through a `--<component>-heading-margin-bottom` slot (#343); `faq` alone kept a bare literal. This adds `--faq-heading-margin-bottom` (length, default `var(--space-lg)`) and routes `.faq__heading`'s bottom margin through it at all three declaration sites:

- base rule — `var(--faq-heading-margin-bottom, var(--space-lg))`
- desktop premium rule (`@media min-width:768px`) — `var(--faq-heading-margin-bottom, 1.65rem)`
- mobile rule (`@media max-width:767px`) — `var(--faq-heading-margin-bottom, 1.25rem)`

`faq` renders no subheading, so the slot governs the space between the heading and the accordion list. Each site keeps today's literal as the fallback, so an unset `faq` heading is byte-identical to before. Follows the #343/#336 precedent exactly; does not disturb the shared band heading scale (#436) or the JSON-LD placement (#432).

## Acceptance criteria

- New slot has a live consumer, byte-identical unset output, and no issue-305 waiver additions — met (the #305 bypass guard enforces all three sites route through the slot).
- Slot reachable by the site-building AI through the documented surface — met (surfaced dynamically via `pp_get_style_slots()` from `schema.json`).
- Existing pages that set the slot are unaffected (slot always wins) — met at both breakpoints via the rendered E2E.

## Files

- `assets/css/components.css` — route the three `.faq__heading` margin-bottom sites through the slot; update stale "faq stays a bare literal" comments.
- `components/faq/schema.json` — add the `--faq-heading-margin-bottom` slot entry.
- `tests/e2e/style-render.spec.ts` — rendered proof: set slot wins at 375 and 1280; unset computes today's literal (26.4px desktop, 20px mobile).
- `README.md`, `AI_CONTEXT.md` — slot-count sync (211→212; faq 17→18).
- `style.css`, `package.json`, `functions.php`, `readme.txt`, `CHANGELOG.md` — version bump 1.4.16→1.4.17 + changelog entry.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — 2123 passed, 8115 assertions (warnings/deprecations identical to base tree; unrelated to this diff).
- `npm test` — 757 passed (20 files), incl. `docs-lint` and the `StyleSlotContractTest` keystone guards.
- `bash scripts/package.sh` — 5-file version sync OK; built zip deleted (releases are CI-built).
- The rendered E2E (`tests/e2e/style-render.spec.ts`) runs in the post-merge WordPress 7.0 E2E job; the #305 bypass guard already pins the CSS routing at PR time.

## Accepted limitations

- Default value unchanged: a specific gap size is a token/opinion choice for the site-building AI, not a component default (per #336's rejected-scope precedent). The bug fixed here is that the gap was inexpressible, not that its default was wrong.

## Reviews (this exact diff)

- `/plan-eng-review` — FULL_REVIEW, 0 issues, 0 critical gaps.
- `/review` — 0 findings; Codex adversarial (cross-model) clean, recommends merge.
- `/document-generate` — no additional stale doc claims beyond the synced counts.
