### PR TITLE
v1.5.12 feat: chat context annotates adjacent same-background components (#378)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -646,7 +646,7 @@ Assembled by `pp_ai_system_prompt()`:
 - Pre-proposal verification checklist (target correct component, confirm slot exists, confirm value is representable)
 - Response format instructions (conversational vs structured proposal)
 
-When page context is included, each component's summary shows: active recipe, overridden style slots with current values, and editable field names per component type.
+When page context is included, each component's summary shows: active recipe, overridden style slots with current values, and editable field names per component type. After the component index, an adjacency hint (#378) lists any consecutive component pair whose **resolved** background matches (per-instance `--{component}-bg` override, else the `theme` bucket — `inverted`, or `muted`/`dark` alias; image-backed and default/inherited bands are skipped), so the "two touching same-color bands" case is a structural fact instead of an inference. It points at the #377 band-fusing heuristic (zero the facing paddings/margins to close the seam); it is context-only and changes no action, prop, or validator.
 
 ### Proposal flow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.5.12] — 2026-07-22 — the chat now sees which touching bands share a background (#378)
+
+**The in-admin chat AI used to receive each component's styling on its own, so the common "two touching bands in the same color" case, the one where a stray gap opens a wrong-color seam between them, had to be inferred from the composition. The page context now spells it out: after the component index it lists every consecutive pair whose resolved background matches, with a pointer to zero the facing paddings/margins. The chat gets the adjacency as a fact, not a deduction, so fixing or avoiding a same-color seam is reliable instead of hit-or-miss.**
+
+A component's resolved background is read from the same inputs the context already carries: a per-instance `--<component>-bg` override wins, otherwise the `theme` band (`inverted`, or `muted` and its deprecated `dark` alias). Bands that inherit the default body background, and image-backed bands, are skipped so the hint only fires where two flat colors actually meet. This is the runtime companion to the v1.4.20 documentation of the band-fusing heuristic (#377); it is context-only and changes no action, prop, validator, or composition data. The match is a best-effort string comparison (whitespace runs and hex case are normalized), not a full CSS-equivalence check, so `#fff` and `#ffffff` are treated as different by design.
+
+### Added
+- Chat page context now annotates consecutive components whose resolved background matches, pointing at the facing paddings/margins that control the seam (#378).
+
+### Tests
+- 15 context-assembly tests covering style-override matches, theme-prop matches, the muted/dark alias, override-beats-theme precedence, whitespace/case normalization, and the skip cases (default, differing, image-backed, transparent, non-consecutive, single component, malformed item), plus an exact-wording snapshot.
+
 ## [v1.5.11] — 2026-07-22 — the footer can now carry a social-icon row (#382)
 
 **The footer had no surface for social profile links, so the near-universal footer social-icon row was inexpressible and dogfoods had to approximate it with a plain text line. There is now a `pp_footer_social` site option: a JSON list of `{network, url}` entries from a closed set of known networks (x, linkedin, facebook, instagram, youtube, github, tiktok, mastodon), rendered under the brand blurb as accessible inline-SVG icon links whose color follows `pp_footer_link_color`. Set it with `update_site_option`; unknown networks, non-URL values, and non-http(s) schemes are rejected with the standard envelope, and an unset option leaves the footer byte-identical.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.5.11-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.12-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.5.11');
+define('PP_VERSION', '1.5.12');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/ai-context.php
+++ b/lib/ai-context.php
@@ -472,6 +472,135 @@ function _pp_summarize_component(array $item, ?array $inspect_target = null): st
     return $summary;
 }
 
+// ── Adjacent Same-Background Hint (#378) ───────────────────────────────────
+
+/**
+ * Sanitizes a background value for display INSIDE the chat system prompt.
+ *
+ * Collapses internal whitespace/newlines (a stored value could carry them via
+ * snapshot restore or an out-of-band write, and a raw newline would fabricate a
+ * spurious context line) and caps length so one pathological value can't bloat
+ * the prompt. This is prompt hygiene, not a security boundary — the value is
+ * never emitted into HTML/CSS here, only into the model's own context.
+ *
+ * @param string $value  Raw style-slot value.
+ * @return string  Single-line, length-capped display string.
+ */
+function _pp_bg_annotation_value(string $value): string {
+    $clean = trim((string) preg_replace('/\s+/', ' ', $value));
+    if (mb_strlen($clean) > 40) {
+        $clean = mb_substr($clean, 0, 37) . '...';
+    }
+    return $clean;
+}
+
+/**
+ * Resolves a component's effective background to a comparison identity for the
+ * adjacency hint (#378). Uses only the inputs the chat context already serializes
+ * — the per-instance `--{component}-bg` style override and the band-level `theme`
+ * prop — with no rendering or CSS parsing (#378 is explicitly not full visual
+ * modeling, and #377 owns the human-facing fusing heuristic).
+ *
+ * Returns an identity for a band that paints a definite, non-default flat
+ * background, or null when it inherits the page/body background (so a pair is never
+ * annotated on a default match). Resolution order (first match wins):
+ *
+ *   1. Image-backed band (section/cta/stats `background_image`, or a hero `cover`
+ *      layout with `image_url`) -> null. The visible band is the image, not a flat
+ *      color; "shares background <color>" would be a false fusing hint. Checked
+ *      first so an image beats a co-set `--*-bg` slot unambiguously.
+ *   2. Per-instance `--{component}-bg` override -> its literal value (what actually
+ *      paints among flat backgrounds). A `transparent` or empty override reveals the
+ *      inherited background, so it resolves to null like the default.
+ *   3. `theme` prop bucket, component-independent so section vs grid compare equal:
+ *      `inverted` -> the dark inverted band; `muted` (and its deprecated `dark`
+ *      alias, #442, which renders the SAME light `--dark` surface) -> muted surface.
+ *   4. Otherwise (default/absent/unknown theme) -> null (inherited body background).
+ *
+ * @param array $item  One composition item (defensively typed).
+ * @return array{id:string,label:string}|null  Identity + display label, or null.
+ */
+function _pp_resolve_component_bg(array $item): ?array {
+    $name  = is_string($item['component'] ?? null) ? $item['component'] : '';
+    $props = is_array($item['props'] ?? null) ? $item['props'] : [];
+    $style = is_array($item['style'] ?? null) ? $item['style'] : [];
+
+    // 1. Image-backed bands are not flat-color bands.
+    $bg_image = $props['background_image'] ?? '';
+    $is_hero_cover = $name === 'hero'
+        && ($props['layout'] ?? '') === 'cover'
+        && is_string($props['image_url'] ?? null)
+        && trim($props['image_url']) !== '';
+    if ((is_string($bg_image) && trim($bg_image) !== '') || $is_hero_cover) {
+        return null;
+    }
+
+    // 2. Per-instance background override wins among flat backgrounds.
+    $override = $style["--{$name}-bg"] ?? null;
+    if (is_string($override)) {
+        $val = trim($override);
+        if ($val !== '' && strtolower($val) !== 'transparent') {
+            // Whitespace-normalize the id so two equal gradients compare equal.
+            $norm = strtolower((string) preg_replace('/\s+/', ' ', $val));
+            return ['id' => "bg:{$norm}", 'label' => _pp_bg_annotation_value($val)];
+        }
+    }
+
+    // 3. Theme bucket.
+    $theme = is_string($props['theme'] ?? null) ? $props['theme'] : '';
+    if ($theme === 'inverted') {
+        return ['id' => 'theme:inverted', 'label' => 'the inverted theme (dark band)'];
+    }
+    // #442: `dark` is a deprecated alias of `muted`; both render the same light band.
+    // The accepted alias set here mirrors pp_theme_class() in lib/helpers.php (which
+    // collapses muted/dark to the same `--dark` class) — if that alias set ever
+    // changes (alias removed, new theme added), update both sites in lockstep.
+    if ($theme === 'muted' || $theme === 'dark') {
+        return ['id' => 'theme:muted', 'label' => 'the muted theme (light surface band)'];
+    }
+
+    // 4. Default / inherited body background.
+    return null;
+}
+
+/**
+ * Builds the adjacency-hint lines for a page composition (#378): one line per
+ * consecutive component pair whose resolved backgrounds are the same non-default
+ * value, so the chat AI gets the "two touching same-color bands" relationship as a
+ * structural fact instead of inference. Vocabulary tracks the #377 band-fusing
+ * heuristic in ai-instructions/style-component.md ("facing paddings/margins").
+ *
+ * @param array $composition  Ordered composition items.
+ * @return string[]  Annotation lines (no leading indent/newline), empty when none.
+ */
+function _pp_adjacent_background_annotations(array $composition): array {
+    $lines = [];
+    $count = count($composition);
+    for ($i = 0; $i < $count - 1; $i++) {
+        $a = is_array($composition[$i] ?? null) ? $composition[$i] : null;
+        $b = is_array($composition[$i + 1] ?? null) ? $composition[$i + 1] : null;
+        if ($a === null || $b === null) {
+            continue;
+        }
+        $bg_a = _pp_resolve_component_bg($a);
+        $bg_b = _pp_resolve_component_bg($b);
+        if ($bg_a === null || $bg_b === null || $bg_a['id'] !== $bg_b['id']) {
+            continue;
+        }
+        $name_a = is_string($a['component'] ?? null) ? $a['component'] : 'component';
+        $name_b = is_string($b['component'] ?? null) ? $b['component'] : 'component';
+        $lines[] = sprintf(
+            '[%d] %s and [%d] %s share background %s (adjacent — facing paddings/margins control the visible seam)',
+            $i,
+            $name_a,
+            $i + 1,
+            $name_b,
+            $bg_a['label']
+        );
+    }
+    return $lines;
+}
+
 // ── Message Formatting ─────────────────────────────────────────────────────
 
 /**
@@ -511,6 +640,18 @@ function pp_ai_format_messages(string $system, array $conversation, ?int $page_i
                     $target = ($inspect_data && isset($inspect_data[$idx])) ? $inspect_data[$idx] : null;
                     $summary = _pp_summarize_component($item, $target);
                     $system_content .= "  [{$idx}] {$summary}\n";
+                }
+
+                // Adjacent same-background hint (#378): flag consecutive bands whose
+                // resolved backgrounds match so the AI treats the "two touching
+                // colored bands" case as a structural fact, not an inference (#377
+                // owns the fusing heuristic these lines point at).
+                $adjacency = _pp_adjacent_background_annotations($page_ctx['composition']);
+                if ($adjacency) {
+                    $system_content .= "Adjacent bands sharing a background (fuse candidates — zero the facing paddings/margins to close the seam):\n";
+                    foreach ($adjacency as $line) {
+                        $system_content .= "  {$line}\n";
+                    }
                 }
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.5.11
+Stable tag: 1.5.12
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.5.11
+Version:          1.5.12
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/AiContextTest.php
+++ b/tests/AiContextTest.php
@@ -693,4 +693,240 @@ class AiContextTest extends TestCase
         $this->assertStringContainsString('not accepted', $prompt);
         $this->assertStringContainsString('100%', $prompt);
     }
+
+    // ── Adjacent Same-Background Hint (#378) ───────────────────────────────
+
+    /**
+     * Seeds a page with the given composition and returns the assembled system
+     * message (the chat page context) for adjacency-hint assertions.
+     */
+    private function pageContextFor(int $post_id, array $composition): string
+    {
+        $GLOBALS['_pp_test_store']['posts'][$post_id] = [
+            'post_type'   => 'page',
+            'post_title'  => 'Adjacency Page',
+            'post_status' => 'publish',
+        ];
+        $GLOBALS['_pp_test_store']['post_meta'][$post_id]['_pp_composition'] =
+            wp_json_encode($composition);
+
+        $messages = pp_ai_format_messages('System', [], $post_id);
+        return $messages[0]['content'];
+    }
+
+    public function testAdjacencyAnnotatedForMatchingStyleOverride(): void
+    {
+        $system = $this->pageContextFor(700, [
+            ['component' => 'section', 'props' => ['title' => 'A'], 'style' => ['--section-bg' => '#092082']],
+            ['component' => 'stats', 'props' => ['title' => 'B'], 'style' => ['--stats-bg' => '#092082']],
+        ]);
+
+        // Exact wording snapshot (guards against silent drift from the #377 vocabulary).
+        $this->assertStringContainsString(
+            '[0] section and [1] stats share background #092082 (adjacent — facing paddings/margins control the visible seam)',
+            $system
+        );
+        $this->assertStringContainsString('Adjacent bands sharing a background', $system);
+    }
+
+    public function testAdjacencyAnnotatedForMatchingThemeProp(): void
+    {
+        $system = $this->pageContextFor(701, [
+            ['component' => 'section', 'props' => ['title' => 'A', 'theme' => 'inverted']],
+            ['component' => 'cta', 'props' => ['title' => 'B', 'theme' => 'inverted']],
+        ]);
+
+        $this->assertStringContainsString(
+            '[0] section and [1] cta share background the inverted theme (dark band) (adjacent — facing paddings/margins control the visible seam)',
+            $system
+        );
+    }
+
+    public function testAdjacencyAnnotatedForMutedDarkAlias(): void
+    {
+        // #442: `dark` is a deprecated alias of `muted`; both render the same light
+        // band, so a muted/dark pair must be treated as sharing a background.
+        $system = $this->pageContextFor(702, [
+            ['component' => 'grid', 'props' => ['title' => 'A', 'theme' => 'muted']],
+            ['component' => 'section', 'props' => ['title' => 'B', 'theme' => 'dark']],
+        ]);
+
+        $this->assertStringContainsString(
+            '[0] grid and [1] section share background the muted theme (light surface band) (adjacent — facing paddings/margins control the visible seam)',
+            $system
+        );
+    }
+
+    public function testAdjacencyNotAnnotatedForDifferingBackgrounds(): void
+    {
+        $system = $this->pageContextFor(703, [
+            ['component' => 'section', 'props' => ['title' => 'A'], 'style' => ['--section-bg' => '#092082']],
+            ['component' => 'stats', 'props' => ['title' => 'B'], 'style' => ['--stats-bg' => '#ffffff']],
+        ]);
+
+        $this->assertStringNotContainsString('Adjacent bands sharing a background', $system);
+        $this->assertStringNotContainsString('share background', $system);
+    }
+
+    public function testAdjacencyNotAnnotatedForDefaultBackgrounds(): void
+    {
+        // Neither band sets an override or a non-default theme -> both inherit the
+        // body background -> the pair is never annotated (issue skip rule).
+        $system = $this->pageContextFor(704, [
+            ['component' => 'section', 'props' => ['title' => 'A']],
+            ['component' => 'stats', 'props' => ['title' => 'B']],
+        ]);
+
+        $this->assertStringNotContainsString('Adjacent bands sharing a background', $system);
+        $this->assertStringNotContainsString('share background', $system);
+    }
+
+    public function testAdjacencyNotAnnotatedForSingleComponent(): void
+    {
+        $system = $this->pageContextFor(705, [
+            ['component' => 'section', 'props' => ['title' => 'A'], 'style' => ['--section-bg' => '#092082']],
+        ]);
+
+        $this->assertStringNotContainsString('Adjacent bands sharing a background', $system);
+        $this->assertStringNotContainsString('share background', $system);
+    }
+
+    public function testAdjacencyNotAnnotatedWhenImageBackedEvenWithMatchingBg(): void
+    {
+        // A background_image makes the visible band the image, not the flat color,
+        // so a co-set --*-bg slot must NOT produce a fusing hint.
+        $system = $this->pageContextFor(706, [
+            ['component' => 'section', 'props' => ['title' => 'A', 'background_image' => 'https://ex.test/a.jpg'], 'style' => ['--section-bg' => '#092082']],
+            ['component' => 'stats', 'props' => ['title' => 'B'], 'style' => ['--stats-bg' => '#092082']],
+        ]);
+
+        $this->assertStringNotContainsString('share background', $system);
+    }
+
+    public function testAdjacencyTransparentOverrideTreatedAsDefault(): void
+    {
+        // `transparent` reveals the inherited background, so two transparent bands
+        // resolve to null and are not annotated.
+        $system = $this->pageContextFor(707, [
+            ['component' => 'section', 'props' => ['title' => 'A'], 'style' => ['--section-bg' => 'transparent']],
+            ['component' => 'stats', 'props' => ['title' => 'B'], 'style' => ['--stats-bg' => 'transparent']],
+        ]);
+
+        $this->assertStringNotContainsString('share background', $system);
+    }
+
+    public function testAdjacencyOnlyMiddlePairAnnotatedInThreeBandRun(): void
+    {
+        // [0] default, [1] and [2] share #092082 -> only the [1]/[2] pair annotated.
+        $system = $this->pageContextFor(708, [
+            ['component' => 'hero', 'props' => ['title' => 'A']],
+            ['component' => 'section', 'props' => ['title' => 'B'], 'style' => ['--section-bg' => '#092082']],
+            ['component' => 'cta', 'props' => ['title' => 'C'], 'style' => ['--cta-bg' => '#092082']],
+        ]);
+
+        $this->assertStringContainsString(
+            '[1] section and [2] cta share background #092082 (adjacent — facing paddings/margins control the visible seam)',
+            $system
+        );
+        $this->assertStringNotContainsString('[0] hero', $this->onlyAdjacencyLines($system));
+    }
+
+    public function testAdjacencyMatchesGradientOverrideIgnoringWhitespaceRunsAndCase(): void
+    {
+        // Same gradient differing only in whitespace RUNS (double vs single space) and
+        // hex case must resolve to the same identity. (Punctuation-level CSS equivalence
+        // like ", " vs "," is intentionally NOT normalized — that would require rendered
+        // -CSS parsing, which #378 puts out of scope; this stays a cheap string hint.)
+        $system = $this->pageContextFor(709, [
+            ['component' => 'section', 'props' => ['title' => 'A'], 'style' => ['--section-bg' => 'linear-gradient(90deg,  #AA0000,  #00BB00)']],
+            ['component' => 'stats', 'props' => ['title' => 'B'], 'style' => ['--stats-bg' => 'linear-gradient(90deg, #aa0000, #00bb00)']],
+        ]);
+
+        $this->assertStringContainsString('share background', $this->onlyAdjacencyLines($system));
+        // Label preserves the first band's raw form with whitespace runs collapsed and case intact.
+        $this->assertStringContainsString('linear-gradient(90deg, #AA0000, #00BB00)', $system);
+    }
+
+    public function testAdjacencyOverrideBeatsThemeBucket(): void
+    {
+        // Both bands carry theme:inverted AND a matching literal override -> the
+        // override wins, so the annotation reports the literal, not the theme label.
+        $system = $this->pageContextFor(710, [
+            ['component' => 'section', 'props' => ['title' => 'A', 'theme' => 'inverted'], 'style' => ['--section-bg' => '#123456']],
+            ['component' => 'cta', 'props' => ['title' => 'B', 'theme' => 'inverted'], 'style' => ['--cta-bg' => '#123456']],
+        ]);
+
+        $this->assertStringContainsString(
+            '[0] section and [1] cta share background #123456 (adjacent — facing paddings/margins control the visible seam)',
+            $system
+        );
+        $this->assertStringNotContainsString('inverted theme', $this->onlyAdjacencyLines($system));
+    }
+
+    public function testAdjacencyLongOverrideValueIsTruncated(): void
+    {
+        $long = 'linear-gradient(180deg, #111111 0%, #222222 40%, #333333 100%)'; // > 40 chars
+        $system = $this->pageContextFor(711, [
+            ['component' => 'section', 'props' => ['title' => 'A'], 'style' => ['--section-bg' => $long]],
+            ['component' => 'stats', 'props' => ['title' => 'B'], 'style' => ['--stats-bg' => $long]],
+        ]);
+
+        // Displayed value capped at 37 chars + '...'; the full value never appears.
+        $this->assertStringContainsString(mb_substr($long, 0, 37) . '...', $system);
+        $this->assertStringNotContainsString($long . ' (adjacent', $system);
+    }
+
+    public function testAdjacencyNotAnnotatedForHeroCoverImage(): void
+    {
+        // A hero cover layout with an image_url is image-backed even with a matching
+        // --hero-bg slot -> no fusing hint.
+        $system = $this->pageContextFor(712, [
+            ['component' => 'hero', 'props' => ['title' => 'A', 'layout' => 'cover', 'image_url' => 'https://ex.test/h.jpg'], 'style' => ['--hero-bg' => '#092082']],
+            ['component' => 'section', 'props' => ['title' => 'B'], 'style' => ['--section-bg' => '#092082']],
+        ]);
+
+        $this->assertStringNotContainsString('share background', $system);
+    }
+
+    public function testAdjacencyNotAnnotatedForNonConsecutiveMatch(): void
+    {
+        // [0] and [2] match but a default band at [1] breaks the run -> no annotation.
+        $system = $this->pageContextFor(713, [
+            ['component' => 'section', 'props' => ['title' => 'A'], 'style' => ['--section-bg' => '#092082']],
+            ['component' => 'grid', 'props' => ['title' => 'B']],
+            ['component' => 'cta', 'props' => ['title' => 'C'], 'style' => ['--cta-bg' => '#092082']],
+        ]);
+
+        $this->assertStringNotContainsString('share background', $system);
+    }
+
+    public function testAdjacencyIsMalformedItemSafe(): void
+    {
+        // A component-less middle item (the realistic malformed case that still flows
+        // through the component-index loop) resolves to null via the is_string guard,
+        // so it breaks the run and never emits a spurious pair or crashes.
+        $system = $this->pageContextFor(714, [
+            ['component' => 'section', 'props' => ['title' => 'A'], 'style' => ['--section-bg' => '#092082']],
+            ['props' => ['title' => 'orphan']],
+            ['component' => 'cta', 'props' => ['title' => 'C'], 'style' => ['--cta-bg' => '#092082']],
+        ]);
+
+        $this->assertStringNotContainsString('share background', $system);
+    }
+
+    /**
+     * Extracts just the adjacency-hint lines from the system content so a negative
+     * assertion about them can't be fooled by the component index (which also
+     * contains "[0] hero").
+     */
+    private function onlyAdjacencyLines(string $system): string
+    {
+        $out = [];
+        foreach (explode("\n", $system) as $line) {
+            if (strpos($line, 'share background') !== false) {
+                $out[] = $line;
+            }
+        }
+        return implode("\n", $out);
+    }
 }


### PR DESCRIPTION
Closes #378

## Scope

Runtime companion to #377 (which documented the band-fusing heuristic in v1.4.20). The in-admin chat page context now annotates consecutive components whose **resolved** background matches, so the AI gets the "two touching same-color bands" relationship as a structural fact instead of an inference (the case that caused a white-seam dogfood defect between two `#092082` bands).

### What changed
- `lib/ai-context.php`: three helpers — `_pp_resolve_component_bg` (resolve a band's effective background to a comparison identity), `_pp_adjacent_background_annotations` (emit one line per consecutive same-identity pair), and `_pp_bg_annotation_value` (single-line, length-capped display sanitizer). Wired into `pp_ai_format_messages` after the component index.
- `AI_CONTEXT.md`: one sentence documenting the new hint in the page-context contents list.

### Resolution rules (per the recorded decision in #378)
- Per-instance `--<component>-bg` override wins; `transparent`/empty resolves to null (inherited).
- Else the `theme` bucket: `inverted`, or `muted` and its deprecated `dark` alias (#442) collapsed to one identity.
- Default/inherited and image-backed bands resolve to null and are never annotated.

Context-only: **no action, prop, validator, or composition-data change.**

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` → **2201 passed** (15 new adjacency tests: style-override match, theme-prop match, muted/dark alias, override-beats-theme precedence, whitespace+case normalization, exact-wording snapshot, and skip cases — default, differing, image-backed, hero-cover, transparent, non-consecutive, single component, malformed item).
- `npm test` → **804 passed**.
- No new warnings/deprecations vs an unmodified-tree baseline (3 warnings / 2 deprecations both before and after).

## Accepted limitations
- Best-effort string-identity comparison (whitespace runs + hex case normalized). No rendered-CSS equivalence, so `#fff` vs `#ffffff` (or `rgb()` vs hex) are treated as different by design — out of scope per #378 ("not rendered-CSS inspection"). A missed equivalence is a safe false-negative (no annotation); the model still has the full composition to reason from.

## Reviews (this session)
- /plan-eng-review + Codex outside voice (plan) — clean, no decision-extending findings.
- /review: 2 specialists (testing, maintainability) + Codex adversarial on the diff. All findings resolved (6 added tests + 1 cross-reference comment); adversarial "injection"/"mbstring" flags refuted (pre-existing whole-file properties the change conforms to).

## Not done here (deliberate)
No tag/release/deploy — CI builds the release zip from tags; maintainer handles tagging and the v1.6.0 rollup.
