### PR TITLE
v1.6.3 fix: capture site-option snapshot presence separately from value (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
-## [v1.6.2] — 2026-07-22 — a colorable "trust strip" row for sections (#475)
+## [v1.6.3] — 2026-07-22 — rollback restores a never-set site option by deleting it (#291)
+
+**When a multi-step AI edit fails partway and rolls back, site options that had no value before the run are now restored to having no value, instead of being left as an empty string. An option that genuinely held an empty string before the run stays an empty string. The batch snapshot records whether each option existed, not just what it held, so a rollback puts the site back exactly as it was.**
+
+Before this, the rollback snapshot stored only an option's value, so "this option was never set" and "this option was set to an empty string" both looked identical at restore time — a single captured `''`. Today every whitelisted option reads back as `''` when unset and normalizes booleans, so the collapse was harmless in practice, but it was a latent fidelity gap: the moment a site-option surface arrives where an existing-but-empty row means something different from an absent row, a rollback would silently restore the wrong one. The snapshot now captures presence and value as a per-key `{exists, value}` pair. On rollback an absent baseline deletes the option's row, an explicit empty-string baseline writes `''`, and any other value is written back as-is. Capture stays scoped to the option whitelist (an unrelated core option is never read into the snapshot), the restore never re-runs current write-time validation on a trusted pre-run baseline (the #281/#233 rule), and the newest option types added since #281 — the social row, the Open Graph / Twitter defaults, the attachment-ID options — all flow through this one generic path. A pre-#291 value-only snapshot, should one ever be replayed, degrades to the previous behavior rather than erroring.
+
+### Fixed
+- Site-option batch rollback now distinguishes an absent baseline (restored by deleting the option) from an explicit empty-string baseline (restored as `''`), where both previously collapsed to the same empty restore (#291).
+
+### Tests
+- PHPUnit `ActionsTest`: snapshot captures `{exists:false}` for an absent whitelisted option, `{exists:true, value:''}` for an explicit empty row, and the stored value otherwise; a non-whitelisted key is recorded absent-shaped without reading (or string-casting) its value; restore deletes an absent baseline, writes `''` for an explicit-empty baseline, writes a value baseline verbatim, leaves non-whitelisted keys untouched, degrades a legacy value-only snapshot to the #281 rule, and an end-to-end batch rolls an absent `pp_footer_social` back to deleted.
+
 
 **A slim post-hero band of short items with a colored dot between them ("No credit card · Cancel anytime · 30-day guarantee") used to be inexpressible: the only route was separator characters typed into body text, and those cannot be recolored because inline `style` spans are (correctly) stripped by the sanitizer. Sections gain a `body_items` prop — a row of short plain-text items rendered as a single centered row below the body, with a CSS-generated middot separator between each. The separator is a real presentational element, so it takes a color from the new `--section-separator-color` style slot and stays silent to screen readers. The items inherit the section body type, so the same `--section-body-size`/`--section-body-weight` slots that set the body's size and weight also set the strip's, and the original brand band (15px/600 text with a lime dot) is now fully expressible with no parent-theme edits.**
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.6.2-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.6.3-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.6.2');
+define('PP_VERSION', '1.6.3');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -724,8 +724,36 @@ function _pp_snapshot_batch_targets(array $steps): array {
         if ($name === 'update_site_option' && isset($params['key'])) {
             $key = (string) $params['key'];
             if (!array_key_exists($key, $site_options)) {
-                $current = pp_site_option($key);
-                $site_options[$key] = is_wp_error($current) ? '' : $current;
+                // Capture PRESENCE and VALUE separately (#291): an option that was
+                // absent (no DB row) and one that held an explicit '' both used to
+                // collapse to the same captured '' (pp_site_option => (string)
+                // get_option($key, '')), so a rollback could not tell "delete the row"
+                // from "write ''". The per-key ['exists' => bool, 'value' => string]
+                // shape keeps them distinct for _pp_restore_batch_snapshot().
+                //
+                // Capture stays WHITELIST-SCOPED, exactly as pp_site_option() gated it:
+                // only OUR options are ever read into the snapshot. A non-whitelisted
+                // key can still appear here (the snapshotter records every
+                // update_site_option step's key up front, before execute rejects an
+                // unauthorized one), so it is recorded as absent-shaped — never read.
+                // This preserves the read boundary (we never pull an unrelated core
+                // option, e.g. a secret, into the bundle) and avoids (string)-casting
+                // a non-scalar core option like active_plugins (an array). Every
+                // whitelisted option stores a scalar string, so (string) is safe here.
+                if (isset(pp_allowed_site_options()[$key])) {
+                    // Object sentinel: get_option() returns it verbatim only when the
+                    // row is absent, so identity inequality is a reliable presence test
+                    // (no real stored value can equal a fresh object).
+                    $absent = new \stdClass();
+                    $raw    = get_option($key, $absent);
+                    $exists = $raw !== $absent;
+                    $site_options[$key] = [
+                        'exists' => $exists,
+                        'value'  => $exists ? (string) $raw : '',
+                    ];
+                } else {
+                    $site_options[$key] = ['exists' => false, 'value' => ''];
+                }
             }
         }
 
@@ -985,34 +1013,49 @@ function _pp_restore_batch_snapshot(array $snapshot): array {
         pp_update_seo_meta($post_id, $state['seo_meta']);
     }
 
-    foreach ($snapshot['site_options'] as $key => $value) {
+    foreach ($snapshot['site_options'] as $key => $baseline) {
         // Only whitelisted options are ours to touch. The batch snapshotter records
         // every update_site_option step's key up front (before execute rejects an
-        // unauthorized one), so a non-whitelisted key can appear here captured as ''
-        // (pp_site_option returns WP_Error for it). Restoring raw would delete_option()
-        // an unrelated core WP option — pp_update_site_option used to block that via its
-        // whitelist check, so the guard has to stay. Only VALUE validation is bypassed.
+        // unauthorized one), so a non-whitelisted key can appear here — recorded as
+        // absent-shaped. Restoring it would delete_option() an unrelated core WP option,
+        // so the whitelist guard stays and runs BEFORE shape normalization. Only VALUE
+        // validation is bypassed.
         if (!isset(pp_allowed_site_options()[$key])) {
             continue;
         }
+        // Normalize the captured baseline to (exists, value). Two shapes:
+        //   - current (#291): ['exists' => bool, 'value' => string], capturing
+        //     presence separately from value.
+        //   - legacy value-only string: pre-#291 snapshots stored just the value,
+        //     collapsing absent and explicit-'' to ''. The snapshot bundle is
+        //     request-scoped (built at the top of pp_ai_execute_batch, consumed in the
+        //     same request, never persisted), so a legacy-shape bundle cannot actually
+        //     reach here across a version boundary — this branch is defensive, and it
+        //     degrades to the #281 rule (empty => delete, else => write raw) rather
+        //     than erroring.
+        if (is_array($baseline)) {
+            $exists = array_key_exists('exists', $baseline) && $baseline['exists'] === true;
+            $value  = (string) ($baseline['value'] ?? '');
+        } else {
+            $value  = (string) $baseline;
+            $exists = $value !== '';
+        }
         // Restore the captured baseline faithfully, bypassing pp_update_site_option's
         // create-time validator. That validator can reject a legitimate captured
-        // baseline and silently drop the write (issue 281): an unset/empty baseline is
-        // captured as '' (pp_site_option => (string) get_option($key, '')), and ''
-        // fails the attachment_id/bool rules; likewise a once-valid value a newer rule
-        // now rejects (e.g. a pp_logo_id whose attachment was later deleted) would fail
-        // re-validation. Either case would leave the applied value in place instead of
+        // baseline and silently drop the write (issue 281): a '' fails the
+        // attachment_id/bool rules, and a once-valid value a newer rule now rejects
+        // (e.g. a pp_logo_id whose attachment was later deleted) would fail
+        // re-validation — either would leave the applied value in place instead of
         // rolling back. This is the same class as restore_composition (issue 233):
         // a restore is never blocked by current validation rules. A captured baseline
-        // is trusted pre-run state (its keys are already whitelisted — only
-        // update_site_option steps populate this map), so it restores verbatim without
-        // re-validation: an empty capture means "was unset/empty" and is restored by
-        // deleting the option (observably identical to '' via pp_site_option); every
-        // other value is written raw.
-        if ((string) $value === '') {
+        // is trusted pre-run state (its keys are already whitelisted), so it restores
+        // verbatim: an ABSENT baseline is restored by deleting the row, an EXPLICIT ''
+        // baseline is written as '' (distinct outcomes, #291), and every other value
+        // is written raw.
+        if (!$exists) {
             delete_option($key);
         } else {
-            update_option($key, (string) $value);
+            update_option($key, $value);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.6.2
+Stable tag: 1.6.3
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.6.2
+Version:          1.6.3
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -4027,6 +4027,230 @@ class ActionsTest extends TestCase
         );
     }
 
+    // ── issue 291: snapshot captures PRESENCE separately from VALUE ─────────────
+    // Pre-#291 the batch snapshot stored only the value, so an ABSENT option (no DB
+    // row) and one holding an explicit '' both collapsed to the same captured '' and
+    // a rollback could not tell "delete the row" from "restore ''". The per-key
+    // ['exists' => bool, 'value' => string] shape keeps them distinct.
+
+    public function testSnapshotCapturesAbsentWhitelistedOptionAsNotExists(): void
+    {
+        // pp_og_image (attachment_id) has no row before the run.
+        $this->assertArrayNotHasKey('pp_og_image', $GLOBALS['_pp_test_store']['options']);
+
+        $snapshot = _pp_snapshot_batch_targets([
+            ['type' => 'action', 'name' => 'update_site_option', 'params' => ['key' => 'pp_og_image']],
+        ]);
+
+        $this->assertSame(
+            ['exists' => false, 'value' => ''],
+            $snapshot['site_options']['pp_og_image'],
+            'an absent whitelisted option must capture exists=false'
+        );
+    }
+
+    public function testSnapshotCapturesExplicitEmptyWhitelistedOptionAsExists(): void
+    {
+        // pp_og_site_name (string) has a row holding an explicit '' before the run.
+        $GLOBALS['_pp_test_store']['options']['pp_og_site_name'] = '';
+
+        $snapshot = _pp_snapshot_batch_targets([
+            ['type' => 'action', 'name' => 'update_site_option', 'params' => ['key' => 'pp_og_site_name']],
+        ]);
+
+        $this->assertSame(
+            ['exists' => true, 'value' => ''],
+            $snapshot['site_options']['pp_og_site_name'],
+            'an explicit empty-string row must capture exists=true so it is not deleted on rollback'
+        );
+    }
+
+    public function testSnapshotCapturesWhitelistedValue(): void
+    {
+        $GLOBALS['_pp_test_store']['options']['pp_twitter_card'] = 'summary';
+
+        $snapshot = _pp_snapshot_batch_targets([
+            ['type' => 'action', 'name' => 'update_site_option', 'params' => ['key' => 'pp_twitter_card']],
+        ]);
+
+        $this->assertSame(
+            ['exists' => true, 'value' => 'summary'],
+            $snapshot['site_options']['pp_twitter_card']
+        );
+    }
+
+    public function testSnapshotDoesNotReadNonWhitelistedOptionValue(): void
+    {
+        // active_plugins is a real WP option stored as an ARRAY. The snapshotter
+        // records every update_site_option step's key up front (before execute rejects
+        // an unauthorized one), but capture stays whitelist-scoped: a non-whitelisted
+        // key is recorded absent-shaped WITHOUT reading (and (string)-casting) its
+        // value. This preserves the read boundary and avoids an "Array to string
+        // conversion" on a non-scalar core option.
+        $GLOBALS['_pp_test_store']['options']['active_plugins'] = ['akismet/akismet.php'];
+
+        $snapshot = _pp_snapshot_batch_targets([
+            ['type' => 'action', 'name' => 'update_site_option', 'params' => ['key' => 'active_plugins']],
+        ]);
+
+        $this->assertSame(
+            ['exists' => false, 'value' => ''],
+            $snapshot['site_options']['active_plugins'],
+            'a non-whitelisted key must be recorded absent-shaped, never read'
+        );
+        // The core option itself is untouched by capture.
+        $this->assertSame(['akismet/akismet.php'], $GLOBALS['_pp_test_store']['options']['active_plugins']);
+    }
+
+    public function testRestoreDeletesAbsentBaselineDistinctFromExplicitEmpty(): void
+    {
+        // An ABSENT baseline (exists=false) restores by DELETING the row, even though
+        // the value field is '' — the presence bit, not the value, decides.
+        $GLOBALS['_pp_test_store']['options']['pp_twitter_card'] = 'summary_large_image'; // stray applied value
+
+        $snapshot = [
+            'created_posts'   => [],
+            'posts'           => [],
+            'site_options'    => ['pp_twitter_card' => ['exists' => false, 'value' => '']],
+            'custom_css'      => null,
+            'token_overrides' => null,
+            'font_urls'       => null,
+            'menus'           => null,
+        ];
+
+        $errors = _pp_restore_batch_snapshot($snapshot);
+
+        $this->assertSame([], $errors);
+        $this->assertArrayNotHasKey(
+            'pp_twitter_card',
+            $GLOBALS['_pp_test_store']['options'],
+            'an absent baseline must be restored by deleting the row'
+        );
+    }
+
+    public function testRestoreWritesExplicitEmptyBaselineDistinctFromAbsent(): void
+    {
+        // An EXPLICIT '' baseline (exists=true, value='') restores by WRITING '' — the
+        // row must survive as an empty string, NOT be deleted. This is the exact case
+        // #291 exists to separate from the absent case above.
+        $GLOBALS['_pp_test_store']['options']['pp_og_site_name'] = 'Applied Co'; // stray applied value
+
+        $snapshot = [
+            'created_posts'   => [],
+            'posts'           => [],
+            'site_options'    => ['pp_og_site_name' => ['exists' => true, 'value' => '']],
+            'custom_css'      => null,
+            'token_overrides' => null,
+            'font_urls'       => null,
+            'menus'           => null,
+        ];
+
+        $errors = _pp_restore_batch_snapshot($snapshot);
+
+        $this->assertSame([], $errors);
+        $this->assertArrayHasKey(
+            'pp_og_site_name',
+            $GLOBALS['_pp_test_store']['options'],
+            'an explicit empty baseline must keep the row (write \'\'), not delete it'
+        );
+        $this->assertSame('', $GLOBALS['_pp_test_store']['options']['pp_og_site_name']);
+    }
+
+    public function testRestoreWritesValueBaselineNewShape(): void
+    {
+        // A present, non-empty baseline (attachment-ID option) restores verbatim.
+        $GLOBALS['_pp_test_store']['options']['pp_og_image'] = '99'; // stray applied value
+
+        $snapshot = [
+            'created_posts'   => [],
+            'posts'           => [],
+            'site_options'    => ['pp_og_image' => ['exists' => true, 'value' => '77']],
+            'custom_css'      => null,
+            'token_overrides' => null,
+            'font_urls'       => null,
+            'menus'           => null,
+        ];
+
+        $errors = _pp_restore_batch_snapshot($snapshot);
+
+        $this->assertSame([], $errors);
+        $this->assertSame('77', $GLOBALS['_pp_test_store']['options']['pp_og_image']);
+    }
+
+    public function testRestoreLeavesNonWhitelistedNewShapeUntouched(): void
+    {
+        // The whitelist guard runs BEFORE shape normalization, so even a new-shape
+        // baseline for a non-whitelisted key never mutates an unrelated core option.
+        $GLOBALS['_pp_test_store']['options']['active_plugins'] = 'a:1:{i:0;s:5:"x/x.php";}';
+
+        $snapshot = [
+            'created_posts'   => [],
+            'posts'           => [],
+            'site_options'    => ['active_plugins' => ['exists' => false, 'value' => '']],
+            'custom_css'      => null,
+            'token_overrides' => null,
+            'font_urls'       => null,
+            'menus'           => null,
+        ];
+
+        $errors = _pp_restore_batch_snapshot($snapshot);
+
+        $this->assertSame([], $errors);
+        $this->assertSame('a:1:{i:0;s:5:"x/x.php";}', $GLOBALS['_pp_test_store']['options']['active_plugins']);
+    }
+
+    public function testRestoreDegradesLegacyValueOnlyShape(): void
+    {
+        // Defensive back-compat: a pre-#291 value-only string baseline degrades to the
+        // #281 rule (empty => delete, non-empty => write raw). The snapshot bundle is
+        // request-scoped and never persisted, so this cannot occur in practice, but the
+        // restore path must not error on the old shape.
+        $GLOBALS['_pp_test_store']['options']['pp_twitter_card']  = 'summary';       // will be deleted (legacy '')
+        $GLOBALS['_pp_test_store']['options']['pp_og_default_description'] = 'stray'; // will be overwritten
+
+        $snapshot = [
+            'created_posts'   => [],
+            'posts'           => [],
+            'site_options'    => [
+                'pp_twitter_card'           => '',              // legacy empty => delete
+                'pp_og_default_description' => 'Prior summary', // legacy value  => write raw
+            ],
+            'custom_css'      => null,
+            'token_overrides' => null,
+            'font_urls'       => null,
+            'menus'           => null,
+        ];
+
+        $errors = _pp_restore_batch_snapshot($snapshot);
+
+        $this->assertSame([], $errors);
+        $this->assertArrayNotHasKey('pp_twitter_card', $GLOBALS['_pp_test_store']['options']);
+        $this->assertSame('Prior summary', $GLOBALS['_pp_test_store']['options']['pp_og_default_description']);
+    }
+
+    public function testBatchRestoresAbsentSocialOptionOnLaterFailure(): void
+    {
+        // End-to-end (#382 + #291): pp_footer_social (the structured 'social' list
+        // option) is absent before the run. On rollback the absent baseline deletes the
+        // row — proving the new option types added since #281 flow through the generic
+        // presence-aware snapshot/restore automatically.
+        $this->assertArrayNotHasKey('pp_footer_social', $GLOBALS['_pp_test_store']['options']);
+
+        $social = json_encode([['network' => 'github', 'url' => 'https://github.com/acme']]);
+        $batch = pp_ai_execute_batch([
+            ['type' => 'action', 'name' => 'update_site_option', 'params' => ['key' => 'pp_footer_social', 'value' => $social]],
+            ['type' => 'action', 'name' => 'unknown_action', 'params' => []],
+        ]);
+
+        $this->assertFalse($batch['ok']);
+        $this->assertTrue($batch['rolled_back']);
+        $this->assertArrayNotHasKey(
+            'pp_footer_social',
+            $GLOBALS['_pp_test_store']['options'],
+            'an absent social-option baseline must be restored by deleting the row'
+        );
+    }
+
     public function testBatchRollsBackCustomCssOnLaterFailure(): void
     {
         $GLOBALS['_pp_test_store']['custom_css'] = '.hero { color: red; }';


### PR DESCRIPTION
Closes #291

## Scope

Site-option batch snapshots now capture **presence and value** separately, so a rollback can distinguish an option that was absent (no DB row) from one that held an explicit empty string.

- `_pp_snapshot_batch_targets` (lib/actions.php): captures a per-key `['exists' => bool, 'value' => string]` pair using an object sentinel with `get_option()` for presence detection. Capture stays **whitelist-scoped** — a non-whitelisted recorded key is stored absent-shaped and never read, preserving the existing read boundary and avoiding a `(string)` cast of a non-scalar core option (e.g. `active_plugins`).
- `_pp_restore_batch_snapshot`: whitelist guard runs first, then shape normalization. An **absent** baseline is restored by `delete_option`, an **explicit `''`** baseline by `update_option('')`, and any other value verbatim. Restore still bypasses current write-time validation on a trusted pre-run baseline (#281/#233 rule). A legacy value-only snapshot degrades to the #281 delete-on-empty behavior rather than erroring.

### Acceptance criteria (all met)
- Tests distinguish absent baseline (→ `delete_option`) from explicit `''` baseline (→ `update_option('')`).
- #281 behavior stays covered (typed round-trips, reject-on-current-rules restored verbatim, unset attachment_id/bool → unset — these run end-to-end through the real snapshotter, now on the new shape).
- Non-whitelisted options are never restored/mutated (regression from #281 green) and are never *read* at capture time.
- Restore bypasses current value validation only for whitelisted captured baselines.
- Newest option types (social, twitter_card, og attachment-ID) flow through the generic path automatically; a legacy string option is covered.

## Recorded decision applied

Per the issue body: capture `{exists, value}` per key; restore absent→delete, explicit-empty→`''`, preserve the #281 no-revalidation rule, stay whitelist-constrained, degrade old-format snapshots. No 7A question was raised — no finding extended the recorded decision.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` → **2268 passed** (8607 assertions; +10 new tests). Warnings/deprecations unchanged from a clean tree (3/2).
- `npm test` (vitest) → **808 passed**.
- `bash scripts/package.sh` → version consistency OK across the five synced files (1.6.3); emitted zip deleted.

## Reviews

- `/plan-eng-review` — clean; 2 findings folded as hardening within the recorded decision. Codex outside voice raised the read-boundary/`(string)`-cast risk, which was folded (capture stays whitelist-scoped).
- `/review` — clean, zero findings. Codex adversarial (inlined diff) flagged sentinel filter-spoofing; refuted with evidence (no `pre_option_`/`default_option_` filters or `add_filter` on any whitelisted key; same `get_option` chain the old capture used).

## Accepted limitations

The legacy value-only snapshot compat is defensive only: the snapshot bundle is request-scoped (built at the top of `pp_ai_execute_batch`, consumed in the same request, never persisted or returned), so a pre-#291 snapshot cannot actually be replayed across a version boundary.

## Not for this PR

Never tag/release/deploy (CI builds the zip from tags). This is the first issue of the v1.7.0 gate; the gate-close minor bump and rollup happen separately.
