### PR TITLE
v1.5.3 fix: bg-image band title-accent + list markers clear WCAG AA over the overlay (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.5.3] — 2026-07-20 — the rest of the accent on a background-image band is readable now too: highlighted title words and list bullets clear WCAG AA over any image (#463)
+
+**v1.5.2 (#461) fixed the default link and stat number on a background-image band, but the other accent-colored things on the same dark scrim were left on the light-surface brand accent — only 1.16:1 over a bright photo, effectively invisible. The highlighted word inside a band heading (`title_accent`), the check/dash/arrow bullets in a section body list, and a full-cover hero's highlighted title word all now route their default through the same `--color-accent-on-overlay` role, so they stay legible no matter what image sits underneath. Set a per-instance color slot and it still wins, exactly as before, and a plain (non-image) band is untouched.**
+
+The accented substring inside a heading paints its own color, so it never inherited the near-white heading color the band already sets — it kept painting brand-blue straight onto the scrim at 1.16:1, failing even the 3:1 large-text bar. The same was true of a non-disc body list marker and of a `cover`-layout hero's title accent, which sits on the identical `--overlay-bg` scrim over an arbitrary image. All of these now fall back to `--color-accent-on-overlay` (near-white, ≥ 4.5:1 against the scrim-over-white worst case) introduced in #461, so no new color ships and the whole guarantee is uniform across every overlay band. Panel list markers stay on the bare accent because a background-image section's panel is a self-contained light surface, not on the scrim.
+
+### Fixed
+- The `title_accent` highlighted word on a `.section--has-bg-image`, `.cta--has-bg-image`, or `.stats--has-bg-image` band, and on a full-cover hero (`.hero--cover`), now routes its default through `--color-accent-on-overlay` instead of the light-surface `--color-accent`, so it clears WCAG AA over any background image rather than failing at 1.16:1. Section body list markers (check/dash/arrow) on an image band get the same readable default. Per-instance `--section-title-accent-color` / `--cta-title-accent-color` / `--stats-title-accent-color` / `--hero-title-accent-color` and `--section-body-marker-color` slots still win, and plain non-image bands render byte-identically (#463).
+
+### Docs
+- `ai-instructions/retheme.md` now states that every accent surface on a background-image band — links, stat numbers, the `title_accent` substring, and section body list markers — routes through `--color-accent-on-overlay`, and that a full-cover hero shares the same overlay-accent guarantee (#463).
+
+### Tests
+- The rendered Playwright E2E (`tests/e2e/style-render.spec.ts`) extends #461's contrast spec to the three title-accent spans, the section list marker glyph, and the hero-cover title accent, proving each clears 4.5:1 against the rendered scrim-over-white composite at 375px and 1280px and that a per-instance slot still wins. css-lint pins lock the routing on every surface and guard against a regression back to the bare accent or the inverted role (#463).
+
 ## [v1.5.2] — 2026-07-20 — links and stat numbers on background-image bands are readable again: a new overlay accent role clears WCAG AA over any image (#461)
 
 **A section, CTA, or stats band with a `background_image` lays a dark scrim over an arbitrary photo, and its default link (or stat number) used the light-surface brand accent — only 1.16:1 over the scrim when the photo is bright, effectively invisible and far below the WCAG AA 4.5:1 bar. Those bands now route their default accent through a new `--color-accent-on-overlay` role that is guaranteed readable no matter what image sits underneath. Set a per-instance color slot and it still wins, exactly as before.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.5.2-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.3-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/retheme.md
+++ b/ai-instructions/retheme.md
@@ -54,8 +54,10 @@ surfaced by the same `stale_warnings` / `masked_derived_override` machinery as e
 other derived token (see below), so you are told when a base change may not reach it.
 
 **Surface-paired accent (the bg-image band).** A section/cta/stats band WITH a
-`background_image` lays a dark `rgba(0,0,0,.55)` overlay over an ARBITRARY image, so its
-accent (section/cta links, stats numbers) routes through a SEPARATE role,
+`background_image` — and a hero with `cover` layout + `image_url` — lays a dark
+`rgba(0,0,0,.55)` overlay over an ARBITRARY image, so EVERY accent surface on that band
+(section/cta links, stats numbers, the `title_accent` substring on all four, and section
+body list markers) routes through a SEPARATE role,
 `--color-accent-on-overlay` (default `#fafbff`), with `--color-accent-on-overlay-hover`
 (default `#ffffff`) for hover. This is NOT the same as `--color-accent-on-inverted`:
 on-inverted is tuned to the SOLID `--color-bg-inverted`, but the overlay sits over an

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -675,6 +675,17 @@
   color: var(--hero-text, var(--color-bg));
 }
 
+/* .hero--cover lays the same --overlay-bg scrim (via .hero__overlay) over an arbitrary
+   image as the section/cta/stats bg-image bands. The accented title substring paints
+   its OWN color (0,1,0) and does NOT inherit the near-white .hero--cover .hero__title
+   above, so it renders bare --color-accent at 1.16:1 over the overlay. Route the default
+   through the overlay accent role (#463) so the guarantee is uniform across all overlay
+   bands; the per-instance --hero-title-accent-color slot still wins. Scoped to
+   .hero--cover — the plain (non-overlay) hero variants keep bare accent. */
+.hero--cover .hero__title-accent {
+  color: var(--hero-title-accent-color, var(--color-accent-on-overlay));
+}
+
 .hero--cover .hero__subtitle {
   color: var(--hero-subtitle-color, var(--color-bg));
   opacity: 0.85;
@@ -1270,6 +1281,25 @@
 
 .section--has-bg-image a:hover {
   color: var(--section-accent-hover, var(--color-accent-on-overlay-hover));
+}
+
+/* The accented title substring paints its OWN color (0,1,0) and does NOT inherit
+   the near-white .section--has-bg-image .section__title above, so on the dark
+   overlay-over-image band it renders bare --color-accent at 1.16:1 (fails even the
+   3:1 large-text bar). Route the default through the overlay accent role (#463,
+   the same fix #461 gave links/numbers); the per-instance --section-title-accent-color
+   slot still wins. on-inverted is tuned to the solid inverted bg, not this overlay. */
+.section--has-bg-image .section__title-accent {
+  color: var(--section-title-accent-color, var(--color-accent-on-overlay));
+}
+
+/* Body list markers on the overlay band: a non-disc body_marker paints its glyph
+   from --pp-list-marker-color, whose default is bare --color-accent (1.16:1 here).
+   Re-map the default to the overlay accent role (#463); the --section-body-marker-color
+   slot still wins. Panel markers stay bare accent — a bg-image section's panel is a
+   self-contained LIGHT surface (#424), not on the overlay. */
+.section--has-bg-image .section__content {
+  --pp-list-marker-color: var(--section-body-marker-color, var(--color-accent-on-overlay));
 }
 
 /* ==========================================================================
@@ -2250,6 +2280,15 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   color: var(--cta-body-color, var(--color-accent-on-overlay-hover));
 }
 
+/* The accented title substring paints its OWN color (0,1,0) and does NOT inherit
+   the near-white .cta--has-bg-image .cta__title above, so on the dark overlay-over-
+   image band it renders bare --color-accent at 1.16:1. Route the default through the
+   overlay accent role (#463, mirroring the cta body-link fix from #461); the
+   per-instance --cta-title-accent-color slot still wins. */
+.cta--has-bg-image .cta__title-accent {
+  color: var(--cta-title-accent-color, var(--color-accent-on-overlay));
+}
+
 
 /* ==========================================================================
    COMPONENT: footer
@@ -2591,6 +2630,15 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
 .stats--has-bg-image .stats__label {
   color: var(--stats-label-color, var(--color-bg));
   opacity: 0.85;
+}
+
+/* The accented heading substring paints its OWN color (0,1,0) and does NOT inherit
+   the near-white .stats--has-bg-image .stats__heading above, so on the dark overlay-
+   over-image band it renders bare --color-accent at 1.16:1. Route the default through
+   the overlay accent role (#463, mirroring the stats-number fix from #461); the
+   per-instance --stats-title-accent-color slot still wins. */
+.stats--has-bg-image .stats__heading-accent {
+  color: var(--stats-title-accent-color, var(--color-accent-on-overlay));
 }
 
 /* ==========================================================================

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.5.2');
+define('PP_VERSION', '1.5.3');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.5.2
+Stable tag: 1.5.3
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.5.2
+Version:          1.5.3
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -4812,6 +4812,169 @@ test.describe('#461 bg-image band accent contrast (rendered)', () => {
   });
 });
 
+test.describe('#463 bg-image band title-accent + markers contrast (rendered)', () => {
+  let pageId = 0;
+
+  test.afterEach(async () => {
+    if (pageId) {
+      try {
+        deletePage(pageId);
+      } catch {
+        /* already cleaned */
+      }
+      pageId = 0;
+    }
+  });
+
+  // #461 fixed links/numbers on the three bg-image bands. #463 closes the remaining
+  // bare-accent surfaces on the same dark overlay-over-image bands: the accented title
+  // substring (which paints its OWN color and does NOT inherit the near-white band
+  // title, so it hit --color-accent at 1.16:1), the section body list markers, and
+  // .hero--cover's title-accent (same --overlay-bg scrim idiom). Same worst-case method
+  // as #461: seed a WHITE background-image, read the rendered overlay's real rgba() and
+  // composite it over white(255) — the worst case for a light-tinted foreground.
+  const WHITE_PNG =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQImWP8//8/AwMDEwMDAwMDAwAkBgMBmjCi+wAAAABJRU5ErkJggg==';
+
+  const bands = () => [
+    {
+      component: 'section',
+      props: {
+        id: 'pp-ov463-sec',
+        background_image: WHITE_PNG,
+        title: 'Overlay accent heading',
+        title_accent: 'accent',
+        body_marker: 'check',
+        body: '<p>Body copy on the image band.</p><ul><li>First point</li><li>Second point</li></ul>',
+      },
+    },
+    {
+      component: 'cta',
+      props: {
+        id: 'pp-ov463-cta',
+        background_image: WHITE_PNG,
+        title: 'Overlay accent cta',
+        title_accent: 'accent',
+        text: 'Sign up before the deadline.',
+        button_text: 'Go',
+        button_url: '/signup',
+      },
+    },
+    {
+      component: 'stats',
+      props: {
+        id: 'pp-ov463-stats',
+        background_image: WHITE_PNG,
+        title: 'Overlay accent stats',
+        title_accent: 'accent',
+        items: [{ number: '42', label: 'Metric' }],
+      },
+    },
+    {
+      component: 'hero',
+      props: {
+        id: 'pp-ov463-hero',
+        layout: 'cover',
+        image_url: WHITE_PNG,
+        title: 'Overlay accent hero',
+        title_accent: 'accent',
+      },
+    },
+  ];
+
+  // Each accent surface: the selector, an optional ::before pseudo (list marker glyph),
+  // the per-instance slot the rule reads first, and the overlay whose rgba() sits behind it.
+  const SURFACES = [
+    { name: 'section title-accent', accent: '.section--has-bg-image .section__title-accent', pseudo: '', slot: '--section-title-accent-color', overlay: '.section--has-bg-image .section__overlay' },
+    { name: 'section list marker', accent: '.section--has-bg-image .section__content--marker-check > ul > li', pseudo: '::before', slot: '--section-body-marker-color', overlay: '.section--has-bg-image .section__overlay' },
+    { name: 'cta title-accent', accent: '.cta--has-bg-image .cta__title-accent', pseudo: '', slot: '--cta-title-accent-color', overlay: '.cta--has-bg-image .cta__overlay' },
+    { name: 'stats heading-accent', accent: '.stats--has-bg-image .stats__heading-accent', pseudo: '', slot: '--stats-title-accent-color', overlay: '.stats--has-bg-image .stats__overlay' },
+    { name: 'hero cover title-accent', accent: '.hero--cover .hero__title-accent', pseudo: '', slot: '--hero-title-accent-color', overlay: '.hero--cover .hero__overlay' },
+  ];
+
+  test('every bg-image title-accent + marker clears AA (4.5:1) over the overlay-over-white worst case @375 + @1280', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E 463 overlay accent-span contrast');
+    setComposition(pageId, bands());
+
+    for (const width of [375, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+
+      for (const s of SURFACES) {
+        await expect(page.locator(s.accent).first()).toBeVisible({ timeout: 10000 });
+
+        const res = await page.evaluate(
+          ({ accentSel, pseudo, overlaySel }) => {
+            const parseRgb = (str: string): number[] => (str.match(/[\d.]+/g) || []).map(Number);
+            const lum = (rgb: number[]): number => {
+              const f = (v: number) => {
+                v /= 255;
+                return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+              };
+              return 0.2126 * f(rgb[0]) + 0.7152 * f(rgb[1]) + 0.0722 * f(rgb[2]);
+            };
+            const el = document.querySelector(accentSel);
+            const ov = document.querySelector(overlaySel);
+            if (!el || !ov) return { found: false, fg: [] as number[], comp: [] as number[], alpha: -1, ratio: 0 };
+            const fg = parseRgb(getComputedStyle(el, pseudo || undefined).color);
+            const o = parseRgb(getComputedStyle(ov).backgroundColor); // rgba(r,g,b,a)
+            const alpha = o.length >= 4 ? o[3] : 1;
+            const comp = [0, 1, 2].map((i) => alpha * (o[i] ?? 0) + (1 - alpha) * 255);
+            const L1 = lum(fg);
+            const L2 = lum(comp);
+            const ratio = (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+            return { found: true, fg, comp, alpha, ratio };
+          },
+          { accentSel: s.accent, pseudo: s.pseudo, overlaySel: s.overlay },
+        );
+
+        expect(res.found, `${s.name} or its overlay not found @${width}`).toBe(true);
+        // The overlay must actually be a translucent scrim (guards a vacuous pass).
+        expect(res.alpha, `${s.name} @${width}: overlay alpha ${res.alpha} is not the expected translucent scrim`).toBeGreaterThan(0);
+        expect(res.alpha).toBeLessThan(1);
+        expect(
+          res.ratio,
+          `${s.name} @${width}: fg=${JSON.stringify(res.fg)} overlay-over-white=${JSON.stringify(res.comp)} ratio=${res.ratio?.toFixed(2)} (need >= 4.5)`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+
+  test('a per-instance slot wins over the on-overlay default on every accent surface @375 + @1280', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E 463 overlay accent-span slot wins');
+    const SLOT = '#00e5ff'; // vivid cyan no token uses — a leak or clobber is obvious
+    const b = bands();
+    // Attach the per-instance style slot each surface's rule reads first. section band
+    // carries both its title-accent and its body-marker slot.
+    (b[0].props as Record<string, unknown>).__pp_style = {
+      '--section-title-accent-color': SLOT,
+      '--section-body-marker-color': SLOT,
+    };
+    (b[1].props as Record<string, unknown>).__pp_style = { '--cta-title-accent-color': SLOT };
+    (b[2].props as Record<string, unknown>).__pp_style = { '--stats-title-accent-color': SLOT };
+    (b[3].props as Record<string, unknown>).__pp_style = { '--hero-title-accent-color': SLOT };
+    setComposition(pageId, b);
+
+    for (const width of [375, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+
+      for (const s of SURFACES) {
+        await expect(page.locator(s.accent).first()).toBeVisible({ timeout: 10000 });
+        const color = await page.evaluate(
+          ({ sel, pseudo }) => getComputedStyle(document.querySelector(sel)!, pseudo || undefined).color,
+          { sel: s.accent, pseudo: s.pseudo },
+        );
+        expect(color, `${s.name} @${width}: per-instance slot must win over the on-overlay default`).toBe('rgb(0, 229, 255)');
+      }
+    }
+  });
+});
+
 /*
  * #439 — a link in cta.text renders as a real anchor, not escaped source.
  *

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -2725,3 +2725,66 @@ describe('CSS lint: bg-image band accent routes through --color-accent-on-overla
         expect(BASE_CSS).toMatch(/--color-accent-on-overlay-hover:[^;]*;\s*\/\*\s*color:/);
     });
 });
+
+describe('CSS lint: bg-image band title-accent + markers route through --color-accent-on-overlay (#463)', () => {
+    // #461 routed the default LINK/NUMBER on the three bg-image bands through the overlay
+    // accent role. #463 closes the remaining bare-accent surfaces on those same overlay
+    // bands: the accented title substring (which paints its OWN color and does NOT inherit
+    // the near-white band title, so it hit --color-accent at 1.16:1), the section body list
+    // markers, and .hero--cover's title-accent (same --overlay-bg scrim idiom). Each default
+    // routes through --color-accent-on-overlay — NOT the bare accent (the 1.16:1 bug) and NOT
+    // --color-accent-on-inverted (tuned to the solid inverted bg). Per-instance slots still win.
+    const stripped = stripComments(COMPONENTS_CSS);
+    const rules = [];
+    const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+    let m;
+    while ((m = ruleRe.exec(stripped)) !== null) {
+        rules.push({ selector: m[1].trim(), body: m[2] });
+    }
+    const rulesFor = (sel) => rules.filter(r => r.selector.split(',').some(s => s.trim() === sel));
+
+    // The four accented title substrings on overlay bands. Each carries its own `color`
+    // rule that must route slot → overlay role.
+    const TITLE_ROUTES = [
+        { sel: '.section--has-bg-image .section__title-accent', slot: '--section-title-accent-color' },
+        { sel: '.cta--has-bg-image .cta__title-accent', slot: '--cta-title-accent-color' },
+        { sel: '.stats--has-bg-image .stats__heading-accent', slot: '--stats-title-accent-color' },
+        { sel: '.hero--cover .hero__title-accent', slot: '--hero-title-accent-color' },
+    ];
+
+    TITLE_ROUTES.forEach(({ sel, slot }) => {
+        test(`${sel} routes through ${slot} then --color-accent-on-overlay`, () => {
+            const matches = rulesFor(sel);
+            expect(matches.length).toBeGreaterThan(0);
+            const re = new RegExp(
+                'color\\s*:\\s*var\\(\\s*' + slot.replace(/[-]/g, '\\-') +
+                '\\s*,\\s*var\\(\\s*\\-\\-color\\-accent\\-on\\-overlay\\s*\\)\\s*\\)'
+            );
+            expect(matches.some(r => re.test(r.body))).toBe(true);
+        });
+
+        // Regression guard: must NOT fall back to bare --color-accent or the inverted role.
+        test(`${sel} does not fall back to bare --color-accent or on-inverted`, () => {
+            const matches = rulesFor(sel);
+            expect(matches.length).toBeGreaterThan(0);
+            const rule = matches.find(r => /color\s*:/.test(r.body));
+            expect(rule).toBeDefined();
+            expect(rule.body).not.toMatch(/var\(\s*--color-accent\s*\)/);
+            expect(rule.body).not.toMatch(/--color-accent-on-inverted/);
+        });
+    });
+
+    // Section body list markers on the overlay band: --pp-list-marker-color is re-mapped
+    // to the overlay role. The selector also carries the near-white color rule, so find the
+    // declaration that actually assigns the marker variable.
+    test('.section--has-bg-image .section__content re-maps --pp-list-marker-color to the overlay role', () => {
+        const rule = rulesFor('.section--has-bg-image .section__content')
+            .find(r => /--pp-list-marker-color\s*:/.test(r.body));
+        expect(rule).toBeDefined();
+        expect(rule.body).toMatch(
+            /--pp-list-marker-color\s*:\s*var\(\s*--section-body-marker-color\s*,\s*var\(\s*--color-accent-on-overlay\s*\)\s*\)/
+        );
+        // Regression guard: the marker default must not be the bare accent (1.16:1) here.
+        expect(rule.body).not.toMatch(/--pp-list-marker-color\s*:\s*var\(\s*--section-body-marker-color\s*,\s*var\(\s*--color-accent\s*\)\s*\)/);
+    });
+});


### PR DESCRIPTION
Closes #463

## What & why
#461 (v1.5.2) routed the default **link/number** on background-image bands through the AA-safe `--color-accent-on-overlay` role. The remaining accent-carrying surfaces on the **same dark overlay-over-image scrim** were left on the light-surface `--color-accent` (`#3157f4`) — **1.16:1** over the overlay-composited-over-white worst case, effectively invisible and far below WCAG AA. #463 closes that gap by extending the exact same #461 mechanism (no new role, no new hex).

Fresh dev evidence (2026-07-20 smoke, dev's real palette): the title-accent spans render `#310CC9` at **2.19:1** over the `rgb(115,115,115)` worst-case composite — quantified and visually obvious. After this change they route to the near-white role (`#fafbff`, 4.59:1).

## Scope (each acceptance criterion)
Routed the default through `--color-accent-on-overlay` via slot-preserving fallback chains (`component slot → overlay role`), slots still winning:
- `.section--has-bg-image .section__title-accent` (`--section-title-accent-color`)
- `.cta--has-bg-image .cta__title-accent` (`--cta-title-accent-color`)
- `.stats--has-bg-image .stats__heading-accent` (`--stats-title-accent-color`)
- `.section--has-bg-image .section__content` body list markers (`--pp-list-marker-color` → `--section-body-marker-color` → overlay role)
- `.hero--cover .hero__title-accent` (`--hero-title-accent-color`) — **hero cover was in scope**: verified in code that `.hero--cover` lays the identical `--overlay-bg` scrim via `.hero__overlay` over an arbitrary image, the same idiom as the section/cta/stats bands.

**Zero new hex** in `components.css` — the role and its `pp_token_families()` registration already shipped in #461. No `base.css` / `lib/wp.php` / token-family change. Panel list markers are deliberately **out of scope** (a bg-image section's panel is a self-contained light surface, #424 — not on the scrim). Plain non-image bands are byte-identical.

## Validation
- **JS (vitest):** `npm test` — 782 passed (includes 12 new #463 css-lint routing pins + regression guards).
- **PHP (phpunit):** `./vendor/bin/phpunit` — 2127 passed (3 warnings + 2 deprecations, unchanged baseline; this change touches zero PHP).
- **E2E (Playwright on wp-env):** new `#463` block — contrast (5 surfaces × 375/1280, ≥4.5:1 over the rendered scrim-over-white composite) + slot-override-wins, both pass; adjacent `#461` block re-run green (no regression).
- Version consistency validated by `scripts/package.sh` (5 files at 1.5.3); build zip deleted (CI builds releases from tags).

## gstack workflows
/plan-eng-review (clean, 0 findings) and /review (clean, scope CLEAN, 0 findings) both ran this session on this exact diff — cited, not re-dispatched. /document-generate applied one AI-doc accuracy update (`retheme.md`).

## Accepted limitations / notes
- Outside voice (Codex) skipped: its sandbox cannot run on this container (bwrap), and this is a mechanical mirror of the already-reviewed #461 pattern with zero architectural surface. Informational only, never a gate.
- No 7A decision was needed — the fix pattern was established and binding.

## Noticed, not touched
- The **inverted** (non-image) stats/section heading-accent (`.stats--inverted`, etc.) still uses bare `--color-accent` on the solid inverted background — a separate, narrower gap outside #463's bg-image scope. Candidate follow-up.