### PR TITLE
v1.5.4 docs: add full inspect-field reference (incl. composition_decode_error) to reference-apply-cli.md (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.5.4] — 2026-07-20 — the full `wp pp operate inspect` field reference lands in the CLI docs, including `composition_decode_error` (#216)
+
+**`docs/reference-apply-cli.md` described `wp pp operate inspect` but only documented the appended `run_id` — the rest of the inspect JSON contract was undocumented in the CLI reference, and the corruption-vs-empty signal `composition_decode_error` (added in #144) lived only in `AI_CONTEXT.md`. The inspect section now carries a complete field table: every top-level field `pp_inspect_site()` returns (`target`, `pages`, `drift`, `preflight`, `tokens`, `conflicts`, `smells`, `token_smells`, `composition_decode_error`) plus the CLI-appended `run_id`, each with its shape and meaning, and a dedicated table for `composition_decode_error`'s `decode_error` / `unexpected_shape` / `null` cases. Documentation only — no output shape or behavior changed.**
+
+An agent inspecting a page before a mutation could not learn from the CLI reference how to tell a genuinely blank page apart from a corrupted one, or what the other inspect fields mean, without reading the source. The new reference enumerates the contract against `pp_inspect_site()` in `lib/operate.php` (the source of truth), so `composition_decode_error` is documented alongside `smells` with the precise rule: a corrupt row surfaces `decode_error` or `unexpected_shape` (never a misleading empty smell list), while an absent, blank, or valid page reads `null`. A doc-drift test pins the reference to the code, so adding a field to inspect now fails CI until the reference documents it.
+
+### Docs
+- `docs/reference-apply-cli.md` gains a `wp pp operate inspect` section with a full field-reference table for every top-level `pp_inspect_site()` field (`lib/operate.php`) plus the CLI-appended `run_id`, and a detail table documenting `composition_decode_error`'s `decode_error` / `unexpected_shape` / `null` semantics against the `pp_get_composition_result()` decode contract (`lib/wp.php`) (#216).
+
+### Tests
+- A doc-drift pin in `tests/js/docs-lint.test.js` extracts the top-level keys from `pp_inspect_site()`'s return array (plus the `run_id` the CLI appends in `lib/cli.php`) and asserts `docs/reference-apply-cli.md` names each one, with a no-op guard so a broken extraction fails loudly instead of passing vacuously — the reference can no longer silently rot when the inspect output shape grows (#216).
+
 ## [v1.5.3] — 2026-07-20 — the rest of the accent on a background-image band is readable now too: highlighted title words and list bullets clear WCAG AA over any image (#463)
 
 **v1.5.2 (#461) fixed the default link and stat number on a background-image band, but the other accent-colored things on the same dark scrim were left on the light-surface brand accent — only 1.16:1 over a bright photo, effectively invisible. The highlighted word inside a band heading (`title_accent`), the check/dash/arrow bullets in a section body list, and a full-cover hero's highlighted title word all now route their default through the same `--color-accent-on-overlay` role, so they stay legible no matter what image sits underneath. Set a per-instance color slot and it still wins, exactly as before, and a plain (non-image) band is untouched.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.5.3-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.4-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/docs/reference-apply-cli.md
+++ b/docs/reference-apply-cli.md
@@ -26,6 +26,48 @@ Pass the same `run_id` to `preflight`, then to `execute`/`reset`, then to `resto
 
 ---
 
+## `wp pp operate inspect` — the INSPECT output
+
+`inspect` is the read-only INSPECT step of the operating loop: one call returns the whole operating picture and mints the run token. It never mutates the site (it does write a run-state row, the same as any `inspect` — see the run token above).
+
+```bash
+wp pp operate inspect
+wp pp operate inspect --post_id=42
+```
+
+**Options**
+
+- `--post_id=<id>` — include page-specific composition smells (and a page-level composition integrity check) for this post. Without it, the page-scoped fields (`smells`, `composition_decode_error`) stay at their empty/`null` defaults.
+
+**Output** — the operating picture as pretty JSON. Every top-level field `pp_inspect_site()` returns (`lib/operate.php`), plus the `run_id` the CLI appends (`PP_Operate_Command::inspect`, `lib/cli.php`):
+
+| Field | Shape | What it is |
+|---|---|---|
+| `target` | `{site_url, wp_root, theme_path, environment}` | The canonical mutation target, auto-resolved from WordPress state (`pp_get_target`). A field is `null` when it can't be resolved. |
+| `pages` | array of `{id, title, status, url}` | Every page using the Composition template (`composition.php`), any status, title-sorted (`pp_composition_pages`). |
+| `drift` | `{has_drift, modified, added, deleted}` (`error` added when the theme dir is unreadable) | Theme-file drift vs the deployment manifest (`pp_check_drift`). No manifest baseline ⇒ `has_drift:false` with empty arrays (it never creates one). |
+| `preflight` | `{ok, checks[]}` | A **site-grain** preflight snapshot computed with no planned files and no post (`pp_preflight`). This is advisory situational awareness — the gate that actually unlocks a mutation is `wp pp apply preflight --run-id=…`, not this. |
+| `tokens` | map of `--token` ⇒ `{value, type}` | Design tokens parsed from `base.css :root {}`, with the type from each token's structured comment (`pp_design_tokens`). |
+| `conflicts` | array of `{selector, component}` | WordPress Custom CSS selectors that target PP component classes (`pp_check_custom_css_conflicts`). Report-only; `[]` when there are none. |
+| `smells` | array of `{type, message, index}` | Page composition smells for `--post_id` (`pp_validate_composition_smells`): hero/layout/wall-of-text advisories, plus `template_owned_component` / `duplicate_component_id` on a page whose stored composition predates those rules. `[]` when no `--post_id` is given, the page's composition is empty, or the page is corrupt (a corrupt page is reported via `composition_decode_error`, not here). |
+| `token_smells` | array of `{type, base_token, token, current, expected, message}` | Masked derived-family overrides (#386, `pp_detect_masked_derived_smells`): a derived override (e.g. `--color-accent-strong`) that diverges from what its base (`--color-accent`) currently derives, so a base change won't show where the override applies. Always computed (site-scoped, independent of `--post_id`); `[]` on a coherently themed site. |
+| `composition_decode_error` | `null` \| `"decode_error"` \| `"unexpected_shape"` | Page composition **integrity** for `--post_id` (#144). Always present in the output; only ever non-`null` when `--post_id` names a page whose stored `_pp_composition` is corrupt rather than genuinely empty (see below). |
+| `run_id` | UUID v4 string | The run token this `inspect` minted, appended by the CLI. Pass it as `--run-id` to every mutating subcommand. |
+
+### `composition_decode_error` in detail (#144)
+
+A page with no composition and a page with a *corrupted* composition both look empty to a naive reader — the same `smells: []`. `composition_decode_error` tells them apart so an agent relying on INSPECT before a mutation is warned about data corruption instead of treating a broken row as a clean, blank page. It is set from the state-classifying decoder `pp_get_composition_result()` (`lib/wp.php`), the single owner of composition decode + classification:
+
+| Value | Meaning | When |
+|---|---|---|
+| `null` | No integrity problem. | No `--post_id`; or the page's `_pp_composition` is absent/blank (a genuinely empty page); or it decodes to a valid JSON list (a real composition). |
+| `"decode_error"` | The stored `_pp_composition` is present but **not decodable JSON** (truncated write, encoding bug, malformed UTF-8). | `--post_id` given and the raw row fails `json_decode`. |
+| `"unexpected_shape"` | The stored value **decodes but is not a list** — a JSON object or scalar, a non-string scalar meta, or an already-decoded non-list array. | `--post_id` given and the decoded value isn't a sequential-keyed list. |
+
+When it is non-`null`, `smells` is `[]` (the corrupt row can't be walked for smells) — read the integrity field, not the empty smell list, to decide the page is broken. The rendering paths are unaffected: `pp_get_composition()` still degrades any corrupt or non-list row to `[]`, so templates never fatal on a bad row; only these read/validate surfaces surface the distinction. `wp pp check page`, `wp pp validate site`, and `wp pp validate page` report the same integrity error rather than "no composition."
+
+---
+
 ## Subcommand summary
 
 | Subcommand | Mutates? | `--run-id` | Needs prior PREFLIGHT | Purpose |

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.5.3');
+define('PP_VERSION', '1.5.4');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.5.3
+Stable tag: 1.5.4
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.5.3
+Version:          1.5.4
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/docs-lint.test.js
+++ b/tests/js/docs-lint.test.js
@@ -119,6 +119,51 @@ describe('docs lint: the token-count guard is not decoration', () => {
     });
 });
 
+// The inspect field reference in docs/reference-apply-cli.md must name every
+// top-level field pp_inspect_site() returns (#216). The doc drifted once already:
+// #144 added composition_decode_error and it lived only in AI_CONTEXT.md until #216
+// backfilled the CLI reference. This pin extracts the keys from the source of truth
+// (the return array in lib/operate.php, plus the run_id the CLI appends in lib/cli.php)
+// so ADDING a field to inspect fails this test until the reference documents it —
+// the reference can't silently rot when the output shape grows.
+const OPERATE_PHP = read('lib/operate.php');
+const CLI_PHP = read('lib/cli.php');
+const APPLY_CLI_DOC = read('docs/reference-apply-cli.md');
+
+// Capture the `return [ ... ];` block inside pp_inspect_site() and pull the quoted
+// top-level keys (each line is `'key' => ...`). Anchored to the function so an
+// unrelated array literal elsewhere in the file can't leak keys in.
+const inspectReturnKeys = () => {
+    const fn = OPERATE_PHP.match(/function pp_inspect_site[\s\S]*?\n {4}return \[\n([\s\S]*?)\n {4}\];/);
+    if (!fn) return [];
+    return [...fn[1].matchAll(/^ {8}'([a-z_]+)'\s*=>/gm)].map((m) => m[1]);
+};
+
+// run_id is appended by the CLI command, not by pp_inspect_site(). Only count it
+// when the append line is actually present, so this stays tied to the code.
+const cliAppendsRunId = /\$result\['run_id'\]\s*=/.test(CLI_PHP);
+
+describe('docs lint: inspect field reference documents every pp_inspect_site() key (#216)', () => {
+    const keys = inspectReturnKeys();
+    const allKeys = cliAppendsRunId ? [...keys, 'run_id'] : keys;
+
+    test('the key extraction is not a no-op', () => {
+        // If the source shape or the regex changes so nothing is extracted, fail
+        // loudly instead of passing vacuously. These four must always be present.
+        expect(keys).toContain('target');
+        expect(keys).toContain('composition_decode_error');
+        expect(keys).toContain('token_smells');
+        expect(cliAppendsRunId).toBe(true);
+    });
+
+    test.each(allKeys.map((k) => [k]))(
+        'reference-apply-cli.md documents the `%s` inspect field',
+        (key) => {
+            expect(APPLY_CLI_DOC).toContain('`' + key + '`');
+        },
+    );
+});
+
 describe('docs lint: no stale #83 quarantine claim', () => {
     // #83 was resolved 2026-07-07 and the broken-media E2E is de-quarantined.
     // Scoped to a quarantine claim naming an issue, so a future legitimate


### PR DESCRIPTION
Closes #216

## Scope
Docs-only (#141 Part 2 housekeeping, follow-up to #144). Adds a complete `wp pp operate inspect` field reference to `docs/reference-apply-cli.md`, enumerated against `pp_inspect_site()` (`lib/operate.php`) as the source of truth.

- New `## wp pp operate inspect — the INSPECT output` section with a field table for **every** top-level field the function returns: `target`, `pages`, `drift`, `preflight`, `tokens`, `conflicts`, `smells`, `token_smells`, `composition_decode_error`, plus the CLI-appended `run_id` (`PP_Operate_Command::inspect`, `lib/cli.php`). Each row gives the shape and meaning, verified against the producing function.
- A dedicated `composition_decode_error` detail table documenting its `null` / `decode_error` / `unexpected_shape` values against the `pp_get_composition_result()` decode contract (`lib/wp.php`), including the null/blank-page case and the "smells is [] on a corrupt row — read the integrity field" rule.

### Acceptance criteria
- Lists every field `pp_inspect_site()` returns, matching the code — including `token_smells` (#386), which post-dates the issue and did not appear in the issue's field list but exists in the code today.
- `composition_decode_error` documented with both error codes and its `null` case.
- No behavior/code change — documentation only. `wp pp operate inspect` output shape is untouched.

## Validation
- `npm test` (vitest): 793 passed, incl. 10 new doc-drift assertions in `tests/js/docs-lint.test.js`.
- `./vendor/bin/phpunit`: 2127 passed (3 warnings / 2 deprecations are the unchanged pre-existing baseline; diff touches zero PHP).
- `bash scripts/package.sh`: version consistency OK across the five synced files (1.5.4); build zip deleted (releases are CI-built from tags).

## Accepted limitation
The doc-drift pin asserts each key name appears somewhere in the reference (backticked). Distinctive keys (`composition_decode_error`, `token_smells`, `run_id`) are strongly pinned; common words (`target`, `drift`, `tokens`) could pass on an incidental match. Section-scoped matching would be more brittle, and the issue asked to "name every key" (presence), so presence is what's pinned. The no-op guard prevents a vacuous pass.

## Note vs the issue text
The issue body phrased `composition_decode_error` as "present only with `--post_id`". Verified against code: the key is **always** present in the output (defaults to `null`); it is only ever non-`null` when `--post_id` names a corrupt page. The reference documents the code's actual behavior (the issue defers to `pp_inspect_site()` as source of truth). No code change — the source of truth is correct.