### PR TITLE
v1.6.4 fix: image-URL prop allowlist is schema-driven (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.6.4] — 2026-07-22 — media-URL validation allowlist is schema-driven, not hardcoded (#154)
+
+**The media-library check that stops the AI from pointing an image prop at a missing or non-image attachment (#124/#153) used to key off a hardcoded `['image_url','background_image']` array in `lib/actions.php`, kept in sync with the component schemas by hand. It now derives that prop set from the schemas themselves: each image-URL prop declares `"format": "image_url"`, and the validator walks the registered component schemas to build its list. A future component that adds a new image prop is media-validated the moment its schema declares the format, with no second allowlist to forget.**
+
+Coverage is unchanged today — the eight image-URL props across seven components (hero/section `image_url`, cta/stats/section `background_image`, and the nested `items[].image_url` on logos/grid/testimonials) are exactly what the old hardcoded pair covered, so nothing an author can do behaves differently. What changes is that the two lists can no longer silently drift apart. `_pp_schema_image_url_props()` stays purely schema-derived so a drift-catcher test can pin it; the consumer, `_pp_extract_urls_from_params()`, then merges the historical `['image_url','background_image']` pair back in as a fail-closed floor. That floor is a safety net, not a maintained allowlist: new props still flow from the schema walk, but the media gate can never fall below its pre-#154 coverage if the component registry is ever transiently empty (a broken `components/` directory, or a static cache poisoned by a wrong `get_template_directory()`) — which would otherwise make `_pp_validate_media_urls_in_params()` fail open through its `empty($urls) → true` early-out, the opposite of the fail-closed rule established in #153.
+
+### Fixed
+- The image-URL prop allowlist in `_pp_extract_urls_from_params()` is now derived from each component schema's `"format": "image_url"` annotation instead of a hardcoded array in a second file, so a new image-bearing prop cannot silently ship without the #124/#153 media-existence and image-type checks (#154).
+- The media gate is now fail-closed against an empty component registry: `['image_url','background_image']` is retained as an un-droppable floor so coverage never regresses below the pre-#154 baseline even if schema derivation yields nothing (#154, #153 precedent).
+
+### Tests
+- PHPUnit `ActionsTest`: the derived prop set is pinned to `['background_image','image_url']` (drift-catcher on any new format-annotated name); every canonical-named or image-described or `*_image`-suffixed schema prop must declare `format: image_url` (forgotten-annotation catcher, non-vacuous ≥8-prop guard); no `format: image_url` prop nests deeper than one `items[]` level (depth guard for the walker); and all eight existing image props still extract (parity).
+- PHPUnit `MediaUrlSchemaDrivenTest`: authors through the real `pp_execute_action('update_component')` surface with a synthetic component declaring a novel `poster_url` image prop — a non-image URL is rejected purely because the schema annotation put it in the derived set (no edit to the extractor), a real image passes, and the fail-closed floor still extracts the canonical props when the registry is empty.
+
 ## [v1.6.3] — 2026-07-22 — rollback restores a never-set site option by deleting it (#291)
 
 **When a multi-step AI edit fails partway and rolls back, site options that had no value before the run are now restored to having no value, instead of being left as an empty string. An option that genuinely held an empty string before the run stays an empty string. The batch snapshot records whether each option existed, not just what it held, so a rollback puts the site back exactly as it was.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.6.3-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.6.4-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/components/cta/schema.json
+++ b/components/cta/schema.json
@@ -60,6 +60,7 @@
       "type": "string",
       "required": false,
       "default": "",
+      "format": "image_url",
       "description": "Optional background image URL. When set, renders as a CSS background-image with a dark overlay. Text automatically uses light colors for contrast."
     },
     "button_variant": {

--- a/components/grid/schema.json
+++ b/components/grid/schema.json
@@ -85,7 +85,7 @@
         "text":      { "type": "string", "required": false, "description": "Card body / supporting text. Inline HTML allowed: a, strong, em, br." },
         "text_role": { "type": "enum", "values": ["mono", "meta", "label", "kicker"], "required": false, "description": "Optional typography role for the card text: 'mono' (code), 'meta' (captions), 'label', or 'kicker' (eyebrow). Adds a .text-<role> class. Invalid/absent → default body text. Set via update_component. 'meta'/'kicker' also set a preset text color; an explicit --grid-item-text-color style slot overrides that preset color at ALL breakpoints (the explicit slot always wins), while the role's size/weight/letter-spacing/transform still apply." },
         "bullets":   { "type": "array", "required": false, "description": "Optional checklist lines rendered below text, each prefixed with a check mark. Plain text only — no HTML/markdown; each line is escaped independently. Use for scannable feature/benefit lists instead of cramming items into one text sentence.", "items": { "type": "string" } },
-        "image_url": { "type": "string", "required": false },
+        "image_url": { "type": "string", "required": false, "format": "image_url" },
         "image_alt": { "type": "string", "required": false, "default": "", "description": "Alt text for the card image. Leave empty only if the image is purely decorative." },
         "link_url":  { "type": "string", "required": false },
         "link_text": { "type": "string", "required": false, "default": "Read more" },

--- a/components/hero/schema.json
+++ b/components/hero/schema.json
@@ -80,6 +80,7 @@
       "type": "string",
       "required": false,
       "default": "",
+      "format": "image_url",
       "description": "Image URL. Rendered as an inline image in the 'split' layout, or as a CSS background-image in the 'cover' layout."
     },
     "image_alt": {

--- a/components/logos/schema.json
+++ b/components/logos/schema.json
@@ -26,7 +26,7 @@
       "required": true,
       "description": "Array of image items. Each: { image_url: string, image_alt: string, image_id?: number, label?: string }. Omit label for pure logo display; include label for icon+category tiles.",
       "items": {
-        "image_url": { "type": "string", "required": true,  "description": "Image or icon URL." },
+        "image_url": { "type": "string", "required": true,  "format": "image_url", "description": "Image or icon URL." },
         "image_alt": { "type": "string", "required": true,  "description": "Alt text. Use the logo or category name; empty string only for decorative images." },
         "image_id":  { "type": "number", "required": false, "default": 0, "description": "Media Library attachment ID (NOT a URL). When it resolves to a real attachment, the image renders responsively with srcset/sizes via wp_get_attachment_image() instead of a single fixed-size <img>. Falls back to image_url when unset or unresolvable. Get an attachment id via the import_media apply." },
         "label":     { "type": "string", "required": false, "description": "Text label below the image. Omit for logo-only rows." }

--- a/components/section/schema.json
+++ b/components/section/schema.json
@@ -48,6 +48,7 @@
       "type": "string",
       "required": false,
       "default": "",
+      "format": "image_url",
       "description": "Image URL. Required for image-left and image-right layouts; ignored in text-only."
     },
     "image_alt": {
@@ -80,6 +81,7 @@
       "type": "string",
       "required": false,
       "default": "",
+      "format": "image_url",
       "description": "Optional background image URL. When set, renders as a CSS background-image with a dark overlay for text readability. Combines with any theme. Text automatically uses light colors for contrast."
     },
     "panel_heading": {

--- a/components/stats/schema.json
+++ b/components/stats/schema.json
@@ -31,6 +31,7 @@
       "type": "string",
       "required": false,
       "default": "",
+      "format": "image_url",
       "description": "Optional background image URL. When set, renders as a CSS background-image with a dark overlay for text readability."
     },
     "items": {

--- a/components/testimonials/schema.json
+++ b/components/testimonials/schema.json
@@ -62,7 +62,7 @@
         "author":    { "type": "string", "required": false, "description": "Name of the person quoted. Plain text — HTML is escaped." },
         "role":      { "type": "string", "required": false, "description": "The author's job title, e.g. 'CEO'." },
         "company":   { "type": "string", "required": false, "description": "The author's company or organization." },
-        "image_url": { "type": "string", "required": false, "description": "Optional avatar image URL." },
+        "image_url": { "type": "string", "required": false, "format": "image_url", "description": "Optional avatar image URL." },
         "image_alt": { "type": "string", "required": false, "default": "", "description": "Alt text for the avatar. Use the author's name; empty string only if image is purely decorative." }
       }
     }

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.6.3');
+define('PP_VERSION', '1.6.4');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -479,13 +479,94 @@ function _pp_collect_logo_ids_from_props(array $props, array &$logo_ids): void {
 }
 
 /**
+ * The set of prop names, across every registered component schema, that hold a
+ * media-library image URL — i.e. carry `"format": "image_url"` in their schema
+ * definition. Derived from the schemas (#154) instead of a hand-maintained
+ * `['image_url','background_image']` array, so a new image-bearing prop is
+ * media-validated the moment its schema declares the format — no second
+ * allowlist in this file to drift out of sync with the component schema.json files.
+ *
+ * Both top-level props and one level of nested `items[]` item-props are scanned;
+ * the returned set is applied at both depths by _pp_collect_urls_from_props(),
+ * preserving the historical uniform traversal (the old hardcoded list was also
+ * applied identically at the flat and item levels). The registry it walks is
+ * statically cached (pp_get_registered_components()), so this stays cheap even
+ * though it recomputes per validation call.
+ *
+ * NOTE ON DEPTH: image props today live at top-level or exactly one `items[]`
+ * level; no schema nests them deeper, and the params walker below mirrors that
+ * single-level shape. A structural test pins this invariant, so a future schema
+ * that nests an image prop deeper fails loudly rather than silently bypassing
+ * validation — the same "no silent coverage gap" guarantee #154 adds on the
+ * prop-name axis, extended to the nesting-depth axis.
+ *
+ * @return string[] Unique, sorted image-URL prop names.
+ */
+function _pp_schema_image_url_props(): array {
+    $names = [];
+    foreach (pp_get_registered_components() as $schema) {
+        if (!is_array($schema) || !isset($schema['props']) || !is_array($schema['props'])) {
+            continue;
+        }
+        foreach ($schema['props'] as $prop_name => $prop_def) {
+            if (_pp_prop_def_is_image_url($prop_def)) {
+                $names[$prop_name] = true;
+            }
+            // Nested array-of-object item props live under props.<prop>.items,
+            // a map of item-prop-name => item-prop-def (logos/grid/testimonials).
+            if (is_array($prop_def) && isset($prop_def['items']) && is_array($prop_def['items'])) {
+                foreach ($prop_def['items'] as $item_prop_name => $item_prop_def) {
+                    if (_pp_prop_def_is_image_url($item_prop_def)) {
+                        $names[$item_prop_name] = true;
+                    }
+                }
+            }
+        }
+    }
+    $names = array_keys($names);
+    sort($names);
+    return $names;
+}
+
+/**
+ * True when a schema prop definition declares `"format": "image_url"` — i.e. its
+ * value is a media-library image URL subject to the #124/#153 existence +
+ * image-type checks.
+ *
+ * @param mixed $prop_def
+ */
+function _pp_prop_def_is_image_url($prop_def): bool {
+    return is_array($prop_def)
+        && isset($prop_def['format'])
+        && $prop_def['format'] === 'image_url';
+}
+
+/**
  * Extracts all URL-like string values from action params.
  * Walks props, composition arrays, and items arrays.
  */
 function _pp_extract_urls_from_params(array $params): array {
     $urls = [];
-    // logo_id is an attachment ID, not a URL — excluded from URL extraction.
-    $url_props = ['image_url', 'background_image'];
+    // Schema-driven (#154): the image-URL prop set comes from every registered
+    // component's `format: image_url` declarations, not a hand-maintained array.
+    // logo_id is an attachment ID (no image_url format), so it stays excluded.
+    //
+    // FAIL-CLOSED FLOOR (#154, orchestrator decision 2026-07-22): the media gate
+    // (#124/#153) must never depend on registry availability. If
+    // pp_get_registered_components() is transiently empty (missing components/,
+    // or a static cache poisoned by a wrong get_template_directory()),
+    // _pp_schema_image_url_props() would return [] and _pp_validate_media_urls_in_params()
+    // would fail OPEN via its `empty($urls) → true` early-out — the opposite of the
+    // maintainer's standing fail-closed rule (#153 precedent). The two historically
+    // covered prop names are merged as an un-droppable MINIMUM so coverage can never
+    // regress below the pre-#154 baseline. This floor is a safety net, NOT a
+    // maintained allowlist: new image props still flow from the schema walk, and
+    // _pp_schema_image_url_props() itself stays purely schema-derived so the
+    // drift-catcher baseline pin stays honest.
+    $url_props = array_values(array_unique(array_merge(
+        ['image_url', 'background_image'],
+        _pp_schema_image_url_props()
+    )));
 
     // Direct props (flat)
     if (isset($params['props']) && is_array($params['props'])) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.6.3
+Stable tag: 1.6.4
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.6.3
+Version:          1.6.4
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -2005,6 +2005,165 @@ class ActionsTest extends TestCase
         $this->assertArrayNotHasKey('image_url', $comp[0]['props']);
     }
 
+    // ── #154: schema-driven image-URL prop allowlist ──────────────────────
+
+    /**
+     * The media-validated prop set is derived from the schemas, not a hardcoded
+     * array. Pins current coverage: adding a `format: image_url` prop with a NEW
+     * NAME to any schema changes this set and trips the assertion, forcing a
+     * conscious review that the new prop really should be media-validated —
+     * instead of a hand-maintained list in lib/actions.php silently drifting.
+     */
+    public function testSchemaImageUrlPropsDerivedFromSchemas(): void
+    {
+        $this->assertSame(
+            ['background_image', 'image_url'],
+            _pp_schema_image_url_props(),
+            'Derived image-URL prop set drifted. If you added a new format:image_url '
+            . 'prop NAME, update this baseline and confirm it must be media-validated.'
+        );
+    }
+
+    /**
+     * Drift-catcher (#154), forgotten-annotation axis. A prop that IS an image URL
+     * but forgets `"format": "image_url"` would silently bypass media validation.
+     * Two nets:
+     *   (a) convention pin — every prop literally named `image_url` or
+     *       `background_image`, at top level or in an items[] item schema, MUST
+     *       carry the format (a new component reusing the canonical name can't
+     *       forget it);
+     *   (b) description net — any string prop whose description reads as a media
+     *       image URL (and isn't an *_id / *_alt / link prop) MUST carry it too,
+     *       catching a differently-NAMED future image prop (avatar_url, poster_url…);
+     *   (c) *_image suffix net — a string prop whose NAME ends in `_image` is
+     *       unambiguously an image (unlike `_url`, which is shared with link
+     *       props like button_url/link_url), so it MUST carry the format too.
+     *
+     * Residual limitation (disclosed, not a regression): a novel image prop named
+     * with an ambiguous `_url` suffix AND a non-image-sounding description (e.g.
+     * "poster_url" described only as "The hero poster.") is caught by none of the
+     * three nets. It is still media-validated the moment its schema declares
+     * format:image_url — and it was equally unvalidated before #154 — so this is a
+     * limit of syntactic drift detection, not a coverage regression.
+     */
+    public function testEveryImageShapedSchemaPropDeclaresImageUrlFormat(): void
+    {
+        $canonicalNames = ['image_url', 'background_image'];
+        // A description clearly denoting a media image URL.
+        $imageDescRe = '/\bimage url\b|\bavatar image\b|\bbackground image url\b|\bphoto url\b/i';
+        // Unambiguous image-name suffix (NOT `_url`, which link props also use).
+        $imageNameRe = '/_image$/';
+        // Props that are URLs but NOT media images, or not URLs at all.
+        $excludeNameRe = '/(_id|_alt|link_url|button_url|cta\d?_url|panel_cta_url)$/';
+
+        $checked = 0;
+        foreach (pp_get_registered_components() as $component => $schema) {
+            if (!isset($schema['props']) || !is_array($schema['props'])) {
+                continue;
+            }
+            // Flatten to (name, def) pairs across top level + one items[] level.
+            $pairs = [];
+            foreach ($schema['props'] as $name => $def) {
+                $pairs[] = [$name, $def, ''];
+                if (is_array($def) && isset($def['items']) && is_array($def['items'])) {
+                    foreach ($def['items'] as $iname => $idef) {
+                        $pairs[] = [$iname, $idef, "{$name}[]."];
+                    }
+                }
+            }
+            foreach ($pairs as [$name, $def, $path]) {
+                if (!is_array($def)) {
+                    continue;
+                }
+                $hasFormat = _pp_prop_def_is_image_url($def);
+                $isString  = ($def['type'] ?? null) === 'string';
+                $desc      = (string) ($def['description'] ?? '');
+                $where     = "{$component}.{$path}{$name}";
+
+                // (a) convention pin
+                if (in_array($name, $canonicalNames, true)) {
+                    $this->assertTrue($hasFormat, "{$where} is a canonical image prop but is missing \"format\": \"image_url\".");
+                    $checked++;
+                    continue;
+                }
+                // (b) description net + (c) *_image suffix net
+                if ($isString && !preg_match($excludeNameRe, $name)
+                    && (preg_match($imageDescRe, $desc) || preg_match($imageNameRe, $name))) {
+                    $this->assertTrue($hasFormat, "{$where} reads as a media image URL (name \"{$name}\", desc \"{$desc}\") but is missing \"format\": \"image_url\".");
+                    $checked++;
+                }
+            }
+        }
+        // Guard the guard: if the enumeration ever finds nothing, the test would
+        // pass vacuously. We know there are 8 image-URL props today.
+        $this->assertGreaterThanOrEqual(8, $checked, 'Image-prop enumeration found too few props — the drift-catcher is not actually running.');
+    }
+
+    /**
+     * Depth guard (#154). The params walker handles image props at top level or
+     * exactly one items[] level. Pin that no schema nests a format:image_url prop
+     * deeper, so a future second-level nesting fails here loudly rather than
+     * silently bypassing validation (the walker would never reach it).
+     */
+    public function testImageUrlPropsNestNoDeeperThanOneItemsLevel(): void
+    {
+        // $itemsLevels = number of items[] array descents to reach $node.
+        // A format:image_url prop at 0 (top-level) or 1 (one items[] level) is
+        // what the params walker handles; 2+ would be silently missed.
+        $findDeep = function ($node, int $itemsLevels, string $path) use (&$findDeep): array {
+            $hits = [];
+            if (!is_array($node)) {
+                return $hits;
+            }
+            if (_pp_prop_def_is_image_url($node) && $itemsLevels > 1) {
+                $hits[] = $path;
+            }
+            if (isset($node['items']) && is_array($node['items'])) {
+                foreach ($node['items'] as $iname => $idef) {
+                    $hits = array_merge($hits, $findDeep($idef, $itemsLevels + 1, "{$path}/items/{$iname}"));
+                }
+            }
+            return $hits;
+        };
+
+        foreach (pp_get_registered_components() as $component => $schema) {
+            if (!isset($schema['props']) || !is_array($schema['props'])) {
+                continue;
+            }
+            foreach ($schema['props'] as $name => $def) {
+                $deep = $findDeep($def, 0, "{$component}/{$name}");
+                $this->assertSame([], $deep, 'Image prop nested deeper than one items[] level: ' . implode(', ', $deep) . '. Update _pp_collect_urls_from_props() to walk that depth.');
+            }
+        }
+    }
+
+    /**
+     * Parity (#154): every image-URL prop across every component — flat and
+     * nested — is still extracted after the switch from the hardcoded list.
+     */
+    public function testExtractUrlsCoversAllExistingImagePropsAcrossComponents(): void
+    {
+        $params = [
+            'composition' => [
+                ['component' => 'hero',         'props' => ['image_url' => 'https://x/hero.jpg']],
+                ['component' => 'cta',          'props' => ['background_image' => 'https://x/cta.jpg']],
+                ['component' => 'stats',        'props' => ['background_image' => 'https://x/stats.jpg']],
+                ['component' => 'section',      'props' => ['image_url' => 'https://x/sec.jpg', 'background_image' => 'https://x/sec-bg.jpg']],
+                ['component' => 'logos',        'props' => ['items' => [['image_url' => 'https://x/logo.jpg']]]],
+                ['component' => 'grid',         'props' => ['items' => [['image_url' => 'https://x/grid.jpg']]]],
+                ['component' => 'testimonials', 'props' => ['items' => [['image_url' => 'https://x/avatar.jpg']]]],
+            ],
+        ];
+        $urls = _pp_extract_urls_from_params($params);
+        sort($urls);
+        $expected = [
+            'https://x/avatar.jpg', 'https://x/cta.jpg', 'https://x/grid.jpg',
+            'https://x/hero.jpg', 'https://x/logo.jpg', 'https://x/sec-bg.jpg',
+            'https://x/sec.jpg', 'https://x/stats.jpg',
+        ];
+        $this->assertSame($expected, $urls);
+    }
+
     public function testPreviewRejectsInvalidMediaUrlIdenticallyToExecute(): void
     {
         // Regression for issue 130: a proposal preview must not show a clean

--- a/tests/MediaUrlSchemaDrivenTest.php
+++ b/tests/MediaUrlSchemaDrivenTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * tests/MediaUrlSchemaDrivenTest.php — #154 authoring-path proof.
+ *
+ * Section 14.1 (authoring-path mandate): exercises the schema-driven image-URL
+ * allowlist through the REAL validation surface (pp_execute_action), not raw
+ * _pp_composition meta writes.
+ *
+ * The proof: register a synthetic component whose schema declares a NEW image
+ * prop NAME the old hardcoded ['image_url','background_image'] list never
+ * contained (`poster_url`, with "format":"image_url"). Author a component write
+ * carrying that prop pointing at a non-image attachment. It must be rejected by
+ * the media gate — which is only possible if _pp_extract_urls_from_params()
+ * picked `poster_url` up purely from the schema annotation, with NO edit to
+ * lib/actions.php. That is exactly the regression #154 makes impossible.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class MediaUrlSchemaDrivenTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['_pp_test_store'] = [
+            'post_meta'          => [],
+            'posts'              => [],
+            'options'            => ['siteurl' => 'https://example.com'],
+            'next_id'            => 100,
+            'attachment_urls'    => [],
+            'attachment_is_image' => [],
+        ];
+
+        $this->tempDir = sys_get_temp_dir() . '/pp-media-schema-' . uniqid();
+        mkdir($this->tempDir . '/components', 0755, true);
+
+        // Mirror the real components so a normal hero page is composable here.
+        $realComponents = dirname(__DIR__) . '/components';
+        foreach (scandir($realComponents) as $name) {
+            if ($name === '.' || $name === '..') {
+                continue;
+            }
+            $src = $realComponents . '/' . $name;
+            if (!is_dir($src)) {
+                continue;
+            }
+            $dst = $this->tempDir . '/components/' . $name;
+            mkdir($dst, 0755, true);
+            foreach (["$name.php", 'schema.json'] as $file) {
+                if (file_exists("$src/$file")) {
+                    copy("$src/$file", "$dst/$file");
+                }
+            }
+        }
+
+        // Synthetic component with a NEW image prop name the old list never had.
+        $mt = $this->tempDir . '/components/mediatest';
+        mkdir($mt, 0755, true);
+        file_put_contents($mt . '/mediatest.php', "<?php // test-only stub renderer\n");
+        file_put_contents($mt . '/schema.json', json_encode([
+            'component'   => 'mediatest',
+            'description' => 'Test-only component with a novel image prop.',
+            'props'       => [
+                'id'         => ['type' => 'string', 'required' => false, 'default' => ''],
+                'poster_url' => ['type' => 'string', 'required' => false, 'format' => 'image_url', 'description' => 'A poster image URL.'],
+            ],
+        ], JSON_PRETTY_PRINT));
+
+        $GLOBALS['_pp_test_template_dir'] = $this->tempDir;
+        $GLOBALS['_pp_registered_components_invalidate'] = true;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        unset($GLOBALS['_pp_test_template_dir']);
+        $GLOBALS['_pp_registered_components_invalidate'] = true;
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Sanity: the schema annotation alone puts the novel prop in the derived set.
+     */
+    public function testNovelImagePropEntersDerivedSetFromSchemaAlone(): void
+    {
+        $this->assertContains('poster_url', _pp_schema_image_url_props(),
+            'poster_url should be media-validated purely because its schema declares format:image_url.');
+    }
+
+    /**
+     * The authoring-path proof (Section 14.1). A component write through
+     * pp_execute_action() carrying the novel poster_url prop, pointing at a
+     * non-image attachment, is rejected by the media gate — proving the
+     * schema-driven extraction covers a prop the old hardcoded list never named.
+     */
+    public function testAuthoringWithNovelImagePropRejectsNonImageViaRealSurface(): void
+    {
+        $id = pp_create_page('Schema-driven media test', 'draft');
+        pp_update_composition($id, [
+            ['component' => 'hero', 'props' => ['title' => 'Original']],
+        ]);
+
+        // A real uploads attachment that is NOT an image.
+        $GLOBALS['_pp_test_store']['attachment_urls'][77] = 'https://example.com/wp-content/uploads/doc.pdf';
+        $GLOBALS['_pp_test_store']['attachment_is_image'][77] = false;
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 0,
+            'props'           => ['poster_url' => 'https://example.com/wp-content/uploads/doc.pdf'],
+        ]);
+
+        $this->assertFalse($result['ok'], 'A novel schema-declared image prop must be media-validated.');
+        $this->assertStringContainsString('does not point to an image', $result['error']);
+
+        // Nothing was written.
+        $comp = pp_get_composition($id);
+        $this->assertArrayNotHasKey('poster_url', $comp[0]['props']);
+    }
+
+    /**
+     * Control: the same novel prop pointing at a real IMAGE attachment passes the
+     * media gate — the rejection above is the image-type check, not a blanket ban.
+     */
+    public function testAuthoringWithNovelImagePropAcceptsRealImageViaRealSurface(): void
+    {
+        $id = pp_create_page('Schema-driven media test ok', 'draft');
+        pp_update_composition($id, [
+            ['component' => 'hero', 'props' => ['title' => 'Original']],
+        ]);
+
+        $GLOBALS['_pp_test_store']['attachment_urls'][78] = 'https://example.com/wp-content/uploads/pic.jpg';
+        $GLOBALS['_pp_test_store']['attachment_is_image'][78] = true;
+
+        $error = _pp_validate_media_urls_in_params([
+            'props' => ['poster_url' => 'https://example.com/wp-content/uploads/pic.jpg'],
+        ]);
+        $this->assertTrue($error, 'A novel schema-declared image prop pointing at a real image must pass the media gate.');
+    }
+
+    /**
+     * Fail-closed floor (#154, orchestrator decision 2026-07-22). If the component
+     * registry is transiently empty (broken/missing components/), the schema walk
+     * yields nothing — but the media gate must NOT fall open. The two historically
+     * covered prop names are still extracted so coverage can never regress below
+     * the pre-#154 baseline. Also proves _pp_schema_image_url_props() itself stays
+     * purely schema-derived (returns [] here), keeping the drift-catcher pin honest.
+     */
+    public function testFailClosedFloorHoldsWhenRegistryIsEmpty(): void
+    {
+        $emptyDir = sys_get_temp_dir() . '/pp-empty-registry-' . uniqid();
+        mkdir($emptyDir, 0755, true); // no components/ subdir → empty registry
+        $GLOBALS['_pp_test_template_dir'] = $emptyDir;
+        $GLOBALS['_pp_registered_components_invalidate'] = true;
+
+        // Purely schema-derived helper sees no components.
+        $this->assertSame([], _pp_schema_image_url_props());
+
+        // The consumer's floor still extracts the canonical props — gate stays closed.
+        $urls = _pp_extract_urls_from_params([
+            'props' => ['image_url' => 'https://x/a.jpg', 'background_image' => 'https://x/b.jpg'],
+        ]);
+        sort($urls);
+        $this->assertSame(['https://x/a.jpg', 'https://x/b.jpg'], $urls);
+
+        rmdir($emptyDir);
+    }
+}


### PR DESCRIPTION
Closes #154

## Summary

The media-library validation gate (#124/#153) that stops the AI from pointing an image prop at a missing or non-image attachment used to key off a hardcoded `['image_url','background_image']` array in `lib/actions.php`, kept in sync with the component schemas by hand. This makes the covered prop set **schema-driven**: each image-URL prop declares `"format": "image_url"` and the validator walks the registered component schemas to build its list.

## Scope (against #154 acceptance)

- **Annotation:** added `"format": "image_url"` to all 8 image-URL props across 7 schemas — top-level `hero.image_url`, `section.image_url`, `cta.background_image`, `stats.background_image`, `section.background_image`, and nested `items[].image_url` on `logos`, `grid`, `testimonials`.
- **Derivation:** new `_pp_schema_image_url_props()` walks `pp_get_registered_components()` for `format:image_url` (top level + one `items[]` level); `_pp_extract_urls_from_params()` consumes it instead of the hardcoded array.
- **Coverage audit (disclosed):** the hardcoded pair covered exactly these 8 props today, so there is **no coverage gap today** — this is behavior parity, not a widening. `image_id`/`logo_id`/`pp_footer_logo_id` are attachment IDs (validated on the #155 logo-id path); `link_url`/`button_url`/`cta_url`/`panel_cta_url` are hrefs, not media.
- **Fail-closed floor:** `_pp_schema_image_url_props()` stays purely schema-derived so the drift-catcher pin stays honest; the consumer merges `['image_url','background_image']` back as an un-droppable minimum, so the media gate never falls below its pre-#154 coverage if the registry is transiently empty (which would otherwise fail OPEN via `_pp_validate_media_urls_in_params()`'s `empty($urls) → true` early-out).

## 7A decision (asked + answered)

An adversarial review flagged that deriving the prop set from the registry couples the media security gate to registry availability (a theoretical fail-open in an already-broken state). Because this is security-relevant and the recorded decision's literal wording said "instead of the hardcoded array," it was surfaced as a decision. **Answered Option B** (orchestrator, recorded on #154): schema-derived + fail-closed floor. The "instead of hardcoded" wording targeted drift, not defense-in-depth removal.

## Validation

- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` — **2276 passing** (+8 new), 3 warnings / 2 deprecations (identical to the clean tree, none introduced).
- JS: `npm test` — **808 passing**.
- `bash scripts/package.sh` validates the five-file version sync (1.6.4); built zip deleted (CI builds release zips from tags).

New tests: derived-set baseline pin + forgotten-annotation drift-catcher (canonical-name + description + `*_image`-suffix nets, non-vacuous ≥8-prop guard); `items[]`-depth guard; full 8-prop extraction parity; **Section 14.1 authoring-path proof** through the real `pp_execute_action('update_component')` surface with a novel `poster_url` image prop; and a fail-closed-floor test for the empty-registry case.

## Accepted limitations

- A hypothetical future image prop named with an ambiguous `_url` suffix AND a non-image-sounding description would not be caught by the syntactic drift-catcher (it is still validated the moment its schema adds `format:image_url`, and was equally unvalidated before #154). Disclosed in the test docblock.
- `lib/ai-context.php:429` has a second hardcoded `['image_url','background_image']` copy used for **display** (component-summary basename), not validation — left untouched (out of the recorded decision's named functions; reusing the sorted derived set there would flip precedence when both props are set). Noted as a DRY follow-up candidate.

## Notes

- Reviews: /plan-eng-review + /review (incl. an independent adversarial subagent) ran this session on this exact diff.
- Section 14.2/14.3/14.4 do not apply (validation-layer change, nothing user-visible, no new CSS mechanism).
- Do NOT squash — bisectable commits (feature+tests, then version+changelog).
