### PR TITLE
v1.6.6 fix: _pp_validate_length() rejects malformed calc()/clamp() and simple-length shapes (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.6.6] — 2026-07-22 — `_pp_validate_length()` rejects malformed calc()/clamp() and simple-length shapes it used to persist as broken CSS (#151)
+
+**The design-token/style-slot length validator accepted several malformed values that the browser silently drops: a unit with no digit (`.em`), a number with multiple dots (`1.2.3rem`), whitespace before the unit (`1.2 rem`), an unbalanced or improperly-nested `calc()` body (`calc(1))`, `calc()1,2()`), and comma misuse inside `calc()` (`calc(1,2,3)`). Each one validated and was written to a custom property, then the browser threw the whole declaration away — a broken style the operator or AI thought they had set. The length grammar now rejects these up front. Every well-formed length still validates unchanged: all units, signed/negative lengths (#467), leading-dot numbers, and nested `clamp()`/`calc()` expressions.**
+
+Per the recorded decision on #151 this buys the cheap, concrete correctness wins (targeted checks, Option C) plus the pure newline fix (Option 4) without building a full CSS `calc()`/`clamp()` grammar parser. The simple-length number body was tightened from the loose `[\d.]+\s*` to a single well-formed number (at least one digit, at most one dot, unit directly attached), preserving the #467 signed-length grammar exactly. The `calc()`/`clamp()` branch gained a proper left-to-right paren-nesting check (which subsumes the count-based balance check the decision named and closes a comma-guard bypass an adversarial review found), a top-level-comma rejection scoped to `calc()` (leaving `clamp()`'s legitimate 3-argument comma form intact), and the `/s` (dotall) modifier on the outer extraction so a legal newline inside the expression extracts instead of failing outright. The injection guards (`{};<>` stripping, the alpha-word-must-be-a-unit check, and the character-class whitelist) are untouched — these were never security holes, only correctness gaps that degraded to dropped CSS. A handful of contrived shapes remain accepted as documented residuals (bare unitless operands like `calc(1)`/`clamp(1,2,3)`, doubled operators `calc(1++2rem)`, two-operand-no-operator `calc(1 1)`); they too only degrade to a dropped declaration, never injection.
+
+### Fixed
+- `_pp_validate_length()` (`lib/apply.php`) now rejects malformed simple lengths (`.em`, `1.2.3rem`, `1.2 rem`), improperly-nested or unbalanced `calc()`/`clamp()` bodies (`calc(1))`, `calc()1,2()`, `calc(1)+(2rem)`), and top-level commas inside `calc()` (`calc(1,2,3)`), instead of persisting them as broken CSS the browser drops (#151).
+- The tightened simple-length number body avoids a quadratic-backtracking (ReDoS) shape a first-cut regex introduced; the shipped form is linear on long inputs (#151, adversarial review finding).
+
+### Docs
+- No AI-facing documentation changed: the accepted length grammar is unchanged (only malformed shapes are now rejected), so `ai-instructions/*` and `lib/ai-context.php` remain accurate (#151).
+
+### Tests
+- Added an accept/reject matrix in `tests/ApplyTest.php` covering every named malformed class, every documented valid shape (all units, signed values, leading-dot, nested clamp/calc), the paren-nesting bypass cases, the newline forms, the documented residuals, a linear-time regression guard, and a Section 14.1 authoring-path test through `update_design_token` with one malformed and one valid value (#151).
+
 ## [v1.6.5] — 2026-07-22 — page lifecycle actions reject unsaved auto-draft targets; stale editor URLs redirect instead of dead-ending (#160)
 
 **A page that was started with "Add New Page" but never saved is a hidden `auto-draft` — it is not in the AI's page inventory and WordPress deletes it on its own after about a week. Until now, an action that knew (or guessed) that page's post ID could still publish it, trash it, or set its slug/SEO on it, materializing a phantom page the tools said didn't exist. Publishing, trashing, and slug/SEO edits now reject an `auto-draft` target with a clear error telling the caller to save the page first. Separately, a bookmarked composition-editor URL for a page that WordPress has since garbage-collected now redirects to the Pages list instead of hitting a hard "Page not found." dead end.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.6.5-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.6.6-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.6.5');
+define('PP_VERSION', '1.6.6');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/apply.php
+++ b/lib/apply.php
@@ -321,6 +321,12 @@ function _pp_check_token_reference_cycle(string $token, string $value) {
  * leading minus for negative lengths (letter-spacing/margins/text-indent go
  * negative), unitless 0, clamp() expressions, and calc() expressions.
  *
+ * The simple-length number body is a single well-formed number: at least one
+ * digit, at most one dot, optional leading minus (#467), and the unit directly
+ * attached (no whitespace). This rejects `.em` (no digit), `1.2.3rem` (multiple
+ * dots), and `1.2 rem` (space before the unit) — malformed shapes the older
+ * loose body accepted and persisted as broken CSS (#151).
+ *
  * clamp/calc use positive-pattern matching: only numeric literals, units,
  * percentage, comma, parentheses, and arithmetic operators are allowed.
  * var() references inside clamp/calc are rejected to prevent injection
@@ -330,30 +336,84 @@ function _pp_check_token_reference_cycle(string $token, string $value) {
  * digit or decimal point) — this is a correctness check, not a security
  * boundary: it rejects structurally nonsensical values like calc(px) or
  * calc((rem) + 1px) that would otherwise validate and persist as broken CSS
- * the browser silently drops (#129).
+ * the browser silently drops (#129). Three more cheap correctness checks
+ * (#151, Option C + Option 4): the extraction allows legal newline whitespace
+ * inside the body (`calc(\n1rem + 2rem)`); an unbalanced-paren body (`calc(1))`)
+ * is rejected; and a top-level comma inside calc() (`calc(1,2,3)`) is rejected
+ * while clamp()'s legitimate 3-argument comma form is left intact.
+ *
+ * Explicitly accepted as residual (documented, won't-fix — each only degrades to
+ * a browser-dropped declaration, never injection, thanks to the {};<> guard plus
+ * the char-class whitelist): bare unitless operands (`calc(1)`, `clamp(1,2,3)`),
+ * doubled operators (`calc(1++2rem)`), and two-operand-no-operator (`calc(1 1)`).
+ * A full CSS calc()/clamp() grammar parser is deliberately not built (#151).
  */
 function _pp_validate_length(string $value): bool {
     // Unitless zero.
     if ($value === '0') {
         return true;
     }
-    // Simple length: optional leading minus, number + unit. Negative lengths are
-    // valid CSS <length> (letter-spacing, margins, text-indent go negative), so the
-    // grammar accepts a single leading '-'; the injection guards and the calc/clamp
-    // positive-pattern below are unchanged. Semantically-inert cases (negative radius,
-    // padding) simply drop per CSS — this is a grammar guard, not a per-property check.
-    if (preg_match('/^-?[\d.]+\s*(rem|px|em|%|vw|vh)$/', $value)) {
+    // Simple length: optional leading minus, a single well-formed number, then a
+    // unit directly attached. Negative lengths are valid CSS <length> (letter-spacing,
+    // margins, text-indent go negative), so the grammar accepts a single leading '-'
+    // (#467); the injection guards and the calc/clamp positive-pattern below are
+    // unchanged. Semantically-inert cases (negative radius, padding) simply drop per
+    // CSS — this is a grammar guard, not a per-property check.
+    //
+    // The number body is `\d+(?:\.\d*)?|\.\d+`: at least one digit, at most one dot,
+    // and a leading-dot form (`.5rem`, `-.5rem`). This rejects malformed shapes the
+    // old loose `[\d.]+\s*` body accepted and persisted as broken CSS the browser
+    // drops (#151): a unit with no digit (`.em`), multiple dots (`1.2.3rem`), and
+    // whitespace between the number and the unit (`1.2 rem` — CSS forbids it).
+    // Unitless zero is handled above; `0` with a unit still validates via the number
+    // body. The second digit run sits behind a mandatory `.` (`(?:\.\d*)?`, never an
+    // adjacent `\d+\.?\d*`) so an all-digit input with a bad unit backtracks linearly,
+    // not quadratically — no catastrophic-backtracking surface on an uncapped value.
+    if (preg_match('/^-?(\d+(?:\.\d*)?|\.\d+)(rem|px|em|%|vw|vh)$/', $value)) {
         return true;
     }
     // clamp() or calc(): positive-pattern — only allow safe characters inside.
     // Safe: digits, dots, units (a-z), %, comma, spaces, parentheses, +, -, *, /
     // Reject anything else (including var, url, env, or any function calls).
     if (preg_match('/^(clamp|calc)\(/', $value)) {
-        // Extract contents between outer parens.
-        if (!preg_match('/^(clamp|calc)\((.+)\)$/', $value, $m)) {
+        // Extract contents between outer parens. The /s (dotall) modifier lets
+        // legal newline whitespace inside the expression (`calc(\n1rem + 2rem)`)
+        // extract instead of failing the greedy `.+` outright (#151, Option 4).
+        if (!preg_match('/^(clamp|calc)\((.+)\)$/s', $value, $m)) {
             return false;
         }
+        $fn       = strtolower($m[1]);
         $contents = $m[2];
+        // Paren nesting: verify the body's parens are PROPERLY nested — never a
+        // closing paren before its matching opener, and balanced at the end. The
+        // greedy outer extraction checks neither, so `calc(1))` leaves a stray ')'
+        // and `calc()1,2()` leaves an improperly-nested `)1,2(` (count-balanced,
+        // but a ')' precedes its '('). A count-only check (substr_count) passes the
+        // latter and would let the top-level-comma guard below be bypassed, since a
+        // leading ')' drives the split walker to negative depth and masks the comma.
+        // A single left-to-right depth walk rejects both — every non-nested body is
+        // structurally broken CSS the browser drops (#151, Option C).
+        $depth = 0;
+        $len   = strlen($contents);
+        for ($i = 0; $i < $len; $i++) {
+            if ($contents[$i] === '(') {
+                $depth++;
+            } elseif ($contents[$i] === ')' && --$depth < 0) {
+                return false;
+            }
+        }
+        if ($depth !== 0) {
+            return false;
+        }
+        // calc() takes a single arithmetic expression, never comma-separated
+        // arguments, so any top-level comma inside calc(...) is malformed
+        // (`calc(1,2,3)`) — reject it (#151, Option C). clamp()'s legitimate
+        // 3-argument comma form is left intact; its arity is not further checked
+        // (bare-number args like `clamp(1,2,3)` remain an accepted residual, per
+        // the recorded decision — they only degrade to a dropped declaration).
+        if ($fn === 'calc' && count(_pp_split_top_level_commas($contents)) > 1) {
+            return false;
+        }
         // Positive pattern: only numeric, dot, units, %, comma, whitespace, parens, arithmetic.
         // Every alphabetic sequence must be an allowed unit word exactly
         // (rem, px, em, vw, vh) — this blocks var, env, url, and any other

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.6.5
+Stable tag: 1.6.6
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.6.5
+Version:          1.6.6
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ApplyTest.php
+++ b/tests/ApplyTest.php
@@ -665,6 +665,213 @@ class ApplyTest extends TestCase
         $this->assertFalse(_pp_validate_length('clamp((rem), 1px, 2px)'));
     }
 
+    // ── Length validator: malformed calc()/clamp() + simple-length body (#151) ──
+    //
+    // #151, recorded decision = Option C (targeted cheap fixes: paren balance +
+    // calc top-level comma) + Option 4 (newline /s), PLUS the orchestrator scope
+    // addition: tighten the simple-length number body (one well-formed number —
+    // optional sign per #467, at most one dot, at least one digit, no whitespace
+    // before the unit). No full CSS calc()/clamp() grammar parser is built; the
+    // residual shapes below are DOCUMENTED as accepted (won't-fix). Every value
+    // the #467 signed grammar pinned above still validates unchanged.
+
+    // -- Simple-length number body: now-rejected malformed shapes ---------------
+
+    public function testLengthRejectsUnitWithNoDigit(): void
+    {
+        // ".em" has a unit but no numeric operand at all — the loose "[\d.]+"
+        // body matched a lone "." and accepted it; the tightened body requires
+        // at least one digit.
+        $this->assertFalse(_pp_validate_length('.em'));
+    }
+
+    public function testLengthRejectsMultipleDotsInBody(): void
+    {
+        // "1.2.3rem" has two dots — not a well-formed number. The old "[\d.]+"
+        // body accepted any run of digits and dots.
+        $this->assertFalse(_pp_validate_length('1.2.3rem'));
+    }
+
+    public function testLengthRejectsWhitespaceBeforeUnit(): void
+    {
+        // CSS forbids whitespace between the number and its unit; "1.2 rem" is
+        // invalid. The old "\s*" between body and unit accepted it.
+        $this->assertFalse(_pp_validate_length('1.2 rem'));
+    }
+
+    public function testLengthRejectsLoneDotUnitCombination(): void
+    {
+        // "." alone with a unit (no digits) — rejected for the same "at least one
+        // digit" reason as ".em".
+        $this->assertFalse(_pp_validate_length('.px'));
+    }
+
+    // -- Simple-length number body: valid shapes stay accepted ------------------
+
+    public function testLengthAcceptsAllUnits(): void
+    {
+        foreach (['2.5rem', '10px', '1.5em', '50%', '100vw', '3vh'] as $v) {
+            $this->assertTrue(_pp_validate_length($v), "expected $v to validate");
+        }
+    }
+
+    public function testLengthAcceptsLeadingDotSimple(): void
+    {
+        // ".5rem" (no leading zero) is a well-formed <length> and stays valid.
+        $this->assertTrue(_pp_validate_length('.5rem'));
+    }
+
+    public function testLengthAcceptsIntegerNoDot(): void
+    {
+        $this->assertTrue(_pp_validate_length('16px'));
+    }
+
+    public function testLengthAcceptsZeroWithUnit(): void
+    {
+        // "0px" (zero WITH a unit) still validates via the number body; unitless
+        // "0" is handled by the earlier explicit branch.
+        $this->assertTrue(_pp_validate_length('0px'));
+    }
+
+    // -- calc(): paren balance (Option C) --------------------------------------
+
+    public function testLengthRejectsUnbalancedTrailingParen(): void
+    {
+        // "calc(1))" — the greedy outer extraction leaves a stray ")" in the
+        // body; the paren-balance check rejects it.
+        $this->assertFalse(_pp_validate_length('calc(1))'));
+    }
+
+    public function testLengthRejectsUnbalancedInnerParen(): void
+    {
+        // "calc((1rem + 2rem)" — an unmatched opening paren inside the body.
+        $this->assertFalse(_pp_validate_length('calc((1rem + 2rem)'));
+    }
+
+    public function testLengthAcceptsBalancedNestedParens(): void
+    {
+        // A genuinely balanced nested expression must still validate.
+        $this->assertTrue(_pp_validate_length('calc((100% - 2rem) / 2)'));
+    }
+
+    public function testLengthRejectsImproperlyNestedButCountBalanced(): void
+    {
+        // "calc()1,2()" -> body ")1,2(" is COUNT-balanced ("("=1, ")"=1) but a
+        // ")" precedes its "(". A substr_count-only check would pass this and let
+        // the top-level comma escape the split walker (which would hit negative
+        // depth). The proper-nesting walk rejects it (#151, adversarial finding).
+        $this->assertFalse(_pp_validate_length('calc()1,2()'));
+    }
+
+    public function testLengthRejectsCountBalancedDetachedGroups(): void
+    {
+        // "calc(1)+(2rem)" is count-balanced but structurally two separate
+        // groups, not a nested expression — rejected by the nesting walk.
+        $this->assertFalse(_pp_validate_length('calc(1)+(2rem)'));
+    }
+
+    public function testLengthRejectsLongDigitRunLinearly(): void
+    {
+        // Regression guard for the ReDoS surface an adversarial pass found in the
+        // first-cut `\d+\.?\d*` body: an all-digit run with a bad unit backtracked
+        // O(N^2). The shipped `\d+(?:\.\d*)?` body is linear, so a long input is
+        // rejected effectively instantly (this test would hang under the old body).
+        $this->assertFalse(_pp_validate_length(str_repeat('9', 50000) . 'x'));
+    }
+
+    // -- calc(): top-level comma (Option C); clamp comma form intact -----------
+
+    public function testLengthRejectsCalcWithTopLevelCommas(): void
+    {
+        // calc() never takes comma-separated arguments — "calc(1,2,3)" is
+        // malformed and is rejected.
+        $this->assertFalse(_pp_validate_length('calc(1,2,3)'));
+    }
+
+    public function testLengthRejectsCalcWithSingleComma(): void
+    {
+        // A single top-level comma inside calc() is equally malformed.
+        $this->assertFalse(_pp_validate_length('calc(1rem, 2rem)'));
+    }
+
+    public function testLengthAcceptsClampThreeArgCommaForm(): void
+    {
+        // clamp()'s legitimate 3-argument comma form is left intact — the
+        // calc-only comma rejection must not touch it.
+        $this->assertTrue(_pp_validate_length('clamp(1rem, 2vw, 3rem)'));
+    }
+
+    // -- Newline handling (Option 4, pure correctness win) ---------------------
+
+    public function testLengthAcceptsNewlineInsideCalc(): void
+    {
+        // Legal newline whitespace inside calc() must extract (via the /s
+        // modifier) and validate, not fail the greedy ".+" extraction outright.
+        $this->assertTrue(_pp_validate_length("calc(\n1rem + 2rem)"));
+    }
+
+    public function testLengthAcceptsNewlineInsideClamp(): void
+    {
+        $this->assertTrue(_pp_validate_length("clamp(1rem,\n2vw, 3rem)"));
+    }
+
+    // -- Documented accepted residuals (won't-fix; only drop to a dropped decl) --
+    //
+    // These pin the recorded decision's EXPLICIT scope boundary: bare unitless
+    // operands, doubled operators, and two-operand-no-operator are accepted as
+    // residual. If a future change tightens them, that is a deliberate scope
+    // extension — these tests make the current boundary explicit, not silent.
+
+    public function testLengthAcceptsBareUnitlessCalcResidual(): void
+    {
+        // "calc(1)" — a lone unitless number. Accepted residual (#151).
+        $this->assertTrue(_pp_validate_length('calc(1)'));
+    }
+
+    public function testLengthAcceptsBareUnitlessClampResidual(): void
+    {
+        // "clamp(1,2,3)" — unitless args, but correct clamp arity and commas.
+        // The malformation is the bare numbers, an accepted residual (#151).
+        $this->assertTrue(_pp_validate_length('clamp(1,2,3)'));
+    }
+
+    public function testLengthAcceptsDoubledOperatorResidual(): void
+    {
+        // "calc(1++2rem)" — doubled operator. Accepted residual (#151).
+        $this->assertTrue(_pp_validate_length('calc(1++2rem)'));
+    }
+
+    public function testLengthAcceptsTwoOperandNoOperatorResidual(): void
+    {
+        // "calc(1 1)" — two operands, no operator. Accepted residual (#151).
+        $this->assertTrue(_pp_validate_length('calc(1 1)'));
+    }
+
+    // -- Section 14.1 authoring-path: real surface, one malformed + one valid ---
+
+    public function testLengthAuthoringPathAcceptsValidThroughUpdateToken(): void
+    {
+        // Exercises the real authoring surface (update_design_token ->
+        // _pp_validate_token_value -> _pp_validate_length), not a raw meta write.
+        $result = pp_validate_apply(
+            'update_design_token',
+            ['token' => '--letter-spacing-heading', 'value' => '-0.02em']
+        );
+        $this->assertTrue($result);
+    }
+
+    public function testLengthAuthoringPathRejectsMalformedThroughUpdateToken(): void
+    {
+        // A malformed length (space before unit) is rejected through the same
+        // real surface with the type-specific error code.
+        $result = pp_validate_apply(
+            'update_design_token',
+            ['token' => '--letter-spacing-heading', 'value' => '1.2 rem']
+        );
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertEquals('invalid_length', $result->get_error_code());
+    }
+
     // ── Type-specific validation: font-family ───────────────────────────────
 
     public function testFontFamilyValidStack(): void


### PR DESCRIPTION
Closes #151

## Scope

Tightens `_pp_validate_length()` (`lib/apply.php`) so malformed CSS length values that used to validate — and then get silently dropped by the browser as broken CSS — are rejected up front. Per the recorded decision on #151: **Option C** (targeted cheap checks) + **Option 4** (newline `/s`), plus the orchestrator scope addition tightening the simple-length number body. No full CSS `calc()`/`clamp()` grammar parser is built.

### What now rejects (previously accepted, malformed)
- Simple lengths: `.em` (no digit), `1.2.3rem` (multiple dots), `1.2 rem` (whitespace before unit).
- `calc()`/`clamp()`: unbalanced / improperly-nested bodies (`calc(1))`, `calc()1,2()`, `calc(1)+(2rem)`); top-level commas inside `calc()` (`calc(1,2,3)`).

### What stays accepted (unchanged grammar)
All well-formed lengths: every unit, signed/negative lengths (`-0.03em`, `-.5rem`, `-2px` — #467 grammar preserved exactly), leading-dot numbers, nested `clamp()`/`calc()`, unitless `0`, and `clamp()`'s legitimate 3-argument comma form.

### Documented accepted residuals (won't-fix, per the decision)
Bare unitless operands (`calc(1)`, `clamp(1,2,3)`), doubled operators (`calc(1++2rem)`), two-operand-no-operator (`calc(1 1)`). Each degrades only to a dropped declaration, never injection — the `{};<>` guard, alpha-word-is-a-unit check, and char-class whitelist are untouched.

## Implementation notes
- Simple-length number body: `-?(\d+(?:\.\d*)?|\.\d+)(unit)` — at least one digit, at most one dot, unit directly attached. The second digit run sits behind a mandatory `.`, so it is **non-backtracking (linear)**, avoiding a ReDoS shape a first-cut regex introduced (caught by the adversarial review pass).
- `calc()`/`clamp()`: a proper left-to-right paren-**nesting** walk replaces the count-based balance check the decision named. It subsumes the count check and closes a comma-guard bypass (a leading `)` drove the split walker to negative depth and hid a top-level comma). Zero valid-value regression.

## 7A questions
None. All changes stay within the recorded decision's two named guards (paren balance + no top-level calc commas) and the recorded number-body tightening. No accepted behavior was expanded.

## Validation
- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` — **2313 passing** (baseline 2288 + 25 new; warnings/deprecations unchanged from baseline).
- JS: `npm test` — **808 passing**.
- `bash scripts/package.sh` — version consistency OK across all five synced files (1.6.6); release zip deleted (CI builds from tags).
- Tests added: accept/reject matrix for every named malformed class, every documented valid shape, the paren-nesting bypass cases, newline forms, documented residuals, a 50k-char linear-time (ReDoS) regression guard, and a Section 14.1 authoring-path test through `update_design_token` (one malformed + one valid).

## gstack workflows
`/plan-eng-review`, `/review` (Claude adversarial subagent — surfaced the ReDoS + comma-bypass, both fixed), `/document-generate` (no doc changes — accepted grammar unchanged).

## Not touched
`_pp_validate_position()` (`lib/apply.php`) carries the same loose `-?[\d.]+` body but is out of scope (#151 names `_pp_validate_length` only) — noted for a possible follow-up.
