### PR TITLE
Release v1.6.0 — brand-fidelity gate rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.6.0] — 2026-07-22 — brand-fidelity release: the v1.6.0 gate is closed (#141)
+
+**This is a gate rollup marker: the seven changes of this release shipped in working versions 1.5.6–1.5.12 below, and this entry carries no new code beyond the five-file version bump and doc freshness. What 1.6.0 marks is the close of the brand-fidelity gate (#141, Part 1.95), opened by a real brand build on v1.5.3 whose spec kept hitting inexpressible defaults. The through-line: precise brand type, color, and layout intent is now reachable through the documented surfaces instead of parent-theme edits. Heading tracking is a real token — `--letter-spacing-heading`, settable to the negative values brands actually use, with the shared length validator learning the signed grammar (#467). Step badges pair fill with authorable ink via `--grid-step-text-color`, so a light badge gets dark numerals (#473). Section body text gained its missing `--section-body-size`/`--section-body-weight` slots (#470). A split hero's media can now track the headline column height with `vertical_align: stretch` — one asset balances any headline length (#477). The footer grew its second menu column (`footer_secondary` + label option) and the social-icon row (`pp_footer_social`, a closed eight-network set with bundled inline SVGs) — both byte-identical when unset (#469, #382). And the in-admin chat's page context now annotates consecutive same-background components with the band-fusing hint, the runtime half of the #377 heuristic (#378).**
+
+This release bumps the version across the five synced files from 1.5.12 to 1.6.0 and updates README.md's project-status strings. Release evidence (recorded on #141): a brand-shaped rendered page at 375 and 1280 — tracking token overriding live, lime step badges with ink numerals, a 15px/600 body strip, stretch heroes measuring content==media height at both 5-line (479px) and 2-line (353px) headlines, and the full four-area footer with secondary Legal column and social row. No behavior changed in this entry itself.
+
+### Docs
+
+- README.md's project-status section now reads v1.6.0 in the release-history range and the "What exists today" heading. readme.txt gains its `= 1.6.0 =` rollup entry.
+
 ## [v1.5.12] — 2026-07-22 — the chat now sees which touching bands share a background (#378)
 
 **The in-admin chat AI used to receive each component's styling on its own, so the common "two touching bands in the same color" case, the one where a stray gap opens a wrong-color seam between them, had to be inferred from the composition. The page context now spells it out: after the component index it lists every consecutive pair whose resolved background matches, with a pointer to zero the facing paddings/margins. The chat gets the adjacency as a fact, not a deduction, so fixing or avoiding a same-color seam is reliable instead of hit-or-miss.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.5.12-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.6.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -419,9 +419,9 @@ npm run env:stop
 
 PromptingPress is in active development by a single developer. It is not yet packaged for broad distribution. The current focus is making the AI-agent workflow reliable and the composition model complete.
 
-See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.5.0.
+See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.6.0.
 
-**What exists today (v1.5.0):**
+**What exists today (v1.6.0):**
 - 12 components with schema contracts and 215 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.5.12');
+define('PP_VERSION', '1.6.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.5.12",
+  "version": "1.6.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.5.12
+Stable tag: 1.6.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -19,6 +19,10 @@ An AI-first WordPress theme built for clarity. PromptingPress uses a component-b
 4. Activate the theme.
 
 == Changelog ==
+
+= 1.6.0 =
+* Brand-fidelity release: heading letter-spacing token (signed lengths accepted), step-badge ink slot, section body size/weight slots, split-hero stretch alignment, footer secondary menu column and social-icon row (closed network set, inline SVG), and chat page-context adjacency hints
+* Verified by a brand-shaped rendered evidence page at mobile and desktop viewports
 
 = 1.5.0 =
 * Default-quality release: one fluid band heading scale at every viewport (no more body-size mobile headings), all nine bands on the shared symmetric rhythm with truthful slot contracts, WCAG AA links and legible panels on dark bands, an honest muted theme value (legacy dark renders identically forever), a documented inline-markup contract for supporting text, and graceful single-column degradation for image-less split heroes

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.5.12
+Version:          1.6.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Closes the v1.6.0 gate (#141 Part 1.95). Seven issues landed in working versions 1.5.6–1.5.12: #467, #473, #470, #477, #469, #382, #378.

Rollup-only change: five-file version bump 1.5.12 → 1.6.0, CHANGELOG v1.6.0 entry, readme.txt rollup + Stable tag, README status strings. No code.

Gate-close evidence (rendered, wp-env, 375+1280): tracking token live (-1.728px default, override moves it); lime #B8F135 step badges with ink rgb(16,24,40) numerals; section body strip at 15px/600; stretch split-heroes with content==media height at 5-line (479px) and 2-line (353px) headlines; footer with both nav columns (aria-labeled), Legal secondary column, and social row (aria-labeled links); no mobile overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)