### PR TITLE
v1.4.18 fix: state the truthful band padding default on six band schemas (#446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.4.18] — 2026-07-20 — every band schema now states the same truthful padding default (#446)
+
+**The six older band schemas (`section`, `grid`, `cta`, `stats`, `faq`, `testimonials`) still advertised `"default": "var(--space-xl)"` on their `--*-padding-top/bottom` slots, but the CSS has routed those slots through the shared `--pp-band-padding` rhythm since #431 — so the default the site-building AI read (~64px) disagreed with what actually renders (the fluid symmetric band rhythm). The three slots minted by #438 (`table`, `logos`, `embed`) already stated the truthful `var(--pp-band-padding)`, so the band family contradicted itself about the same fact. All nine band schemas now state the same, truthful default, and a test keeps the padding-slot family consistent so it cannot drift apart again.**
+
+This is a metadata-only change to schema `default` fields (descriptive text the AI reads to predict unset output). It is not a styling change: the `default` field is never emitted as CSS — `pp_render_style_vars()` reads only a slot's `type` and emits only explicitly-set overrides — so an unset band renders byte-identically to before, falling through the stylesheet's own `var(--x-padding-top, var(--pp-band-padding))` chain. The six schemas' padding slot entries (default plus description) are now byte-identical to the #438 three. `hero` is deliberately left alone: its CSS falls back to `var(--space-xl)`/`var(--space-2xl)`, not the band rhythm, so its `var(--space-xl)` default is truthful and it is not a band.
+
+### Fixed
+- `components/{section,grid,cta,stats,faq,testimonials}/schema.json` — the `--*-padding-top/bottom` style slots now declare `"default": "var(--pp-band-padding)"` with the shared band-rhythm description, matching the already-truthful `table`/`logos`/`embed` schemas (#438). The stale `var(--space-xl)` default no longer teaches the AI the wrong geometry for these bands. Zero rendered-output difference (#446).
+
+### Tests
+- `tests/SchemaThemeConsistencyTest.php` adds `testBandPaddingSlotDefaultsAreUniformAndTruthful`, which asserts that all nine band components' `--*-padding-top/bottom` slot `default` fields are uniform and equal `var(--pp-band-padding)`, and guards that `hero` (a non-band) does not adopt the band default on either edge. The test fails if any band diverges again. `tests/ActionsTest.php` refreshes the illustrative slot description in the `_pp_suggest_alternative_value` padding example to the current band wording (#446).
+
 ## [v1.4.17] — 2026-07-20 — the `faq` header rhythm is now fully authorable (#352)
 
 **The gap below a `faq` heading was the one band-heading rhythm the site-building AI could not touch. Every other header-bearing band (`section`, `grid`, `testimonials`) already routed its heading's bottom margin through a style slot; `faq` alone kept a bare literal, so "tighten this FAQ header" was inexpressible. A new `--faq-heading-margin-bottom` slot closes that gap. Set it to pull the accordion list closer to the heading or push it further away; leave it unset and the band renders exactly as before.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.4.17-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.18-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/components/cta/schema.json
+++ b/components/cta/schema.json
@@ -75,8 +75,8 @@
     "variant_classes": ["cta--full-width", "cta--inline", "cta--dark", "cta--inverted"],
     "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-surface", "--color-bg-inverted", "--color-accent", "--overlay-bg"],
     "style_slots": {
-      "--cta-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the CTA section" },
-      "--cta-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the CTA section" },
+      "--cta-padding-top": { "type": "length", "default": "var(--pp-band-padding)", "description": "Top padding of the band. Defaults to the shared symmetric band rhythm (fluid ~68-80px desktop, ~54px mobile); set an explicit length to override." },
+      "--cta-padding-bottom": { "type": "length", "default": "var(--pp-band-padding)", "description": "Bottom padding of the band. Defaults to the shared symmetric band rhythm; set an explicit length to override." },
       "--cta-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
       "--cta-text": { "type": "color", "default": "var(--color-text)", "description": "Title text color" },
       "--cta-title-accent-color": { "type": "color", "default": "var(--color-accent)", "description": "Color of the title_accent substring within the title, if set" },

--- a/components/faq/schema.json
+++ b/components/faq/schema.json
@@ -48,8 +48,8 @@
     "variant_classes": [],
     "tokens": ["--space-xl", "--space-2xl", "--color-border", "--color-surface"],
     "style_slots": {
-      "--faq-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the FAQ section" },
-      "--faq-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the FAQ section" },
+      "--faq-padding-top": { "type": "length", "default": "var(--pp-band-padding)", "description": "Top padding of the band. Defaults to the shared symmetric band rhythm (fluid ~68-80px desktop, ~54px mobile); set an explicit length to override." },
+      "--faq-padding-bottom": { "type": "length", "default": "var(--pp-band-padding)", "description": "Bottom padding of the band. Defaults to the shared symmetric band rhythm; set an explicit length to override." },
       "--faq-bg": { "type": "gradient", "default": "var(--color-surface)", "description": "Section background color or gradient" },
       "--faq-item-bg": { "type": "gradient", "default": "var(--color-bg)", "description": "Individual accordion item background color or gradient" },
       "--faq-eyebrow-color": { "type": "color", "default": "var(--color-text)", "description": "Eyebrow pill text color" },

--- a/components/grid/schema.json
+++ b/components/grid/schema.json
@@ -98,8 +98,8 @@
     "variant_classes": ["grid--steps", "grid--dark", "grid--inverted", "grid--uniform", "grid--image-icon"],
     "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-surface", "--color-border", "--color-bg-inverted"],
     "style_slots": {
-      "--grid-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the grid section" },
-      "--grid-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the grid section" },
+      "--grid-padding-top": { "type": "length", "default": "var(--pp-band-padding)", "description": "Top padding of the band. Defaults to the shared symmetric band rhythm (fluid ~68-80px desktop, ~54px mobile); set an explicit length to override." },
+      "--grid-padding-bottom": { "type": "length", "default": "var(--pp-band-padding)", "description": "Bottom padding of the band. Defaults to the shared symmetric band rhythm; set an explicit length to override." },
       "--grid-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
       "--grid-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Heading text color" },
       "--grid-heading-accent-color": { "type": "color", "default": "var(--color-accent)", "description": "Color of the title_accent substring within the heading, if set" },

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -144,8 +144,8 @@
     "variant_classes": ["section--text-only", "section--image-left", "section--image-right", "section--centered", "section--text-panel", "pp-section--dark", "pp-section--inverted"],
     "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted", "--overlay-bg"],
     "style_slots": {
-      "--section-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the section" },
-      "--section-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the section" },
+      "--section-padding-top": { "type": "length", "default": "var(--pp-band-padding)", "description": "Top padding of the band. Defaults to the shared symmetric band rhythm (fluid ~68-80px desktop, ~54px mobile); set an explicit length to override." },
+      "--section-padding-bottom": { "type": "length", "default": "var(--pp-band-padding)", "description": "Bottom padding of the band. Defaults to the shared symmetric band rhythm; set an explicit length to override." },
       "--section-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
       "--section-text": { "type": "color", "default": "var(--color-text)", "description": "Content text color" },
       "--section-accent": { "type": "color", "default": "var(--color-accent)", "description": "Link color" },

--- a/components/stats/schema.json
+++ b/components/stats/schema.json
@@ -48,8 +48,8 @@
     "variant_classes": ["stats--dark", "stats--inverted"],
     "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-bg-inverted", "--overlay-bg"],
     "style_slots": {
-      "--stats-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the stats section" },
-      "--stats-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the stats section" },
+      "--stats-padding-top": { "type": "length", "default": "var(--pp-band-padding)", "description": "Top padding of the band. Defaults to the shared symmetric band rhythm (fluid ~68-80px desktop, ~54px mobile); set an explicit length to override." },
+      "--stats-padding-bottom": { "type": "length", "default": "var(--pp-band-padding)", "description": "Bottom padding of the band. Defaults to the shared symmetric band rhythm; set an explicit length to override." },
       "--stats-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
       "--stats-title-size": { "type": "length", "default": "1.875rem", "description": "Section heading (title) font size" },
       "--stats-title-color": { "type": "color", "default": "var(--color-text)", "description": "Section heading text color" },

--- a/components/testimonials/schema.json
+++ b/components/testimonials/schema.json
@@ -72,8 +72,8 @@
     "variant_classes": ["testimonials--stack", "testimonials--dark", "testimonials--inverted"],
     "tokens": ["--space-xl", "--space-2xl", "--space-3xl", "--color-bg", "--color-surface", "--color-border", "--color-bg-inverted"],
     "style_slots": {
-      "--testimonials-padding-top": { "type": "length", "default": "var(--space-xl)", "description": "Top padding of the section" },
-      "--testimonials-padding-bottom": { "type": "length", "default": "var(--space-xl)", "description": "Bottom padding of the section" },
+      "--testimonials-padding-top": { "type": "length", "default": "var(--pp-band-padding)", "description": "Top padding of the band. Defaults to the shared symmetric band rhythm (fluid ~68-80px desktop, ~54px mobile); set an explicit length to override." },
+      "--testimonials-padding-bottom": { "type": "length", "default": "var(--pp-band-padding)", "description": "Bottom padding of the band. Defaults to the shared symmetric band rhythm; set an explicit length to override." },
       "--testimonials-bg": { "type": "gradient", "default": "transparent", "description": "Background color or gradient" },
       "--testimonials-heading-size": { "type": "length", "default": "var(--pp-band-heading-size)", "description": "Heading font size. Defaults to the shared responsive band-heading scale (fluid ~28px mobile to ~42px desktop); set an explicit length to override." },
       "--testimonials-heading-color": { "type": "color", "default": "var(--color-text)", "description": "Heading text color" },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.4.17');
+define('PP_VERSION', '1.4.18');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.4.17
+Stable tag: 1.4.18
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.4.17
+Version:          1.4.18
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -3581,7 +3581,7 @@ class ActionsTest extends TestCase
 
     public function testSuggestAlternativeForPaddingLength(): void
     {
-        $suggestion = _pp_suggest_alternative_value('length', 'Top padding of the grid section', 'var(--space-xl)');
+        $suggestion = _pp_suggest_alternative_value('length', 'Top padding of the band. Defaults to the shared symmetric band rhythm (fluid ~68-80px desktop, ~54px mobile); set an explicit length to override.', 'var(--pp-band-padding)');
         $this->assertStringContainsString('"0"', $suggestion);
     }
 

--- a/tests/SchemaThemeConsistencyTest.php
+++ b/tests/SchemaThemeConsistencyTest.php
@@ -116,4 +116,107 @@ class SchemaThemeConsistencyTest extends TestCase
             $this->assertStringContainsString('inverted', $theme['description']);
         }
     }
+
+    /**
+     * Schema contract: the band padding slots must state ONE truthful default
+     * everywhere. This is the test that would have caught the #446 drift, where
+     * six older band schemas (section, grid, cta, stats, faq, testimonials) still
+     * declared `"default": "var(--space-xl)"` on their `--*-padding-top/bottom`
+     * slots even though the CSS has routed those slots through
+     * `var(--pp-band-padding)` since #431 — while the three #438 schemas (table,
+     * logos, embed) already declared the truthful `var(--pp-band-padding)`. The
+     * `default` field is descriptive metadata the AI reads to predict unset output
+     * (never emitted as CSS — see pp_render_style_vars(), which reads only a slot's
+     * `type`), so a stale default teaches the AI wrong geometry for every band.
+     *
+     * The band set is hardcoded rather than derived from CSS on purpose: these
+     * nine are the canonical bands that route padding through the shared
+     * `--pp-band-padding` rhythm. `hero` ALSO has `--hero-padding-top/bottom`
+     * slots, but its CSS falls back to `var(--space-xl)` / `var(--space-2xl)`
+     * (NOT the band rhythm), so its `var(--space-xl)` default is truthful and it
+     * is deliberately excluded — the drift class this test guards is band-only.
+     */
+    public function testBandPaddingSlotDefaultsAreUniformAndTruthful(): void
+    {
+        // The canonical band components: their `--*-padding-top/bottom` slots
+        // route through `--pp-band-padding`. `hero` is NOT a band here (see docblock).
+        // Intentional delta from the 8-member $bandComponents in
+        // testThemeEnumAdvertisesMutedNotDark() above: `table` has no `theme` prop
+        // (so it is absent from the #442 theme list) but DOES route padding through
+        // the band rhythm, so it belongs here. Do not "sync" the two lists.
+        $bandComponents = ['section', 'grid', 'cta', 'stats', 'faq', 'testimonials', 'table', 'logos', 'embed'];
+        $schemas        = $this->loadSchemas();
+
+        $expected = 'var(--pp-band-padding)';
+
+        // family suffix (`padding-top` | `padding-bottom`) => [component => default]
+        $families = [];
+        foreach ($bandComponents as $component) {
+            $this->assertArrayHasKey($component, $schemas, "missing schema for '{$component}'");
+            $slots = $schemas[$component]['styling']['style_slots'] ?? null;
+            $this->assertIsArray($slots, "'{$component}' has no style_slots");
+
+            $found = 0;
+            foreach ($slots as $slotName => $slotDef) {
+                if (!preg_match('/-(padding-(?:top|bottom))$/', $slotName, $m)) {
+                    continue;
+                }
+                $this->assertArrayHasKey('default', $slotDef, "'{$component}' slot '{$slotName}' has no default");
+                $families[$m[1]][$component] = $slotDef['default'];
+                $found++;
+            }
+            // Every band declares exactly a top and a bottom band-padding slot.
+            $this->assertSame(2, $found, "'{$component}' must declare exactly one padding-top and one padding-bottom band slot");
+        }
+
+        $this->assertArrayHasKey('padding-top', $families, 'no band padding-top slots found');
+        $this->assertArrayHasKey('padding-bottom', $families, 'no band padding-bottom slots found');
+
+        foreach ($families as $family => $componentToDefault) {
+            $uniqueDefaults = array_unique(array_values($componentToDefault), SORT_REGULAR);
+            $this->assertCount(
+                1,
+                $uniqueDefaults,
+                sprintf(
+                    "Band slot family '%s' has divergent `default` values across components (%s). "
+                    . "Every band's padding default must be the same, truthful `%s` — the shared "
+                    . "rhythm the CSS actually routes through since #431/#438 (#446).",
+                    $family,
+                    implode(', ', array_map(
+                        static fn ($c, $d) => "{$c}={$d}",
+                        array_keys($componentToDefault),
+                        array_values($componentToDefault)
+                    )),
+                    $expected
+                )
+            );
+            $this->assertSame(
+                $expected,
+                $uniqueDefaults[0],
+                sprintf(
+                    "Band slot family '%s' default is '%s' but must be the truthful '%s' (#446). "
+                    . "The CSS routes these slots through the shared band rhythm; declaring "
+                    . "`var(--space-xl)` teaches the AI the wrong unset geometry.",
+                    $family,
+                    $uniqueDefaults[0],
+                    $expected
+                )
+            );
+        }
+
+        // Guard the exclusion: hero must NOT silently adopt the band default on
+        // EITHER edge — if it ever does, either hero became a band (update this list)
+        // or someone mis-edited it (including a one-sided top-only/bottom-only edit).
+        // Its truthful default is the space-scale token.
+        $heroSlots = $schemas['hero']['styling']['style_slots'] ?? [];
+        foreach (['--hero-padding-top', '--hero-padding-bottom'] as $heroSlot) {
+            $this->assertNotSame(
+                $expected,
+                $heroSlots[$heroSlot]['default'] ?? null,
+                "hero is not a band (its CSS falls back to var(--space-xl)/var(--space-2xl)); "
+                . "if hero now routes through --pp-band-padding, add it to \$bandComponents (#446). "
+                . "Offending slot: {$heroSlot}."
+            );
+        }
+    }
 }


### PR DESCRIPTION
Closes #446

## Summary

The six older band schemas (`section`, `grid`, `cta`, `stats`, `faq`, `testimonials`) still declared `"default": "var(--space-xl)"` on their `--*-padding-top/bottom` style slots, but the CSS has routed those slots through the shared `--pp-band-padding` rhythm since #431 — so the AI-facing stated default disagreed with what actually renders. The three #438 schemas (`table`, `logos`, `embed`) already state the truthful `var(--pp-band-padding)`. All nine band padding slot entries (`default` + `description`) are now byte-identical, and a test keeps the family consistent.

## Scope (against acceptance criteria)

- **All nine band padding slots declare the same, truthful default** — the six schemas now use `"default": "var(--pp-band-padding)"` with the band-rhythm description byte-identical to the #438 three.
- **Test fails if any band diverges again** — `tests/SchemaThemeConsistencyTest.php::testBandPaddingSlotDefaultsAreUniformAndTruthful` asserts the nine bands' `--*-padding-top/bottom` `default` fields are uniform and equal `var(--pp-band-padding)`, and guards `hero` (both edges) against silently adopting the band default.

## Why this is metadata-only (zero rendered-output difference)

The `default` field is descriptive AI context, consumed only by `lib/ai-context.php` (prompt text + override detection), `lib/ai-chat.php` (error messages), and `lib/operate.php` (inspect summary). It is **never emitted as CSS**: `pp_render_style_vars()` (lib/wp.php) iterates only explicitly-set overrides and reads a slot's `type`, never its `default`. An unset band falls through the stylesheet's own `var(--x-padding-top, var(--pp-band-padding))` chain, so output is byte-identical to before.

`hero` is deliberately excluded: its CSS falls back to `var(--space-xl)`/`var(--space-2xl)`, not the band rhythm, so its `var(--space-xl)` default is truthful and it is not a band.

## Validation

- PHPUnit: `./vendor/bin/phpunit --configuration phpunit.xml` — 2124 tests, 8181 assertions, green (baseline warnings/deprecations unchanged: 3 warnings, 2 deprecations).
- Vitest: `npm test` — 757 tests, green.
- `bash scripts/package.sh` validated the five-file version sync (1.4.18); the side-effect zip was deleted.
- The new test was verified to fail on injected drift and restore cleanly.

## Reviews (this session)

- `/plan-eng-review`: clean, 0 issues; Codex outside voice converged.
- `/review`: Codex adversarial (3 findings, all refuted with repo evidence — the `--pp-band-padding` token is intentionally internal and absent from every schema's public `tokens` array, matching the #438 three); testing + maintainability specialists (test verified to catch the drift; applied a two-sided hero guard and a cross-reference comment on the intentional 8-vs-9 band-list delta).

## Accepted limitations / follow-up

- The band set in the test is hardcoded (mirroring the sibling #442 test in the same file). A testing-specialist suggestion to derive the band set from CSS as a tripwire was declined as over-engineering — it would add CSS-regex parsing/coupling the plan and Codex explicitly weighed against. Noted as a candidate follow-up.

No 7A decisions were required.
