### PR TITLE
v1.5.6 feat: heading letter-spacing design token (#467)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -366,7 +366,7 @@ Derived:    --color-text-secondary, --color-accent-strong, --color-border-accent
             --color-accent-on-overlay, --color-accent-on-overlay-hover
 Spacing:    --space-xs, --space-sm, --space-md, --space-lg, --space-xl, --space-2xl, --space-3xl
 Typography: --font-body, --font-heading, --font-weight-heading, --line-height-body, --line-height-heading,
-            --font-mono
+            --letter-spacing-heading, --font-mono
 Button:     --btn-padding-y, --btn-padding-x, --btn-radius,
             --btn-bg, --btn-text, --btn-border-color, --btn-shadow
 Shape:      --radius, --max-width, --measure-body, --measure-body-wide, --measure-centered,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.5.6] — 2026-07-21 — heading letter-spacing is now a design token, so a brand can set its own heading tracking (#467)
+
+**Heading tracking was the one heading typography value you couldn't reach: `--font-heading`, `--font-weight-heading`, and `--line-height-heading` were tokens, but `letter-spacing` was hard-coded to `-0.03em` on the shared `h1–h6` rule. A brand adopting a different display face that needs looser or tighter tracking (say `-0.01em`) had no way to set it without editing the parent theme. There is now a `--letter-spacing-heading` token (length, default `-0.03em`) that the `h1–h6` rule consumes, so `update_design_token` can set heading tracking site-wide. An unset site renders byte-identically — the computed tracking on every heading is unchanged.**
+
+Because heading tracking is naturally negative, the shared `length` validator now accepts negative values (an optional leading minus on a simple length, and signed operands inside `calc()`/`clamp()`), which it previously rejected for every length token. This models the CSS `<length>` grammar correctly — `letter-spacing`, margins, and `text-indent` legitimately go negative — so a value like `-0.01em` validates through the write path. The validators were always grammar guards, not per-property semantic guards, so a value that is inert for a given property (a negative radius, say) still simply drops per CSS; the trust posture is unchanged. `"-"` alone, a double minus, and any injection characters stay rejected.
+
+### Added
+- `--letter-spacing-heading` (length, default `-0.03em`) registered in `assets/css/base.css`, joining `pp_design_tokens()` and the `update_design_token` write path. The shared `h1–h6` rule consumes `var(--letter-spacing-heading)` instead of a literal, so setting the token retracks every heading at once; unset output is byte-identical. Documented in the AI token reference (`AI_CONTEXT.md`) (#467).
+
+### Changed
+- The shared length validator (`_pp_validate_length`) now accepts grammar-valid negative lengths: a single leading minus on a simple length (e.g. `-0.01em`, `-.5rem`) and signed operands inside `calc()`/`clamp()`. This widens every `length` token, not just heading tracking; injection guards and the calc/clamp positive-pattern are untouched (#467).
+
+### Tests
+- PHPUnit: a `pp_design_tokens()` assertion that `--letter-spacing-heading` is exposed as a `length` with default `-0.03em`; a css-source pin that the `h1–h6` rule routes through the token and no bare `letter-spacing: -0.03em` remains; and validator coverage for the signed grammar — `-0.03em` / `-.5rem` / `-2px` and a signed `calc()` term accept, `"-"` alone / `--0.03em` / `-em` reject, plus an end-to-end `update_design_token` accept of `-0.01em`. A Playwright E2E asserts the default tracking renders on a band heading (`ratio ~ -0.03`) and that a real `:root` token override changes it, at 1280 and 375 (#467).
+
 ## [v1.5.5] — 2026-07-21 — a Spanish (or any non-ASCII) meta description sets and renders correctly now: accents and em-dashes stop turning into literal `u00e1` (#471)
 
 **Setting a page's `meta_description` or `seo_title` to text with accents, ñ, or an em-dash through `update_seo_meta` corrupted every non-ASCII character: `prueba áéíóú ñ —guion` was stored and rendered as `prueba u00e1u00e9u00edu00f3u00fa u00f1 u2014guion`. A non-English site could not set a correct meta description, the exact job the action exists for. The stored value and the rendered `<meta name="description">` now carry the real UTF-8 text, and `seo_title` overrides the `<title>` with its real characters too. Pages already saved with the mangled text heal the moment their SEO metadata is set again.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.5.5-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.6-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -45,6 +45,7 @@
   --font-weight-heading: 650;     /* number: Heading font weight */
   --line-height-body:    1.6;     /* number: Body text line height */
   --line-height-heading: 1.2;     /* number: Heading line height */
+  --letter-spacing-heading: -0.03em;  /* length: Heading tracking (letter-spacing) — negative tightens */
 
   /* Button rhythm */
   --btn-padding-y: var(--space-sm);  /* length: Button vertical padding */
@@ -241,7 +242,7 @@ h6 {
   line-height: var(--line-height-heading);
   color: var(--color-text);
   text-wrap: balance;
-  letter-spacing: -0.03em;
+  letter-spacing: var(--letter-spacing-heading);
 }
 
 h1 { font-size: 2.375rem; }

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.5.5');
+define('PP_VERSION', '1.5.6');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/apply.php
+++ b/lib/apply.php
@@ -317,8 +317,9 @@ function _pp_check_token_reference_cycle(string $token, string $value) {
 
 /**
  * Validates a CSS length value.
- * Accepts: numeric value with unit (rem, px, em, %, vw, vh), unitless 0,
- * clamp() expressions, and calc() expressions.
+ * Accepts: numeric value with unit (rem, px, em, %, vw, vh) including a single
+ * leading minus for negative lengths (letter-spacing/margins/text-indent go
+ * negative), unitless 0, clamp() expressions, and calc() expressions.
  *
  * clamp/calc use positive-pattern matching: only numeric literals, units,
  * percentage, comma, parentheses, and arithmetic operators are allowed.
@@ -336,8 +337,12 @@ function _pp_validate_length(string $value): bool {
     if ($value === '0') {
         return true;
     }
-    // Simple length: number + unit.
-    if (preg_match('/^[\d.]+\s*(rem|px|em|%|vw|vh)$/', $value)) {
+    // Simple length: optional leading minus, number + unit. Negative lengths are
+    // valid CSS <length> (letter-spacing, margins, text-indent go negative), so the
+    // grammar accepts a single leading '-'; the injection guards and the calc/clamp
+    // positive-pattern below are unchanged. Semantically-inert cases (negative radius,
+    // padding) simply drop per CSS — this is a grammar guard, not a per-property check.
+    if (preg_match('/^-?[\d.]+\s*(rem|px|em|%|vw|vh)$/', $value)) {
         return true;
     }
     // clamp() or calc(): positive-pattern — only allow safe characters inside.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.5.5
+Stable tag: 1.5.6
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.5.5
+Version:          1.5.6
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ApplyTest.php
+++ b/tests/ApplyTest.php
@@ -569,6 +569,64 @@ class ApplyTest extends TestCase
         $this->assertTrue(_pp_validate_length('calc(.5rem + 1rem)'));
     }
 
+    // ── Length validator: signed (negative) lengths (#467) ─────────────────
+    //
+    // Heading tracking is inherently negative (default -0.03em; a brand may want
+    // -0.01em), so the `length` grammar accepts a single leading minus on simple
+    // lengths and signed operands inside calc/clamp. Grammar-only: "-" alone and a
+    // double minus stay rejected, and the injection/positive-pattern guards are intact.
+
+    public function testLengthAcceptsNegativeEm(): void
+    {
+        // The token's own default value must validate through the write path.
+        $this->assertTrue(_pp_validate_length('-0.03em'));
+    }
+
+    public function testLengthAcceptsNegativeRemLeadingDot(): void
+    {
+        // "-.5rem"-style negatives (no leading zero) must validate too.
+        $this->assertTrue(_pp_validate_length('-.5rem'));
+    }
+
+    public function testLengthAcceptsNegativePx(): void
+    {
+        $this->assertTrue(_pp_validate_length('-2px'));
+    }
+
+    public function testLengthUpdateTokenAcceptsNegativeHeadingTracking(): void
+    {
+        // #467 end-to-end write path: the operator's brand value reaches the token.
+        $result = pp_validate_apply(
+            'update_design_token',
+            ['token' => '--letter-spacing-heading', 'value' => '-0.01em']
+        );
+        $this->assertTrue($result);
+    }
+
+    public function testLengthRejectsBareMinus(): void
+    {
+        // A lone "-" has no numeric operand — must stay rejected.
+        $this->assertFalse(_pp_validate_length('-'));
+    }
+
+    public function testLengthRejectsDoubleMinus(): void
+    {
+        // Only a SINGLE leading minus is grammar; "--0.03em" is not a length.
+        $this->assertFalse(_pp_validate_length('--0.03em'));
+    }
+
+    public function testLengthRejectsMinusUnitNoOperand(): void
+    {
+        // "-em" is a bare unit with no operand behind the sign.
+        $this->assertFalse(_pp_validate_length('-em'));
+    }
+
+    public function testLengthAcceptsNegativeTermInCalc(): void
+    {
+        // A signed operand inside calc() stays valid (real operand behind the unit).
+        $this->assertTrue(_pp_validate_length('calc(-0.01em + 2px)'));
+    }
+
     public function testLengthAcceptsWhitespaceAfterOpeningParen(): void
     {
         // "calc( 1rem + 2rem)" — valid CSS with a space right after the
@@ -1924,6 +1982,17 @@ class ApplyTest extends TestCase
         $this->assertArrayHasKey('--line-height-heading', $tokens);
         $this->assertSame('number', $tokens['--line-height-heading']['type']);
         $this->assertSame('1.2', $tokens['--line-height-heading']['value']);
+    }
+
+    public function testNewTokensLetterSpacingHeadingExists(): void
+    {
+        // #467: heading tracking is tokenized so a brand can set its own letter-spacing.
+        // Registered in base.css's first :root block as a `length` token so it joins
+        // pp_design_tokens() and the update_design_token write path like its siblings.
+        $tokens = pp_design_tokens();
+        $this->assertArrayHasKey('--letter-spacing-heading', $tokens);
+        $this->assertSame('length', $tokens['--letter-spacing-heading']['type']);
+        $this->assertSame('-0.03em', $tokens['--letter-spacing-heading']['value']);
     }
 
     public function testNewTokensBtnPaddingYExists(): void

--- a/tests/TypographyRoleTest.php
+++ b/tests/TypographyRoleTest.php
@@ -54,6 +54,36 @@ class TypographyRoleTest extends TestCase
         );
     }
 
+    // ── Heading letter-spacing token (#467) ────────────────────────────────
+
+    public function testBaseCssDeclaresHeadingLetterSpacingToken(): void
+    {
+        $base = file_get_contents($this->themeRoot . '/assets/css/base.css');
+        $this->assertStringContainsString(
+            '--letter-spacing-heading',
+            $base,
+            'base.css must declare --letter-spacing-heading so a brand can set heading tracking.'
+        );
+    }
+
+    public function testHeadingRuleRoutesLetterSpacingThroughToken(): void
+    {
+        // The shared h1-h6 rule must consume the token, not a literal — otherwise the
+        // token exists but nothing reads it. Pins that letter-spacing routes through
+        // var(--letter-spacing-heading) and no bare `letter-spacing: -0.03em` remains.
+        $base = file_get_contents($this->themeRoot . '/assets/css/base.css');
+        $this->assertMatchesRegularExpression(
+            '/letter-spacing:\s*var\(--letter-spacing-heading\)/',
+            $base,
+            'the h1-h6 rule should consume var(--letter-spacing-heading), not a literal.'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/letter-spacing:\s*-0\.03em/',
+            $base,
+            'no heading rule should hard-code letter-spacing: -0.03em once the token exists.'
+        );
+    }
+
     // ── Utility classes ───────────────────────────────────────────────────
 
     public function testUtilitiesDeclareRoleClasses(): void

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -525,6 +525,75 @@ test.describe('Safe-surface rendered proof', () => {
     }
   });
 
+  // #467: heading letter-spacing is tokenized (--letter-spacing-heading, default
+  // -0.03em). The static TypographyRoleTest proves the h1-h6 rule routes through the
+  // token; only getComputedStyle proves the browser renders it once the cascade applies,
+  // and that a :root override (the operator's real write path via update_design_token,
+  // injected as an inline :root block after pp-base) actually changes heading tracking.
+  //
+  // A section renders its title as a real <h2 class="section__title">, and no component
+  // rule sets its own letter-spacing, so the shared base rule governs it. Assert at 1280
+  // AND 375 (the #86/#349 mobile-hid-it lesson) using the RATIO letter-spacing/font-size,
+  // which is font-size-independent (em tracking is relative to the element's own size):
+  //   unset  -> ratio ~ -0.03 (byte-identical default)
+  //   set     -> ratio ~ the override, and the computed value actually changed.
+  test('#467 headings honor --letter-spacing-heading; unset is byte-identical at both breakpoints @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Heading Letter Spacing Token');
+    setComposition(pageId, [
+      { component: 'section', props: { id: 'pp-sec01', title: 'Heading tracking', body: '<p>Body copy.</p>' } },
+    ]);
+
+    // Ensure a clean :root (no stray token override from another run).
+    execSync('npx wp-env run cli wp option delete pp_token_overrides', {
+      cwd: process.cwd(),
+      stdio: 'ignore',
+    });
+
+    const trackingRatio = () =>
+      page.locator('main .section__title').first().evaluate((el) => {
+        const cs = getComputedStyle(el);
+        const font = parseFloat(cs.fontSize);
+        const ls = parseFloat(cs.letterSpacing); // computed to px; "normal" -> NaN
+        return { font, ls, ratio: ls / font };
+      });
+
+    try {
+      // 1) UNSET: the default -0.03em renders on the heading at both breakpoints.
+      for (const width of [1280, 375]) {
+        await page.setViewportSize({ width, height: 900 });
+        await page.goto(`/?page_id=${pageId}`);
+        await expect(page.locator('main .section__title')).toBeVisible({ timeout: 10000 });
+        const unset = await trackingRatio();
+        expect(unset.font).toBeGreaterThan(0);
+        expect(unset.ls).toBeLessThan(0); // negative tracking, not "normal"
+        expect(Math.abs(unset.ratio - -0.03)).toBeLessThan(0.005);
+      }
+
+      // 2) A :root override through the real design-token store changes heading tracking.
+      // 0.25em is positive and distinctive, so a clobber or a dead token is unmistakable.
+      execSync(
+        `npx wp-env run cli wp option update pp_token_overrides '{"--letter-spacing-heading":"0.25em"}' --format=json`,
+        { cwd: process.cwd(), stdio: 'ignore' },
+      );
+
+      for (const width of [1280, 375]) {
+        await page.setViewportSize({ width, height: 900 });
+        await page.goto(`/?page_id=${pageId}`);
+        await expect(page.locator('main .section__title')).toBeVisible({ timeout: 10000 });
+        const set = await trackingRatio();
+        expect(set.ls).toBeGreaterThan(0); // flipped from negative — the override took
+        expect(Math.abs(set.ratio - 0.25)).toBeLessThan(0.005);
+      }
+    } finally {
+      execSync('npx wp-env run cli wp option delete pp_token_overrides', {
+        cwd: process.cwd(),
+        stdio: 'ignore',
+      });
+    }
+  });
+
   // #24: a hero-surface slot must reach the rendered inner shell (.hero__surface only
   // renders for the split variant with proof markup).
   test('#24 hero surface honors --hero-surface-border-width', async ({ page }) => {


### PR DESCRIPTION
Closes #467

## Summary
Heading tracking was the one heading typography value an operator couldn't reach: `--font-heading`, `--font-weight-heading`, and `--line-height-heading` were tokens, but `letter-spacing` was hard-coded to `-0.03em` on the shared `h1–h6` rule in `assets/css/base.css`. This registers a `--letter-spacing-heading` token (length, default `-0.03em`) that the `h1–h6` rule consumes, so `update_design_token` can set heading tracking site-wide. Unset output is byte-identical.

## Scope (against acceptance criteria)
- **Token registration:** `--letter-spacing-heading` added to the first `:root` block of `assets/css/base.css` with the standard annotated comment (`/* length: ... */`), so it auto-joins `pp_design_tokens()` and the AI-facing registry exactly like its `--font-weight-heading` / `--line-height-heading` siblings.
- **Consumption:** the shared `h1–h6` rule now uses `letter-spacing: var(--letter-spacing-heading)` instead of the literal.
- **Sweep:** every other `letter-spacing` declaration in `components.css` is on an eyebrow/label/key (uppercase, positive tracking — body-role UI, the same class as `--text-kicker-spacing`), not a heading. No `*__title` / `*__heading` rule sets its own letter-spacing, so component titles inherit the shared rule and the token routing is complete. Band headings render as real `<h2 class="section__title">`.
- **Validator (recorded-decision extension):** `_pp_validate_length` now accepts a single leading minus on simple lengths (signed `calc()`/`clamp()` operands already validated). This is required because the token's own default and its motivating brand value (`-0.01em`) are negative, and the shared `length` validator previously rejected all negatives. Grammar-only: the `{};<>` injection guard and the calc/clamp positive-pattern are untouched. This widens all `length` tokens to grammar-valid negatives; semantically-inert cases (negative radius/padding) simply drop per CSS.
- **Docs:** `AI_CONTEXT.md` token list updated. The runtime AI registry is auto-derived from base.css via `pp_design_tokens()`.

## 7A decision (asked & answered)
The literal issue said "register a `length` token," but I found the shared `length` validator rejects negative values — so `update_design_token('--letter-spacing-heading', '-0.01em')` (the issue's cited brand case) would be rejected. I raised this as a DECISION NEEDED. The maintainer chose **Option A**: type `length` + extend `_pp_validate_length` grammar-only to accept signed simple lengths and signed calc/clamp terms, injection guards untouched, CHANGELOG stating all length tokens now accept grammar-valid negatives. This PR implements exactly that. Recorded on issue #467.

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` → **2147 tests pass** (+11 new; warnings/deprecations at baseline 3/2, confirmed unchanged against a stashed tree).
- `npm test` (vitest) → **793 tests pass** (docs-lint included — no token-count claim broken).
- `bash scripts/package.sh` → version consistency OK across all five files at 1.5.6; built zip deleted (releases are CI-built from tags).
- New tests: `pp_design_tokens()` exposure + `length`/`-0.03em` type assertion; css-source pin that `h1–h6` routes through `var(--letter-spacing-heading)` and no bare `letter-spacing: -0.03em` remains; validator signed accept (`-0.03em`, `-.5rem`, `-2px`, `calc(-0.01em + 2px)`) and reject (`-` alone, `--0.03em`, `-em`) cases + an end-to-end `update_design_token` accept of `-0.01em`; rendered E2E asserting default tracking (`ratio ~ -0.03`) and a real `:root` token override at 1280 and 375.

## Accepted limitations / disclosed
- Pre-existing (not introduced here): the simple-length number body `[\d.]+` is loose (accepts `.em`, `1.2.3rem`, and space-before-unit), so its negative mirror is now accepted too. This looseness predates #467 and is out of the "grammar-only, add-minus" recorded decision; a malformed value is harmlessly dropped by the browser and injection chars remain blocked upstream. Left as-is; flagged for the maintainer.

## Reviews (this session, on this exact diff)
- `/plan-eng-review` — clean, no findings.
- `/review` + Codex adversarial outside-voice — all 4 Codex findings verified against the repo and refuted (pre-existing regex looseness; negatives-on-all-length-tokens is the accepted recorded decision; E2E option-clobber is safe under `workers: 1` + established `actions.spec.ts` cleanup convention).

Do not tag/release/deploy — CI builds the release zip from tags; the maintainer handles tagging separately.
