### PR TITLE
v1.7.6 fix: bounded pre-1.0 CTA legacy-prop alias map + schema-rename drift-catcher (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.7.6] — 2026-07-26 — pre-1.0 pages stay editable: a bounded legacy CTA-prop compatibility map (#495)
+
+**A page built before v1.0 could be locked out of a simple, safe edit. Early CTA blocks stored `cta_text`/`cta_url`; v1 renamed those props to `button_text`/`button_url` and the strict validator (which rejects unknown props to stop phantom fields) then refused the WHOLE page — so a targeted edit to an unrelated section was rejected because some other CTA still carried the old names. This release ships a bounded, audited compatibility map for exactly those pre-1.0 CTA renames. Validation and rendering now accept the old names, and any edit that touches a component rewrites its props to the current names, so the page heals one edit at a time. Genuinely unknown props are still rejected exactly as before.**
+
+The map is deliberately small and closed: only the CTA block, only `cta_text`→`button_text` and `cta_url`→`button_url`. It is per-component on purpose — the hero block uses `cta_text`/`cta_url` as its own current props, and those are never touched. A targeted single-component edit heals only the component it touches and leaves every other component's stored shape alone, so there is no surprise whole-page rewrite; a full-page save (or an undo/restore) heals the whole composition at once. A page that still stores the old names renders its real button now instead of a default label. A CI guard makes this the last such surprise: any future change that renames or removes a component prop without shipping a compatibility entry (or an explicit migration note) fails the test suite, so the "add compatibility when you rename" rule is enforced by the build, not by memory.
+
+### Fixed
+- A targeted safe edit to any component on a pre-1.0 page no longer fails because an unrelated component still carries the old CTA prop names. Validation and rendering accept the bounded legacy names (`cta.cta_text`/`cta.cta_url`), and a write that touches a component canonicalizes its props to `button_text`/`button_url`; untouched components keep their stored shape and heal on their next edit. Unknown, non-mapped props are still rejected with the same error (#495).
+- A pre-1.0 CTA that still stores `cta_text`/`cta_url` now renders its authored button label and link on the front end instead of the renderer's default (#495).
+
+### Tests
+- `tests/ActionsTest.php`: legacy-shaped compositions exercised through the real action surface — a targeted edit succeeds while an untouched legacy CTA is present (and keeps its stored shape), a write that touches the CTA heals it to canonical, a legacy-named edit to an already-healed component lands instead of being silently dropped, canonical-wins on conflicting old+new props, `hero`'s current `cta_text`/`cta_url` are never rewritten, `add_component`/`update_composition`/`create_page` heal on write, unknown non-mapped props still reject, `reorder` preserves untouched legacy props, and `restore_composition` heals a legacy snapshot (#495).
+- `tests/ComponentPropsTest.php`: a resolved legacy CTA renders the authored button label and URL, not the default (#495).
+- `tests/WpAbstractionTest.php`: `pp_composition()` resolves legacy CTA props for rendering without mutating stored data, and leaves `hero`'s current props untouched (#495).
+- `tests/SchemaValidationTest.php`: the legacy-alias inventory is pinned, the schema-rename drift-catcher fails a simulated rename that ships no compatibility entry (and a symmetric guard forces new props into the pinned baseline), and the alias helper's malformed-input guards are covered (#495).
+
 ## [v1.7.5] — 2026-07-23 — the default homepage seed is now a curated branded multi-band starter (#512)
 
 **A fresh PromptingPress activation used to seed a three-component homepage (hero, one section, one CTA) that proved the composition system worked but presented the product like a rough default. `pp_default_homepage_composition()` now returns a curated six-band branded starter: a dark split hero with a workflow proof surface, an audience/problem band, a files-vs-WordPress mechanism band, a speed/trust card grid, a maintainability/proof band, and a closing CTA. A new install now opens on a page that reads as a polished branded product, not a placeholder, so a first-time operator immediately understands what PromptingPress is, who it is for, and why structured composition matters.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.7.5-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.7.6-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.7.5');
+define('PP_VERSION', '1.7.6');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -1948,7 +1948,9 @@ pp_register_action('add_component', [
     },
     'preview' => function (array $params): array {
         $current   = pp_get_composition($params['post_id']);
-        $new_item  = ['component' => $params['component'], 'props' => $params['props']];
+        // Mirror execute's normalize-on-write (issue #495) so the preview reflects
+        // the canonical shape that will actually be stored.
+        $new_item  = _pp_apply_legacy_prop_aliases(['component' => $params['component'], 'props' => $params['props']]);
         if (!empty($params['style'])) {
             $new_item['style'] = $params['style'];
         }
@@ -1964,7 +1966,10 @@ pp_register_action('add_component', [
     },
     'execute' => function (array $params): array {
         $current   = pp_get_composition($params['post_id']);
-        $new_item  = ['component' => $params['component'], 'props' => $params['props']];
+        // Normalize-on-write (issue #495): a freshly authored component heals its
+        // recognized legacy prop keys to canonical on the way in. Only this new
+        // item is normalized; existing (untouched) components keep their stored shape.
+        $new_item  = _pp_apply_legacy_prop_aliases(['component' => $params['component'], 'props' => $params['props']]);
         if (!empty($params['style'])) {
             $new_item['style'] = $params['style'];
         }
@@ -2343,7 +2348,16 @@ pp_register_action('update_component', [
         _pp_resolve_id_param($params, $params['post_id']);
         $composition = pp_get_composition($params['post_id']);
         $before_props = $composition[$params['component_index']]['props'] ?? [];
-        $after_props  = _pp_merge_component_props($before_props, $params['props']);
+        // Mirror execute (issue #495): canonicalize the incoming patch first (so a
+        // legacy-named edit lands), then normalize the merged item, so the preview's
+        // reported "after" and changes match the canonical shape that will be stored.
+        $patch_props  = _pp_apply_legacy_prop_aliases(
+            array_merge($composition[$params['component_index']], ['props' => $params['props']])
+        )['props'];
+        $after_props  = _pp_merge_component_props($before_props, $patch_props);
+        $after_props  = _pp_apply_legacy_prop_aliases(
+            array_merge($composition[$params['component_index']], ['props' => $after_props])
+        )['props'];
 
         $changes = _pp_diff_props($before_props, $after_props, $params['component_index']);
 
@@ -2362,9 +2376,28 @@ pp_register_action('update_component', [
         _pp_resolve_id_param($params, $params['post_id']);
         $composition  = pp_get_composition($params['post_id']);
         $before_props = $composition[$params['component_index']]['props'] ?? [];
-        $after_props  = _pp_merge_component_props($before_props, $params['props']);
+        // Normalize-on-write, touched item only (issue #495). The INCOMING PATCH is
+        // canonicalized FIRST so a legacy-named edit (e.g. cta_text) to a component
+        // that already healed to button_text overwrites the canonical prop instead
+        // of being dropped by canonical-wins — an accepted legacy-named edit must
+        // land, never silently no-op behind ok:true.
+        $patch_props  = _pp_apply_legacy_prop_aliases(
+            array_merge($composition[$params['component_index']], ['props' => $params['props']])
+        )['props'];
+        $after_props  = _pp_merge_component_props($before_props, $patch_props);
 
         $composition[$params['component_index']]['props'] = $after_props;
+
+        // Then canonicalize any legacy prop keys the STORED component still carries
+        // (untouched by the patch), so the touched component heals to the current
+        // shape. Only this touched item is normalized — untouched components keep
+        // their stored props, so a targeted edit heals incrementally.
+        $composition[$params['component_index']] = _pp_apply_legacy_prop_aliases(
+            $composition[$params['component_index']]
+        );
+        // Reflect the normalization in the reported diff so `changes` matches what
+        // is actually stored (a touched legacy cta stores button_text, not cta_text).
+        $after_props = $composition[$params['component_index']]['props'];
 
         $changes = _pp_diff_props($before_props, $after_props, $params['component_index']);
 

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -168,6 +168,15 @@ function pp_normalize_composition(array $items): array {
     // Legacy `variant` is still decoded on the RESTORE/READ paths only, which call
     // pp_migrate_legacy_variant_keys() explicitly (restore_composition, lib/wp.php,
     // the editor read path) — see that helper's #233 note.
+
+    // Normalize-on-write for the bounded pre-1.0 prop RENAMES (issue #495).
+    // UNLIKE `variant`, these renames DO ship a write-time alias: create_page and
+    // update_composition supply the WHOLE composition, so canonicalizing every
+    // item here heals a legacy-shaped composition on save. The single-component
+    // read-then-write actions do NOT route through here (they normalize only the
+    // touched item), so a targeted edit heals incrementally and leaves untouched
+    // components in their stored shape.
+    $items = pp_normalize_legacy_props($items);
     return $items;
 }
 
@@ -240,6 +249,124 @@ function pp_migrate_legacy_variant_keys(array $items): array {
             $items[$i]['props'][$target] = $value;
         }
         unset($items[$i]['props']['variant']);
+    }
+    return $items;
+}
+
+/**
+ * The bounded, closed map of pre-1.0 component-scoped prop RENAMES whose old
+ * names can still exist in stored compositions (issue #495).
+ *
+ * This is NOT a general schema-evolution framework and NOT a forever alias
+ * surface. It is a fixed, audited inventory of the pre-1.0 renames the #147
+ * strict gate could not have caught (the gate has rejected unknown props since
+ * 1.0; the post-1.0 convention ships compatibility WITH every rename — #442).
+ * The closed audit found exactly one component with such renames:
+ *
+ *   cta: cta_text -> button_text, cta_url -> button_url
+ *
+ * The map is deliberately PER-COMPONENT: `hero` declares `cta_text`/`cta_url`
+ * as its CURRENT canonical props (the hero's own button), so a global alias
+ * would corrupt hero content. The `variant` -> `layout`/`theme` rename is NOT
+ * here — it is handled by the separate write-reject + read-migrate mechanism
+ * (pp_migrate_legacy_variant_keys, #69/#388), a different contract.
+ *
+ * Pinned by SchemaValidationTest::testLegacyPropAliasInventoryIsPinned and
+ * guarded against silent future drift by the schema-rename drift-catcher
+ * (SchemaValidationTest::testSchemaRenameDriftIsCaught): a future schema change
+ * that removes/renames a prop must add an entry HERE (or an explicit migration
+ * note) or CI fails.
+ *
+ * @return array<string, array<string, string>>  component => [old_prop => canonical_prop]
+ */
+function pp_legacy_prop_aliases(): array {
+    return [
+        'cta' => [
+            'cta_text' => 'button_text',
+            'cta_url'  => 'button_url',
+        ],
+    ];
+}
+
+/**
+ * Canonicalizes the recognized legacy prop keys on a SINGLE composition item
+ * (issue #495), the alias-on-read + normalize-on-write primitive.
+ *
+ * Only rewrites keys inside `props`, only after the component name is known,
+ * and only for components that declare a legacy-alias map. Genuinely unknown
+ * keys are left untouched so the #147 strict gate still rejects them — this is
+ * a bounded compatibility shim, not a hole in unknown-prop rejection.
+ *
+ * CANONICAL-WINS: if BOTH the legacy and canonical keys are present on the same
+ * item, the canonical value is kept and the legacy key is dropped (an explicit
+ * author value beats a stale legacy one). Otherwise the legacy value carries
+ * across to the canonical key. Either way the legacy key is removed, so the
+ * result is a pure-canonical view.
+ *
+ * Used on THREE surfaces with different persistence semantics:
+ *   - validation (pp_validate_composition_errors): a TRANSIENT resolved copy,
+ *     so the required-prop and unknown-prop checks see canonical names; stored
+ *     data is never mutated by validation.
+ *   - write (pp_normalize_composition + the touched item in update_component /
+ *     add_component): persists the canonical form so a touched component heals.
+ *   - render (pp_composition): a transient resolved view so a legacy-shaped
+ *     stored cta renders its authored button; never written back.
+ *
+ * @param  array $item  One composition item ({component|type, props}).
+ * @return array        The item with any recognized legacy prop keys canonicalized.
+ */
+function _pp_apply_legacy_prop_aliases(array $item): array {
+    if (!isset($item['props']) || !is_array($item['props'])) {
+        return $item;
+    }
+    // A corrupt/raw-written item (reached via the restore path's normalize, which
+    // runs over arbitrary history-ring snapshots) can carry a non-scalar
+    // component key. Casting it would emit "Array to string conversion"; no alias
+    // map applies to a malformed name anyway, so leave the item untouched and let
+    // the shared validator report the real problem (mirrors the non-scalar
+    // component guard in pp_validate_composition_errors).
+    $raw_component = $item['component'] ?? $item['type'] ?? '';
+    if (!is_scalar($raw_component)) {
+        return $item;
+    }
+    $component = (string) $raw_component;
+    $aliases   = pp_legacy_prop_aliases()[$component] ?? [];
+    if ($aliases === []) {
+        return $item;
+    }
+    foreach ($aliases as $old => $canonical) {
+        if (!array_key_exists($old, $item['props'])) {
+            continue;
+        }
+        // Canonical-wins: only carry the legacy value across when the canonical
+        // key is absent. Either way the legacy key is removed.
+        if (!array_key_exists($canonical, $item['props'])) {
+            $item['props'][$canonical] = $item['props'][$old];
+        }
+        unset($item['props'][$old]);
+    }
+    return $item;
+}
+
+/**
+ * Array wrapper for _pp_apply_legacy_prop_aliases() (issue #495): canonicalizes
+ * recognized legacy prop keys across every item of a composition.
+ *
+ * This is the WRITE-PATH normalizer for the full-replace surfaces
+ * (pp_normalize_composition, and thereby create_page / update_composition /
+ * restore_composition). The single-component read-then-write actions
+ * (update_component / add_component) normalize only the touched item directly,
+ * so untouched components keep their stored (legacy) prop shape and the
+ * composition heals incrementally rather than all at once.
+ *
+ * @param  array $items  Composition array.
+ * @return array         Items with recognized legacy prop keys canonicalized.
+ */
+function pp_normalize_legacy_props(array $items): array {
+    foreach ($items as $i => $item) {
+        if (is_array($item)) {
+            $items[$i] = _pp_apply_legacy_prop_aliases($item);
+        }
     }
     return $items;
 }
@@ -423,6 +550,17 @@ function pp_validate_composition_errors(array $items): array {
             );
             continue;
         }
+
+        // Alias-on-read (issue #495). Resolve the bounded pre-1.0 legacy prop
+        // renames (cta.cta_text -> button_text, cta.cta_url -> button_url) into
+        // a TRANSIENT canonical view of this item BEFORE any prop check runs, so
+        // both the required-prop loop below (button_text/button_url are required)
+        // and the unknown-prop gate further down see the canonical names. $item
+        // is the local loop copy, so this never mutates the caller's $items or
+        // stored data — write-time healing is normalize-on-write, done separately
+        // by the action layer on the touched item only. A genuinely unknown key
+        // is left untouched and still rejected by the unknown-prop gate.
+        $item = _pp_apply_legacy_prop_aliases($item);
 
         $schema = $registered[$name];
         if (!empty($schema['props'])) {

--- a/lib/wp.php
+++ b/lib/wp.php
@@ -224,7 +224,22 @@ function pp_composition(): array {
         return [];
     }
     $items = json_decode($raw, true);
-    return is_array($items) ? pp_migrate_stored_composition($items) : [];
+    if (!is_array($items)) {
+        return [];
+    }
+    // Render-path resolution (issue #495): a legacy-shaped stored cta still
+    // carries cta_text/cta_url, and the renderer reads button_text/button_url,
+    // so without this a legacy button would render its default label. Resolve the
+    // recognized legacy prop keys to canonical for RENDERING only. This is a
+    // transient view — the stored composition is never mutated here, so an
+    // untouched legacy component keeps its stored shape until a write heals it
+    // (normalize-on-write). The action read path (pp_get_composition_result /
+    // pp_get_composition) deliberately does NOT resolve, so a targeted
+    // update_component writing the whole array back preserves untouched components.
+    $items = pp_migrate_stored_composition($items);
+    return function_exists('pp_normalize_legacy_props')
+        ? pp_normalize_legacy_props($items)
+        : $items;
 }
 
 // ── Site-state read functions (action-layer support) ─────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.7.5
+Stable tag: 1.7.6
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.7.5
+Version:          1.7.6
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -576,6 +576,293 @@ class ActionsTest extends TestCase
         $this->assertSame('unknown_prop', $result['error_code'], 'validate-stage rejection must carry its code (#312)');
     }
 
+    // ── Bounded legacy prop-rename alias map (issue #495) ──
+    //
+    // Pre-1.0, `cta` renamed cta_text->button_text and cta_url->button_url (both
+    // now REQUIRED). Stored legacy compositions still carry the old names, which
+    // used to block a targeted edit to ANY component because the whole composition
+    // is validated. The map makes validation + rendering accept exactly those
+    // mapped names and normalizes them on a write that touches the component;
+    // untouched components keep their stored shape (incremental heal). The #147
+    // strict gate is otherwise unchanged — genuinely unknown keys still reject.
+    // These exercise the REAL action surface (Section 14.1), not raw-meta unit calls.
+
+    /** A legacy-shaped composition: a section plus a cta carrying the old prop names. */
+    private function seedLegacyCtaComposition(): int
+    {
+        $id = pp_create_page('Legacy-shaped page', 'draft');
+        // Thin writer, no validation — persists the legacy shape as a live install would hold it.
+        pp_update_composition($id, [
+            ['component' => 'section', 'props' => ['title' => 'Intro', 'body' => 'Hello world.']],
+            ['component' => 'cta',     'props' => ['cta_text' => 'View on GitHub', 'cta_url' => 'https://example.com/repo']],
+        ]);
+        return $id;
+    }
+
+    public function testTargetedEditSucceedsWhenAnUntouchedComponentHasLegacyProps(): void
+    {
+        // The dogfood bug: a safe edit to the SECTION was rejected because the
+        // untouched cta carried cta_text/cta_url. Alias-on-read must let it through.
+        $id = $this->seedLegacyCtaComposition();
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 0, // the section — NOT the legacy cta
+            'props'           => ['title' => 'Updated intro'],
+        ]);
+
+        $this->assertTrue($result['ok'], 'a targeted edit must succeed despite an untouched legacy-prop component');
+        $comp = pp_get_composition($id);
+        $this->assertSame('Updated intro', $comp[0]['props']['title'], 'the targeted edit landed');
+        // The untouched cta keeps its STORED (legacy) prop shape — incremental heal,
+        // not a whole-composition migration.
+        $this->assertArrayHasKey('cta_text', $comp[1]['props'], 'untouched component keeps its legacy prop key');
+        $this->assertArrayNotHasKey('button_text', $comp[1]['props'], 'untouched component is NOT normalized');
+    }
+
+    public function testWriteTouchingLegacyComponentNormalizesItToCanonical(): void
+    {
+        $id = $this->seedLegacyCtaComposition();
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 1, // the cta itself
+            'props'           => ['title' => 'Ready to start?'],
+        ]);
+
+        $this->assertTrue($result['ok'], 'editing the legacy cta must succeed');
+        $cta = pp_get_composition($id)[1]['props'];
+        $this->assertArrayNotHasKey('cta_text', $cta, 'a write touching the component heals cta_text');
+        $this->assertArrayNotHasKey('cta_url', $cta, 'a write touching the component heals cta_url');
+        $this->assertSame('View on GitHub', $cta['button_text'], 'legacy value carries to the canonical prop');
+        $this->assertSame('https://example.com/repo', $cta['button_url'], 'legacy value carries to the canonical prop');
+        $this->assertSame('Ready to start?', $cta['title'], 'the actual edit landed too');
+    }
+
+    public function testUnknownNonMappedKeyStillRejectsOnLegacyComposition(): void
+    {
+        // Aliasing must not become a hole: a genuinely unknown key still rejects
+        // with the current error, even on a legacy-shaped composition.
+        $id = $this->seedLegacyCtaComposition();
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 1,
+            'props'           => ['not_a_real_prop' => 'x'],
+        ]);
+
+        $this->assertFalse($result['ok'], 'an unknown non-mapped key must still reject');
+        $this->assertSame('unknown_prop', $result['error_code']);
+        $this->assertStringContainsString('not_a_real_prop', $result['error']);
+    }
+
+    public function testCanonicalWinsWhenBothLegacyAndCanonicalPropsPresent(): void
+    {
+        $id = pp_create_page('Conflict page', 'draft');
+        pp_update_composition($id, [
+            ['component' => 'cta', 'props' => [
+                'cta_text'    => 'OLD legacy label',
+                'button_text' => 'NEW canonical label',
+                'cta_url'     => 'https://old.example.com',
+                'button_url'  => 'https://new.example.com',
+            ]],
+        ]);
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 0,
+            'props'           => ['title' => 'Heading'],
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $cta = pp_get_composition($id)[0]['props'];
+        $this->assertArrayNotHasKey('cta_text', $cta, 'the legacy text key is dropped');
+        $this->assertArrayNotHasKey('cta_url', $cta, 'the legacy url key is dropped');
+        $this->assertSame('NEW canonical label', $cta['button_text'], 'the explicit canonical value wins over the legacy one');
+        $this->assertSame('https://new.example.com', $cta['button_url'], 'canonical-wins holds for the url alias too');
+    }
+
+    public function testLegacyNamedEditToAnAlreadyHealedComponentLands(): void
+    {
+        // Regression: an edit that uses the LEGACY prop name against a component whose
+        // stored props already use the canonical name must land, not be silently
+        // dropped by canonical-wins (the "ok:true but no effect" class). The incoming
+        // patch is canonicalized before the merge, so cta_text overwrites button_text.
+        $id = pp_create_page('Already healed', 'draft');
+        pp_update_composition($id, [
+            ['component' => 'cta', 'props' => ['button_text' => 'Old label', 'button_url' => '/old']],
+        ]);
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 0,
+            'props'           => ['cta_text' => 'New label', 'cta_url' => '/new'], // legacy names
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $cta = pp_get_composition($id)[0]['props'];
+        $this->assertSame('New label', $cta['button_text'], 'a legacy-named edit must overwrite the canonical prop, not be dropped');
+        $this->assertSame('/new', $cta['button_url']);
+        $this->assertArrayNotHasKey('cta_text', $cta, 'no legacy key persists after the write');
+
+        // The reported change log must match what was stored (canonical), not the
+        // pre-normalization legacy shape.
+        $paths = array_map(static fn ($c) => $c['path'] ?? '', $result['changes']);
+        $joined = implode(' ', $paths);
+        $this->assertStringNotContainsString('cta_text', $joined, 'the change log reports the canonical prop, not the legacy alias');
+    }
+
+    public function testTargetedEditDoesNotRewriteHeroCurrentProps(): void
+    {
+        // hero.cta_text/cta_url are CURRENT canonical props (not aliases). A write
+        // touching the hero must leave them exactly as authored — the per-component
+        // map must never treat them as legacy.
+        $id = pp_create_page('Hero write path', 'draft');
+        pp_update_composition($id, [
+            ['component' => 'hero', 'props' => ['title' => 'Hi', 'cta_text' => 'Go', 'cta_url' => '/go']],
+        ]);
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 0,
+            'props'           => ['title' => 'Hello'],
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $hero = pp_get_composition($id)[0]['props'];
+        $this->assertSame('Go', $hero['cta_text'], 'hero cta_text is canonical and must survive a write');
+        $this->assertSame('/go', $hero['cta_url'], 'hero cta_url is canonical and must survive a write');
+        $this->assertArrayNotHasKey('button_text', $hero, 'hero must not gain a cta-only canonical prop');
+    }
+
+    public function testAddComponentPreviewReflectsCanonicalShape(): void
+    {
+        $id = pp_create_page('Add preview', 'draft');
+        pp_update_composition($id, [['component' => 'section', 'props' => ['body' => 'x']]]);
+
+        $preview = pp_get_action('add_component')['preview']([
+            'post_id'   => $id,
+            'component' => 'cta',
+            'props'     => ['cta_text' => 'Sign up', 'cta_url' => '/signup'],
+        ]);
+
+        $encoded = json_encode($preview);
+        $this->assertStringContainsString('button_text', $encoded, 'preview reflects the canonical shape that will be stored');
+        $this->assertStringNotContainsString('cta_text', $encoded, 'preview does not show the legacy alias');
+    }
+
+    public function testReorderPreservesUntouchedLegacyProps(): void
+    {
+        // Whole-array rewrite actions that do not author props (reorder/remove/style)
+        // must not heal legacy props: they preserve the stored shape.
+        $id = $this->seedLegacyCtaComposition(); // [section, cta(legacy)]
+
+        $result = pp_execute_action('reorder_components', [
+            'post_id' => $id,
+            'order'   => [1, 0],
+        ]);
+
+        $this->assertTrue($result['ok'], 'reorder must succeed on a legacy-shaped composition');
+        $comp = pp_get_composition($id);
+        // cta is now at index 0 after the reorder; it keeps its stored legacy props.
+        $this->assertSame('cta', $comp[0]['component']);
+        $this->assertArrayHasKey('cta_text', $comp[0]['props'], 'reorder must not heal untouched legacy props');
+        $this->assertArrayNotHasKey('button_text', $comp[0]['props']);
+    }
+
+    public function testRestoreCompositionHealsLegacyProps(): void
+    {
+        // restore_composition is a full-replace surface (it goes through
+        // pp_normalize_composition), so a restored legacy-shaped snapshot heals to
+        // canonical. This is value-preserving (the same content, canonical keys) and
+        // consistent with the existing legacy-`variant` migration on restore.
+        $id = pp_create_page('Restore heal', 'draft');
+        // v1: a legacy-shaped composition.
+        pp_update_composition($id, [
+            ['component' => 'cta', 'props' => ['cta_text' => 'Legacy', 'cta_url' => '/legacy']],
+        ]);
+        // v2: a different composition, so v1 is pushed onto the history ring.
+        pp_update_composition($id, [
+            ['component' => 'section', 'props' => ['body' => 'current']],
+        ]);
+
+        $result = pp_execute_action('restore_composition', ['post_id' => $id, 'steps_back' => 1]);
+        $this->assertTrue($result['ok'], 'restore of a legacy snapshot must succeed');
+
+        $restored = pp_get_composition($id);
+        $this->assertSame('cta', $restored[0]['component']);
+        $this->assertArrayNotHasKey('cta_text', $restored[0]['props'], 'restore heals legacy props to canonical');
+        $this->assertSame('Legacy', $restored[0]['props']['button_text'], 'the legacy value is preserved under the canonical key');
+        $this->assertSame('/legacy', $restored[0]['props']['button_url']);
+    }
+
+    public function testAddComponentHealsLegacyCtaPropsOnTheNewItem(): void
+    {
+        $id = pp_create_page('Add legacy cta', 'draft');
+        pp_update_composition($id, [['component' => 'section', 'props' => ['body' => 'x']]]);
+
+        $result = pp_execute_action('add_component', [
+            'post_id'   => $id,
+            'component' => 'cta',
+            'props'     => ['cta_text' => 'Sign up', 'cta_url' => '/signup'],
+        ]);
+
+        $this->assertTrue($result['ok'], 'a freshly authored legacy-shaped cta is accepted');
+        $cta = pp_get_composition($id)[1]['props'];
+        $this->assertArrayNotHasKey('cta_text', $cta, 'the new item is normalized on write');
+        $this->assertSame('Sign up', $cta['button_text']);
+        $this->assertSame('/signup', $cta['button_url']);
+    }
+
+    public function testAddComponentStillRejectsUnknownKeyAlongsideLegacyProps(): void
+    {
+        $id = pp_create_page('Add legacy+garbage', 'draft');
+        pp_update_composition($id, [['component' => 'section', 'props' => ['body' => 'x']]]);
+
+        $result = pp_execute_action('add_component', [
+            'post_id'   => $id,
+            'component' => 'cta',
+            'props'     => ['cta_text' => 'Sign up', 'cta_url' => '/signup', 'garbage' => 'no'],
+        ]);
+
+        $this->assertFalse($result['ok'], 'a mapped alias does not smuggle an unrelated unknown key through');
+        $this->assertStringContainsString('garbage', $result['error']);
+        $this->assertCount(1, pp_get_composition($id), 'the rejected component was not appended');
+    }
+
+    public function testUpdateCompositionHealsLegacyCtaPropsOnFullReplace(): void
+    {
+        $id = pp_create_page('Full replace legacy', 'draft');
+
+        $result = pp_execute_action('update_composition', [
+            'post_id'     => $id,
+            'composition' => [
+                ['component' => 'cta', 'props' => ['cta_text' => 'Go', 'cta_url' => '/go']],
+            ],
+        ]);
+
+        $this->assertTrue($result['ok'], 'a full-replace legacy-shaped composition is accepted and healed');
+        $cta = pp_get_composition($id)[0]['props'];
+        $this->assertArrayNotHasKey('cta_text', $cta);
+        $this->assertSame('Go', $cta['button_text']);
+        $this->assertSame('/go', $cta['button_url']);
+    }
+
+    public function testCreatePageHealsLegacyCtaProps(): void
+    {
+        $result = pp_execute_action('create_page', [
+            'title'       => 'New legacy page',
+            'composition' => [
+                ['component' => 'cta', 'props' => ['cta_text' => 'Go', 'cta_url' => '/go']],
+            ],
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $cta = pp_get_composition($result['target']['post_id'])[0]['props'];
+        $this->assertArrayNotHasKey('cta_text', $cta, 'create_page normalizes legacy props on write');
+        $this->assertSame('Go', $cta['button_text']);
+    }
+
     // ── Retired `variant` prop is rejected at write time (#388) ──
     //
     // #69 split `variant` into `layout`/`theme`. v1's public API accepts NO alias:

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -32,6 +32,32 @@ class ComponentPropsTest extends TestCase
         return ob_get_clean();
     }
 
+    // ── Legacy cta prop-rename renders the authored button (issue #495) ────
+    //
+    // A pre-1.0 cta stored cta_text/cta_url; the renderer reads button_text/
+    // button_url. After alias resolution (the render path runs
+    // pp_normalize_legacy_props), the authored label/href must appear in the HTML
+    // instead of the renderer's defaults. This is the rendered-output evidence
+    // that "rendering accepts the mapped names": the resolved item renders
+    // byte-for-byte like a normal button_text cta.
+
+    public function testLegacyCtaPropsRenderAuthoredButtonAfterResolution(): void
+    {
+        $resolved = pp_normalize_legacy_props([
+            ['component' => 'cta', 'props' => [
+                'cta_text' => 'View on GitHub',
+                'cta_url'  => 'https://example.com/repo',
+            ]],
+        ])[0];
+
+        $html = $this->render('cta', $resolved['props']);
+
+        $this->assertStringContainsString('View on GitHub', $html, 'authored legacy label must render');
+        $this->assertStringContainsString('https://example.com/repo', $html, 'authored legacy url must render');
+        // The renderer's fallback defaults must NOT leak through.
+        $this->assertStringNotContainsString('Get Started', $html, 'the default button label must not appear');
+    }
+
     // ── Section Centered Layout ────────────────────────────────────────────
 
     public function testSectionCenteredIsValidLayout(): void

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -2223,6 +2223,216 @@ class SchemaValidationTest extends TestCase
         }
     }
 
+    // ── Legacy prop-rename alias map + schema-rename drift-catcher (#495) ──
+    //
+    // The alias map (lib/admin.php, pp_legacy_prop_aliases) is the audited, closed
+    // inventory of pre-1.0 component-scoped prop RENAMES whose old names can still
+    // exist in stored compositions. Two guards keep it honest:
+    //   1. An inventory PIN so the closed set cannot silently grow or shrink.
+    //   2. A drift-catcher that fails a FUTURE schema change which removes/renames a
+    //      prop without shipping an alias entry (or an explicit migration note) —
+    //      making the alias-at-introduction convention structural, not remembered.
+
+    /**
+     * The pinned baseline of declared props per component AS OF #495. This is a
+     * FROZEN LITERAL, deliberately NOT re-globbed from the live schemas at runtime:
+     * if it were regenerated each run, removing a prop would also remove it from the
+     * baseline and the drift would be invisible. A future prop removal/rename leaves
+     * the prop here but drops it from the live schema, so the drift-catcher fires
+     * unless the same change adds an alias entry or a migration note. When you
+     * intentionally ADD a prop, append it here in the same change.
+     */
+    private const PINNED_PROP_BASELINE = [
+        'cta'          => ['id', 'title', 'title_accent', 'eyebrow', 'text', 'button_text', 'button_url', 'layout', 'theme', 'background_image', 'button_variant'],
+        'embed'        => ['id', 'title', 'content', 'theme'],
+        'faq'          => ['id', 'title', 'title_accent', 'eyebrow', 'theme', 'items'],
+        'footer'       => ['location', 'show_logo', 'logo_text', 'logo_id', 'logo_alt', 'bg', 'text', 'link_color', 'blurb', 'contact', 'copyright', 'menu_label', 'contact_label', 'secondary_location', 'secondary_label', 'note', 'social'],
+        'grid'         => ['id', 'title', 'title_accent', 'eyebrow', 'subheading', 'heading_align', 'layout', 'card_emphasis', 'theme', 'columns', 'image_treatment', 'items'],
+        'hero'         => ['id', 'title', 'title_accent', 'eyebrow', 'subtitle', 'cta_text', 'cta_url', 'cta2_text', 'cta2_url', 'cta_variant', 'cta2_variant', 'layout', 'image_url', 'image_alt', 'image_id', 'spacing', 'width', 'split_ratio', 'vertical_align', 'proof'],
+        'logos'        => ['id', 'title', 'theme', 'items'],
+        'nav'          => ['location', 'logo_text', 'logo_id', 'logo_alt', 'bg', 'text', 'link_color'],
+        'section'      => ['id', 'title', 'title_accent', 'eyebrow', 'subheading', 'heading_align', 'body', 'image_url', 'image_alt', 'image_id', 'layout', 'theme', 'background_image', 'panel_heading', 'panel_body', 'panel_items', 'panel_cta_text', 'panel_cta_url', 'panel_cta_variant', 'panel_items_marker', 'body_marker', 'body_items'],
+        'stats'        => ['id', 'title', 'title_accent', 'theme', 'background_image', 'items'],
+        'table'        => ['id', 'title', 'headers', 'rows', 'caption'],
+        'testimonials' => ['id', 'title', 'title_accent', 'eyebrow', 'subheading', 'heading_align', 'layout', 'theme', 'items'],
+    ];
+
+    /**
+     * Explicit escape hatch for a prop retired WITHOUT a write-time alias (e.g. a
+     * rename handled by a separate migration such as `variant`, #388). Empty today:
+     * every removed prop in scope of #495 ships an alias instead. A future retirement
+     * that is genuinely migrated out-of-band records `component => [prop => note]` here.
+     */
+    private const SCHEMA_RENAME_MIGRATION_NOTES = [];
+
+    /**
+     * Pure drift detector: any baseline prop that no longer exists in the live
+     * schema must be covered by an alias-map entry OR a migration note, else it is
+     * a violation. Kept as a static helper so the real run and the simulated-rename
+     * test share one implementation.
+     *
+     * @param array<string,string[]>              $baseline   component => prop names
+     * @param array<string,string[]>              $liveProps  component => prop names
+     * @param array<string,array<string,string>>  $aliasMap   component => [old => canonical]
+     * @param array<string,array<string,string>>  $notes      component => [prop => note]
+     * @return string[]  Human-readable violations (empty = no drift).
+     */
+    private static function detectSchemaRenameDrift(array $baseline, array $liveProps, array $aliasMap, array $notes): array
+    {
+        $violations = [];
+        foreach ($baseline as $component => $props) {
+            $live = $liveProps[$component] ?? [];
+            foreach ($props as $prop) {
+                if (in_array($prop, $live, true)) {
+                    continue; // still declared — no drift
+                }
+                $aliased = isset($aliasMap[$component]) && array_key_exists($prop, $aliasMap[$component]);
+                $noted   = isset($notes[$component]) && array_key_exists($prop, $notes[$component]);
+                if (!$aliased && !$noted) {
+                    $violations[] = sprintf(
+                        'Component "%s" prop "%s" was removed/renamed without an alias-map entry or migration note.',
+                        $component,
+                        $prop
+                    );
+                }
+            }
+        }
+        return $violations;
+    }
+
+    /** Live declared props per component, read from the shipped schemas. */
+    private function liveProps(): array
+    {
+        $out = [];
+        foreach (glob($this->themeRoot . '/components/*/schema.json') as $schemaFile) {
+            $schema = json_decode(file_get_contents($schemaFile), true);
+            $name   = $schema['component'] ?? basename(dirname($schemaFile));
+            $out[$name] = array_keys($schema['props'] ?? []);
+        }
+        return $out;
+    }
+
+    public function testLegacyPropAliasInventoryIsPinned(): void
+    {
+        // The closed audit result. If a future change adds/removes a legacy alias,
+        // this pin forces the change to be deliberate and reviewed.
+        $this->assertSame(
+            [
+                'cta' => [
+                    'cta_text' => 'button_text',
+                    'cta_url'  => 'button_url',
+                ],
+            ],
+            pp_legacy_prop_aliases(),
+            'The legacy prop-alias inventory changed — update the audit and this pin together.'
+        );
+    }
+
+    public function testLiveSchemasHaveNoUnaliasedRenameDriftFromBaseline(): void
+    {
+        // The real guard: today baseline == live, so there is no drift. This freezes
+        // the baseline; a future prop removal/rename without an alias entry or a
+        // migration note fails HERE.
+        $drift = self::detectSchemaRenameDrift(
+            self::PINNED_PROP_BASELINE,
+            $this->liveProps(),
+            pp_legacy_prop_aliases(),
+            self::SCHEMA_RENAME_MIGRATION_NOTES
+        );
+        $this->assertSame([], $drift, implode("\n", $drift));
+
+        // The alias map must stay coherent with the schemas: every canonical target
+        // must actually exist as a live prop (no dangling alias).
+        $live = $this->liveProps();
+        foreach (pp_legacy_prop_aliases() as $component => $map) {
+            foreach ($map as $old => $canonical) {
+                $this->assertContains(
+                    $canonical,
+                    $live[$component] ?? [],
+                    sprintf('Alias %s.%s -> %s points at a prop that no longer exists.', $component, $old, $canonical)
+                );
+            }
+        }
+    }
+
+    public function testEveryLiveSchemaPropIsPinnedInBaseline(): void
+    {
+        // Symmetric guard (the add-path): a newly ADDED prop that the author forgets
+        // to append to PINNED_PROP_BASELINE would leave the baseline stale, so a LATER
+        // removal of that prop could escape the drift-catcher. Forcing every live prop
+        // into the baseline makes the alias-at-introduction convention structural in
+        // BOTH directions: a schema change must touch the baseline in the same commit,
+        // and a rename then fails on both the remove-path (needs an alias) and here.
+        foreach ($this->liveProps() as $component => $props) {
+            $baseline = self::PINNED_PROP_BASELINE[$component] ?? null;
+            $this->assertNotNull(
+                $baseline,
+                sprintf('Component "%s" is not in PINNED_PROP_BASELINE — add it (SchemaValidationTest).', $component)
+            );
+            foreach ($props as $prop) {
+                $this->assertContains(
+                    $prop,
+                    $baseline,
+                    sprintf('Prop "%s.%s" is not pinned in PINNED_PROP_BASELINE — append it in this same change.', $component, $prop)
+                );
+            }
+        }
+    }
+
+    public function testSchemaRenameDriftIsCaught(): void
+    {
+        // Simulate a future rename: the baseline says cta had a `headline` prop, the
+        // live schema no longer declares it. With no alias entry, this MUST be caught.
+        $baseline = ['cta' => ['id', 'headline', 'button_text']];
+        $live     = ['cta' => ['id', 'button_text']]; // `headline` removed
+
+        $unaliased = self::detectSchemaRenameDrift($baseline, $live, [], []);
+        $this->assertNotEmpty($unaliased, 'a schema rename with no alias entry must be flagged');
+        $this->assertStringContainsString('headline', $unaliased[0]);
+
+        // Shipping an alias entry in the SAME change clears it.
+        $withAlias = self::detectSchemaRenameDrift($baseline, $live, ['cta' => ['headline' => 'button_text']], []);
+        $this->assertSame([], $withAlias, 'an alias entry for the renamed prop clears the drift');
+
+        // An explicit migration note also clears it (the out-of-band-migration escape hatch).
+        $withNote = self::detectSchemaRenameDrift($baseline, $live, [], ['cta' => ['headline' => 'migrated by #999']]);
+        $this->assertSame([], $withNote, 'a migration note for the renamed prop clears the drift');
+    }
+
+    public function testAliasHelperGuardsNonScalarComponentWithoutWarning(): void
+    {
+        // The restore path runs the alias normalizer over arbitrary history-ring
+        // snapshots, which can carry a malformed (non-scalar) component key. The
+        // helper must return the item untouched and emit NO "Array to string
+        // conversion" warning (a raw (string) cast on an array would).
+        $item = ['component' => ['not', 'scalar'], 'props' => ['cta_text' => 'x']];
+
+        $warned = false;
+        set_error_handler(function () use (&$warned) { $warned = true; return true; });
+        try {
+            $result = _pp_apply_legacy_prop_aliases($item);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertFalse($warned, 'a non-scalar component must not trigger a PHP warning');
+        $this->assertSame($item, $result, 'a malformed-component item is returned untouched');
+    }
+
+    public function testAliasHelperLeavesItemsWithoutUsablePropsUnchanged(): void
+    {
+        // No props key, and a non-array props value: both early-return untouched.
+        $noProps = ['component' => 'cta'];
+        $this->assertSame($noProps, _pp_apply_legacy_prop_aliases($noProps));
+
+        $scalarProps = ['component' => 'cta', 'props' => 'nope'];
+        $this->assertSame($scalarProps, _pp_apply_legacy_prop_aliases($scalarProps));
+
+        // A component with no alias map (hero's cta_text is a CURRENT prop) is untouched.
+        $hero = ['component' => 'hero', 'props' => ['cta_text' => 'Get Started']];
+        $this->assertSame($hero, _pp_apply_legacy_prop_aliases($hero));
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
 
     private function removeDir(string $dir): void

--- a/tests/WpAbstractionTest.php
+++ b/tests/WpAbstractionTest.php
@@ -196,6 +196,58 @@ class WpAbstractionTest extends TestCase
         $this->assertSame($modern, $result, 'Modern-shape compositions must render unchanged (migration is a no-op).');
     }
 
+    // ── pp_composition() legacy prop-rename resolution (issue #495) ────────
+    //
+    // A pre-1.0 `cta` stored `cta_text`/`cta_url`; the renderer reads
+    // `button_text`/`button_url`, so without render-path resolution a legacy
+    // button rendered its default label. pp_composition() resolves the bounded
+    // alias map for display only — the stored composition is NEVER mutated here
+    // (untouched components heal only on a write that touches them).
+
+    public function testPpCompositionResolvesLegacyCtaPropsOnRender(): void
+    {
+        $stored = wp_json_encode([
+            ['component' => 'cta', 'props' => [
+                'cta_text' => 'View on GitHub',
+                'cta_url'  => 'https://example.com/repo',
+            ]],
+        ]);
+        $GLOBALS['_pp_test_store']['post_meta'][0]['_pp_composition'] = $stored;
+
+        $result = pp_composition();
+
+        $this->assertArrayNotHasKey('cta_text', $result[0]['props'], 'legacy cta_text must resolve away on render.');
+        $this->assertArrayNotHasKey('cta_url', $result[0]['props'], 'legacy cta_url must resolve away on render.');
+        $this->assertSame('View on GitHub', $result[0]['props']['button_text'], 'cta_text value must carry to button_text.');
+        $this->assertSame('https://example.com/repo', $result[0]['props']['button_url'], 'cta_url value must carry to button_url.');
+
+        // Render resolution is a transient view: stored meta is untouched.
+        $this->assertSame(
+            $stored,
+            $GLOBALS['_pp_test_store']['post_meta'][0]['_pp_composition'],
+            'render-path resolution must NOT mutate the stored composition.'
+        );
+    }
+
+    public function testPpCompositionDoesNotResolveHeroCtaProps(): void
+    {
+        // hero.cta_text/cta_url are CURRENT canonical props, not aliases — the
+        // per-component map must leave them exactly as authored.
+        $GLOBALS['_pp_test_store']['post_meta'][0]['_pp_composition'] = wp_json_encode([
+            ['component' => 'hero', 'props' => [
+                'title'    => 'Hi',
+                'cta_text' => 'Get Started',
+                'cta_url'  => '/docs',
+            ]],
+        ]);
+
+        $result = pp_composition();
+
+        $this->assertSame('Get Started', $result[0]['props']['cta_text'], 'hero cta_text is canonical and must be preserved.');
+        $this->assertSame('/docs', $result[0]['props']['cta_url'], 'hero cta_url is canonical and must be preserved.');
+        $this->assertArrayNotHasKey('button_text', $result[0]['props'], 'hero must not gain a cta-only canonical prop.');
+    }
+
     public function testPpCompositionLeavesNonListShapeUnchanged(): void
     {
         // Defensive-parity pin: pp_composition() has never enforced list shape


### PR DESCRIPTION
Closes #495

## Scope (rescoped kernel, per the issue's 2026-07-23 maintainer decision)
The bounded, audited alias map for the pre-1.0 CTA prop renames, plus the schema-rename policy drift-catcher. NOT a general migration framework; the #147 unknown-prop rejection posture is unchanged.

**Audit result (closed inventory):** the only pre-1.0 component-scoped prop renames whose old names can exist in stored compositions and are not already handled by another mechanism are `cta.cta_text`→`button_text` and `cta.cta_url`→`button_url`. The alias map is **per-component** because `hero` declares `cta_text`/`cta_url` as CURRENT canonical props (a global map would corrupt hero). The `variant`→`layout`/`theme` rename is deliberately excluded (write-rejected + read-migrated per #388); `theme` `dark`→`muted` (#442) and grid `default`→`cards` are value renames, out of scope.

## Design (recorded decision: alias-on-read + normalize-on-write)
- **Alias-on-read (validation):** `pp_validate_composition_errors` resolves the legacy names into a transient canonical view before the required-prop and unknown-prop checks — the shared engine, no second validator. Unknown non-mapped props still reject with the same error.
- **Normalize-on-write, touched item only:** `update_component` (incoming patch canonicalized before the merge so a legacy-named edit lands, then the merged item healed) and `add_component` heal the touched/new component; `pp_normalize_composition` heals the full-replace paths (create_page / update_composition / restore). Read-then-write actions read the raw stored shape, so **untouched components keep their stored props and heal incrementally**.
- **Render:** `pp_composition()` resolves aliases transiently so a legacy cta renders its authored button; the stored composition is never mutated on the read path.
- **Drift-catcher (test-only):** a pinned prop baseline (a frozen literal, never runtime-globbed) + the alias inventory pin fail CI on any future prop rename/removal that ships no alias entry or migration note — in both the remove-path and the add-path.

## Acceptance criteria
- [x] A targeted safe edit to ANY component succeeds when an untouched component carries a mapped legacy prop (through the real action surface, Section 14.1).
- [x] A write touching the legacy component normalizes it; untouched components keep their stored shape.
- [x] Unknown non-mapped keys still reject with the current error.
- [x] The drift-catcher fails a simulated schema rename without an alias entry; the audit inventory is pinned.

## Validation
- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → **2378 passed** (22 new; 3 warnings / 2 deprecations, both at baseline).
- JS: `npm test` → **808 passed**.
- Version sync validated by `scripts/package.sh` (build zip deleted; CI builds release zips from tags).

## Review
- `/plan-eng-review` + Codex outside-voice ran on the plan and converged.
- `/review`: testing + maintainability + security specialists and Claude + Codex adversarial passes. Security specialist: no findings (the strict gate is not weakened). Two real correctness fixes to the new code were applied within the recorded decision: (1) `update_component` computed `changes` from pre-normalized props (reported-vs-stored divergence); (2) a legacy-named edit to an already-healed component was silently dropped by canonical-wins — the incoming patch is now canonicalized before the merge so the edit lands. Plus a symmetric drift-catcher guard and added edge-case tests.

## Accepted limitations / notes
- `restore_composition` now heals a legacy-shaped snapshot to canonical (it is a full-replace surface). This is value-preserving (same content, canonical keys) and consistent with the existing legacy-`variant` migration on restore; a restored composition is no longer byte-identical to the snapshot for legacy CTA props, matching the pre-existing `variant` behavior.
- No AI-facing doc changes: `button_text`/`button_url` remain the advertised, still-accurate authoring contract; legacy acceptance is intentionally compatibility-only, not advertised.

## 7A questions
None. No review finding extended the recorded decision; all fixes were mechanical/correctness within it.