### PR TITLE
v1.6.2 feat: section body_items inline-items row with slot-colorable separator (#475)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -391,7 +391,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**215 style slots** across 10 components: hero (41), section (38), grid (37), cta (31), testimonials (26), faq (18), stats (12), embed (4), logos (4), table (4).
+**216 style slots** across 10 components: hero (41), section (39), grid (37), cta (31), testimonials (26), faq (18), stats (12), embed (4), logos (4), table (4).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.6.2] — 2026-07-22 — a colorable "trust strip" row for sections (#475)
+
+**A slim post-hero band of short items with a colored dot between them ("No credit card · Cancel anytime · 30-day guarantee") used to be inexpressible: the only route was separator characters typed into body text, and those cannot be recolored because inline `style` spans are (correctly) stripped by the sanitizer. Sections gain a `body_items` prop — a row of short plain-text items rendered as a single centered row below the body, with a CSS-generated middot separator between each. The separator is a real presentational element, so it takes a color from the new `--section-separator-color` style slot and stays silent to screen readers. The items inherit the section body type, so the same `--section-body-size`/`--section-body-weight` slots that set the body's size and weight also set the strip's, and the original brand band (15px/600 text with a lime dot) is now fully expressible with no parent-theme edits.**
+
+`body_items` is a list of plain-text strings, escaped at output like every other text field: at most 8 items, each at most 80 characters, and a write that exceeds either bound or passes a non-string entry is rejected up front instead of silently truncated. The row renders only when it has content, after the body when both are set, and the page is byte-identical when it is unset. The separator color defaults to the muted text color and, on the inverted and background-image bands, follows the same light on-dark text color as its sibling text, so a dark band never gets an invisible dot. The row wraps to more centered rows at narrow widths, so it needs no mobile-specific rule. The bounds check is a generic, schema-driven rule in the shared write-time validator, so it holds for every write path (add/update component, update composition, create page) without a second validator.
+
+### Added
+- `section.body_items` — a centered row of up to 8 short plain-text items (≤80 chars each) rendered below the body with a CSS-generated middot separator between each, escaped at output; over-bound or non-string entries are rejected at write time (#475).
+- `--section-separator-color` style slot — colors the `body_items` separator; defaults to the muted text color, and follows the light on-inverted / on-overlay text color on dark and image bands like sibling text (#475).
+
+### Tests
+- PHPUnit `SchemaValidationTest`: `body_items` bounds (≤8 items, ≤80 chars, non-string and non-array rejected, unset sentinels accepted), the generic check not rippling to `panel_items`, and unknown-prop staying strict alongside a valid `body_items`.
+- PHPUnit `SectionInlineItemsTest`: the row renders only when set (byte-identical when unset), `esc_html` on each item, `<li>` count, ordering after the body, rendering across layouts, and CSS pins for the flex row, the body-type-slot inheritance, and the separator routing (base + overlay).
+- E2E `style-render.spec.ts` at 375 + 1280: computed separator color (muted default, slot override, inverted routing), wrap at narrow width, and the brand strip (15px/600 body type + a lime separator) computing correctly.
+- css-lint: every separator `color` declaration routes through `var(--section-separator-color …)` at both declaration sites.
+
+### Docs
+- `ai-instructions/composition.md` (section props row + a `body_items` worked example), `components/section/README.md`, the section `schema.json` prop and slot descriptions, and the `AI_CONTEXT.md` / `README.md` style-slot counts (215 → 216) document the new capability (#475).
+
 ## [v1.6.1] — 2026-07-22 — social-share cards you can actually set (#468)
 
 **Sharing a PromptingPress page used to produce a bare link: the theme emitted zero Open Graph or Twitter tags, and `update_seo_meta` only reached meta description, title, and canonical. There was no way to set a share image or the card text short of editing the parent theme or bolting on an SEO plugin. This release adds a first-class social-meta surface. Four site options declare the defaults — `pp_og_image` (a Media Library image attachment, the same typed rule as the logo), `pp_og_site_name`, `pp_og_default_description`, and `pp_twitter_card` (summary or summary_large_image) — and `update_seo_meta` gains per-page `og_title` and `twitter_title` overrides. The theme renders the full `og:*`/`twitter:*` set in the page head, resolved through page → site → WordPress fallback chains.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.6.1-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.6.2-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-215 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+216 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -422,7 +422,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.6.0.
 
 **What exists today (v1.6.0):**
-- 12 components with schema contracts and 215 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 216 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -44,7 +44,7 @@ See `AI_CONTEXT.md` → Component index for the current list. As of last update:
 | Name    | Required props                          | Optional props (selection)                              |
 |---------|-----------------------------------------|---------------------------------------------------------|
 | hero    | title                                   | title_accent, eyebrow, subtitle, cta_text, cta_url, cta2_text, cta2_url, cta_variant, cta2_variant, layout, image_url, image_id, image_alt, spacing, width, split_ratio, vertical_align, proof |
-| section | body                                    | title, title_accent, eyebrow, subheading, heading_align, layout, theme, image_url, image_id, image_alt, background_image |
+| section | body                                    | title, title_accent, eyebrow, subheading, heading_align, layout, theme, image_url, image_id, image_alt, background_image, body_marker, body_items |
 | faq     | items[] {question, answer}              | title, title_accent, eyebrow, theme, id                 |
 | grid    | items[] {title, text, ...}              | title, title_accent, eyebrow, subheading, heading_align, layout, card_emphasis, theme, columns, image_treatment |
 | table   | headers[], rows[][]                     | title, caption                                          |
@@ -187,6 +187,23 @@ A monospace spec panel with paired label/value rows, one row emphasised via a pe
     "body": "<ul><li>Transparent pricing</li><li>Cancel anytime</li></ul>",
     "body_marker": "check"
   }
+}
+```
+
+#### section inline-items row: `body_items`
+
+`body_items` renders a short "trust strip" — a single centered row of brief plain-text items with a CSS-generated middot (`·`) separator between each. Use it for the slim post-hero meta row (e.g. "No credit card · Cancel anytime · 30-day guarantee"), not for multi-line content (use `body` or `panel_items` for that). Each entry is a plain-text string (escaped, no HTML): at most **8 items**, each at most **80 characters** — a write that exceeds either bound, or passes a non-string entry, is rejected with `invalid_prop_value` (nothing persists). The row renders only when non-empty; when both `body` and `body_items` are set, the row renders after the body.
+
+The items inherit the section body type, so the `--section-body-size` / `--section-body-weight` slots (a slim 15px/600 strip needs no extra typography slots). Colour the separator with the `--section-separator-color` style slot (defaults to the muted text colour; it follows the light on-inverted / on-background-image text colour like sibling text on dark bands). The glyph is a fixed middot.
+
+```json
+{
+  "component": "section",
+  "props": {
+    "body": "<p>Everything you need to launch.</p>",
+    "body_items": ["No credit card", "Cancel anytime", "30-day guarantee"]
+  },
+  "style": { "--section-body-size": "15px", "--section-body-weight": "600", "--section-separator-color": "#84cc16" }
 }
 ```
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1100,6 +1100,47 @@
   margin-bottom: 0;
 }
 
+/* Inline-items row (issue 475): a centered single-row band of short items with a
+   CSS-generated separator between them (the "trust strip" pattern — e.g. a slim
+   post-hero band of short items with a colored middot between each). It sits in the
+   section body scope, right after .section__content, and reads the SAME #470 body
+   type slots so the items inherit the section body size/weight (the brand band's
+   15px/600). flex-wrap lets the row wrap to further centered rows at narrow widths,
+   so no mobile-specific rule is needed. Unset (no body_items) emits no markup, so
+   output stays byte-identical. */
+.section__inline-items {
+  list-style: none;
+  margin: var(--space-md) 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: center;
+  gap: var(--space-xs) var(--space-sm);
+  text-align: center;
+  font-size: var(--section-body-size, inherit);
+  font-weight: var(--section-body-weight, inherit);
+}
+
+.section__inline-item {
+  margin: 0;
+}
+
+/* The separator is a CSS-generated middot before every item except the first, so
+   it is never a content character: it can be slot-colored and stays out of the
+   accessibility tree. The `/ ""` alternative-text empties its a11y name, and the
+   <ul role="list"> keeps list semantics intact. The glyph is FIXED (middot) in this
+   issue. Color routes through --section-separator-color, defaulting to the muted
+   role like sibling text; on the inverted band --color-muted is already remapped to
+   the light on-inverted color (.pp-section--inverted below), so the default follows
+   the sibling text there automatically — no separate inverted rule. The bg-image
+   overlay default is remapped below (mirrors the #461/#463 links/markers). */
+.section__inline-items li + li::before {
+  content: "\00b7" / "";
+  margin-right: var(--space-sm);
+  color: var(--section-separator-color, var(--color-muted));
+}
+
 /* Image variants: side-by-side grid at md+ */
 .section__grid {
   display: flex;
@@ -1333,6 +1374,16 @@
    self-contained LIGHT surface (#424), not on the overlay. */
 .section--has-bg-image .section__content {
   --pp-list-marker-color: var(--section-body-marker-color, var(--color-accent-on-overlay));
+}
+
+/* Inline-items separator on the overlay band (issue 475): unlike the inverted band,
+   .section--has-bg-image does NOT remap --color-muted, so the muted default would
+   stay dark and vanish on the dark overlay. Route the default through the light
+   on-overlay text color like sibling body text (.section--has-bg-image .section__content
+   above resolves to --color-bg); the --section-separator-color slot still wins.
+   Mirrors the inverted band's automatic --color-muted remap. */
+.section--has-bg-image .section__inline-items li + li::before {
+  color: var(--section-separator-color, var(--color-bg));
 }
 
 /* ==========================================================================

--- a/components/section/README.md
+++ b/components/section/README.md
@@ -20,6 +20,7 @@ Generic text + optional image section. Use this for "what is this", "how it work
 | `theme`            | enum   | No       | `'default'`   | Background color/tone: `default` / `muted` (light tinted surface band) / `inverted` (genuinely dark band) |
 | `background_image` | string | No       | `''`          | Optional background image URL with dark overlay for text readability |
 | `body_marker`        | enum   | No       | `'disc'`      | List marker for top-level `<ul>` lists in `body`: `disc` / `check` / `dash` / `arrow`. Colour via the `--section-body-marker-color` slot |
+| `body_items`         | array  | No       | `[]`          | Optional centered row of short plain-text items rendered below the body with a CSS-generated middot separator between each. Max 8 items, each ≤80 chars (over-bound or non-string rejected at write time). Inherits the body type slots; colour the separator via `--section-separator-color` |
 | `panel_items_marker` | enum   | No       | `'disc'`      | text-panel layout: list marker for the string entries of `panel_items`: `disc` / `check` / `dash` / `arrow`. Colour via the `--section-panel-marker-color` slot. Paired rows never show a marker |
 
 ### Content panel (`text-panel` layout)

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -137,6 +137,15 @@
       "required": false,
       "default": "disc",
       "description": "List marker for top-level <ul> lists in body. 'disc' (default) leaves body lists exactly as before. 'check' renders a check mark, 'dash' an en dash, 'arrow' a rightwards arrow. Applies only to lists authored as a direct child of the body (nested lists keep their disc). The marker colour is authorable via the --section-body-marker-color style slot (defaults to the site accent). Just a marker choice — not a distinct list type."
+    },
+    "body_items": {
+      "type": "array",
+      "item_type": "string",
+      "max_items": 8,
+      "item_max_length": 80,
+      "required": false,
+      "default": [],
+      "description": "Optional row of short inline text items (a 'trust strip' or meta row) rendered as a single centered flex row below the body, with a CSS-generated middot separator between each item. Each entry is a plain-text string (escaped, no HTML); at most 8 items, each at most 80 characters — a write that exceeds either bound, or carries a non-string entry, is rejected. Renders only when non-empty; when both body and body_items are set the row renders after the body. The items inherit the section body type (--section-body-size / --section-body-weight), so a 15px/600 strip needs no extra typography slots. Colour the separator with the --section-separator-color style slot (defaults to the muted text colour; light on inverted/background-image bands like sibling text). Not for multi-line content — use body or panel_items for that."
     }
   },
   "styling": {
@@ -181,7 +190,8 @@
       "--section-panel-text": { "item_eligible": true, "type": "color", "default": "var(--color-text)", "description": "text-panel layout: text color inside the content panel (heading, body, list, and paired rows) — set a light value for a dark panel. item_eligible: also settable per paired-row via panel_items[].style, where it recolours that single row to emphasise or de-emphasise it against its siblings." },
       "--section-panel-font": { "type": "font-family", "default": "inherit", "description": "text-panel layout: font family of the content panel. Defaults to inherit (the panel uses the page font, unchanged). Set to var(--font-mono) for a monospace panel (spec sheets, config/stat readouts), or any comma-separated font stack." },
       "--section-panel-marker-color": { "type": "color", "default": "var(--color-accent)", "description": "text-panel layout: marker (glyph) color of the panel list when panel_items_marker is check/dash/arrow. Mirrors grid's --grid-bullet-color. Set a light value for a check-list on a dark panel. Ignored while panel_items_marker is 'disc'." },
-      "--section-body-marker-color": { "type": "color", "default": "var(--color-accent)", "description": "Marker (glyph) color of body lists when body_marker is check/dash/arrow. Ignored while body_marker is 'disc'." }
+      "--section-body-marker-color": { "type": "color", "default": "var(--color-accent)", "description": "Marker (glyph) color of body lists when body_marker is check/dash/arrow. Ignored while body_marker is 'disc'." },
+      "--section-separator-color": { "type": "color", "default": "var(--color-muted)", "description": "Colour of the CSS-generated middot separator between body_items entries. Defaults to the muted text colour; on inverted and background-image bands it follows the light on-inverted/on-overlay text colour like sibling text unless set. Ignored when body_items is empty." }
     },
     "recipes": {
       "accent-panel": {

--- a/components/section/section.php
+++ b/components/section/section.php
@@ -22,6 +22,19 @@ $layout           = $props['layout']           ?? 'text-only';
 $theme            = $props['theme']            ?? 'default';
 $background_image = $props['background_image'] ?? '';
 
+// Inline-items row (issue 475): an optional centered row of short plain-text
+// items with a CSS-generated, slot-colorable separator between them. Plain
+// strings only (no HTML, esc_html at render); the write-time validator caps the
+// count/length and rejects non-strings, so here we only drop empty strings for a
+// byte-identical unset path. Renders after the body when both are set.
+$body_items = is_array($props['body_items'] ?? null) ? $props['body_items'] : [];
+$body_items = array_values(array_filter(
+    $body_items,
+    static function ($item) {
+        return is_string($item) && $item !== '';
+    }
+));
+
 // text-panel layout: right-hand content panel props (see schema.json).
 $panel_heading      = $props['panel_heading']      ?? '';
 $panel_body         = $props['panel_body']         ?? '';
@@ -129,6 +142,18 @@ if ($background_image) {
 }
 $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"' : '';
 
+// Build the inline-items row once (issue 475) and place it in each layout's body
+// scope, after .section__content. role="list" keeps list semantics while the
+// CSS-generated `li + li::before` separator stays out of the accessibility tree.
+$inline_items_html = '';
+if (!empty($body_items)) {
+    $items_markup = '';
+    foreach ($body_items as $body_item) {
+        $items_markup .= '<li class="section__inline-item">' . esc_html($body_item) . '</li>';
+    }
+    $inline_items_html = '<ul class="section__inline-items" role="list">' . $items_markup . '</ul>';
+}
+
 ?>
 <section<?php echo $id ? ' id="' . esc_attr($id) . '"' : ''; ?> class="section section--<?php echo esc_attr($layout); ?><?php echo esc_attr($theme_class); ?><?php echo esc_attr($bg_image_class); ?>" data-pp-component="section"<?php echo $style_attr; ?>>
     <?php if ($background_image) : ?>
@@ -155,6 +180,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                 <div class="section__content<?php echo esc_attr($content_marker_class); ?>">
                     <?php echo wp_kses_post($body); ?>
                 </div>
+                <?php echo $inline_items_html; ?>
             </div>
 
         <?php elseif ($layout === 'text-panel') : ?>
@@ -177,6 +203,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                     <div class="section__content<?php echo esc_attr($content_marker_class); ?>">
                         <?php echo wp_kses_post($body); ?>
                     </div>
+                    <?php echo $inline_items_html; ?>
                 </div>
 
                 <div class="section__panel">
@@ -245,6 +272,7 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
                     <div class="section__content<?php echo esc_attr($content_marker_class); ?>">
                         <?php echo wp_kses_post($body); ?>
                     </div>
+                    <?php echo $inline_items_html; ?>
                 </div>
 
                 <?php if ($layout === 'image-right') : ?>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.6.1');
+define('PP_VERSION', '1.6.2');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -569,6 +569,90 @@ function pp_validate_composition_errors(array $items): array {
             }
         }
 
+        // Bounded string-array props (issue 475). A prop whose schema declares
+        // `item_type: "string"` MAY also declare `max_items` and/or `item_max_length`
+        // bounds. When it does, a supplied value must be an array of plain strings,
+        // at most `max_items` of them, each at most `item_max_length` characters —
+        // otherwise the write is rejected with the standard envelope instead of the
+        // renderer silently dropping the offending entries (the reported-success-
+        // without-effect class, same rationale as the issue 379 numeric-bounds and
+        // issue 380 strict-enum checks above). Generic + schema-driven: only props
+        // declaring `item_type: "string"` are checked, so the object-or-string
+        // panel_items array (no item_type) is untouched. "Unset" is the key being
+        // absent, null, the empty string, or an empty array — that preserves the
+        // prop's default (an empty row renders nothing). Runs in the shared validator;
+        // restore_composition (#233) reports it via _pp_composition_findings() but
+        // never blocks on it.
+        if (isset($item['props']) && is_array($item['props']) && !empty($schema['props'])) {
+            foreach ($schema['props'] as $prop_name => $prop_def) {
+                if (($prop_def['type'] ?? null) !== 'array'
+                    || ($prop_def['item_type'] ?? null) !== 'string'
+                ) {
+                    continue;
+                }
+                if (!array_key_exists($prop_name, $item['props'])) {
+                    continue;
+                }
+                $value = $item['props'][$prop_name];
+                if ($value === null || $value === '' || $value === []) {
+                    continue; // unset sentinel — keeps the prop's default (empty row)
+                }
+                if (!is_array($value)) {
+                    $errors[] = new WP_Error(
+                        'invalid_prop_value',
+                        sprintf(
+                            'Component "%s" prop "%s" must be an array of strings; got %s.',
+                            $name,
+                            $prop_name,
+                            gettype($value)
+                        )
+                    );
+                    continue 2;
+                }
+                if (isset($prop_def['max_items']) && count($value) > (int) $prop_def['max_items']) {
+                    $errors[] = new WP_Error(
+                        'invalid_prop_value',
+                        sprintf(
+                            'Component "%s" prop "%s" accepts at most %d items; got %d.',
+                            $name,
+                            $prop_name,
+                            (int) $prop_def['max_items'],
+                            count($value)
+                        )
+                    );
+                    continue 2;
+                }
+                $item_max_length = isset($prop_def['item_max_length']) ? (int) $prop_def['item_max_length'] : null;
+                foreach ($value as $entry) {
+                    if (!is_string($entry)) {
+                        $errors[] = new WP_Error(
+                            'invalid_prop_value',
+                            sprintf(
+                                'Component "%s" prop "%s" items must be strings; got %s.',
+                                $name,
+                                $prop_name,
+                                gettype($entry)
+                            )
+                        );
+                        continue 3;
+                    }
+                    if ($item_max_length !== null && mb_strlen($entry) > $item_max_length) {
+                        $errors[] = new WP_Error(
+                            'invalid_prop_value',
+                            sprintf(
+                                'Component "%s" prop "%s" items must be at most %d characters; got %d.',
+                                $name,
+                                $prop_name,
+                                $item_max_length,
+                                mb_strlen($entry)
+                            )
+                        );
+                        continue 3;
+                    }
+                }
+            }
+        }
+
         // Validate optional style key against schema-declared style slots.
         $available_slots = $schema['styling']['style_slots'] ?? [];
         if (isset($item['style']) && is_array($item['style']) && !empty($item['style'])) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.6.1
+Stable tag: 1.6.2
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.6.1
+Version:          1.6.2
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -246,7 +246,7 @@ class SchemaValidationTest extends TestCase
     {
         $expected = [
             'hero'    => 41,
-            'section' => 38,
+            'section' => 39,
             'grid'    => 37,
             'cta'     => 31,
         ];
@@ -642,6 +642,111 @@ class SchemaValidationTest extends TestCase
             'A non-strict enum (layout/theme) with an invalid value must still validate '
             . '(render-time coercion preserved); the #380 strict check must not ripple to it.'
         );
+    }
+
+    // ── Section inline-items row (issue 475) ─────────────────────────────
+    //
+    // section.body_items declares `item_type: "string"` with max_items:8 and
+    // item_max_length:80 in schema.json, so the shared validator's generic
+    // bounded-string-array check accepts only an array of ≤8 strings each ≤80
+    // chars (and the unset sentinel), and rejects everything else with
+    // invalid_prop_value — the write never persists an over-bound row the
+    // renderer would silently truncate. The bounds are read from schema, not
+    // hardcoded per component.
+
+    private function sectionCompositionWithBodyItems($bodyItems): array
+    {
+        $props = ['body' => '<p>Body.</p>'];
+        // '__ABSENT__' omits the key entirely; anything else is supplied verbatim.
+        if ($bodyItems !== '__ABSENT__') {
+            $props['body_items'] = $bodyItems;
+        }
+        return [['component' => 'section', 'props' => $props]];
+    }
+
+    /**
+     * @dataProvider validBodyItemsProvider
+     */
+    public function testSectionBodyItemsAcceptsInBoundArrays($bodyItems): void
+    {
+        $result = pp_validate_composition($this->sectionCompositionWithBodyItems($bodyItems));
+        $this->assertTrue($result, 'body_items=' . var_export($bodyItems, true) . ' must validate.');
+    }
+
+    public static function validBodyItemsProvider(): array
+    {
+        return [
+            'single item'        => [['One']],
+            'max 8 items'        => [['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']],
+            'exactly 80 chars'   => [[str_repeat('x', 80)]],
+            'unset: absent'      => ['__ABSENT__'],
+            'unset: null'        => [null],
+            'unset: empty str'   => [''],
+            'unset: empty array' => [[]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidBodyItemsProvider
+     */
+    public function testSectionBodyItemsRejectsOutOfBoundOrNonString($bodyItems): void
+    {
+        $result = pp_validate_composition($this->sectionCompositionWithBodyItems($bodyItems));
+        $this->assertInstanceOf(\WP_Error::class, $result, 'body_items=' . var_export($bodyItems, true) . ' must be rejected.');
+        $this->assertSame('invalid_prop_value', $result->get_error_code());
+        // The envelope names the offending prop so the caller/AI can correct it.
+        $this->assertStringContainsString('body_items', $result->get_error_message());
+    }
+
+    public static function invalidBodyItemsProvider(): array
+    {
+        return [
+            'nine items (over max)'  => [['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']],
+            'item over 80 chars'     => [[str_repeat('x', 81)]],
+            'non-string entry (int)' => [['ok', 42]],
+            'non-string entry (arr)' => [[['label' => 'x']]],
+            'scalar not array'       => ['just a string'],
+            'numeric not array'      => [7],
+        ];
+    }
+
+    /**
+     * The bounded string-array check is OPT-IN (only props declaring
+     * item_type:"string"). It must NOT ripple to section.panel_items, whose
+     * entries are strings OR {label,value} objects and which declares no
+     * item_type — a mixed panel_items array must still validate.
+     */
+    public function testBoundedArrayCheckDoesNotRippleToPanelItems(): void
+    {
+        $result = pp_validate_composition([
+            ['component' => 'section', 'props' => [
+                'body'        => '<p>x</p>',
+                'layout'      => 'text-panel',
+                'panel_items' => ['A bullet', ['label' => 'Uptime', 'value' => '99.9%']],
+            ]],
+        ]);
+        $this->assertTrue(
+            $result,
+            'panel_items (string-or-object array, no item_type) must still validate; '
+            . 'the #475 bounded-string-array check must not ripple to it.'
+        );
+    }
+
+    /**
+     * An unknown prop key on section still rejects with unknown_prop even when a
+     * valid body_items is present — the #147 strict-key gate is untouched by #475.
+     */
+    public function testUnknownPropStillStrictAlongsideBodyItems(): void
+    {
+        $result = pp_validate_composition([
+            ['component' => 'section', 'props' => [
+                'body'       => '<p>x</p>',
+                'body_items' => ['One', 'Two'],
+                'not_a_prop' => 'x',
+            ]],
+        ]);
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('unknown_prop', $result->get_error_code());
     }
 
     // ── Featured first-card remnant slots (issue 293) ────────────────────
@@ -1221,6 +1326,14 @@ class SchemaValidationTest extends TestCase
                     && !empty($prop_def['values'])
                 ) {
                     $props[$prop_name] = $prop_def['values'][0];
+                } elseif (
+                    ($prop_def['type'] ?? null) === 'array'
+                    && ($prop_def['item_type'] ?? null) === 'string'
+                ) {
+                    // Bounded string-array prop (issue 475, e.g. section.body_items):
+                    // the placeholder 'x' would be rejected as "not an array". A single
+                    // short string satisfies the count/length bounds.
+                    $props[$prop_name] = ['x'];
                 } else {
                     $props[$prop_name] = 'x';
                 }

--- a/tests/SectionInlineItemsTest.php
+++ b/tests/SectionInlineItemsTest.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * tests/SectionInlineItemsTest.php
+ *
+ * Section inline-items row (issue 475): section.body_items renders a centered
+ * single-row band of short plain-text items with a CSS-generated, slot-colorable
+ * separator between them. The renderer emits `<ul class="section__inline-items"
+ * role="list">` only when body_items is non-empty, after .section__content; the
+ * separator is a `li + li::before` pseudo-element (never a content character) so it
+ * can be slot-colored and stays out of the accessibility tree.
+ *
+ * Two halves: render pins (assert the emitted HTML) and CSS-content pins (PHPUnit
+ * does not execute CSS, so — like SectionBodyListTest/TypographyRoleTest — we assert
+ * the source declares the routing rules; the computed cascade is covered by the
+ * style-render e2e).
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class SectionInlineItemsTest extends TestCase
+{
+    private string $themeRoot;
+    private string $componentsCss;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->themeRoot     = dirname(__DIR__);
+        $this->componentsCss = file_get_contents($this->themeRoot . '/assets/css/components.css');
+        $GLOBALS['_pp_test_store'] = [
+            'post_meta' => [], 'posts' => [], 'options' => [], 'next_id' => 100, 'custom_css' => '',
+        ];
+    }
+
+    private function render(string $component, array $props): string
+    {
+        ob_start();
+        pp_get_component($component, $props);
+        return ob_get_clean();
+    }
+
+    // ── Render: the row appears only when body_items is set ───────────────
+
+    public function testUnsetBodyItemsEmitsNoRowAndStaysByteIdentical(): void
+    {
+        $without = $this->render('section', ['layout' => 'text-only', 'body' => '<p>Hi</p>']);
+        $withEmpty = $this->render('section', ['layout' => 'text-only', 'body' => '<p>Hi</p>', 'body_items' => []]);
+
+        $this->assertStringNotContainsString('section__inline-items', $without,
+            'unset body_items must emit no inline-items row.');
+        $this->assertSame($without, $withEmpty,
+            'an empty body_items array must render byte-identically to the unset case.');
+    }
+
+    public function testBodyItemsRendersRowWithRoleList(): void
+    {
+        $html = $this->render('section', [
+            'layout'     => 'text-only',
+            'body'       => '<p>Hi</p>',
+            'body_items' => ['No credit card', 'Cancel anytime'],
+        ]);
+        $this->assertMatchesRegularExpression(
+            '/<ul class="section__inline-items" role="list">/',
+            $html,
+            'body_items must render a <ul class="section__inline-items" role="list">.'
+        );
+    }
+
+    public function testEachItemRendersAsListItemWithMatchingCount(): void
+    {
+        $html = $this->render('section', [
+            'layout'     => 'text-only',
+            'body'       => '<p>Hi</p>',
+            'body_items' => ['One', 'Two', 'Three'],
+        ]);
+        $this->assertSame(3, substr_count($html, 'section__inline-item">'),
+            'each body_items entry must render exactly one <li class="section__inline-item">.');
+        $this->assertStringContainsString('<li class="section__inline-item">One</li>', $html);
+        $this->assertStringContainsString('<li class="section__inline-item">Two</li>', $html);
+        $this->assertStringContainsString('<li class="section__inline-item">Three</li>', $html);
+    }
+
+    public function testItemsAreEscapedAsPlainText(): void
+    {
+        $html = $this->render('section', [
+            'layout'     => 'text-only',
+            'body'       => '<p>Hi</p>',
+            'body_items' => ['<b>bold</b> & "risky"'],
+        ]);
+        $this->assertStringContainsString('&lt;b&gt;bold&lt;/b&gt; &amp; &quot;risky&quot;', $html,
+            'body_items entries must be escaped with esc_html (no raw HTML).');
+        $this->assertStringNotContainsString('<b>bold</b>', $html,
+            'raw HTML in a body_items entry must not survive into the row.');
+    }
+
+    public function testEmptyStringEntriesAreDropped(): void
+    {
+        $html = $this->render('section', [
+            'layout'     => 'text-only',
+            'body'       => '<p>Hi</p>',
+            'body_items' => ['One', '', 'Two'],
+        ]);
+        $this->assertSame(2, substr_count($html, 'section__inline-item">'),
+            'empty-string entries must be dropped from the row.');
+    }
+
+    public function testRowRendersAfterBodyContent(): void
+    {
+        $html = $this->render('section', [
+            'layout'     => 'text-only',
+            'body'       => '<p>Body prose.</p>',
+            'body_items' => ['Meta'],
+        ]);
+        $contentPos = strpos($html, 'section__content');
+        $rowPos     = strpos($html, 'section__inline-items');
+        $this->assertNotFalse($contentPos);
+        $this->assertNotFalse($rowPos);
+        $this->assertLessThan($rowPos, $contentPos,
+            'the inline-items row must render after .section__content when both are set.');
+    }
+
+    public function testRowRendersInImageAndPanelLayouts(): void
+    {
+        $image = $this->render('section', [
+            'layout'     => 'image-right',
+            'body'       => '<p>Hi</p>',
+            'image_url'  => 'https://example.com/x.png',
+            'body_items' => ['Meta'],
+        ]);
+        $this->assertStringContainsString('section__inline-items', $image,
+            'the row must render in the image layout body scope.');
+
+        $panel = $this->render('section', [
+            'layout'        => 'text-panel',
+            'body'          => '<p>Hi</p>',
+            'panel_heading' => 'Panel',
+            'body_items'    => ['Meta'],
+        ]);
+        $this->assertStringContainsString('section__inline-items', $panel,
+            'the row must render in the text-panel layout body scope.');
+    }
+
+    // ── CSS pins: the row layout, the separator, and slot routing ─────────
+
+    public function testInlineItemsRowIsACenteredWrappingFlexRow(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/\.section__inline-items\s*\{[^}]*display:\s*flex/s',
+            $this->componentsCss,
+            '.section__inline-items must be a flex row.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/\.section__inline-items\s*\{[^}]*flex-wrap:\s*wrap/s',
+            $this->componentsCss,
+            '.section__inline-items must wrap (the responsive default, no mobile rule).'
+        );
+        $this->assertMatchesRegularExpression(
+            '/\.section__inline-items\s*\{[^}]*justify-content:\s*center/s',
+            $this->componentsCss,
+            '.section__inline-items must be centered.'
+        );
+    }
+
+    public function testInlineItemsInheritBodyTypeSlots(): void
+    {
+        // The row reads the SAME #470 slots as .section__content, so a 15px/600
+        // brand strip needs no extra typography slots.
+        $this->assertMatchesRegularExpression(
+            '/\.section__inline-items\s*\{[^}]*font-size:\s*var\(--section-body-size,/s',
+            $this->componentsCss,
+            '.section__inline-items must read --section-body-size (issue 470 scope).'
+        );
+        $this->assertMatchesRegularExpression(
+            '/\.section__inline-items\s*\{[^}]*font-weight:\s*var\(--section-body-weight,/s',
+            $this->componentsCss,
+            '.section__inline-items must read --section-body-weight (issue 470 scope).'
+        );
+    }
+
+    public function testSeparatorIsCssGeneratedAndScreenReaderQuiet(): void
+    {
+        // Middot glyph via ::before with empty alt-text, so it never becomes a
+        // content character and stays out of the accessibility tree.
+        $this->assertMatchesRegularExpression(
+            '/\.section__inline-items li \+ li::before\s*\{[^}]*content:\s*"\\\\00b7"\s*\/\s*""/s',
+            $this->componentsCss,
+            'the separator must be a CSS-generated middot with empty alt-text (content: "\\00b7" / "").'
+        );
+    }
+
+    public function testSeparatorColorRoutesThroughSlotWithMutedDefault(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/\.section__inline-items li \+ li::before\s*\{[^}]*color:\s*var\(--section-separator-color,\s*var\(--color-muted\)\)/s',
+            $this->componentsCss,
+            'the separator color must route through var(--section-separator-color, var(--color-muted)).'
+        );
+    }
+
+    public function testSeparatorRoutesThroughOnOverlayRoleOnBgImageBand(): void
+    {
+        // .section--has-bg-image does not remap --color-muted, so the separator
+        // default is re-routed to the light on-overlay text color like sibling text.
+        $this->assertMatchesRegularExpression(
+            '/\.section--has-bg-image \.section__inline-items li \+ li::before\s*\{[^}]*color:\s*var\(--section-separator-color,\s*var\(--color-bg\)\)/s',
+            $this->componentsCss,
+            'on the bg-image band the separator default must route through var(--section-separator-color, var(--color-bg)).'
+        );
+    }
+
+    public function testSeparatorColorSlotIsDeclaredInSchema(): void
+    {
+        $schema = json_decode(file_get_contents($this->themeRoot . '/components/section/schema.json'), true);
+        $slots  = $schema['styling']['style_slots'];
+        $this->assertArrayHasKey('--section-separator-color', $slots,
+            'schema must declare the --section-separator-color style slot.');
+        $this->assertSame('color', $slots['--section-separator-color']['type']);
+        $this->assertSame('var(--color-muted)', $slots['--section-separator-color']['default']);
+    }
+}

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -455,6 +455,118 @@ test.describe('Safe-surface rendered proof', () => {
     }
   });
 
+  // #475: section.body_items renders a centered row of short items with a
+  // CSS-generated `li + li::before` middot separator. The separator color routes
+  // through --section-separator-color (default --color-muted); on the inverted band
+  // the default follows the light on-inverted text like sibling text (--color-muted
+  // is remapped to --color-bg there). PHP/CSS pins prove the routing declarations;
+  // only getComputedStyle('::before') proves the browser paints the middot the right
+  // color once the cascade applies. The items also inherit the #470 body type slots,
+  // so the brand strip (15px/600 + a lime middot) is fully expressible. Per the
+  // #86/#349 mobile-hid-it lesson, assert at 1280 AND 375.
+  test('#475 body_items separator honors --section-separator-color + inverted routing + brand type @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Section Inline Items Separator');
+    const LIME = '#84cc16'; // rgb(132, 204, 22) — the brand strip's colored middot
+    setComposition(pageId, [
+      // 0: default separator (unset slot) — muted default.
+      { component: 'section', props: { id: 'pp-sec-default', body: '<p>Body.</p>', body_items: ['One', 'Two', 'Three'] } },
+      // 1: explicit var(--color-muted) — must be byte-identical to the unset default.
+      { component: 'section', props: { id: 'pp-sec-explicit', body: '<p>Body.</p>', body_items: ['One', 'Two', 'Three'] }, style: { '--section-separator-color': 'var(--color-muted)' } },
+      // 2: overridden separator color — the slot genuinely changes the middot.
+      { component: 'section', props: { id: 'pp-sec-override', body: '<p>Body.</p>', body_items: ['One', 'Two', 'Three'] }, style: { '--section-separator-color': LIME } },
+      // 3: inverted band, unset separator — routes like sibling text (light).
+      { component: 'section', props: { id: 'pp-sec-inverted', theme: 'inverted', body: '<p>Body.</p>', body_items: ['One', 'Two', 'Three'] } },
+      // 4: the brand strip — 15px/600 body type + a lime middot.
+      { component: 'section', props: { id: 'pp-sec-brand', body: '<p>Body.</p>', body_items: ['One', 'Two', 'Three'] }, style: { '--section-body-size': '15px', '--section-body-weight': '600', '--section-separator-color': LIME } },
+    ]);
+
+    // The 2nd <li> carries the `li + li::before` separator; read its ::before color.
+    const sepColor = (id: string) =>
+      page.locator(`#${id} .section__inline-item`).nth(1).evaluate((el) => getComputedStyle(el, '::before').color);
+    const itemColor = (id: string) =>
+      page.locator(`#${id} .section__inline-item`).nth(1).evaluate((el) => getComputedStyle(el).color);
+    const itemType = (id: string) =>
+      page.locator(`#${id} .section__inline-item`).nth(0).evaluate((el) => {
+        const cs = getComputedStyle(el);
+        return { size: cs.fontSize, weight: cs.fontWeight };
+      });
+
+    for (const width of [1280, 375]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator('.section__inline-items')).toHaveCount(5, { timeout: 10000 });
+
+      // Default separator == explicit var(--color-muted): #475 changed no default.
+      const def = await sepColor('pp-sec-default');
+      const explicit = await sepColor('pp-sec-explicit');
+      expect(def).toBe(explicit);
+
+      // The override slot genuinely repaints the middot lime, and differs from muted.
+      expect(await sepColor('pp-sec-override')).toBe('rgb(132, 204, 22)');
+      expect(await sepColor('pp-sec-override')).not.toBe(def);
+
+      // Inverted routing: the separator follows the light sibling text (both resolve
+      // through the band's remapped --color-muted → --color-bg), and it is NOT the
+      // dark default muted the light bands paint.
+      const invSep = await sepColor('pp-sec-inverted');
+      expect(invSep).toBe(await itemColor('pp-sec-inverted'));
+      expect(invSep).not.toBe(def);
+
+      // Brand strip: the items inherit the #470 body type slots (15px / 600) and the
+      // separator is lime — the full original symptom, expressible with zero new
+      // typography slots.
+      const brand = await itemType('pp-sec-brand');
+      expect(brand.size).toBe('15px');
+      expect(brand.weight).toBe('600');
+      expect(await sepColor('pp-sec-brand')).toBe('rgb(132, 204, 22)');
+    }
+  });
+
+  // #475: the row is a flex-wrap row — its responsive behavior is wrapping to
+  // additional centered rows at narrow widths, with no mobile-specific rule. Prove
+  // the SAME markup lays out on one line at 1280 and wraps to more than one line at
+  // 375 (distinct top offsets = distinct flex lines).
+  test('#475 body_items row wraps at narrow width, single row at desktop', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Section Inline Items Wrap');
+    setComposition(pageId, [
+      {
+        component: 'section',
+        props: {
+          id: 'pp-sec-wrap',
+          body: '<p>Body.</p>',
+          body_items: [
+            'No credit card required',
+            'Cancel anytime',
+            'Thirty day guarantee',
+            'Priority support included',
+            'Unlimited seats',
+            'Ships worldwide',
+          ],
+        },
+      },
+    ]);
+
+    const lineCount = () =>
+      page.locator('#pp-sec-wrap .section__inline-item').evaluateAll((els) => {
+        const tops = new Set(els.map((el) => Math.round(el.getBoundingClientRect().top)));
+        return tops.size;
+      });
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+    await expect(page.locator('#pp-sec-wrap .section__inline-item')).toHaveCount(6, { timeout: 10000 });
+    expect(await lineCount()).toBe(1); // all six on one line at desktop
+
+    await page.setViewportSize({ width: 375, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+    await expect(page.locator('#pp-sec-wrap .section__inline-item')).toHaveCount(6, { timeout: 10000 });
+    expect(await lineCount()).toBeGreaterThan(1); // wraps to multiple centered rows at mobile
+  });
+
   // #357: grid card content alignment is authorable via the `align`-typed
   // --grid-item-text-align slot. Default `left` is byte-identical to today; `center`
   // and `right` must actually MOVE the glyphs, not merely set a declaration. The

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -328,8 +328,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('hero/section/grid/cta schemas declare 147 style slots (subset of the total)', () => {
-        expect(allSlots.length).toBe(147);
+    test('hero/section/grid/cta schemas declare 148 style slots (subset of the total)', () => {
+        expect(allSlots.length).toBe(148);
     });
 
     allSlots.forEach(({ component, slotName }) => {
@@ -682,6 +682,63 @@ describe('CSS lint: grid steps numeral color routes through --grid-step-text-col
         };
         expect(scan('.grid--steps .pp-step-number { color: var(--color-bg); }').length).toBe(1);
         expect(scan('.grid--steps .pp-step-number { color: var(--grid-step-text-color, var(--color-bg)); }').length).toBe(0);
+    });
+});
+
+describe('CSS lint: inline-items separator color routes through --section-separator-color (#475)', () => {
+    // The body_items middot separator is a `li + li::before` pseudo-element whose
+    // color MUST route through the --section-separator-color slot at every
+    // declaration site (the base rule + the bg-image overlay re-route), so a future
+    // bare `color: var(--color-muted)` cannot silently re-kill the slot. The base
+    // default is --color-muted; the overlay default is --color-bg (that band does
+    // not remap --color-muted). Both are valid slot-routed fallbacks.
+    const stripped = stripComments(COMPONENTS_CSS);
+    const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+
+    // Every innermost rule whose selector targets the separator pseudo-element.
+    function separatorRules() {
+        const out = [];
+        let m;
+        while ((m = ruleRe.exec(stripped)) !== null) {
+            const sel = m[1].replace(/\s+/g, ' ').trim();
+            if (/\.section__inline-items li \+ li::before$/.test(sel)) out.push({ sel, body: m[2] });
+        }
+        return out;
+    }
+
+    test('finds the separator rule(s) — base + overlay', () => {
+        // Base rule + the .section--has-bg-image overlay re-route = at least two.
+        expect(separatorRules().length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('every separator `color` declaration routes through var(--section-separator-color …)', () => {
+        const offenders = [];
+        separatorRules().forEach(({ sel, body }) => {
+            (body.match(/(?<![-a-z])color\s*:[^;}]+/gi) || []).forEach((d) => {
+                if (!/color\s*:\s*var\(\s*--section-separator-color\b/.test(d.trim())) {
+                    offenders.push(`${sel} { ${d.trim()} }`);
+                }
+            });
+        });
+        expect(offenders).toEqual([]);
+    });
+
+    // Detection proof: a bare separator color must be CAUGHT and a slot-routed one
+    // must PASS, so a parser regression can't make the scan vacuous.
+    test('detector flags a bare separator color but passes a slot-routed one', () => {
+        const scan = (fixture) => {
+            const rr = /([^{}]+)\{([^{}]*)\}/g;
+            let mm; const out = [];
+            while ((mm = rr.exec(fixture)) !== null) {
+                if (!/\.section__inline-items li \+ li::before\s*$/.test(mm[1].replace(/\s+/g, ' ').trim())) continue;
+                (mm[2].match(/(?<![-a-z])color\s*:[^;}]+/gi) || []).forEach((d) => {
+                    if (!/color\s*:\s*var\(\s*--section-separator-color\b/.test(d.trim())) out.push(d);
+                });
+            }
+            return out;
+        };
+        expect(scan('.section__inline-items li + li::before { color: var(--color-muted); }').length).toBe(1);
+        expect(scan('.section__inline-items li + li::before { color: var(--section-separator-color, var(--color-muted)); }').length).toBe(0);
     });
 });
 


### PR DESCRIPTION
Closes #475

## Scope
Adds a `section.body_items` capability: a centered row of short plain-text items rendered below the body with a CSS-generated, slot-colorable middot separator between them (the "trust strip" pattern). Implements the binding recorded design (orchestrator, 2026-07-22) verbatim.

Against each acceptance criterion:
- **Surface**: new `section` prop `body_items` — array of plain strings, rendered as `<ul class="section__inline-items" role="list">` in a single centered flex row, only when non-empty, after the body when both are set. No new component. Rendered in every layout's body scope.
- **Bounds (#147 discipline)**: cap 8 items, each ≤80 chars; non-string / non-array / over-count / over-length rejected at write time with `invalid_prop_value`. Enforced by a generic, schema-driven bounded-string-array check (`item_type`/`max_items`/`item_max_length`) in the shared `pp_validate_composition` engine — no second validator. Does not ripple to `panel_items` (no `item_type`).
- **Separator**: CSS-generated `li + li::before` middot via `content: "\00b7" / ""` (screen-reader-quiet; `role="list"` keeps semantics). Glyph fixed (middot).
- **Slot**: `--section-separator-color` (color, default `var(--color-muted)`). On the inverted band the existing `--color-muted` → `--color-bg` remap carries it (subheading idiom, no extra rule); on the bg-image overlay a rule routes the default through the on-overlay text color like sibling text (#461/#463 idiom).
- **#470 interplay**: items read `--section-body-size`/`--section-body-weight`, so the brand strip (15px/600 + lime dot) needs zero new typography slots.
- **Escaping/byte-identity**: `esc_html` on each item; byte-identical when unset.

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml` — 2258 tests green (3 warnings, 2 deprecations = unmodified-tree baseline).
- `npm test` (vitest) — 808 tests green.
- `bash scripts/package.sh` — version consistency OK across the five synced files (1.6.2); built zip deleted (CI builds release zips).
- New tests: `SchemaValidationTest` (bounds accept/reject, non-string/non-array reject, unset sentinels, no-ripple to `panel_items`, unknown-prop-still-strict); `SectionInlineItemsTest` (render only-when-set + byte-identical unset, `esc_html`, `<li>` count, ordering after body, cross-layout, CSS pins); `style-render.spec.ts` @smoke at 375+1280 (computed separator color: muted default / slot override / inverted routing; wrap at narrow width; brand strip 15px/600 + lime); css-lint separator-routing pin (both declaration sites) + slot-count 147→148.

## Accepted limitations
- All-empty-strings `body_items` (e.g. `['','']`) validates but renders nothing (render-time `array_filter` drops empties). Kept consistent with the sibling `panel_items` precedent, which already filters empty/shapeless entries at render without rejecting; rejecting empties would add a guard the recorded decision did not specify. Cosmetic edge, disclosed rather than tightened.
- Glyph is a fixed middot (design defers a bounded enum to a later issue if a real build needs it).

## 7A questions
None. The one adversarial-review finding (all-empty array) was resolved as a precedent-consistent no-change per Section 7A (rejecting empties would extend the recorded decision), not escalated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)