### PR TITLE
v1.5.2 fix: bg-image band accent role clears WCAG AA (#461)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -362,7 +362,8 @@ To change a token: use `pp_execute_apply('update_design_token', ['token' => '...
 Colors:     --color-bg, --color-surface, --color-text, --color-muted,
             --color-border, --color-accent, --color-accent-hover, --color-bg-inverted
 Derived:    --color-text-secondary, --color-accent-strong, --color-border-accent, --color-surface-accent,
-            --color-accent-on-inverted, --color-accent-on-inverted-hover
+            --color-accent-on-inverted, --color-accent-on-inverted-hover,
+            --color-accent-on-overlay, --color-accent-on-overlay-hover
 Spacing:    --space-xs, --space-sm, --space-md, --space-lg, --space-xl, --space-2xl, --space-3xl
 Typography: --font-body, --font-heading, --font-weight-heading, --line-height-body, --line-height-heading,
             --font-mono
@@ -379,7 +380,7 @@ Text roles: --text-kicker-color, --text-kicker-size, --text-kicker-weight, --tex
 > Source of truth: the `:root` block in `assets/css/base.css`, parsed by `pp_design_tokens()`.
 > Every token above is overridable via `update_design_token`. Regenerate this list from `base.css` rather than editing it by hand — `--breakpoint-*` live in a comment and are **not** overridable.
 
-**Token families:** Changing a base token (`--color-accent` or `--color-text`) auto-derives related tokens (hover, strong, border-accent, surface-accent, on-inverted + on-inverted-hover, text-secondary) when they have no existing override. Existing overrides are always preserved — a base change never touches them (#386). Because a preserved override keeps winning in the rendered CSS, a base change can succeed (`ok:true`) yet not be visible where that override applies. To surface this, the apply returns a `stale_warnings` entry for any preserved derived override that DIVERGES from the value the new base would derive (equal-to-derivable overrides are coherent and not flagged), and the same condition is reported at INSPECT as a `masked_derived_override` token smell. `pp_masked_derived_overrides()` is the one shared engine behind both surfaces.
+**Token families:** Changing a base token (`--color-accent` or `--color-text`) auto-derives related tokens (hover, strong, border-accent, surface-accent, on-inverted + on-inverted-hover, on-overlay + on-overlay-hover, text-secondary) when they have no existing override. Existing overrides are always preserved — a base change never touches them (#386). Because a preserved override keeps winning in the rendered CSS, a base change can succeed (`ok:true`) yet not be visible where that override applies. To surface this, the apply returns a `stale_warnings` entry for any preserved derived override that DIVERGES from the value the new base would derive (equal-to-derivable overrides are coherent and not flagged), and the same condition is reported at INSPECT as a `masked_derived_override` token smell. `pp_masked_derived_overrides()` is the one shared engine behind both surfaces.
 
 Token overrides survive theme updates — `base.css` is overwritten on update, but overrides persist in the database. See `ai-instructions/retheme.md` for the full retheme workflow.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.5.2] — 2026-07-20 — links and stat numbers on background-image bands are readable again: a new overlay accent role clears WCAG AA over any image (#461)
+
+**A section, CTA, or stats band with a `background_image` lays a dark scrim over an arbitrary photo, and its default link (or stat number) used the light-surface brand accent — only 1.16:1 over the scrim when the photo is bright, effectively invisible and far below the WCAG AA 4.5:1 bar. Those bands now route their default accent through a new `--color-accent-on-overlay` role that is guaranteed readable no matter what image sits underneath. Set a per-instance color slot and it still wins, exactly as before.**
+
+The overlay sits over an unknown image, so the role's default is chosen against the worst case: the scrim composited over a pure-white image (an effective background near `rgb(115,115,115)`). Contrast there tops out at 4.74:1 for any color, so the only values that clear AA are near-white — `--color-accent-on-overlay` ships at `#fafbff` (4.59:1), with `--color-accent-on-overlay-hover` at pure white. The name describes the role, not the hue: a link on a photo band is carried by its underline, and near-white is the sole choice that stays legible over a bright image. This is a separate role from the inverted-band `--color-accent-on-inverted` (#437), which is tuned to the solid dark inverted background and only reaches ~2.2:1 over the arbitrary-image scrim. The new role joins the accent token family, so rethemeing `--color-accent` auto-derives a matching on-overlay tint and a pinned override that diverges is flagged by the same stale-warning machinery as every other derived token (#386).
+
+### Fixed
+- Default links on a `.section--has-bg-image` band and default numbers on a `.stats--has-bg-image` band now route through `--color-accent-on-overlay` instead of the light-surface `--color-accent`, so they clear WCAG AA over any background image rather than failing at 1.16:1. A CTA band with a `background_image` gains the same guarantee: a link written into the CTA body now has an explicit readable default where it previously fell back to the unreadable light accent. Per-instance `--section-accent` / `--stats-number-color` / `--cta-body-color` slots still win on all three bands (#461).
+
+### Docs
+- `ai-instructions/retheme.md` documents the overlay accent role and its pairing contract (the default must stay ≥ 4.5:1 against the scrim-over-white worst case, which is why it is intentionally near-white), and both it and `AI_CONTEXT.md` now list all eight auto-derived accent-family tokens (#461).
+
+### Tests
+- A rendered Playwright E2E (`tests/e2e/style-render.spec.ts`) seeds all three background-image bands with a white image fixture at 375px and 1280px and proves each accent surface clears 4.5:1 against the rendered scrim-over-white composite, and that a per-instance color slot still wins. css-lint pins lock the routing on every band (and guard against a regression back to the bare accent or the inverted role), and a `pp_token_families()` test pins the new roles as registered, auto-derived, divergence-tracked family members (#461).
+
 ## [v1.5.1] — 2026-07-20 — the global button tokens become a real one-knob: `--btn-bg` / `--btn-text` at `:root` now restyle every composed button (#458)
 
 **Setting `--btn-bg`, `--btn-text`, `--btn-border-color`, or `--btn-shadow` at `:root` now recolors every primary button on a composed page — the section-panel CTA, the CTA-block button, and the hero button together. #441 registered these four global button tokens so the AI could discover them, but on a real page the premium `main .btn` cascade and the `.cta` / `.hero` button rules routed their fill, border, ink, and shadow through per-component slots, not through `--btn-*`, so the "global button" knob was discoverable yet nearly inert. It is now a genuine site-wide knob: change one token and every button follows, while a button that a component already restyled keeps its own look.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.5.1-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.2-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/retheme.md
+++ b/ai-instructions/retheme.md
@@ -53,6 +53,23 @@ leave it unpinned; a pinned on-inverted override that diverges from that derivat
 surfaced by the same `stale_warnings` / `masked_derived_override` machinery as every
 other derived token (see below), so you are told when a base change may not reach it.
 
+**Surface-paired accent (the bg-image band).** A section/cta/stats band WITH a
+`background_image` lays a dark `rgba(0,0,0,.55)` overlay over an ARBITRARY image, so its
+accent (section/cta links, stats numbers) routes through a SEPARATE role,
+`--color-accent-on-overlay` (default `#fafbff`), with `--color-accent-on-overlay-hover`
+(default `#ffffff`) for hover. This is NOT the same as `--color-accent-on-inverted`:
+on-inverted is tuned to the SOLID `--color-bg-inverted`, but the overlay sits over an
+unknown image, so its worst case is the overlay composited over a pure-WHITE image
+(effective bg ≈ `rgb(115,115,115)`). **Pairing contract:** the default must be ≥ 4.5:1
+against that worst-case composite, not against any single image. Because the overlay over
+white has a hard contrast CEILING of 4.74:1 for any foreground, the only values that clear
+AA there are near-white — so `--color-accent-on-overlay` is intentionally near-white; the
+name describes the ROLE (accent on an overlay surface), not the hue, and the link's
+affordance comes from its underline. The programmatic path auto-derives it (a near-white
+accent tint) when you change `--color-accent` and leave it unpinned; a pinned override
+that diverges is surfaced by the same `stale_warnings` / `masked_derived_override`
+machinery as every other derived token.
+
 Example retheme — warm neutral:
 ```css
 --color-bg:           #fefefe;
@@ -214,4 +231,4 @@ Or from PHP: `pp_execute_apply('update_design_token', ['token' => '--color-accen
 
 The apply layer validates token names, enforces type-specific value constraints, and verifies the write via database read-back. Use this path when rethemeing programmatically (e.g. from an AI interface).
 
-**Token family derivation:** When you change `--color-accent`, six derived tokens (`--color-accent-hover`, `--color-accent-strong`, `--color-border-accent`, `--color-surface-accent`, `--color-accent-on-inverted`, `--color-accent-on-inverted-hover`) are auto-filled if they have no existing override. Changing `--color-text` auto-derives `--color-text-secondary`. **A base-token change never touches an existing derived override** — a deliberately pinned derived value survives. That is safe for pins, but it means a base change can succeed (`ok:true`) yet have no visible effect where a stale derived override still wins (e.g. you set `--color-accent` blue but an old orange `--color-accent-strong` keeps the CTA orange). To make that visible, the apply returns a `stale_warnings` entry for any preserved derived override that **diverges** from the value the new base would derive, naming the masking token so you can decide whether to update it. A coherent override (one that already equals the derivable value) is not flagged. The same divergence is reported at INSPECT as a `masked_derived_override` token smell (see `token_smells` in `wp pp operate inspect`), so you catch it before making a change, not only after. This issue makes the state visible; it never recomputes or clobbers your derived overrides.
+**Token family derivation:** When you change `--color-accent`, eight derived tokens (`--color-accent-hover`, `--color-accent-strong`, `--color-border-accent`, `--color-surface-accent`, `--color-accent-on-inverted`, `--color-accent-on-inverted-hover`, `--color-accent-on-overlay`, `--color-accent-on-overlay-hover`) are auto-filled if they have no existing override. Changing `--color-text` auto-derives `--color-text-secondary`. **A base-token change never touches an existing derived override** — a deliberately pinned derived value survives. That is safe for pins, but it means a base change can succeed (`ok:true`) yet have no visible effect where a stale derived override still wins (e.g. you set `--color-accent` blue but an old orange `--color-accent-strong` keeps the CTA orange). To make that visible, the apply returns a `stale_warnings` entry for any preserved derived override that **diverges** from the value the new base would derive, naming the masking token so you can decide whether to update it. A coherent override (one that already equals the derivable value) is not flagged. The same divergence is reported at INSPECT as a `masked_derived_override` token smell (see `token_smells` in `wp pp operate inspect`), so you catch it before making a change, not only after. This issue makes the state visible; it never recomputes or clobbers your derived overrides.

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -27,6 +27,8 @@
   --color-surface-accent:   #e8ecfe;  /* color: Accent-washed backgrounds, eyebrows */
   --color-accent-on-inverted:       #9dafee;  /* color: Link/accent on the inverted (dark) band — light accent tint, 8.33:1 on --color-bg-inverted (--color-accent's 3.23:1 fails AA there) */
   --color-accent-on-inverted-hover: #c1cdfc;  /* color: Hover state for on-inverted links — brighter tint, 11.4:1 on --color-bg-inverted */
+  --color-accent-on-overlay:        #fafbff;  /* color: Link/accent on a bg-image band (dark rgba(0,0,0,.55) overlay over an ARBITRARY image). The name is the ROLE, not the hue: the worst case is the overlay over a pure-WHITE image (effective bg rgb(115,115,115)), whose contrast CEILING for any foreground is 4.74:1, so a near-white value is the only one that clears AA (4.5:1). #fafbff = 4.59:1 there. on-inverted (#9dafee) is tuned to the solid inverted bg, only ~2.2:1 here (#437 flagged a fixed tint can't be trusted over an arbitrary image). */
+  --color-accent-on-overlay-hover:  #ffffff;  /* color: Hover state for on-overlay links — pure white, 4.74:1 (the ceiling) over the worst-case overlay-over-white composite */
 
   /* Spacing — the layout scale */
   --space-xs:  0.25rem;   /* length: 4px */

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1258,8 +1258,18 @@
   color: var(--section-text, var(--color-bg));
 }
 
+/* The dark overlay makes this a dark surface over an arbitrary image, so the
+   light-surface accent (--color-accent) is only 1.16:1 over the overlay-over-white
+   worst case and fails WCAG AA. Route the default through the overlay accent role
+   (#461); an explicit --section-accent slot still wins. Mirrors the inverted-band
+   pattern above, but with the overlay role (on-inverted is tuned to the solid
+   inverted bg, not the arbitrary-image overlay). */
 .section--has-bg-image a {
-  color: var(--section-accent, var(--color-accent));
+  color: var(--section-accent, var(--color-accent-on-overlay));
+}
+
+.section--has-bg-image a:hover {
+  color: var(--section-accent-hover, var(--color-accent-on-overlay-hover));
 }
 
 /* ==========================================================================
@@ -2225,6 +2235,21 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   opacity: 0.85;
 }
 
+/* A cta__body link sits DIRECTLY on the dark overlay-over-image band. The light-
+   surface accent fails WCAG AA there, so its default routes through the overlay
+   accent role (#461), mirroring the .cta--inverted .cta__body a rule above but with
+   the overlay role (not on-inverted, which is tuned to the solid inverted bg). Reads
+   through the existing --cta-body-color slot first so the #61/#86 dark-surface-slot
+   contract holds; unset, it falls back to the AA on-overlay tint. Scoped to .cta__body
+   so the premium CTA button (owned by the main .btn cascade) is untouched. */
+.cta--has-bg-image .cta__body a {
+  color: var(--cta-body-color, var(--color-accent-on-overlay));
+}
+
+.cta--has-bg-image .cta__body a:hover {
+  color: var(--cta-body-color, var(--color-accent-on-overlay-hover));
+}
+
 
 /* ==========================================================================
    COMPONENT: footer
@@ -2556,7 +2581,11 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 }
 
 .stats--has-bg-image .stats__number {
-  color: var(--stats-number-color, var(--color-accent));
+  /* Accent-colored number on the dark overlay-over-image band: the light-surface
+     accent is only 1.16:1 over the overlay-over-white worst case. Route the default
+     through the overlay accent role (#461, ≥4.5:1); an explicit --stats-number-color
+     slot still wins. on-inverted is tuned to the solid inverted bg, not this overlay. */
+  color: var(--stats-number-color, var(--color-accent-on-overlay));
 }
 
 .stats--has-bg-image .stats__label {

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.5.1');
+define('PP_VERSION', '1.5.2');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -2060,6 +2060,15 @@ function pp_token_families(): array {
             // #386 stale-warning / masked-derived machinery like any other derived.
             '--color-accent-on-inverted'       => ['mix' => 'white', 'ratio' => 0.55],
             '--color-accent-on-inverted-hover' => ['mix' => 'white', 'ratio' => 0.70],
+            // On-overlay accent roles (#461): links/numbers on a bg-image band sit on a
+            // dark rgba(0,0,0,.55) overlay over an ARBITRARY image. The worst case is the
+            // overlay over pure white (rgb(115,115,115)), where the contrast ceiling for
+            // ANY foreground is 4.74:1 — so the default is mechanically near-white to clear
+            // AA (4.5:1). Derived by mixing accent almost fully toward white so a retheme's
+            // new accent still resolves to a near-white on-overlay tint; registered here so
+            // a pinned override that DIVERGES surfaces in the #386 machinery like on-inverted.
+            '--color-accent-on-overlay'        => ['mix' => 'white', 'ratio' => 0.976],
+            '--color-accent-on-overlay-hover'  => ['mix' => 'white', 'ratio' => 1.0],
         ],
         '--color-text' => [
             '--color-text-secondary' => ['mix' => 'white', 'ratio' => 0.20],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.5.1
+Stable tag: 1.5.2
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.5.1
+Version:          1.5.2
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ApplyTest.php
+++ b/tests/ApplyTest.php
@@ -711,9 +711,9 @@ class ApplyTest extends TestCase
         $this->assertTrue($result['ok']);
         $this->assertEquals('update_design_token', $result['apply']);
         $this->assertEquals('design', $result['domain']);
-        // 1 base change + 6 derived accent family tokens auto-updated (#437 added
-        // --color-accent-on-inverted + --color-accent-on-inverted-hover)
-        $this->assertCount(7, $result['changes']);
+        // 1 base change + 8 derived accent family tokens auto-updated (#437 added
+        // --color-accent-on-inverted + -hover; #461 added --color-accent-on-overlay + -hover)
+        $this->assertCount(9, $result['changes']);
         $this->assertEquals('#3157f4', $result['changes'][0]['from']);
         $this->assertEquals('#b45309', $result['changes'][0]['to']);
 
@@ -726,6 +726,8 @@ class ApplyTest extends TestCase
         $this->assertArrayHasKey('--color-surface-accent', $overrides);
         $this->assertArrayHasKey('--color-accent-on-inverted', $overrides);
         $this->assertArrayHasKey('--color-accent-on-inverted-hover', $overrides);
+        $this->assertArrayHasKey('--color-accent-on-overlay', $overrides);
+        $this->assertArrayHasKey('--color-accent-on-overlay-hover', $overrides);
     }
 
     public function testAccentFamilyDerivation(): void
@@ -784,6 +786,50 @@ class ApplyTest extends TestCase
             'A divergent on-inverted override must surface in the #386 masking machinery');
     }
 
+    public function testOnOverlayAccentIsRegisteredDerivedColor(): void
+    {
+        // #461: the on-overlay accent roles (links/numbers on a bg-image band, which
+        // sits on a dark rgba(0,0,0,.55) overlay over an ARBITRARY image) must be
+        // REGISTERED derived colors, exactly like the #437 on-inverted pair, so
+        // (a) a retheme's new accent auto-produces matching on-overlay tints, and
+        // (b) a pinned on-overlay override that diverges surfaces in the #386
+        // masked-derived / stale-warning machinery like every other derived token.
+
+        // Registered in the --color-accent family (the divergence-detection surface).
+        $family = pp_token_families()['--color-accent'];
+        $this->assertArrayHasKey('--color-accent-on-overlay', $family);
+        $this->assertArrayHasKey('--color-accent-on-overlay-hover', $family);
+
+        // The shipped default derives to the exact base.css literals (#fafbff / #ffffff):
+        // near-white by necessity — the overlay-over-white worst case has a 4.74:1
+        // contrast ceiling, so only a near-white value clears WCAG AA (4.5:1) there.
+        $defaultDerived = pp_derive_family_tokens('--color-accent', '#3157f4');
+        $this->assertEquals('#fafbff', $defaultDerived['--color-accent-on-overlay'],
+            'on-overlay default is the near-white value that clears AA over the worst-case overlay composite');
+        $this->assertEquals('#ffffff', $defaultDerived['--color-accent-on-overlay-hover'],
+            'on-overlay hover is pure white (the 4.74:1 ceiling)');
+
+        // Auto-derived as a near-white accent tint when the base changes (unpinned):
+        // every channel brighter than the base accent, hover brighter still.
+        $derived = pp_derive_family_tokens('--color-accent', '#7a4f2e');
+        $this->assertArrayHasKey('--color-accent-on-overlay', $derived);
+        $this->assertArrayHasKey('--color-accent-on-overlay-hover', $derived);
+        $base = _pp_hex_to_rgb('#7a4f2e');
+        $onOv = _pp_hex_to_rgb($derived['--color-accent-on-overlay']);
+        $onOvHover = _pp_hex_to_rgb($derived['--color-accent-on-overlay-hover']);
+        $this->assertGreaterThan($base[0], $onOv[0], 'on-overlay is a near-white tint');
+        $this->assertGreaterThanOrEqual($onOv[0], $onOvHover[0], 'hover is at least as bright');
+        // Near-white: every channel is high regardless of the base accent hue.
+        $this->assertGreaterThan(240, min($onOv), 'on-overlay is near-white on every channel');
+
+        // Participates in divergence detection: a pinned on-overlay override that
+        // no longer matches what the new base derives is reported as masking (#386).
+        pp_set_token_override('--color-accent-on-overlay', '#123456');
+        $masking = pp_masked_derived_overrides('--color-accent', '#7a4f2e');
+        $this->assertContains('--color-accent-on-overlay', array_column($masking, 'token'),
+            'A divergent on-overlay override must surface in the #386 masking machinery');
+    }
+
     public function testTextFamilyDerivation(): void
     {
         $result = pp_execute_apply('update_design_token', ['token' => '--color-text', 'value' => '#1a1208']);
@@ -828,9 +874,9 @@ class ApplyTest extends TestCase
         // Changes should NOT include --color-accent-strong (it was skipped)
         $changed_tokens = array_column($result['changes'], 'token');
         $this->assertNotContains('--color-accent-strong', $changed_tokens);
-        // But should include the other 5 derived + 1 base = 6 changes (#437 grew
-        // the accent family from 4 to 6 derived tokens)
-        $this->assertCount(6, $result['changes']);
+        // But should include the other 7 derived + 1 base = 8 changes (#437 grew
+        // the accent family from 4 to 6 derived tokens; #461 grew it to 8)
+        $this->assertCount(8, $result['changes']);
     }
 
     public function testDivergentDerivedOverrideReturnsStaleWarnings(): void
@@ -1115,14 +1161,14 @@ class ApplyTest extends TestCase
 
     public function testResetAllDesignTokensClearsAll(): void
     {
-        // Setting --color-accent also auto-derives 6 family tokens (#437 grew the
-        // accent family from 4 to 6): 7 total + 1 for --color-bg = 8
+        // Setting --color-accent also auto-derives 8 family tokens (#437 grew the
+        // accent family from 4 to 6; #461 grew it to 8): 9 total + 1 for --color-bg = 10
         pp_execute_apply('update_design_token', ['token' => '--color-accent', 'value' => '#b45309']);
         pp_execute_apply('update_design_token', ['token' => '--color-bg', 'value' => '#000000']);
 
         $result = pp_execute_apply('reset_all_design_tokens', []);
         $this->assertTrue($result['ok']);
-        $this->assertCount(8, $result['changes']);
+        $this->assertCount(10, $result['changes']);
         $this->assertSame([], pp_get_token_overrides());
     }
 

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -4670,6 +4670,148 @@ test.describe('#437 inverted link contrast (rendered)', () => {
   }
 });
 
+test.describe('#461 bg-image band accent contrast (rendered)', () => {
+  let pageId = 0;
+
+  test.afterEach(async () => {
+    if (pageId) {
+      try {
+        deletePage(pageId);
+      } catch {
+        /* already cleaned */
+      }
+      pageId = 0;
+    }
+  });
+
+  // A bg-image band lays a dark rgba(0,0,0,.55) overlay over an ARBITRARY image. The
+  // WORST case for a light-tinted foreground is the overlay over a pure-WHITE image
+  // (effective bg rgb(115,115,115)), where the contrast ceiling is 4.74:1 — so #461's
+  // default accent (--color-accent-on-overlay #fafbff, 4.59:1) is near-white by
+  // necessity. We seed each band with a WHITE background-image fixture. The overlay is
+  // a SEPARATE absolutely-positioned element (a sibling of the link, NOT an ancestor),
+  // so the link's own/ancestor background never carries the scrim: we read the rendered
+  // overlay's real rgba() and composite it over white(255) analytically — that IS the
+  // worst-case rendered composite, and it exercises each component's real overlay recipe.
+  const WHITE_PNG =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQImWP8//8/AwMDEwMDAwMDAwAkBgMBmjCi+wAAAABJRU5ErkJggg==';
+
+  const bands = () => [
+    {
+      component: 'section',
+      props: {
+        id: 'pp-ov-sec',
+        background_image: WHITE_PNG,
+        title: 'Overlay section',
+        body: '<p>Body copy with an inline <a href="/somewhere">text link</a> on the image band.</p>',
+      },
+    },
+    {
+      component: 'cta',
+      props: {
+        id: 'pp-ov-cta',
+        background_image: WHITE_PNG,
+        title: 'Overlay cta',
+        text: 'Read our <a href="/terms">terms</a> before you sign up.',
+        button_text: 'Go',
+        button_url: '/signup',
+      },
+    },
+    {
+      component: 'stats',
+      props: {
+        id: 'pp-ov-stats',
+        background_image: WHITE_PNG,
+        title: 'Overlay stats',
+        items: [{ number: '42', label: 'Metric' }],
+      },
+    },
+  ];
+
+  // Each accent surface + the overlay element whose rendered rgba() sits behind it.
+  const SURFACES = [
+    { name: 'section link', accent: '.section--has-bg-image .section__content a', overlay: '.section--has-bg-image .section__overlay' },
+    { name: 'cta body link', accent: '.cta--has-bg-image .cta__body a', overlay: '.cta--has-bg-image .cta__overlay' },
+    { name: 'stats number', accent: '.stats--has-bg-image .stats__number', overlay: '.stats--has-bg-image .stats__overlay' },
+  ];
+
+  test('all three bg-image accent surfaces clear AA (4.5:1) over the overlay-over-white worst case @375 + @1280', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E 461 overlay accent contrast');
+    setComposition(pageId, bands());
+
+    for (const width of [375, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+
+      for (const s of SURFACES) {
+        await expect(page.locator(s.accent).first()).toBeVisible({ timeout: 10000 });
+
+        const res = await page.evaluate(
+          ({ accentSel, overlaySel }) => {
+            const parseRgb = (str: string): number[] => (str.match(/[\d.]+/g) || []).map(Number);
+            const lum = (rgb: number[]): number => {
+              const f = (v: number) => {
+                v /= 255;
+                return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+              };
+              return 0.2126 * f(rgb[0]) + 0.7152 * f(rgb[1]) + 0.0722 * f(rgb[2]);
+            };
+            const el = document.querySelector(accentSel);
+            const ov = document.querySelector(overlaySel);
+            if (!el || !ov) return { found: false, fg: [] as number[], comp: [] as number[], alpha: -1, ratio: 0 };
+            const fg = parseRgb(getComputedStyle(el).color);
+            const o = parseRgb(getComputedStyle(ov).backgroundColor); // rgba(r,g,b,a)
+            const alpha = o.length >= 4 ? o[3] : 1;
+            // Composite the rendered overlay over a pure-white image (the worst case).
+            const comp = [0, 1, 2].map((i) => alpha * (o[i] ?? 0) + (1 - alpha) * 255);
+            const L1 = lum(fg);
+            const L2 = lum(comp);
+            const ratio = (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+            return { found: true, fg, comp, alpha, ratio };
+          },
+          { accentSel: s.accent, overlaySel: s.overlay },
+        );
+
+        expect(res.found, `${s.name} or its overlay not found @${width}`).toBe(true);
+        // The overlay must actually be a translucent scrim (guards a vacuous pass if a
+        // refactor made the overlay opaque or dropped its alpha).
+        expect(res.alpha, `${s.name} @${width}: overlay alpha ${res.alpha} is not the expected translucent scrim`).toBeGreaterThan(0);
+        expect(res.alpha).toBeLessThan(1);
+        expect(
+          res.ratio,
+          `${s.name} @${width}: fg=${JSON.stringify(res.fg)} overlay-over-white=${JSON.stringify(res.comp)} ratio=${res.ratio?.toFixed(2)} (need >= 4.5)`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+
+  test('a per-instance slot wins over the on-overlay default on every band @375 + @1280', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E 461 overlay slot wins');
+    const SLOT = '#00e5ff'; // vivid cyan no token uses — a leak or clobber is obvious
+    const b = bands();
+    // Attach the per-instance style slot that each band's accent rule reads first.
+    (b[0].props as Record<string, unknown>).__pp_style = { '--section-accent': SLOT };
+    (b[1].props as Record<string, unknown>).__pp_style = { '--cta-body-color': SLOT };
+    (b[2].props as Record<string, unknown>).__pp_style = { '--stats-number-color': SLOT };
+    setComposition(pageId, b);
+
+    for (const width of [375, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+
+      for (const s of SURFACES) {
+        await expect(page.locator(s.accent).first()).toBeVisible({ timeout: 10000 });
+        const color = await page.evaluate((sel) => getComputedStyle(document.querySelector(sel)!).color, s.accent);
+        expect(color, `${s.name} @${width}: per-instance slot must win over the on-overlay default`).toBe('rgb(0, 229, 255)');
+      }
+    }
+  });
+});
+
 /*
  * #439 — a link in cta.text renders as a real anchor, not escaped source.
  *

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -2670,3 +2670,58 @@ describe('CSS lint: #441 global button token contract (consumed ⊆ registered�
         expect(okOrphans).toEqual([]);
     });
 });
+
+describe('CSS lint: bg-image band accent routes through --color-accent-on-overlay (#461)', () => {
+    // A bg-image band lays a dark rgba(0,0,0,.55) overlay over an ARBITRARY image.
+    // The light-surface accent (--color-accent) is only 1.16:1 over the overlay-over-
+    // white worst case and fails WCAG AA. #461 routes the default accent on ALL THREE
+    // bg-image variants (section link, cta body link, stats number) through the overlay
+    // accent role — NOT --color-accent-on-inverted (tuned to the solid inverted bg, not
+    // the arbitrary-image overlay). The per-instance slot must still win. These pins
+    // guard against a regression back to the bare accent OR to the inverted role.
+    const stripped = stripComments(COMPONENTS_CSS);
+    const rules = [];
+    const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+    let m;
+    while ((m = ruleRe.exec(stripped)) !== null) {
+        rules.push({ selector: m[1].trim(), body: m[2] });
+    }
+    const ruleFor = (sel) => rules.find(r => r.selector.split(',').some(s => s.trim() === sel));
+
+    // Each entry: selector, the slot it must route through, and the overlay role fallback.
+    const ROUTES = [
+        { sel: '.section--has-bg-image a', slot: '--section-accent', role: '--color-accent-on-overlay' },
+        { sel: '.section--has-bg-image a:hover', slot: '--section-accent-hover', role: '--color-accent-on-overlay-hover' },
+        { sel: '.cta--has-bg-image .cta__body a', slot: '--cta-body-color', role: '--color-accent-on-overlay' },
+        { sel: '.cta--has-bg-image .cta__body a:hover', slot: '--cta-body-color', role: '--color-accent-on-overlay-hover' },
+        { sel: '.stats--has-bg-image .stats__number', slot: '--stats-number-color', role: '--color-accent-on-overlay' },
+    ];
+
+    ROUTES.forEach(({ sel, slot, role }) => {
+        test(`${sel} routes through ${slot} then ${role}`, () => {
+            const rule = ruleFor(sel);
+            expect(rule).toBeDefined();
+            const re = new RegExp(
+                'color\\s*:\\s*var\\(\\s*' + slot.replace(/[-]/g, '\\-') +
+                '\\s*,\\s*var\\(\\s*' + role.replace(/[-]/g, '\\-') + '\\s*\\)\\s*\\)'
+            );
+            expect(rule.body).toMatch(re);
+        });
+
+        // Regression guard: the bg-image accent must NOT fall back to the bare accent
+        // (the 1.16:1 bug) or the on-inverted role (wrong surface).
+        test(`${sel} does not fall back to bare --color-accent or on-inverted`, () => {
+            const rule = ruleFor(sel);
+            expect(rule).toBeDefined();
+            expect(rule.body).not.toMatch(/var\(\s*--color-accent\s*\)/);
+            expect(rule.body).not.toMatch(/--color-accent-on-inverted/);
+        });
+    });
+
+    // The overlay tokens must be declared in base.css with a type comment so the AI
+    // token validator can reason about them, exactly like the on-inverted pair.
+    test('base.css declares the overlay accent tokens with color type comments', () => {
+        expect(BASE_CSS).toMatch(/--color-accent-on-overlay:[^;]*;\s*\/\*\s*color:/);
+        expect(BASE_CSS).toMatch(/--color-accent-on-overlay-hover:[^;]*;\s*\/\*\s*color:/);
+    });
+});


### PR DESCRIPTION
Closes #461

## Scope
On a `section`/`cta`/`stats` band with a `background_image`, a dark `rgba(0,0,0,.55)` overlay sits over an arbitrary image. The default accent (link/number) used the light-surface `--color-accent` (#3157f4) — only **1.16:1** over the overlay composited over a bright/white image, far below WCAG AA (4.5:1).

This adds a new overlay-specific accent role and routes all three bg-image band variants through it. Per-instance slots still win.

- **New token** `--color-accent-on-overlay: #fafbff` (+ `-hover: #ffffff`) in `base.css`, registered in the `--color-accent` family in `pp_token_families()` so the #386 divergence/stale-warning machinery covers it exactly like #437's on-inverted pair.
- **Routing** (`assets/css/components.css`), slots keep winning:
  - `.section--has-bg-image a` (+ `:hover`) — was bare `--color-accent` (the 1.16:1 bug)
  - `.stats--has-bg-image .stats__number` — was bare `--color-accent`
  - `.cta--has-bg-image .cta__body a` (+ `:hover`) — **new rule**, mirrors the shipped `.cta--inverted .cta__body a` contract (a link there previously fell to the base accent)
- **Docs**: `ai-instructions/retheme.md` gains the overlay pairing-contract; `retheme.md` + `AI_CONTEXT.md` now list all eight derived accent-family tokens.

## Recorded scope decision (binding — see #461 comment, Option A)
The default is **intentionally near-white**. The overlay-over-pure-white worst case has an effective background of `rgb(115,115,115)`, whose contrast **ceiling for any foreground is 4.74:1** — so near-white is the only value that clears AA over an arbitrary bright image. `#fafbff` computes **4.59:1**; the token name describes the *role*, not the hue, and a link's affordance comes from its underline. `--color-accent-on-inverted` (#437) was deliberately NOT reused: it is tuned to the solid inverted band (`#0f172a`) and reaches only ~2.2:1 over this overlay.

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` — **2127 pass** (warnings/deprecations identical to a stashed baseline tree).
- `npm test` (vitest) — **773 pass** (includes the new css-lint routing pins + regression guards).
- E2E on wp-env (`tests/e2e/style-render.spec.ts`): new **#461** describe (3 tests) green at 375px + 1280px — each of the three accent surfaces ≥4.5:1 against the rendered overlay-over-white composite, plus slot-override-wins; adjacent **#437** inverted-contrast (9 tests) still green (no regression on the shared CSS).
- `bash scripts/package.sh` — five-file version sync OK at 1.5.2; built zip deleted (releases are CI-built from tags).

## Reviews (this session)
- `/plan-eng-review` + Codex outside-voice: verified the derivation math, family-count deltas, and the E2E compositing approach; scoping (Option A near-white) confirmed against the recorded decision.
- `/review` + Claude adversarial subagent: core diff independently verified (math, 5-file version sync, cascade/specificity, non-vacuous E2E). No critical findings.

## Accepted limitations / follow-up
- The **title-accent** spans (`.section__title-accent`, `.cta__title-accent`, `.stats__heading-accent`) and section list markers on the same bg-image bands still fall back to bare `--color-accent` — a pre-existing AA gap on sibling surfaces, out of this issue's recorded scope ("nothing else"). Filed as **#463** (includes the related `.hero__title-accent` cover gap). This PR's CHANGELOG scopes its claim to links and stat numbers, so nothing shipped is inaccurate.

Version: PATCH 1.5.1 → 1.5.2. No tag/release/deploy in this PR.