### PR TITLE
v1.5.8 feat: authorable section body type slots (#470)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -390,7 +390,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**213 style slots** across 10 components: hero (41), grid (37), section (36), cta (31), testimonials (26), faq (18), stats (12), embed (4), logos (4), table (4).
+**215 style slots** across 10 components: hero (41), section (38), grid (37), cta (31), testimonials (26), faq (18), stats (12), embed (4), logos (4), table (4).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.5.8] — 2026-07-21 — a section's body text size and weight are now style slots, so you can set a deliberate type step (#470)
+
+**The `section` component's body copy took whatever the built-in body scale gave it — there was no way to ask for a compact utility band at, say, 15px/600, an emphasis paragraph, or dense spec text through the documented style surface. There are now two style slots, `--section-body-size` (length) and `--section-body-weight` (number), that the body/content text consumes at every breakpoint. Set them for a deliberate size/weight step; leave them unset and every section renders byte-identically to before. Naming follows the existing `--cta-body-size` idiom.**
+
+This is a slot-parity change only, in the same class as the CTA body-size and hero title-weight slots that already exist — no new component, no restyled defaults (#336 precedent: make it expressible, don't retune). The slots are routed through every place the section body font-size/weight is declared: the base `.section__content` rule and both the desktop and mobile typography rules. The mobile size fallback chains through `var(--cta-body-size, 1rem)`, the exact value that rule used before, so unset output is unchanged even when a composition also sets `--cta-body-size`. The separator/glyph half of the original brand-band report is tracked separately and is not part of this change.
+
+### Added
+- `--section-body-size` (length) and `--section-body-weight` (number) style slots on the `section` component. The body/content text consumes `var(--section-body-size, …)` / `var(--section-body-weight, …)` at the base rule and at both the desktop premium and mobile typography rules, with today's literals as the fallbacks, so an unset section is byte-identical. Surfaced through `pp_get_style_slots()` and the schema `style_slots`; the AI slot reference is schema-derived, so both appear automatically (#470).
+
+### Tests
+- PHPUnit: `SchemaValidationTest` moves the section slot count (36→38) and the schema-derived doc-count sync (213→215). The keystone `StyleSlotContractTest` auto-discovers both slots and proves the CSS consumes each on a type-compatible property. css-lint routing guards require every section body `font-size`/`font-weight` declaration to route through the slot at the base rule and both media rules, plus a pin that the mobile size fallback chains through `--cta-body-size`. A Playwright E2E renders a section whose body is set to 22px/850 at 1280 and 375 and asserts an unset section stays weight 430 at the historical rem size (#470).
+
+### Docs
+- `AI_CONTEXT.md` and `README.md` style-slot totals move 213→215, and the `AI_CONTEXT.md` per-component breakdown reorders (`section (38)` now above `grid (37)`) (#470).
+
 ## [v1.5.7] — 2026-07-21 — a light-fill steps badge can now get ink numerals: the step number color is its own style slot (#473)
 
 **The numbered `grid` steps badge fills through a slot (`--grid-step-color`), but its numeral color was hard-coded to `var(--color-bg)`. On a light accent (say a lime brand green), the badge filled correctly while the numeral stayed light and dropped to about 1.9:1 contrast, with no way to make it ink. There is now a `--grid-step-text-color` (color) style slot that the numeral consumes, defaulting to `var(--color-bg)` so an unset badge renders byte-identically. A steps block can now pair a light fill with ink numerals, the same fill+ink control the CTA button already exposes through `--cta-button-bg` / `--cta-button-color`.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.5.7-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.8-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-213 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+215 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.5.0.
 
 **What exists today (v1.5.0):**
-- 12 components with schema contracts and 213 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 215 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1028,6 +1028,17 @@
 .section__content {
   color: var(--section-text, var(--section-text-theme-color, var(--color-text)));
   max-width: var(--section-body-width, 42rem);
+  /* Body type slots (issue 470): the section body text has no font-size/weight of
+     its own here — the `main > .section .section__content` premium/mobile rules
+     (further down this file) set it at every breakpoint, and those (0,2,1) rules
+     outrank this base (0,1,0) at ALL viewport widths. `inherit` is therefore
+     byte-identical to declaring nothing (unchanged output, incl. the 767-768px
+     sub-pixel gap between the two media queries), while giving the slot-contract
+     keystone an in-block consumption. Mirrors .cta__body's base (var(--cta-body-size,
+     inherit)). Setting either slot routes through the premium/mobile rules, which
+     read the SAME slot with today's literal as the fallback. */
+  font-size: var(--section-body-size, inherit);
+  font-weight: var(--section-body-weight, inherit);
   /* Body list-marker colour (issue 339): read by the shared marker rules only
      when the operator opts into a non-disc body_marker; inert otherwise. */
   --pp-list-marker-color: var(--section-body-marker-color, var(--color-accent));
@@ -3228,8 +3239,8 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   main > .section .section__content,
   main > .section .section__content p {
     color: var(--section-text, var(--section-text-theme-color, var(--color-text-secondary)));
-    font-size: 1.065rem;
-    font-weight: 430;
+    font-size: var(--section-body-size, 1.065rem);
+    font-weight: var(--section-body-weight, 430);
     line-height: 1.76;
   }
 
@@ -3321,8 +3332,19 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
     margin-bottom: var(--faq-heading-margin-bottom, 1.25rem);
   }
 
+  /* Section body split out of the shared mobile type rule (issue 470) so its own
+     --section-body-size / --section-body-weight slots reach it here. The size
+     fallback CHAINS through var(--cta-body-size, 1rem) — the exact value the
+     shared rule used before the split — so an unset section body is byte-identical
+     at this breakpoint, including the historical case where a composition set
+     --cta-body-size (section body still follows it when its own slot is unset). */
   main > .section .section__content,
-  main > .section .section__content p,
+  main > .section .section__content p {
+    font-size: var(--section-body-size, var(--cta-body-size, 1rem));
+    font-weight: var(--section-body-weight, 430);
+    line-height: 1.65;
+  }
+
   main > .grid .grid__item-text,
   main > .faq .faq__answer,
   main > .cta .cta__body {

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -162,6 +162,8 @@
       "--section-subheading-margin-bottom": { "type": "length", "default": "var(--space-md)", "description": "Space between the subheading and the content below it" },
       "--section-title-margin-bottom": { "type": "length", "default": "var(--space-md)", "description": "Space between the title and the subheading below it" },
       "--section-body-width": { "type": "length", "default": "42rem", "description": "Max width of the content column" },
+      "--section-body-size": { "type": "length", "default": "inherit", "description": "Body text font size" },
+      "--section-body-weight": { "type": "number", "default": "inherit", "description": "Body text font weight" },
       "--section-border-color": { "type": "color", "default": "transparent", "description": "Top and bottom border color" },
       "--section-border-width": { "type": "length", "default": "0", "description": "Top and bottom border width" },
       "--section-radius": { "type": "length", "default": "0", "description": "Border radius" },

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.5.7');
+define('PP_VERSION', '1.5.8');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.5.7
+Stable tag: 1.5.8
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.5.7
+Version:          1.5.8
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -246,7 +246,7 @@ class SchemaValidationTest extends TestCase
     {
         $expected = [
             'hero'    => 41,
-            'section' => 36,
+            'section' => 38,
             'grid'    => 37,
             'cta'     => 31,
         ];

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -1459,6 +1459,70 @@ test.describe('Safe-surface rendered proof', () => {
     expect(widths.rendered).toBeGreaterThan(640);
   });
 
+  // #470: the section body text size + weight are authorable via --section-body-size
+  // (length) and --section-body-weight (number). Before #470 the body font-size/weight
+  // was baked as literals in the desktop premium and mobile rules, so a deliberate
+  // type step (compact utility band, emphasis paragraph) was unreachable. The slots
+  // must reach the rendered body at BOTH breakpoints (the #86/#349 mobile-hid-it
+  // lesson), and an UNSET section must render byte-identically to today: weight 430 at
+  // both, size 1.065rem (desktop) / 1rem (mobile) resolved against the page's own root.
+  // Two sections prove both halves in one render: section 0 SET, section 1 UNSET.
+  test('#470 section body honors --section-body-size / --section-body-weight at both breakpoints; unset byte-identical @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Section Body Type Slots');
+    setComposition(pageId, [
+      {
+        component: 'section',
+        props: { id: 'pp-sec01', title: 'Set body type', body: '<p>Deliberate size and weight.</p>' },
+      },
+      {
+        component: 'section',
+        props: { id: 'pp-sec02', title: 'Default body type', body: '<p>Unchanged defaults.</p>' },
+      },
+    ]);
+
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    await page.waitForSelector('#pp-ai-messages', { timeout: 10000 });
+
+    // Distinctive, unambiguous values: 22px is no theme literal, 850 is no default weight.
+    const res = await styleComponent(
+      page,
+      pageId,
+      { '--section-body-size': '22px', '--section-body-weight': '850' },
+      undefined,
+      0,
+    );
+    expect(res.success).toBe(true);
+
+    const bodyType = (i: number) =>
+      page.locator('.section__content').nth(i).locator('p').first().evaluate((el) => {
+        const cs = getComputedStyle(el);
+        const rootPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
+        return { fontSize: cs.fontSize, fontWeight: cs.fontWeight, rootPx };
+      });
+
+    for (const width of [1280, 375]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator('.section__content')).toHaveCount(2, { timeout: 10000 });
+
+      // Set slot reaches the body at BOTH breakpoints — the issue's case.
+      const set = await bodyType(0);
+      expect(set.fontSize).toBe('22px');
+      expect(set.fontWeight).toBe('850');
+
+      // Unset renders byte-identically to today: weight 430 at both breakpoints,
+      // size 1.065rem (desktop) / 1rem (mobile) resolved against the page's own root
+      // font-size — the exact historical literal, and NOT the set section's value.
+      const unset = await bodyType(1);
+      expect(unset.fontWeight).toBe('430');
+      const remFactor = width >= 768 ? 1.065 : 1;
+      expect(unset.fontSize).toBe(`${remFactor * unset.rootPx}px`);
+      expect(unset.fontSize).not.toBe('22px');
+    }
+  });
+
   /**
    * #332 — WP core's global stylesheet ships attribute-SUBSTRING selectors:
    *

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -328,8 +328,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('hero/section/grid/cta schemas declare 145 style slots (subset of the total)', () => {
-        expect(allSlots.length).toBe(145);
+    test('hero/section/grid/cta schemas declare 147 style slots (subset of the total)', () => {
+        expect(allSlots.length).toBe(147);
     });
 
     allSlots.forEach(({ component, slotName }) => {
@@ -1788,6 +1788,43 @@ describe('CSS lint: premium layer honors padding/type/width slots (#302)', () =>
                 expect(d).toMatch(/max-width\s*:\s*var\(\s*--section-body-width\s*,\s*40rem\s*\)/);
             });
         });
+    });
+
+    // ---- Section body type slots (issue 470) ----
+    // font-size / font-weight for the section body must route through
+    // --section-body-size / --section-body-weight at EVERY declaration site: the
+    // base .section__content rule (in-block, keystone consumption) plus the desktop
+    // premium (main > .section .section__content[, ... p]) and mobile rules. A bare
+    // literal at any site would defeat the slot (the #302/#305 dead-slot class).
+    // The base .section__content rule (in-block, keystone consumption).
+    test('base .section__content routes font-size/weight through the body slots', () => {
+        assertPropRoutesThroughSlot('.section__content', 'font-size', '--section-body-size', 1);
+        assertPropRoutesThroughSlot('.section__content', 'font-weight', '--section-body-weight', 1);
+    });
+
+    // Both breakpoints declare the section body via the grouped
+    // `main > .section .section__content, main > .section .section__content p` list.
+    // The `p` selector is the one that terminates each rule (the bare container
+    // selector only ever appears mid-list, never immediately before `{`), and it
+    // shares the rule body with the container, so pinning it covers both. Presence 2
+    // = desktop premium block + mobile block.
+    test('section body premium + mobile rules route font-size through --section-body-size', () => {
+        assertPropRoutesThroughSlot('main > .section .section__content p', 'font-size', '--section-body-size', 2);
+    });
+
+    test('section body premium + mobile rules route font-weight through --section-body-weight', () => {
+        assertPropRoutesThroughSlot('main > .section .section__content p', 'font-weight', '--section-body-weight', 2);
+    });
+
+    // The mobile size fallback must CHAIN through --cta-body-size (byte-identical to
+    // the pre-split shared rule): unset section body still follows a set --cta-body-size.
+    test('mobile section body size chains through the historical cta-body-size fallback', () => {
+        const bodies = bodiesForExactSelector('main > .section .section__content p');
+        const sizeDecls = bodies
+            .flatMap(b => b.match(/font-size\s*:[^;}]+/g) || [])
+            .filter(d => /--section-body-size/.test(d));
+        // At least the mobile rule uses the chained fallback.
+        expect(sizeDecls.some(d => /var\(\s*--section-body-size\s*,\s*var\(\s*--cta-body-size\s*,\s*1rem\s*\)\s*\)/.test(d))).toBe(true);
     });
 
     // ---- Stats contained-card slots (issue 383) ----


### PR DESCRIPTION
Closes #470

## Scope
Adds two style slots to the `section` component so its body/content text size and weight are authorable, the same slot-parity class as `--cta-body-size` (size) and `--hero-title-weight` (number/weight):

- `--section-body-size` (length) and `--section-body-weight` (number) in `components/section/schema.json` `style_slots`.
- Routed through `font-size`/`font-weight` at **every** section-body declaration site (issue-302/305 dead-slot mandate): the base `.section__content` rule (`inherit` fallback, the keystone's in-block consumption, byte-identical to today's no-declaration at all widths), the desktop premium rule (`1.065rem` / `430` fallbacks), and the mobile rule (split out of the shared grid/faq/cta rule; size fallback **chains** through `var(--cta-body-size, 1rem)` to preserve the exact pre-split behavior).
- Slot-parity only: no new component, no restyled defaults (#336 precedent). AI slot docs are schema-derived (`lib/ai-context.php` `pp_get_style_slots`), so both slots surface automatically.

## Acceptance criteria
- Setting the slots on a seeded section renders the computed size/weight at 375 and 1280 — E2E asserts 22px/850 at both breakpoints.
- Unset is byte-identical — E2E asserts weight 430 + the historical rem size at both breakpoints; grid/faq/cta mobile rule is unchanged.
- Keystone `StyleSlotContractTest` auto-discovers both slots.

## Validation
- PHPUnit: `./vendor/bin/phpunit --configuration phpunit.xml` — 2149 tests, 0 failures (3 warnings + 2 deprecations are pre-existing, confirmed against a clean tree).
- JS: `npm test` (vitest) — 804 passed, including the new css-lint routing pins (base + both media rules + cta-body-size chain) and the updated slot-count assertion (145→147 for hero/section/grid/cta).
- `bash scripts/package.sh` — version consistency OK across the five synced files (1.5.8); built zip deleted (releases are CI-built from tags).
- E2E `#470` @smoke added to `tests/e2e/style-render.spec.ts` (runs in PR CI).

## Accepted limitations
- The separator glyph/color half of the original brand-band report is out of scope (tracked separately as #475, needs-design).
- Version bumped PATCH 1.5.7 → 1.5.8 (working versions run patch-ahead of tags between gates; #470 is a normal issue in the v1.6.0 milestone, not the milestone bump).

## Reviews (this session)
- `/plan-eng-review` — clean, 0 findings.
- `/review` — clean, 0 findings; adversarial pass run inline (Codex sandbox git is blocked on this container per the known-failure playbook).