### PR TITLE
v1.6.5 fix: reject unsaved auto-draft targets on page actions; redirect GC'd editor URLs (#160)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -533,6 +533,8 @@ These are the keys every action returns, not the complete set for every action. 
 | `assign_menu_location` | site | menu_id (req), location (req) | Replace. `location` must be a registered theme location (`primary`, `footer`, `footer_secondary`) |
 | `set_menu` | site | name (req), items (req), location | **Declarative replace** — mirrors `update_composition`. Creates the menu by name if it doesn't exist; clears and replaces ALL its items with the given ordered list (each `{page_id}` or `{url, label}`); optionally assigns a location, all in one call |
 
+**Auto-draft status gate (#160).** `publish_page`, `trash_page`, `update_page_slug`, and `update_seo_meta` reject a target whose `post_status` is still `auto-draft` (WordPress's hidden, self-GC'd "Add New Page" placeholder, which `pp_composition_pages()` already omits from the inventory) with `error_code: auto_draft` — save the page first. `update_composition` and `update_page_title` are exempt: they are the first-save path that promotes an auto-draft to a real `draft` (#121). `restore_page` is unaffected (trash-gated).
+
 ### WP-CLI
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.6.5] — 2026-07-22 — page lifecycle actions reject unsaved auto-draft targets; stale editor URLs redirect instead of dead-ending (#160)
+
+**A page that was started with "Add New Page" but never saved is a hidden `auto-draft` — it is not in the AI's page inventory and WordPress deletes it on its own after about a week. Until now, an action that knew (or guessed) that page's post ID could still publish it, trash it, or set its slug/SEO on it, materializing a phantom page the tools said didn't exist. Publishing, trashing, and slug/SEO edits now reject an `auto-draft` target with a clear error telling the caller to save the page first. Separately, a bookmarked composition-editor URL for a page that WordPress has since garbage-collected now redirects to the Pages list instead of hitting a hard "Page not found." dead end.**
+
+The status gate lands on exactly the four page actions that assume a real, materialized page and must not create one on the fly: `publish_page`, `trash_page`, `update_page_slug`, and `update_seo_meta`. Each rejects an `auto-draft` target up front with the standard `auto_draft`-coded error envelope, before any write. The two actions that legitimately operate on a brand-new page's own auto-draft — `update_composition` and `update_page_title`, the first-save path that promotes an auto-draft to a real draft — are deliberately untouched, so "Add New Page" and its first save keep working exactly as before. `restore_page` is likewise unchanged: it still restores trashed pages, and `trash` was never gated. One accepted consequence of the gate: a slug or SEO write no longer incidentally promotes an auto-draft to a draft (an undocumented, untested side effect that only ever fired if a client wrote metadata before the page had a title or content) — save the page first, then set its slug or SEO. For the stale-URL case, the redirect runs before the editor page renders, so a garbage-collected bookmark lands somewhere useful rather than dead-ending. Auto-draft cleanup itself depends on WP-Cron firing; the README now documents that so a `DISABLE_WP_CRON` or very-low-traffic install knows abandoned auto-drafts can accumulate (harmless, hidden housekeeping, mirroring WordPress core's own new-post flow).
+
+### Fixed
+- `publish_page`, `trash_page`, `update_page_slug`, and `update_seo_meta` now reject a target whose `post_status` is `auto-draft` with a clear `auto_draft` error, instead of acting on a page the AI's inventory doesn't list (#160). `update_composition` and `update_page_title` (the #121 promote-on-write first-save path) and `restore_page` (trash-gated) are unaffected.
+- A composition-editor URL for a garbage-collected or missing page now redirects to the Pages list before the page renders, instead of a hard `wp_die('Page not found.')` dead end (#160).
+
+### Docs
+- README setup notes now document that abandoned `auto-draft` cleanup relies on WP-Cron, so `DISABLE_WP_CRON` or very-low-traffic installs may accumulate hidden auto-drafts (#160).
+
+### Tests
+- PHPUnit `ActionsTest`: authoring through the real `pp_execute_action()` surface, each of the four gated actions rejects an `auto-draft` target with `ok:false` and `error_code: auto_draft`; the same actions still succeed on `draft` and `publish` targets; `update_composition` and `update_page_title` still promote an auto-draft on save (existing pins hold); `restore_page` still restores a trashed page; and `_pp_reject_auto_draft()` is defensive against a `0` id.
+- PHPUnit `AdminTest`: `pp_composition_missing_post_redirect_url()` returns the Pages-list URL for a missing/GC'd post and for a non-page post, and `null` for a real page and for an absent post id.
+
 ## [v1.6.4] — 2026-07-22 — media-URL validation allowlist is schema-driven, not hardcoded (#154)
 
 **The media-library check that stops the AI from pointing an image prop at a missing or non-image attachment (#124/#153) used to key off a hardcoded `['image_url','background_image']` array in `lib/actions.php`, kept in sync with the component schemas by hand. It now derives that prop set from the schemas themselves: each image-URL prop declares `"format": "image_url"`, and the validator walks the registered component schemas to build its list. A future component that adds a new image prop is media-validated the moment its schema declares the format, with no second allowlist to forget.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.6.4-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.6.5-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -335,6 +335,8 @@ AI_RULES.md                Hard coding invariants
 3. Upload the ZIP file and activate PromptingPress
 
 On activation, PromptingPress creates a Home page with the Composition template and assigns it as the static front page.
+
+> ℹ️ **WP-Cron dependency:** "Add New Page" creates a hidden `auto-draft` placeholder that WordPress cleans up (`wp_delete_auto_drafts()`) roughly 7 days later — but only when WP-Cron actually fires, which is driven by site traffic. On an install with `DISABLE_WP_CRON` set, or very low traffic (plausible for an internal admin tool), abandoned auto-drafts can accumulate silently. They stay hidden from the Pages list, so this is harmless housekeeping, not data risk. If it matters for your install, hit `wp-cron.php` from a real system cron. This mirrors WordPress core's own new-post flow.
 
 <details>
 <summary><strong>Developer install (clone the repo)</strong></summary>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.6.4');
+define('PP_VERSION', '1.6.5');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -1616,7 +1616,7 @@ pp_register_action('update_page_slug', [
     // Page metadata: needs only that the page EXISTS, not a populated composition (#358).
     'requires_composition' => false,
     'description' => 'Updates a page slug (post_name) / permalink (#134). WordPress de-duplicates the slug internally on collision (suffixing -2, -3, ...) — the result reports the actual slug that was set, which may differ from the one requested.',
-    'semantics'   => 'Replace. Slug is sanitized via sanitize_title() and, on a naming collision with another post, de-duplicated by WordPress core — never silently. The resulting slug is always reported in changes.',
+    'semantics'   => 'Replace. Slug is sanitized via sanitize_title() and, on a naming collision with another post, de-duplicated by WordPress core — never silently. The resulting slug is always reported in changes. Rejects an unsaved auto-draft target (auto_draft): save the page first.',
     'params'      => [
         'post_id' => ['type' => 'int',    'required' => true],
         'slug'    => ['type' => 'string', 'required' => true],
@@ -1625,6 +1625,10 @@ pp_register_action('update_page_slug', [
         $exists = _pp_validate_page_exists($params['post_id']);
         if (is_wp_error($exists)) {
             return $exists;
+        }
+        $not_auto_draft = _pp_reject_auto_draft($params['post_id']);
+        if (is_wp_error($not_auto_draft)) {
+            return $not_auto_draft;
         }
         if (sanitize_title($params['slug']) === '') {
             return new WP_Error('invalid_slug', 'Slug must not be empty after sanitization.');
@@ -1658,7 +1662,7 @@ pp_register_action('update_seo_meta', [
     // Page metadata: needs only that the page EXISTS, not a populated composition (#358).
     'requires_composition' => false,
     'description' => 'Sets page-specific SEO metadata: meta_description, seo_title (overrides the rendered <title> tag), canonical_url, and the per-page social-title overrides og_title and twitter_title (#468). og_title overrides the Open Graph title for this page (falls back to seo_title, then the post title); twitter_title overrides the Twitter-card title (falls back to the og_title chain). Both are optional and capped at 200 chars like seo_title. There is no per-page og_description (the page meta_description already fills og:description, falling back to the site-wide pp_og_default_description) or per-page og_image (set the site-wide pp_og_image via update_site_option). The first-class, safe-surface alternative to hand-patching theme PHP for per-page metadata (#41).',
-    'semantics'   => 'Patch. meta is shallow-merged into existing SEO metadata; unspecified keys are left unchanged. Set a key to "" to clear it. Accepted keys: meta_description, seo_title, canonical_url, og_title, twitter_title.',
+    'semantics'   => 'Patch. meta is shallow-merged into existing SEO metadata; unspecified keys are left unchanged. Set a key to "" to clear it. Accepted keys: meta_description, seo_title, canonical_url, og_title, twitter_title. Rejects an unsaved auto-draft target (auto_draft): save the page first.',
     'params'      => [
         'post_id' => ['type' => 'int',   'required' => true],
         'meta'    => ['type' => 'array', 'required' => true],
@@ -1667,6 +1671,10 @@ pp_register_action('update_seo_meta', [
         $exists = _pp_validate_page_exists($params['post_id']);
         if (is_wp_error($exists)) {
             return $exists;
+        }
+        $not_auto_draft = _pp_reject_auto_draft($params['post_id']);
+        if (is_wp_error($not_auto_draft)) {
+            return $not_auto_draft;
         }
         return _pp_validate_seo_meta($params['meta']);
     },
@@ -1859,7 +1867,7 @@ pp_register_action('publish_page', [
     // Page lifecycle: acts on post_status, needs only that the page EXISTS (#358).
     'requires_composition' => false,
     'description' => 'Publishes a page (sets post_status to publish).',
-    'semantics'   => 'Sets post_status to "publish". Idempotent on already-published pages.',
+    'semantics'   => 'Sets post_status to "publish". Idempotent on already-published pages. Rejects an unsaved auto-draft target (auto_draft): save the page first.',
     'params'      => [
         'post_id' => ['type' => 'int', 'required' => true],
     ],
@@ -1867,6 +1875,10 @@ pp_register_action('publish_page', [
         $exists = _pp_validate_page_exists($params['post_id']);
         if (is_wp_error($exists)) {
             return $exists;
+        }
+        $not_auto_draft = _pp_reject_auto_draft($params['post_id']);
+        if (is_wp_error($not_auto_draft)) {
+            return $not_auto_draft;
         }
         return true;
     },
@@ -2390,7 +2402,7 @@ pp_register_action('trash_page', [
     // unpopulatable through the operate surface (#358).
     'requires_composition' => false,
     'description' => 'Moves a page to the trash (reversible, does not permanently delete). Works on a page created empty (no composition required).',
-    'semantics'   => 'Moves post_status to "trash". Reversible via restore_page.',
+    'semantics'   => 'Moves post_status to "trash". Reversible via restore_page. Rejects an unsaved auto-draft target (auto_draft): an auto-draft is not a real page (WordPress GCs it on its own).',
     'params'      => [
         'post_id' => ['type' => 'int', 'required' => true],
     ],
@@ -2398,6 +2410,10 @@ pp_register_action('trash_page', [
         $exists = _pp_validate_page_exists($params['post_id']);
         if (is_wp_error($exists)) {
             return $exists;
+        }
+        $not_auto_draft = _pp_reject_auto_draft($params['post_id']);
+        if (is_wp_error($not_auto_draft)) {
+            return $not_auto_draft;
         }
         $post = get_post($params['post_id']);
         if ($post->post_status === 'trash') {
@@ -3048,6 +3064,45 @@ function _pp_validate_page_exists(int $post_id) {
     }
     if ($post->post_type !== 'page') {
         return new WP_Error('not_a_page', sprintf('Post %d is not a page (type: %s).', $post_id, $post->post_type));
+    }
+    return true;
+}
+
+/**
+ * Rejects a target whose post_status is still 'auto-draft' (#160).
+ *
+ * An 'auto-draft' is WordPress's hidden, ~7-day-GC'd placeholder for a page
+ * that has never had a meaningful save — pp_composition_pages() (the AI chat's
+ * "## Pages" inventory) excludes it by design, so it is NOT a "real" page an
+ * action should assume exists. This guard is called by the mutating page
+ * actions that assume a materialized page and must NOT create/promote one:
+ * publish_page, trash_page, update_page_slug, update_seo_meta.
+ *
+ * Deliberately NOT folded into _pp_validate_page_exists(): update_composition
+ * and update_page_title are the #121 promote-on-write path — a brand-new page's
+ * first editor save legitimately targets its own auto-draft and is promoted to
+ * 'draft' by pp_execute_action() after a successful write. Gating them here
+ * would break "Add New Page" (see pp_composition_workspace_page / the AJAX save
+ * handlers in lib/admin.php, and the promote pins in tests/ActionsTest.php).
+ *
+ * Callers run _pp_validate_page_exists() first, so a missing/non-page post is
+ * already rejected before this runs; this guard only distinguishes auto-draft
+ * from a real status. Defensive against a null/0 id: only rejects when an
+ * actual post is found.
+ *
+ * @param int $post_id Post ID to check.
+ * @return true|WP_Error  true if not an auto-draft, WP_Error('auto_draft') otherwise.
+ */
+function _pp_reject_auto_draft(int $post_id) {
+    $post = $post_id ? get_post($post_id) : null;
+    if ($post && $post->post_status === 'auto-draft') {
+        return new WP_Error(
+            'auto_draft',
+            sprintf(
+                'Page %d is an unsaved auto-draft, not a real page yet. Add a title or content to save it first.',
+                $post_id
+            )
+        );
     }
     return true;
 }

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -937,7 +937,7 @@ add_action('wp_ajax_pp_save_composition', function () {
 // ── Admin Page Registration ───────────────────────────────────────────────────
 
 add_action('admin_menu', function () {
-    add_submenu_page(
+    $hook = add_submenu_page(
         null,                          // hidden — no parent menu
         'Edit Composition',
         'Edit Composition',
@@ -945,7 +945,54 @@ add_action('admin_menu', function () {
         'pp-composition',
         'pp_composition_workspace_page'
     );
+    // Redirect a stale/GC'd-post URL BEFORE the page renders (#160). The
+    // load-{hook} action fires in wp-admin/admin.php before admin-header.php
+    // emits any output, so wp_safe_redirect() works here — a redirect from the
+    // render callback below would hit "headers already sent" and silently fail.
+    if ($hook) {
+        add_action('load-' . $hook, 'pp_composition_workspace_load');
+    }
 });
+
+/**
+ * Decides where a composition-editor request should be redirected, if anywhere,
+ * BEFORE the page renders (#160). Pure so it is unit-testable: no output, no
+ * exit, no redirect side effect.
+ *
+ * Returns the Pages-list URL when the requested post is missing (e.g. an
+ * 'auto-draft' hard-deleted by WordPress's ~7-day auto-draft GC — a stale
+ * bookmark) or is not a page, so a bookmarked editor URL lands somewhere useful
+ * instead of a dead end. Returns null when the request should proceed to the
+ * normal render callback (a real page, or no post specified — the callback
+ * reports "No page specified." for the latter).
+ *
+ * @param int $post_id Requested post id (0 when absent).
+ * @return string|null Redirect URL, or null to proceed.
+ */
+function pp_composition_missing_post_redirect_url(int $post_id): ?string {
+    if (!$post_id) {
+        return null; // no post specified — the render callback handles this case
+    }
+    $post = get_post($post_id);
+    if (!$post || $post->post_type !== 'page') {
+        return admin_url('edit.php?post_type=page');
+    }
+    return null;
+}
+
+/**
+ * load-{hook} handler for the composition editor: friendly redirect for a
+ * missing/GC'd post before any output (#160). The thin, untestable glue
+ * (wp_safe_redirect + exit) around the pure decision above.
+ */
+function pp_composition_workspace_load(): void {
+    $post_id  = isset($_GET['post']) ? (int) $_GET['post'] : 0;
+    $redirect = pp_composition_missing_post_redirect_url($post_id);
+    if ($redirect !== null) {
+        wp_safe_redirect($redirect);
+        exit;
+    }
+}
 
 // Add body class for full-width CSS overrides
 add_filter('admin_body_class', function (string $classes): string {
@@ -967,6 +1014,10 @@ function pp_composition_workspace_page(): void {
     $post = get_post($post_id);
 
     if (!$post || $post->post_type !== 'page') {
+        // Unreachable in the normal flow: pp_composition_workspace_load()
+        // (load-{hook}) already redirected a missing/GC'd post to the Pages
+        // list before output (#160). Kept as a defensive net for the case the
+        // load hook never ran; a redirect here would fail (headers already sent).
         wp_die('Page not found.');
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.6.4
+Stable tag: 1.6.5
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.6.4
+Version:          1.6.5
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -1184,6 +1184,99 @@ class ActionsTest extends TestCase
         $this->assertSame('auto-draft', $GLOBALS['_pp_test_store']['posts'][$id]['post_status']);
     }
 
+    // ── #160: page lifecycle actions reject unsaved auto-draft targets ──────
+    // The four actions that assume a real, materialized page reject a target
+    // still in 'auto-draft' with the standard ok:false / error_code:auto_draft
+    // envelope, authored through the real pp_execute_action() surface. The two
+    // promote-on-write actions (update_composition, update_page_title) and
+    // restore_page are deliberately NOT gated — pinned elsewhere in this file.
+
+    public function testPublishPageRejectsAutoDraftTarget(): void
+    {
+        $id = pp_create_page('', 'auto-draft');
+        $result = pp_execute_action('publish_page', ['post_id' => $id]);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('auto_draft', $result['error_code']);
+        // Rejected before execute: still a hidden auto-draft, not published.
+        $this->assertSame('auto-draft', $GLOBALS['_pp_test_store']['posts'][$id]['post_status']);
+    }
+
+    public function testTrashPageRejectsAutoDraftTarget(): void
+    {
+        $id = pp_create_page('', 'auto-draft');
+        $result = pp_execute_action('trash_page', ['post_id' => $id]);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('auto_draft', $result['error_code']);
+        $this->assertSame('auto-draft', $GLOBALS['_pp_test_store']['posts'][$id]['post_status']);
+    }
+
+    public function testUpdatePageSlugRejectsAutoDraftTarget(): void
+    {
+        $id = pp_create_page('', 'auto-draft');
+        $result = pp_execute_action('update_page_slug', ['post_id' => $id, 'slug' => 'product']);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('auto_draft', $result['error_code']);
+        // Accepted side effect (#160): a slug write no longer promotes an auto-draft.
+        $this->assertSame('auto-draft', $GLOBALS['_pp_test_store']['posts'][$id]['post_status']);
+    }
+
+    public function testUpdateSeoMetaRejectsAutoDraftTarget(): void
+    {
+        $id = pp_create_page('', 'auto-draft');
+        $result = pp_execute_action('update_seo_meta', [
+            'post_id' => $id,
+            'meta'    => ['meta_description' => 'Should not apply'],
+        ]);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('auto_draft', $result['error_code']);
+        // Accepted side effect (#160): an SEO write no longer promotes an auto-draft.
+        $this->assertSame('auto-draft', $GLOBALS['_pp_test_store']['posts'][$id]['post_status']);
+    }
+
+    public function testPublishPageAllowsRealStatusTargets(): void
+    {
+        // Normal statuses are unaffected by the auto-draft gate.
+        $draft = pp_create_page('Draft Page', 'draft');
+        $this->assertTrue(pp_execute_action('publish_page', ['post_id' => $draft])['ok']);
+        $this->assertSame('publish', $GLOBALS['_pp_test_store']['posts'][$draft]['post_status']);
+
+        $published = pp_create_page('Published Page', 'publish');
+        $this->assertTrue(pp_execute_action('publish_page', ['post_id' => $published])['ok']);
+    }
+
+    public function testTrashPageAllowsRealStatusTarget(): void
+    {
+        $id = pp_create_page('Draft Page', 'draft');
+        $result = pp_execute_action('trash_page', ['post_id' => $id]);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('trash', $GLOBALS['_pp_test_store']['posts'][$id]['post_status']);
+    }
+
+    public function testAutoDraftGateLeavesPromoteThenPublishLifecycleIntact(): void
+    {
+        // The #121 promote-on-write path is untouched: writing composition to a
+        // brand-new auto-draft still succeeds and promotes it to 'draft', after
+        // which publish_page (now gated) accepts it as a real page.
+        $id = pp_create_page('', 'auto-draft');
+        $write = pp_execute_action('update_composition', [
+            'post_id'     => $id,
+            'composition' => [['component' => 'hero', 'props' => ['title' => 'Hi']]],
+        ]);
+        $this->assertTrue($write['ok']);
+        $this->assertSame('draft', $GLOBALS['_pp_test_store']['posts'][$id]['post_status']);
+
+        $publish = pp_execute_action('publish_page', ['post_id' => $id]);
+        $this->assertTrue($publish['ok']);
+        $this->assertSame('publish', $GLOBALS['_pp_test_store']['posts'][$id]['post_status']);
+    }
+
+    public function testRejectAutoDraftHelperIsDefensiveOnEmptyId(): void
+    {
+        // Callers run _pp_validate_page_exists() first; the guard must not treat
+        // a 0 id as an auto-draft (get_post(0) yields no post).
+        $this->assertTrue(_pp_reject_auto_draft(0));
+    }
+
     public function testPpUpdateSiteOptionRejectsUnwhitelisted(): void
     {
         $result = pp_update_site_option('admin_email', 'test@example.com');

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * tests/AdminTest.php — PHPUnit tests for lib/admin.php helpers.
+ *
+ * Covers the pure, output-free decision helpers behind the composition
+ * workspace admin page (the thin wp_safe_redirect/exit and render glue is not
+ * unit-testable and is exercised via E2E).
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class AdminTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['_pp_test_store'] = [
+            'post_meta' => [],
+            'posts'     => [],
+            'options'   => [],
+            'next_id'   => 100,
+        ];
+    }
+
+    // ── #160: composition-editor redirect for a missing/GC'd post ───────────
+
+    public function testRedirectUrlForMissingOrGcdPost(): void
+    {
+        // A bookmarked URL for a post WordPress has since force-deleted (the
+        // ~7-day auto-draft GC) resolves to no post → redirect to the Pages list.
+        $url = pp_composition_missing_post_redirect_url(4242);
+        $this->assertSame('https://example.com/wp-admin/edit.php?post_type=page', $url);
+    }
+
+    public function testRedirectUrlForNonPagePost(): void
+    {
+        $GLOBALS['_pp_test_store']['posts'][7] = [
+            'post_type'   => 'post',
+            'post_status' => 'publish',
+        ];
+        $url = pp_composition_missing_post_redirect_url(7);
+        $this->assertSame('https://example.com/wp-admin/edit.php?post_type=page', $url);
+    }
+
+    public function testNoRedirectForRealPage(): void
+    {
+        $id = pp_create_page('Real Page', 'draft');
+        $this->assertNull(pp_composition_missing_post_redirect_url($id));
+    }
+
+    public function testNoRedirectForAbsentPostId(): void
+    {
+        // No post specified — the render callback reports "No page specified.";
+        // the load hook must not redirect.
+        $this->assertNull(pp_composition_missing_post_redirect_url(0));
+    }
+}


### PR DESCRIPTION
Closes #160

## Scope

Auto-draft edge cases surfaced by #121's adversarial review. Implements the binding recorded decision (Option B, four-action reject set):

1. **Status gating.** `publish_page`, `trash_page`, `update_page_slug`, and `update_seo_meta` now reject a target whose `post_status` is still `auto-draft` (WordPress's hidden, self-GC'd "Add New Page" placeholder, which `pp_composition_pages()` already omits from the AI inventory). Rejection is the standard `ok:false` envelope with `error_code: auto_draft`, before execute, via a new `_pp_reject_auto_draft()` guard called at the top of those four validate callables (not folded into the shared `_pp_validate_page_exists()`).
2. **GC dead-end UX.** A composition-editor URL for a missing/garbage-collected post now redirects to the Pages list (`edit.php?post_type=page`) instead of `wp_die('Page not found.')`. The redirect runs on the page's `load-{hook}` action (before `admin-header.php` output, where `wp_safe_redirect()` actually works — a redirect from the render callback would hit "headers already sent"), decided by the pure, unit-tested `pp_composition_missing_post_redirect_url()` helper.
3. **Cron caveat.** README setup docs now note that `auto-draft` cleanup relies on WP-Cron, so `DISABLE_WP_CRON` / very-low-traffic installs can accumulate hidden auto-drafts (docs only, no code — mirrors WP core's own new-post flow).

## 7A outcome (recorded-decision reconciliation)

The issue's original decision listed **six** actions to gate, including `update_composition` and `update_page_title`. Those two are the #121 promote-on-write path: a brand-new page's first editor save legitimately targets its own `auto-draft` and is promoted to `draft` by `pp_execute_action()` (pinned by `ActionsTest` promote tests). Gating them would break "Add New Page → first save." This contradiction was escalated and resolved by a binding orchestrator decision to **Option B (four-action set)** — the two promote-path actions stay ungated; `restore_page` stays trash-gated. Rationale for including slug/SEO: the AI surface never creates auto-drafts, so an AI action targeting one is always the phantom-page case.

## Accepted limitation

A slug or SEO write no longer incidentally promotes an `auto-draft` to a `draft` (an undocumented, untested side effect that only fired if a client wrote metadata before the page had a title or content). Save the page first, then set its slug/SEO. Stated in the CHANGELOG.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — **2288 pass** (3 warnings / 2 PHPUnit deprecations, both pre-existing — identical count on the base tree via git-stash comparison). +12 new tests: the four actions reject an auto-draft target through the real `pp_execute_action()` surface with `error_code: auto_draft`; normal `draft`/`publish` targets unaffected; the promote-then-publish lifecycle stays intact; `restore_page` still restores a trashed page; the redirect-decision helper returns the Pages URL for missing/non-page posts and `null` for a real page.
- `npm test` (vitest) — **808 pass**.
- `bash scripts/package.sh` — version consistency OK across the five synced files (1.6.5); built zip deleted (releases are CI-built from tags).

## Reviews (this session)

- `/plan-eng-review` — plan locked; one architecture finding (redirect must run pre-output) folded before coding.
- `/review` + Codex adversarial — CLEAN; all three Codex findings verified as false positives (missing #121 context) and refuted with file:line evidence.

## Not touched

`update_composition`, `update_page_title`, `restore_page`, and the shared `_pp_validate_page_exists()` are unchanged.
