### PR TITLE
v1.5.5 fix: update_seo_meta stores non-ASCII correctly (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.5.5] — 2026-07-21 — a Spanish (or any non-ASCII) meta description sets and renders correctly now: accents and em-dashes stop turning into literal `u00e1` (#471)
+
+**Setting a page's `meta_description` or `seo_title` to text with accents, ñ, or an em-dash through `update_seo_meta` corrupted every non-ASCII character: `prueba áéíóú ñ —guion` was stored and rendered as `prueba u00e1u00e9u00edu00f3u00fa u00f1 u2014guion`. A non-English site could not set a correct meta description, the exact job the action exists for. The stored value and the rendered `<meta name="description">` now carry the real UTF-8 text, and `seo_title` overrides the `<title>` with its real characters too. Pages already saved with the mangled text heal the moment their SEO metadata is set again.**
+
+The action JSON-encoded the metadata before writing it, and WordPress's meta layer then stripped the backslashes off the resulting `\uXXXX` escapes, leaving `á` as the literal `u00e1`. The write now stores the metadata as raw UTF-8 and shields it from that stripping pass, the same storage approach the composition (page content) path has always used, so accents, ñ, em-dashes, CJK, emoji, quotes, and backslashes all round-trip byte-for-byte. Nothing else about the action changed: patch semantics, the length caps, canonical-URL validation, and clearing a field with `""` all behave exactly as before.
+
+### Fixed
+- `update_seo_meta` (and `pp_update_seo_meta()`) now store `meta_description` and `seo_title` as raw UTF-8, so non-ASCII text is preserved end-to-end instead of being mangled into literal `uXXXX` sequences in the stored `_pp_seo_meta` and in the rendered `<meta name="description">` / `<title>` tags. Values that were already corrupted are plain (wrong) strings that read back without error and heal on the next write; no migration is needed (#471).
+
+### Tests
+- New PHPUnit round-trip regressions assert byte-identical read-back for Spanish accents, the em-dash, CJK, a non-BMP emoji, double quotes, a literal backslash, and a literal `á`-looking string, plus a patch-merge case and rendered-tag checks for both the meta description and the `seo_title` override. A Playwright E2E drives the real `wp pp action execute update_seo_meta` path on WordPress and asserts the rendered `<head>` shows the correct UTF-8. The PHPUnit harness now models WordPress's unslash-on-write so this class of corruption can no longer pass the suite silently (#471).
+
 ## [v1.5.4] — 2026-07-20 — the full `wp pp operate inspect` field reference lands in the CLI docs, including `composition_decode_error` (#216)
 
 **`docs/reference-apply-cli.md` described `wp pp operate inspect` but only documented the appended `run_id` — the rest of the inspect JSON contract was undocumented in the CLI reference, and the corruption-vs-empty signal `composition_decode_error` (added in #144) lived only in `AI_CONTEXT.md`. The inspect section now carries a complete field table: every top-level field `pp_inspect_site()` returns (`target`, `pages`, `drift`, `preflight`, `tokens`, `conflicts`, `smells`, `token_smells`, `composition_decode_error`) plus the CLI-appended `run_id`, each with its shape and meaning, and a dedicated table for `composition_decode_error`'s `decode_error` / `unexpected_shape` / `null` cases. Documentation only — no output shape or behavior changed.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.5.4-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.5-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.5.4');
+define('PP_VERSION', '1.5.5');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -2777,7 +2777,17 @@ function pp_update_seo_meta(int $post_id, array $meta) {
     }
 
     $updated = array_merge(pp_get_seo_meta($post_id), $meta);
-    update_post_meta($post_id, '_pp_seo_meta', wp_json_encode($updated));
+    // JSON_UNESCAPED_UNICODE stores non-ASCII (accents, em-dash) as raw UTF-8
+    // instead of \uXXXX escapes — without it, update_post_meta()'s unslash pass
+    // stripped the backslash and turned "á" into a literal "u00e1" (#471).
+    // wp_slash() then protects the escapes that are still present in any JSON
+    // string (\" and \\) from that same unslash pass. Same store idiom as the
+    // composition path (see the _pp_composition write in pp_apply_composition()).
+    update_post_meta(
+        $post_id,
+        '_pp_seo_meta',
+        wp_slash(wp_json_encode($updated, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES))
+    );
     return true;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.5.4
+Stable tag: 1.5.5
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.5.4
+Version:          1.5.5
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -1508,6 +1508,99 @@ class ActionsTest extends TestCase
         $this->assertSame('https://example.com/default', pp_seo_canonical_url_override('https://example.com/default', null));
     }
 
+    // ── #471: non-ASCII / special-char round-trip through the store ─────────
+    // These read the meta straight back after a write and assert byte-identical
+    // values. Before the wp_slash()+JSON_UNESCAPED_UNICODE fix, update_post_meta
+    // unslashed the \uXXXX escapes wp_json_encode() emitted, so "á" was stored
+    // as the literal "u00e1". The harness (tests/bootstrap.php) now models WP's
+    // unslash-on-write, so a missing wp_slash() would resurface the corruption.
+
+    public function testUpdateSeoMetaPreservesSpanishAccentsAndEmDash(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $value = 'prueba áéíóú ñ —guion';
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => $value]]);
+        $this->assertSame($value, pp_get_seo_meta($id)['meta_description']);
+    }
+
+    public function testUpdateSeoMetaPreservesNonBmpEmoji(): void
+    {
+        // Non-BMP (4-byte UTF-8) must survive too — the composition path already
+        // stores raw UTF-8 the same way, and WP's meta table is utf8mb4.
+        $id = pp_create_page('Page', 'draft');
+        $value = 'Launch day 🚀🎉 — vámonos';
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => $value]]);
+        $this->assertSame($value, pp_get_seo_meta($id)['meta_description']);
+    }
+
+    public function testUpdateSeoMetaPreservesNonAsciiInSeoTitle(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $value = 'Título en Español — 日本語';
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['seo_title' => $value]]);
+        $this->assertSame($value, pp_get_seo_meta($id)['seo_title']);
+    }
+
+    public function testUpdateSeoMetaPreservesDoubleQuotes(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $value = 'She said "hola" to everyone';
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => $value]]);
+        $this->assertSame($value, pp_get_seo_meta($id)['meta_description']);
+    }
+
+    public function testUpdateSeoMetaPreservesLiteralBackslash(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        $value = 'path C:\\Users\\ñoño and a trailing \\';
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => $value]]);
+        $this->assertSame($value, pp_get_seo_meta($id)['meta_description']);
+    }
+
+    public function testUpdateSeoMetaPreservesLiteralUnicodeEscapeString(): void
+    {
+        // A user who literally types the six characters á must get them
+        // back verbatim — not have them collapse to "á" or "u00e1".
+        $id = pp_create_page('Page', 'draft');
+        $value = 'literal escape: \\u00e1 stays as-is';
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => $value]]);
+        $this->assertSame($value, pp_get_seo_meta($id)['meta_description']);
+    }
+
+    public function testUpdateSeoMetaNonAsciiPatchDoesNotCorruptExistingKey(): void
+    {
+        // The stored JSON is re-read and merged on every patch; a non-ASCII
+        // value written first must survive a later patch to a different key.
+        $id = pp_create_page('Page', 'draft');
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['meta_description' => 'café ñandú —']]);
+        pp_execute_action('update_seo_meta', ['post_id' => $id, 'meta' => ['seo_title' => 'Título']]);
+        $meta = pp_get_seo_meta($id);
+        $this->assertSame('café ñandú —', $meta['meta_description']);
+        $this->assertSame('Título', $meta['seo_title']);
+    }
+
+    public function testSeoMetaDescriptionTagRendersNonAsciiCorrectly(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        pp_update_seo_meta($id, ['meta_description' => 'prueba áéíóú ñ —guion']);
+        $GLOBALS['_pp_test_store']['is_singular'] = true;
+        $GLOBALS['_pp_test_store']['queried_object_id'] = $id;
+        ob_start();
+        pp_seo_meta_description_tag();
+        $html = ob_get_clean();
+        $this->assertStringContainsString('content="prueba áéíóú ñ —guion"', $html);
+        $this->assertStringNotContainsString('u00e1', $html);
+    }
+
+    public function testSeoDocumentTitleOverrideReturnsNonAsciiVerbatim(): void
+    {
+        $id = pp_create_page('Page', 'draft');
+        pp_update_seo_meta($id, ['seo_title' => 'Título en Español — 日本語']);
+        $GLOBALS['_pp_test_store']['is_singular'] = true;
+        $GLOBALS['_pp_test_store']['queried_object_id'] = $id;
+        $this->assertSame('Título en Español — 日本語', pp_seo_document_title_override(''));
+    }
+
     // ── Action: publish_page ──────────────────────────────────────────────
 
     public function testPublishPageExecute(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -363,7 +363,13 @@ if (!function_exists('get_post_meta')) {
 
 if (!function_exists('update_post_meta')) {
     function update_post_meta(int $post_id, string $key, $value): bool {
-        $GLOBALS['_pp_test_store']['post_meta'][$post_id][$key] = $value;
+        // Real WordPress unslashes the meta value before storing (it expects
+        // SLASHED input from the historical magic-quotes contract). Model that
+        // here so tests exercise the true store round-trip: code that forgets
+        // to wp_slash() a wp_json_encode()'d payload loses its backslashes,
+        // exactly as in production (#471). Paired with the wp_slash() stub
+        // below, a correctly wp_slash()'d write is a net no-op.
+        $GLOBALS['_pp_test_store']['post_meta'][$post_id][$key] = wp_unslash($value);
         return true;
     }
 }
@@ -637,10 +643,15 @@ if (!function_exists('wp_unslash')) {
 }
 
 if (!function_exists('wp_slash')) {
-    // No-op: real WP adds slashes then update_post_meta strips them.
-    // Our stubs don't strip, so wp_slash must be transparent.
+    // Real WP adds slashes (before ', ", \, NUL) and recurses into arrays.
+    // Model it faithfully so it forms an exact inverse pair with the wp_unslash
+    // stub: a wp_slash()'d value survives update_post_meta()'s unslash pass
+    // byte-for-byte, while an unslashed wp_json_encode() payload does not (#471).
     function wp_slash($value) {
-        return $value;
+        if (is_array($value)) {
+            return array_map('wp_slash', $value);
+        }
+        return is_string($value) ? addslashes($value) : $value;
     }
 }
 

--- a/tests/e2e/actions.spec.ts
+++ b/tests/e2e/actions.spec.ts
@@ -137,6 +137,41 @@ test.describe('Action Layer CLI', () => {
     await expect(hero).toBeVisible({ timeout: 10000 });
     await expect(page.locator('.hero__title').first()).toContainText('Seed Hero');
   });
+
+  test('update_seo_meta renders non-ASCII meta description as UTF-8 (#471)', async ({ page }) => {
+    const description = 'prueba áéíóú ñ —guion';
+    const runId = ppOperateInspect();
+
+    // 1. Create + publish a page so it renders on the front end.
+    ppPreflight(runId);
+    const createResult = ppAction('create_page', {
+      title: 'E2E SEO Meta Test',
+      composition: [{ component: 'hero', props: { title: 'Seed Hero' } }],
+    }, runId);
+    expect(createResult.ok).toBe(true);
+    pageId = (createResult.target as any).post_id;
+
+    // 2. Set the Spanish meta description through the real action path — the
+    //    exact repro from #471, via WP-CLI with no JSON tooling in between.
+    ppPreflight(runId, pageId);
+    const seoResult = ppAction('update_seo_meta', {
+      post_id: pageId,
+      meta: { meta_description: description },
+    }, runId);
+    expect(seoResult.ok).toBe(true);
+
+    const pubResult = ppAction('publish_page', { post_id: pageId }, runId);
+    expect(pubResult.ok).toBe(true);
+
+    // 3. The rendered <head> must carry the correct UTF-8 text, not the
+    //    "u00e1"-mangled escapes that #471 stored.
+    await page.goto(`/?page_id=${pageId}`);
+    const content = await page
+      .locator('head meta[name="description"]')
+      .getAttribute('content');
+    expect(content).toBe(description);
+    expect(content).not.toContain('u00e1');
+  });
 });
 
 /**


### PR DESCRIPTION
Closes #471

## Problem
`update_seo_meta` corrupted every non-ASCII character in `meta_description` / `seo_title`: `prueba áéíóú ñ —guion` stored and rendered as `prueba u00e1u00e9u00edu00f3u00fa u00f1 u2014guion`. A non-English site could not set a correct meta description.

Root cause (`lib/wp.php` `pp_update_seo_meta`): the metadata was `wp_json_encode()`d and handed to `update_post_meta()` without `wp_slash()` and without `JSON_UNESCAPED_UNICODE`. `update_post_meta()` unslashes on write, stripping the backslashes off the emitted `\uXXXX` escapes, so `á` became the literal `u00e1`. The composition (`_pp_composition`) path survives because it already wraps its encode in `wp_slash(...)` with the unescaped-unicode flags.

## Fix
Store via `wp_slash(wp_json_encode($updated, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES))` — the exact idiom the composition write path uses. Non-ASCII is stored as raw UTF-8 and shielded from the unslash pass, so accents, ñ, em-dashes, CJK, emoji, quotes, and backslashes round-trip byte-for-byte. Patch semantics, length caps, canonical-URL validation, and `""`-clears are unchanged. Previously-corrupted values read back without error and heal on the next write (no migration).

## Scope
- Only `lib/wp.php:2780` (the SEO meta write) was affected. Swept `lib/` for the same unslashed-`wp_json_encode`-into-meta/option idiom: the composition write (`:2657`) and history ring (`:2647`) already use the correct `wp_slash` + flags idiom; every `update_option` site stores native PHP arrays/scalars (WP serializes them — not the JSON-into-string idiom, not vulnerable). No other same-bug site.
- Test harness (`tests/bootstrap.php`) now models WP's magic-quotes round-trip (`update_post_meta` unslashes; `wp_slash` uses `addslashes`) so this corruption class can no longer pass the suite silently. Full suite (2136 PHP) stays green with the change.

## Validation
- PHPUnit: 2136 tests, 8243 assertions green (`./vendor/bin/phpunit --configuration phpunit.xml`). New round-trip regressions were verified to FAIL against the pre-fix code with the exact `u00e1`/`u2014` corruption, and pass after the fix.
- JS: 793 tests green (`npm test`).
- E2E: `tests/e2e/actions.spec.ts` full spec (17 tests) green on wp-env, including a new test driving `wp pp action execute update_seo_meta` end-to-end and asserting the rendered `<head>` shows correct UTF-8.

## Reviews
- `/plan-eng-review` and `/review` ran on this diff (3 converging Claude specialist/adversarial passes + a Codex adversarial pass). No critical findings. Codex suggested dropping `JSON_UNESCAPED_UNICODE` — refuted: the composition path already stores raw UTF-8 the same way and the recorded fix explicitly requires the flag; added a non-BMP emoji round-trip test to pin it.

## Accepted limitations (pre-existing, out of scope)
- Length caps use `strlen()` (byte count), so a multibyte value hits the 320/200 cap in bytes, not characters.
- `wp_json_encode()` returning `false` on invalid UTF-8 would store `false` and still return `true` — unreachable through the JSON action layer (json_decode rejects invalid UTF-8 upstream).

No 7A decision was required (no accepted-behavior/public-surface expansion beyond the recorded fix).
