### PR TITLE
Release v1.7.0 — actions/integrity hardening gate rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.7.0] — 2026-07-22 — actions/integrity hardening: the v1.7.0 gate is closed (#141)
+
+**This is a gate rollup marker: the four changes of this release shipped in working versions 1.6.3–1.6.6 below, and this entry carries no new code beyond the five-file version bump and doc freshness. What 1.7.0 marks is the close of the actions/integrity hardening gate (#141, Part 1.96) — the mutation and validation trust layer tightened after the brand-fidelity feature run. Batch rollback now restores what was actually there: site-option snapshots capture presence separately from value, so an absent option rolls back to absent and an explicit-empty to empty (#291). The media-URL security gate derives its prop coverage from component schemas via \"format\": \"image_url\" — a new image prop is covered the day its schema declares it — with an un-droppable two-name floor so the gate can never fail open on registry failure (#154). Page actions that assume a materialized page (publish, trash, slug, SEO) reject auto-draft phantoms with a clear envelope while the Add-New-Page first-save promotion path stays intact, and a garbage-collected editor URL redirects instead of dying (#160). And the length validator's grammar closed its malformed-shape holes — no digitless or multi-dot numbers, no whitespace before units, proper paren nesting, no top-level calc commas — with the signed #467 grammar preserved and the accepted residuals documented (#151).**
+
+This release bumps the version across the five synced files from 1.6.6 to 1.7.0 and updates README.md's project-status strings. Release evidence (recorded on #141): full suites green per issue; three of the four issues produced pre-landing decision escalations (fail-closed floor, four-action reject set, walker-vs-count guard) — the gate hardened itself while hardening the theme. No behavior changed in this entry itself.
+
+### Docs
+
+- README.md's project-status section now reads v1.7.0 in the release-history range and the "What exists today" heading. readme.txt gains its `= 1.7.0 =` rollup entry.
+
 ## [v1.6.6] — 2026-07-22 — `_pp_validate_length()` rejects malformed calc()/clamp() and simple-length shapes it used to persist as broken CSS (#151)
 
 **The design-token/style-slot length validator accepted several malformed values that the browser silently drops: a unit with no digit (`.em`), a number with multiple dots (`1.2.3rem`), whitespace before the unit (`1.2 rem`), an unbalanced or improperly-nested `calc()` body (`calc(1))`, `calc()1,2()`), and comma misuse inside `calc()` (`calc(1,2,3)`). Each one validated and was written to a custom property, then the browser threw the whole declaration away — a broken style the operator or AI thought they had set. The length grammar now rejects these up front. Every well-formed length still validates unchanged: all units, signed/negative lengths (#467), leading-dot numbers, and nested `clamp()`/`calc()` expressions.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.6.6-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.7.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -421,9 +421,9 @@ npm run env:stop
 
 PromptingPress is in active development by a single developer. It is not yet packaged for broad distribution. The current focus is making the AI-agent workflow reliable and the composition model complete.
 
-See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.6.0.
+See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.7.0.
 
-**What exists today (v1.6.0):**
+**What exists today (v1.7.0):**
 - 12 components with schema contracts and 216 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.6.6');
+define('PP_VERSION', '1.7.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.6.6",
+  "version": "1.7.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.6.6
+Stable tag: 1.7.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -19,6 +19,10 @@ An AI-first WordPress theme built for clarity. PromptingPress uses a component-b
 4. Activate the theme.
 
 == Changelog ==
+
+= 1.7.0 =
+* Actions/integrity hardening: snapshot rollback distinguishes absent from explicit-empty site options; the media-URL gate is schema-driven with a fail-closed floor; publish/trash/slug/SEO actions reject auto-draft phantoms (first-save promotion intact) and GC'd editor URLs redirect; the length validator rejects malformed number/paren/comma shapes with documented residuals
+* Verified by full PHP/JS/E2E suites per issue and authoring-path tests through the real action surfaces
 
 = 1.6.0 =
 * Brand-fidelity release: heading letter-spacing token (signed lengths accepted), step-badge ink slot, section body size/weight slots, split-hero stretch alignment, footer secondary menu column and social-icon row (closed network set, inline SVG), and chat page-context adjacency hints

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.6.6
+Version:          1.7.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Closes the v1.7.0 gate (#141 Part 1.96). Four issues landed in working versions 1.6.3–1.6.6: #291, #154, #160, #151.

Rollup-only change: five-file version bump 1.6.6 → 1.7.0, CHANGELOG v1.7.0 entry, readme.txt rollup + Stable tag, README status strings. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)