### PR TITLE
v1.7.9 fix: native screenshot doctor tri-state + preflight capability finding (#497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.7.9] — 2026-07-26 — native screenshot readiness is a definitive available / unavailable / broken state, never an ambient warning (#497)
+
+**Native screenshot capture depends on a browser command you configure (`PP_BROWSER_CMD`). On installs where it was never set up, every visual-verification step emitted the same "not configured" warning forever, so operators routed around the product's own evidence path with external tooling. Screenshot readiness now reports exactly one definitive state — available (configured and a real capture succeeded), unavailable (not configured, with candidate binaries found on your `$PATH` and the one-line setup step), or broken (configured but failing, with the concrete error). `wp pp screenshot doctor` is the in-band setup-and-diagnose surface: it probes by default, so "configured" always means "actually captured a screenshot," not "resolves on paper."**
+
+`doctor` now runs a real minimal capture by default (pass `--no-probe` for a fast capability-only check) and, when nothing is configured, lists candidate browser binaries it found on `$PATH` as discovery hints — clearly marked as needing to be wrapped to the adapter contract, since PromptingPress blesses no specific tool. `wp pp apply preflight` surfaces the same tri-state as a non-blocking capability finding: `unavailable` and `broken` render distinctly instead of collapsing into one repeated warning, each pointing at `wp pp screenshot doctor`. Preflight stays read-only and never launches a browser — it does the cheap check (does the command resolve, is its binary on `$PATH`) and leaves capture-verification to `doctor`. A configured command whose binary is missing is reported `broken` without ever running a process, but a working setup that uses a shell form the cheap check can't resolve (an env-var prefix, a bare name on a different runtime `$PATH`) is proven by the probe rather than mislabeled. A capture that "succeeds" but writes zero bytes is treated as broken, so the operating loop can never claim native `VERIFIED` off a non-working browser.
+
+### Fixed
+- Screenshot readiness (`pp_screenshot_readiness()`, `wp pp screenshot doctor`, and the preflight `screenshot_readiness` finding) now reports an explicit `state` of `available` / `unavailable` / `broken` instead of a single not-configured warning. A stable unconfigured install reports `unavailable` as a capability STATE, not a per-run nag; `unavailable` and `broken` render as distinct capability-class findings in preflight, each with `next_action: wp pp screenshot doctor` (#497).
+
+### Added
+- `wp pp screenshot doctor` probes by default (runs a real minimal capture so `available` vs `broken` is definitive) and, when `PP_BROWSER_CMD` is unconfigured, detects candidate browser binaries on `$PATH` as setup hints. `--no-probe` keeps the fast, no-browser-launch capability check. It stays read-only: the probe writes a temp file it deletes immediately (#497).
+
+### Docs
+- `docs/screenshot-setup.md` documents the tri-state, the default-probe behavior, `--no-probe`, and the candidate-binaries aid. `docs/running-an-ai-agent.md` gains a "configure it once" section so operators find the setup path where they look, and `docs/reference-apply-cli.md` plus `ai-instructions/operating-loop.md` describe the preflight tri-state finding (#497).
+
+### Tests
+- `tests/ScreenshotTest.php`: the three states through `pp_screenshot_readiness()` (unconfigured → `unavailable`; configured-but-binary-missing → `broken` with no process launched; a fake adapter that writes a PNG → capture-verified `available` with a byte count; a failing probe → `broken`), a regression that a shell-form command whose first token isn't on `$PATH` is `broken` on the cheap check but arbitrated to `available` by the probe, candidate detection returns a list, quote-aware first-token parsing, and the preflight `screenshot_readiness` finding carrying `unavailable` / `broken` distinctly without preflight launching a browser (#497).
+
 ## [v1.7.8] — 2026-07-26 — readiness warnings are now classified, actionable, and acknowledgeable (#496)
 
 **Preflight and readiness warnings used to arrive as an undifferentiated pile: theme-file drift, a site-configuration gap, and a missing environment tool all looked the same and persisted run after run, so operators learned to ignore all of them — which masks the one that matters. Every finding now carries a class (integrity, configuration, or capability) and a sanctioned next action. Integrity drift has a one-command re-baseline that records the installed release, so drift always means "changed since this release." A deliberate configuration gap (a purposely menu-less footer, say) can be acknowledged as intentional and stops showing as a warning, reversibly. A completed operation now reports zero unexplained warnings.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.7.8-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.7.9-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/operating-loop.md
+++ b/ai-instructions/operating-loop.md
@@ -108,7 +108,7 @@ Run: `wp pp screenshot capture --post_id=<id> --playbook=<name>`
 
 This captures screenshots at both viewports (1280px desktop + 375px mobile) unless the playbook declares otherwise.
 
-To diagnose capture readiness BEFORE you reach this step, run `wp pp screenshot doctor` (add `--probe` to attempt a real capture). It reports whether `PP_BROWSER_CMD` resolves, from where, and in which context (CLI vs web), with remediation. `wp pp apply preflight` also surfaces a non-blocking screenshot-readiness warning — a missing browser never blocks a typed mutation, it only means you cannot reach native `VERIFIED`. Setup: `docs/screenshot-setup.md`.
+To diagnose capture readiness BEFORE you reach this step, run `wp pp screenshot doctor`. It probes by default (attempts a real capture) and reports one definitive tri-state: `available` (configured and capture-verified), `unavailable` (`PP_BROWSER_CMD` not configured — lists candidate binaries + the setup step), or `broken` (configured but failing, with the error). Add `--no-probe` for a fast capability-only check. It also reports where `PP_BROWSER_CMD` resolves from and in which context (CLI vs web). `wp pp apply preflight` surfaces the same state as a non-blocking capability finding (`unavailable` and `broken` render distinctly) — a missing browser never blocks a typed mutation, it only means you cannot reach native `VERIFIED`. Setup: `docs/screenshot-setup.md`.
 
 **Three status paths** (the capture command returns the matching `status` in its result):
 - **Browser configured and capture succeeds**: Continue to REVIEW with screenshots.
@@ -202,7 +202,7 @@ Three playbooks are available. Each one customizes the loop for a specific opera
 | `wp pp apply reset --run-id=<uuid> [--token=<name>]` | APPLY | Required | Reset token overrides to product defaults — all, or one with `--token`. This is the deliberate "back to base.css" path, NOT a per-run undo. Use `apply restore` to undo a specific run. |
 | `wp pp screenshot capture --post_id=<id> --playbook=<name>` | SCREENSHOT | — | Capture both viewports |
 | `wp pp screenshot capture --capture-url=<url> --width=<px>` | SCREENSHOT | — | Capture single URL |
-| `wp pp screenshot doctor [--probe]` | SCREENSHOT | — | Diagnose capture readiness (PP_BROWSER_CMD + context) |
+| `wp pp screenshot doctor [--no-probe]` | SCREENSHOT | — | Diagnose capture readiness — tri-state available/unavailable/broken (probes by default) |
 | `wp pp readiness status` | any | — | Read-only: current findings grouped by class (integrity/configuration/capability) with per-finding next actions (#496) |
 | `wp pp readiness rebaseline` | any | — | Re-baseline the deployment manifest against the installed release (resolves integrity drift) |
 | `wp pp readiness acknowledge <finding-key> [--note=<text>]` | any | — | Record a configuration finding as intentional (reversible) |

--- a/docs/reference-apply-cli.md
+++ b/docs/reference-apply-cli.md
@@ -220,6 +220,14 @@ The checks that can run (`pp_preflight`, `lib/operate.php`):
 
 `ok` is `true` only when no **error-grade** check failed. Rows with `severity: warning` (nav readiness, screenshot readiness, non-overlapping drift) surface a problem without blocking.
 
+**Screenshot readiness tri-state (#497).** The `screenshot_readiness` row carries a `state`:
+`available` (healthy, no finding), `unavailable` (`PP_BROWSER_CMD` not configured), or
+`broken` (configured but the binary is missing from `$PATH`). `unavailable` and `broken`
+are distinct capability-class findings, each with `next_action: wp pp screenshot doctor` —
+never a single ambient warning. Preflight does the cheap **non-exec** check only (it never
+launches a browser); run `wp pp screenshot doctor` to capture-verify `available` and to turn
+a probe-time failure into `broken`. See `docs/screenshot-setup.md`.
+
 **Uploads writability (#229).** `import_media` sideloads a file into `wp-content/uploads/YYYY/MM/`, so a preflight with `--apply=import_media` runs `uploads_writable` instead of asserting "no filesystem writes." The check mirrors execute-time `wp_mkdir_p()` semantics: it walks from the dated path to the **deepest existing ancestor** and requires it to be a writable directory — so a fresh site whose `uploads/` doesn't exist yet passes (WordPress creates it), while an unwritable intermediate directory (`uploads/2026` rsync'd `0555`) or a regular file occupying a path segment fails closed even when `uploads/` itself is writable. The `theme_writable` row still passes for media applies (the theme directory is untouched) with a message pointing at `uploads_writable`.
 
 **Unknown apply name (issue 245).** The `--apply` flag exists so preflight can verify the named apply's preconditions, so a name that matches no registered apply is a hard error, not a no-op. Without the guard, `--apply=import_medai` (a typo) would resolve to "no apply planned," skip the apply-routed filesystem checks, pass clean, and record a `PREFLIGHT` state asserting "no filesystem writes" the operator never earned — the same false-pass class as #227/#229, one level up. Any **provided** non-empty apply value is validated (including the falsy literal `--apply=0`, which is never a registered name); an empty `--apply=` is treated as "no apply planned," same as omitting the flag. The `apply_known` check is error-grade, so an unknown name makes `ok` false and no `PREFLIGHT` is recorded:
@@ -471,7 +479,7 @@ Readiness/preflight warnings carry a **class** and a sanctioned **next action**,
 |---|---|---|
 | `integrity` | Theme file drift vs the recorded release baseline | `wp pp readiness rebaseline` |
 | `configuration` | Site-state gap resolvable through a safe surface (e.g. an unassigned menu location) | Fix through the surface (e.g. `set_menu`), **or** acknowledge as intentional |
-| `capability` | An environment tool is missing (e.g. a screenshot browser, #497) | Run the finding's next action (e.g. `wp pp screenshot doctor`) |
+| `capability` | An environment tool is missing or misconfigured (e.g. a screenshot browser, #497 — the finding's `state` is `unavailable` or `broken`) | Run the finding's next action (e.g. `wp pp screenshot doctor`) |
 
 Only **findings** carry a class; passing/healthy rows and hard preconditions do not. Only **configuration** findings are acknowledgeable.
 

--- a/docs/running-an-ai-agent.md
+++ b/docs/running-an-ai-agent.md
@@ -110,6 +110,32 @@ Do not report VERIFIED without screenshots and a completed review.
 That single block closes the "I'll just edit the file" gap at the instruction level.
 The framework then closes it again inside the `wp pp` surface.
 
+### Native screenshot evidence — configure it once (#497)
+
+Screenshots come from a browser command you configure (`PP_BROWSER_CMD`); PromptingPress
+ships no bundled browser. Check readiness with one command before you rely on visual proof:
+
+```bash
+wp pp screenshot doctor             # resolves PP_BROWSER_CMD + runs a real probe capture
+wp pp screenshot doctor --no-probe  # fast capability-only check (no browser launch)
+```
+
+`doctor` reports one definitive tri-state, so evidence is never an ambient "may not work"
+warning:
+
+- **`available`** — configured and a real probe capture succeeded. Handoffs say
+  "evidence captured natively."
+- **`unavailable`** — `PP_BROWSER_CMD` not configured. `doctor` lists candidate binaries
+  found on `$PATH` and the one-line setup step. Handoffs say "native evidence explicitly
+  unavailable" and fall back to another visual-proof method — this is a stable capability
+  state, not a per-run nag.
+- **`broken`** — configured but failing (binary missing, or the probe failed), with the
+  concrete error to fix.
+
+`wp pp apply preflight` surfaces the same state as a **non-blocking** capability finding
+(`unavailable` and `broken` render distinctly), so a missing browser never blocks a safe
+typed change. Full setup: `docs/screenshot-setup.md`.
+
 ## ✍️ Step 2 — Give it a task
 
 Keep the task itself short. The contract above carries the safety steps, so you just

--- a/docs/screenshot-setup.md
+++ b/docs/screenshot-setup.md
@@ -49,18 +49,41 @@ Resolution order is **constant first, then environment variable**:
 ## Diagnosing it
 
 ```bash
-wp pp screenshot doctor          # capability check: does PP_BROWSER_CMD resolve, and from where?
-wp pp screenshot doctor --probe  # also runs a real minimal capture to confirm the adapter works
+wp pp screenshot doctor             # full diagnosis: resolves + runs a real probe capture
+wp pp screenshot doctor --no-probe  # fast capability-only check (no browser launch)
 ```
 
-`doctor` is read-only and never mutates the site. It reports `ready`, the `source`
-(`constant` / `env`), the `context` (`cli` / `web`), and remediation when not ready.
+`doctor` reports exactly one definitive **tri-state** so screenshot evidence is never an
+ambient "may not work" warning:
+
+| `state` | Meaning | What `doctor` tells you |
+|---------|---------|-------------------------|
+| `available` | `PP_BROWSER_CMD` resolves and a real probe capture succeeded | the resolved binary, source, context, and the captured byte count |
+| `unavailable` | `PP_BROWSER_CMD` is not configured | candidate browser binaries found on `$PATH` + the one-line setup pointer |
+| `broken` | configured but failing (binary missing from `$PATH`, or the probe capture itself failed) | the concrete failure, so you know exactly what to fix |
+
+By default `doctor` **probes** — it attempts a real minimal capture, so `available` vs
+`broken` is definitive. `--no-probe` does the cheap capability-only check (resolve
+`PP_BROWSER_CMD`, confirm its binary is on `$PATH`) without launching a browser; it cannot
+tell `available` from a probe-time `broken`.
+
+`doctor` is read-only and never mutates the site (the probe writes a temp file it deletes
+immediately). It reports `state`, `ready` (`state === "available"`), the `source`
+(`constant` / `env`), the `context` (`cli` / `web`), any `candidates`, and remediation.
 It exits `1` when not ready, so you can gate scripts on it.
+
+The `candidates` list is a **discovery aid, not an endorsement**: PromptingPress blesses no
+specific tool. Each candidate still has to be wrapped to the adapter contract
+(`<url> --width --height --output`) before it can back `PP_BROWSER_CMD`.
 
 ## What happens when it is not configured
 
-- **Preflight** (`wp pp apply preflight`) surfaces a **non-blocking warning**:
-  screenshot readiness is advisory. A missing browser does **not** block typed
+- **Preflight** (`wp pp apply preflight`) surfaces a **non-blocking**, classified
+  **capability finding** carrying the same `state` — `unavailable` and `broken` render
+  distinctly (they never collapse into one generic warning), each with
+  `next_action: wp pp screenshot doctor`. Preflight does the cheap non-exec check only (it
+  never launches a browser), so it can report a binary-missing `broken` but leaves
+  probe-verification to `doctor`. A missing browser does **not** block typed
   content/composition mutations — browser availability is an environment capability,
   not a prerequisite for a safe typed change.
 - **Capture** (`wp pp screenshot capture`) returns an explicit status, matching the

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.7.8');
+define('PP_VERSION', '1.7.9');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -1695,27 +1695,44 @@ class PP_Screenshot_Command extends WP_CLI_Command {
     }
 
     /**
-     * Diagnoses screenshot-capture readiness for the current runtime context.
+     * Diagnoses screenshot-capture readiness for the current runtime context (#497).
      *
-     * Reports whether PP_BROWSER_CMD resolves, from where (constant vs env), and in which
-     * context (CLI `wp` vs web PHP — they can resolve different config). With --probe it
-     * attempts a real minimal capture to confirm the adapter actually launches and writes
-     * a file. Read-only: never mutates the site. Exits 1 when not ready so scripts and the
-     * operating loop can gate visual-proof steps on it.
+     * Reports one definitive tri-state so native screenshot evidence is never an ambient
+     * warning:
+     *   - `available`   — PP_BROWSER_CMD resolves and a real probe capture succeeded.
+     *   - `unavailable` — not configured; lists candidate browser binaries found on $PATH
+     *                     plus the one-line setup pointer.
+     *   - `broken`      — configured but failing (binary missing, or the probe capture
+     *                     itself failed), with the concrete failure.
+     *
+     * Reports where PP_BROWSER_CMD resolves from (constant vs env) and in which context
+     * (CLI `wp` vs web PHP — they can resolve different config). Probes by default: it
+     * attempts a real minimal capture so `available` vs `broken` is definitive. Pass
+     * --no-probe for a fast capability-only check (no browser launch). Read-only: it never
+     * mutates site state (the probe writes a temp file it deletes). Exits 1 when not ready
+     * so scripts and the operating loop can gate visual-proof steps on it.
      *
      * ## OPTIONS
      *
      * [--probe]
-     * : Attempt a real minimal capture against the home URL to confirm the adapter runs.
+     * : Attempt a real minimal capture (this is the DEFAULT; flag kept for explicitness).
+     *
+     * [--no-probe]
+     * : Capability-only check — resolve PP_BROWSER_CMD and check its binary without
+     *   launching a browser. Cannot distinguish `available` from a probe-time `broken`.
      *
      * ## EXAMPLES
      *
      *     wp pp screenshot doctor
-     *     wp pp screenshot doctor --probe
+     *     wp pp screenshot doctor --no-probe
      *
      */
     public function doctor($args, $assoc_args) {
-        $readiness = pp_screenshot_readiness(isset($assoc_args['probe']));
+        // Probe by default so the tri-state is definitive; --no-probe opts out. In
+        // WP-CLI a negatable flag is read off the base key: --no-probe sets 'probe' to
+        // false, --probe sets it true, absent uses the default (true).
+        $probe = (bool) \WP_CLI\Utils\get_flag_value($assoc_args, 'probe', true);
+        $readiness = pp_screenshot_readiness($probe, true);
         WP_CLI::line(json_encode($readiness, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         if (!$readiness['ready']) {
             WP_CLI::halt(1);

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -241,6 +241,9 @@ function pp_classify_findings(array $checks): array {
         $by_class[$class][] = [
             'check'            => $check['check'] ?? '',
             'pass'             => (bool) ($check['pass'] ?? false),
+            // Tri-state capability sub-state (#497), e.g. screenshot readiness
+            // 'unavailable' vs 'broken'. Null for findings that carry no sub-state.
+            'state'            => $check['state'] ?? null,
             'acknowledgeable'  => (bool) ($check['acknowledgeable'] ?? false),
             'acknowledged'     => (bool) ($check['acknowledged'] ?? false),
             // Surface the operator's recorded rationale in the read surface — it
@@ -659,22 +662,31 @@ function pp_preflight(array $context = [], ?array $drift = null): array {
     // The operating loop forbids native VERIFIED without screenshots, so surface capture
     // readiness BEFORE mutation. A missing browser is a capability warning, not a gate:
     // typed mutations may still proceed; the run just cannot claim native VERIFIED.
+    // Read-only capability check: no probe here (preflight must not launch a browser).
+    // The tri-state `state` (#497) still renders distinctly: `unavailable` (not
+    // configured) and `broken` (configured but the binary is missing) are separate
+    // capability findings, while `available` is healthy. `wp pp screenshot doctor`
+    // upgrades `available` to a capture-verified verdict and turns a probe failure into
+    // `broken` — this surface reports the cheap, non-exec verdict.
     $shot = pp_screenshot_readiness();
-    if ($shot['ready']) {
+    if ($shot['state'] === 'available') {
         // Healthy: not a finding, no class.
         $checks[] = [
             'check'    => 'screenshot_readiness',
             'pass'     => true,
             'severity' => 'warning',
+            'state'    => 'available',
             'message'  => 'Native screenshot capture is ready (' . $shot['message'] . ').',
         ];
     } else {
-        // Capability-class finding (#496): an environment tool is missing (#497).
+        // Capability-class finding (#496): an environment tool is missing/misconfigured
+        // (#497). `unavailable` and `broken` render distinctly via the `state` field.
         $checks[] = [
             'check'       => 'screenshot_readiness',
             'pass'        => false,
             'severity'    => 'warning',
             'class'       => 'capability',
+            'state'       => $shot['state'],
             'next_action' => 'wp pp screenshot doctor',
             'message'     => $shot['message'] . ' Typed mutations may still proceed; native VERIFIED requires a '
               . 'working capture — run `wp pp screenshot doctor` to diagnose.',

--- a/lib/screenshot.php
+++ b/lib/screenshot.php
@@ -90,25 +90,125 @@ function pp_screenshot_resolve_browser_cmd(): array {
 }
 
 /**
- * Reports screenshot-capture readiness for the CURRENT runtime context (CLI `wp` and
- * web PHP can resolve different env/config, so the reported context matters). Capability
- * detection only by default; pass $probe=true to actually attempt a tiny capture and
- * confirm the adapter launches, writes a file, and exits cleanly.
+ * Extracts the executable token from a configured browser command. PP_BROWSER_CMD
+ * is a command line (e.g. `node /path/shot.js`, `"/opt/my browser/pp-shot"`), so the
+ * binary to check is its first shell token, quote-aware.
  *
- * Basis for both `wp pp screenshot doctor` and the non-blocking preflight readiness
- * warning. Never mutates the site and never blocks anything.
- *
- * @param bool $probe  When true, run a real minimal capture against the home URL.
- * @return array{ready: bool, source: ?string, context: string, browser_cmd: ?string,
- *               probe: ?array, message: string}
+ * @param string $cmd  The configured command line.
+ * @return string  The first token (the binary), or '' when none.
  */
-function pp_screenshot_readiness(bool $probe = false): array {
+function pp_screenshot_command_binary(string $cmd): string {
+    $cmd = trim($cmd);
+    if ($cmd === '') {
+        return '';
+    }
+    // Quote-aware first token: honor a leading '...' or "..." so a path with spaces
+    // resolves as one binary rather than being split.
+    $q = $cmd[0];
+    if ($q === '"' || $q === "'") {
+        $end = strpos($cmd, $q, 1);
+        return $end !== false ? substr($cmd, 1, $end - 1) : substr($cmd, 1);
+    }
+    $parts = preg_split('/\s+/', $cmd, 2);
+    return $parts[0] ?? '';
+}
+
+/**
+ * Resolves a bare binary name against $PATH (or checks an explicit path directly).
+ * Cheap and side-effect-free: stat-only, no process launch — safe for the read-only
+ * preflight surface.
+ *
+ * @param string $binary  A binary name or path.
+ * @return ?string  The resolved executable path, or null when not found/executable.
+ */
+function pp_screenshot_which(string $binary): ?string {
+    if ($binary === '') {
+        return null;
+    }
+    // Explicit path (absolute or relative with a slash): check it directly. Require a
+    // regular file, not just any x-bit inode — a directory carries the execute bit but is
+    // not an adapter.
+    if (strpos($binary, '/') !== false) {
+        return (is_file($binary) && is_executable($binary)) ? $binary : null;
+    }
+    $path = (string) getenv('PATH');
+    foreach (explode(PATH_SEPARATOR, $path) as $dir) {
+        if ($dir === '') {
+            continue;
+        }
+        $candidate = rtrim($dir, '/') . '/' . $binary;
+        if (is_file($candidate) && is_executable($candidate)) {
+            return $candidate;
+        }
+    }
+    return null;
+}
+
+/**
+ * Detects common browser/screenshot binaries on $PATH. These are DISCOVERY HINTS
+ * only: PromptingPress blesses no specific tool — each candidate still has to be
+ * wrapped to the adapter contract (`<url> --width --height --output`) before it can
+ * back PP_BROWSER_CMD. Used by `wp pp screenshot doctor` to help an operator go from
+ * unconfigured to configured without leaving the CLI.
+ *
+ * @return array[]  Each: ['name' => string, 'path' => string]. Empty when none found.
+ */
+function pp_screenshot_candidate_browsers(): array {
+    // Ordered rough-to-precise: purpose-built shot wrappers first, then raw browsers.
+    $names = [
+        'pp-shot', 'shot-scraper', 'pageres', 'wkhtmltoimage', 'playwright',
+        'chromium', 'chromium-browser', 'google-chrome', 'google-chrome-stable',
+        'chrome', 'chrome-headless-shell', 'firefox',
+    ];
+    $found = [];
+    foreach ($names as $name) {
+        $resolved = pp_screenshot_which($name);
+        if ($resolved !== null) {
+            $found[] = ['name' => $name, 'path' => $resolved];
+        }
+    }
+    return $found;
+}
+
+/**
+ * Reports screenshot-capture readiness for the CURRENT runtime context (CLI `wp` and
+ * web PHP can resolve different env/config, so the reported context matters) as an
+ * explicit tri-state (#497):
+ *
+ *   - `available`   — PP_BROWSER_CMD resolves AND its binary is on $PATH. When $probe
+ *                     is set, a real capture also ran and succeeded (definitive).
+ *   - `unavailable` — PP_BROWSER_CMD is not configured for this context. Carries the
+ *                     one-line setup pointer; this is a capability STATE, not a per-run
+ *                     warning.
+ *   - `broken`      — PP_BROWSER_CMD is configured but failing: the binary is missing
+ *                     from $PATH (cheap, no-exec detection), or (with $probe) the real
+ *                     capture failed. Carries the concrete failure.
+ *
+ * Without $probe this is a cheap, side-effect-free capability check (stat-only) safe for
+ * the read-only preflight surface: it can definitively report `unavailable` and a
+ * binary-missing `broken`, and reports `available` optimistically (resolves; not yet
+ * capture-verified). `wp pp screenshot doctor` passes $probe=true to make `available`
+ * vs `broken` definitive by attempting a real capture. Never mutates the site and never
+ * blocks anything.
+ *
+ * `ready` is retained as a convenience alias: `ready === (state === 'available')`.
+ *
+ * @param bool $probe             When true, run a real minimal capture against the home URL.
+ * @param bool $include_candidates When true, attach detected candidate browser binaries
+ *                                 (a doctor-facing setup aid; off by default so preflight
+ *                                 stays lean).
+ * @return array{ready: bool, state: string, source: ?string, context: string,
+ *               browser_cmd: ?string, probe: ?array, candidates?: array, message: string}
+ */
+function pp_screenshot_readiness(bool $probe = false, bool $include_candidates = false): array {
     $resolved = pp_screenshot_resolve_browser_cmd();
     $context  = (php_sapi_name() === 'cli') ? 'cli' : 'web';
 
+    // ── unavailable: nothing configured ─────────────────────────────────────
     if ($resolved['cmd'] === null) {
-        return [
+        $result = [
             'ready'       => false,
+            'state'       => 'unavailable',
             'source'      => null,
             'context'     => $context,
             'browser_cmd' => null,
@@ -118,16 +218,55 @@ function pp_screenshot_readiness(bool $probe = false): array {
                 . 'wp-config.php (PHP constant). Required adapter shape: '
                 . '<url> --width=<px> --height=<px> --output=<path>. See docs/screenshot-setup.md.',
         ];
+        if ($include_candidates) {
+            $result['candidates'] = pp_screenshot_candidate_browsers();
+        }
+        return $result;
     }
 
+    // ── configured: decide available vs broken ──────────────────────────────
+    // Cheap, stat-only resolution of the command's binary. This is DEFINITIVE only for
+    // the no-probe (preflight) surface: a bare token that doesn't resolve on $PATH is a
+    // clearly-broken config. But PP_BROWSER_CMD is a shell command line — an env-var
+    // prefix (`FOO=1 chromium ...`), `A && B`, a shell builtin, or a bare name present at
+    // the adapter's runtime PATH but not this context's PATH are all things the token
+    // parser cannot resolve yet still capture fine. So when we PROBE, the real capture is
+    // the arbiter: the binary-missing early return only fires without a probe.
+    $binary   = pp_screenshot_command_binary($resolved['cmd']);
+    $bin_path = pp_screenshot_which($binary);
+
+    if ($bin_path === null && !$probe) {
+        $result = [
+            'ready'       => false,
+            'state'       => 'broken',
+            'source'      => $resolved['source'],
+            'context'     => $context,
+            'browser_cmd' => $resolved['cmd'],
+            'probe'       => null,
+            'message'     => 'PP_BROWSER_CMD is set (' . $resolved['source'] . ') but its command "'
+                . $binary . '" was not found on $PATH (or is not executable) in the ' . $context
+                . ' context. Run `wp pp screenshot doctor` to capture-verify (it may still work via a '
+                . 'shell form the check cannot resolve), or fix the path. See docs/screenshot-setup.md.',
+        ];
+        if ($include_candidates) {
+            $result['candidates'] = pp_screenshot_candidate_browsers();
+        }
+        return $result;
+    }
+
+    // Optimistic baseline: resolves (or will be probe-arbitrated). The message is only
+    // surfaced on the no-probe path (the probe block overwrites it), where $bin_path is
+    // non-null, so guard the null case defensively.
     $result = [
         'ready'       => true,
+        'state'       => 'available',
         'source'      => $resolved['source'],
         'context'     => $context,
         'browser_cmd' => $resolved['cmd'],
         'probe'       => null,
-        'message'     => 'PP_BROWSER_CMD resolved from ' . $resolved['source'] . ' for the '
-            . $context . ' context.',
+        'message'     => 'PP_BROWSER_CMD resolved from ' . $resolved['source']
+            . ($bin_path !== null ? ' (' . $bin_path . ')' : '')
+            . ' for the ' . $context . ' context. Run `wp pp screenshot doctor` to capture-verify.',
     ];
 
     if ($probe) {
@@ -141,6 +280,7 @@ function pp_screenshot_readiness(bool $probe = false): array {
             'height' => 240,
             'output' => $tmp,
         ]);
+        $bytes = (file_exists($tmp) && ($capture['ok'] ?? false)) ? filesize($tmp) : 0;
         if (file_exists($tmp)) {
             @unlink($tmp);
         }
@@ -148,14 +288,26 @@ function pp_screenshot_readiness(bool $probe = false): array {
             'ok'      => $capture['ok'],
             'error'   => $capture['error'] ?? null,
             'message' => $capture['message'] ?? null,
+            'bytes'   => $bytes,
         ];
-        $result['ready'] = $capture['ok'];
-        if (!$capture['ok']) {
+        // A capture that "succeeded" but produced no bytes is not real evidence — treat it
+        // as broken so a delete race can never masquerade as `available`.
+        if (($capture['ok'] ?? false) && $bytes > 0) {
+            $result['message'] = 'PP_BROWSER_CMD (' . $resolved['source'] . ') captured a real probe '
+                . 'in the ' . $context . ' context: ' . $bytes . '-byte PNG. Native screenshot '
+                . 'evidence is available.';
+        } else {
+            $result['ready']   = false;
+            $result['state']   = 'broken';
             $result['message'] = 'PP_BROWSER_CMD is set (' . $resolved['source'] . ') but a probe '
                 . 'capture in the ' . $context . ' context failed: '
-                . ($capture['message'] ?? $capture['error'] ?? 'unknown')
+                . ($capture['message'] ?? $capture['error'] ?? ($bytes === 0 ? 'empty capture' : 'unknown'))
                 . '. Fix the adapter before relying on native screenshot evidence.';
         }
+    }
+
+    if ($include_candidates && $result['state'] !== 'available') {
+        $result['candidates'] = pp_screenshot_candidate_browsers();
     }
 
     return $result;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.7.8
+Stable tag: 1.7.9
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.7.8
+Version:          1.7.9
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ScreenshotTest.php
+++ b/tests/ScreenshotTest.php
@@ -121,9 +121,15 @@ class ScreenshotTest extends TestCase
         putenv('PP_BROWSER_CMD');
         $readiness = pp_screenshot_readiness();
         $this->assertFalse($readiness['ready']);
+        // Tri-state (#497): unconfigured is the definitive `unavailable` STATE, not an
+        // ambient "may not work" warning.
+        $this->assertSame('unavailable', $readiness['state']);
         $this->assertSame('cli', $readiness['context']); // PHPUnit runs under the CLI SAPI
         $this->assertNull($readiness['source']);
         $this->assertStringContainsString('PP_BROWSER_CMD', $readiness['message']);
+        // No probe requested and no candidates requested: candidates stays out of the
+        // lean (preflight) shape.
+        $this->assertArrayNotHasKey('candidates', $readiness);
     }
 
     public function testReadinessReadyWhenEnvConfigured(): void
@@ -132,11 +138,134 @@ class ScreenshotTest extends TestCase
         try {
             $readiness = pp_screenshot_readiness(); // capability only, no probe
             $this->assertTrue($readiness['ready']);
+            // /bin/true resolves on $PATH → `available` (resolves; not yet capture-verified).
+            $this->assertSame('available', $readiness['state']);
             $this->assertSame('env', $readiness['source']);
             $this->assertSame('/bin/true', $readiness['browser_cmd']);
         } finally {
             putenv('PP_BROWSER_CMD');
         }
+    }
+
+    public function testReadinessBrokenStateWhenBinaryMissingNoExec(): void
+    {
+        // Configured but the command's binary is not on $PATH → `broken`, detected WITHOUT
+        // launching a process (cheap enough for the read-only preflight surface).
+        putenv('PP_BROWSER_CMD=/nonexistent/pp-screenshot-binary-xyz');
+        try {
+            $readiness = pp_screenshot_readiness(); // no probe
+            $this->assertFalse($readiness['ready']);
+            $this->assertSame('broken', $readiness['state']);
+            $this->assertNull($readiness['probe'], 'binary-missing broken must not have run a probe');
+            $this->assertStringContainsString('not found on $PATH', $readiness['message']);
+        } finally {
+            putenv('PP_BROWSER_CMD');
+        }
+    }
+
+    public function testReadinessAvailableStateWithVerifiedProbe(): void
+    {
+        // A fake adapter that honors the contract (writes a PNG to --output, exits 0) makes
+        // the probe path reach a definitive, capture-verified `available` — and we inspect
+        // what it wrote (Section 14.2): a non-empty file.
+        $adapter = $this->screenshotDir . '/fake-adapter.sh';
+        file_put_contents($adapter, <<<'SH'
+#!/bin/sh
+out=""
+for arg in "$@"; do
+  case "$arg" in
+    --output=*) out="${arg#--output=}" ;;
+  esac
+done
+[ -n "$out" ] || exit 3
+printf '\211PNG\r\n\032\n fake pixels' > "$out"
+exit 0
+SH
+        );
+        chmod($adapter, 0755);
+        putenv('PP_BROWSER_CMD=' . $adapter);
+        try {
+            $readiness = pp_screenshot_readiness(true); // probe
+            $this->assertTrue($readiness['ready'], $readiness['message']);
+            $this->assertSame('available', $readiness['state']);
+            $this->assertIsArray($readiness['probe']);
+            $this->assertTrue($readiness['probe']['ok'], 'the fake adapter capture should succeed');
+            $this->assertGreaterThan(0, $readiness['probe']['bytes'], 'probe must report the captured byte count');
+        } finally {
+            putenv('PP_BROWSER_CMD');
+            foreach (glob(pp_screenshot_dir() . '/.doctor-probe-*.png') ?: [] as $f) {
+                @unlink($f);
+            }
+        }
+    }
+
+    public function testProbeArbitratesShellFormWhoseFirstTokenIsNotOnPath(): void
+    {
+        // Regression: a shell command line whose FIRST token is not a $PATH binary (here an
+        // env-var prefix) is `broken` on the cheap no-exec check, but `doctor --probe` must
+        // NOT short-circuit — the real capture is the arbiter, and this one captures fine.
+        $adapter = $this->screenshotDir . '/env-prefixed-adapter.sh';
+        file_put_contents($adapter, <<<'SH'
+#!/bin/sh
+out=""
+for arg in "$@"; do
+  case "$arg" in --output=*) out="${arg#--output=}" ;; esac
+done
+[ -n "$out" ] || exit 3
+printf '\211PNG\r\n\032\n fake pixels' > "$out"
+exit 0
+SH
+        );
+        chmod($adapter, 0755);
+        // First token is `PP_FAKE=1`, which is not a binary on $PATH.
+        putenv('PP_BROWSER_CMD=PP_FAKE=1 ' . $adapter);
+        try {
+            // No probe: the cheap check cannot resolve the first token → broken.
+            $cheap = pp_screenshot_readiness();
+            $this->assertSame('broken', $cheap['state']);
+
+            // Probe (doctor default): the actual capture succeeds → available, not a false broken.
+            $probed = pp_screenshot_readiness(true);
+            $this->assertSame('available', $probed['state'], $probed['message']);
+            $this->assertTrue($probed['ready']);
+            $this->assertTrue($probed['probe']['ok']);
+            $this->assertGreaterThan(0, $probed['probe']['bytes']);
+        } finally {
+            putenv('PP_BROWSER_CMD');
+            foreach (glob(pp_screenshot_dir() . '/.doctor-probe-*.png') ?: [] as $f) {
+                @unlink($f);
+            }
+        }
+    }
+
+    public function testReadinessCandidatesIncludedForDoctorWhenUnconfigured(): void
+    {
+        // Doctor passes include_candidates=true so an unconfigured operator gets discovery
+        // hints. The set may be empty on a browserless container — the CONTRACT is that the
+        // key is present and is a list, each entry naming a binary + resolved path.
+        putenv('PP_BROWSER_CMD');
+        $readiness = pp_screenshot_readiness(true, true); // doctor shape: probe + candidates
+        $this->assertSame('unavailable', $readiness['state']);
+        $this->assertArrayHasKey('candidates', $readiness);
+        $this->assertIsArray($readiness['candidates']);
+        foreach ($readiness['candidates'] as $cand) {
+            $this->assertArrayHasKey('name', $cand);
+            $this->assertArrayHasKey('path', $cand);
+        }
+    }
+
+    public function testCandidateBrowsersReturnsList(): void
+    {
+        $candidates = pp_screenshot_candidate_browsers();
+        $this->assertIsArray($candidates);
+    }
+
+    public function testCommandBinaryIsQuoteAwareFirstToken(): void
+    {
+        $this->assertSame('/usr/bin/node', pp_screenshot_command_binary('/usr/bin/node /path/shot.js --flag'));
+        $this->assertSame('/opt/my browser/pp-shot', pp_screenshot_command_binary('"/opt/my browser/pp-shot" --width=1'));
+        $this->assertSame('pp-shot', pp_screenshot_command_binary('pp-shot'));
+        $this->assertSame('', pp_screenshot_command_binary('   '));
     }
 
     public function testPreflightSurfacesScreenshotReadinessAsNonBlockingWarning(): void
@@ -166,6 +295,51 @@ class ScreenshotTest extends TestCase
         );
     }
 
+    public function testPreflightUnavailableFindingCarriesUnavailableState(): void
+    {
+        // #497: preflight renders the tri-state distinctly. Unconfigured → a capability
+        // finding tagged state `unavailable`, surfaced in the classified findings block.
+        putenv('PP_BROWSER_CMD');
+        $result = pp_preflight([]);
+        $shot = array_values(array_filter(
+            $result['checks'],
+            fn ($c) => ($c['check'] ?? '') === 'screenshot_readiness'
+        ))[0];
+        $this->assertFalse($shot['pass']);
+        $this->assertSame('capability', $shot['class']);
+        $this->assertSame('unavailable', $shot['state']);
+        $this->assertSame('wp pp screenshot doctor', $shot['next_action']);
+        // The classified findings block copies the sub-state through.
+        $cap = $result['findings']['by_class']['capability'];
+        $row = array_values(array_filter($cap, fn ($r) => ($r['check'] ?? '') === 'screenshot_readiness'))[0];
+        $this->assertSame('unavailable', $row['state']);
+    }
+
+    public function testPreflightBrokenFindingCarriesBrokenState(): void
+    {
+        // #497: a configured-but-missing binary renders as `broken` in preflight, WITHOUT
+        // preflight launching a browser (the cheap non-exec check), and stays non-blocking.
+        putenv('PP_BROWSER_CMD=/nonexistent/pp-screenshot-binary-xyz');
+        try {
+            $result = pp_preflight([]);
+            $shot = array_values(array_filter(
+                $result['checks'],
+                fn ($c) => ($c['check'] ?? '') === 'screenshot_readiness'
+            ))[0];
+            $this->assertFalse($shot['pass']);
+            $this->assertSame('capability', $shot['class']);
+            $this->assertSame('broken', $shot['state']);
+            // Distinct from `unavailable`: the two states never collapse into one warning.
+            $blocking = array_filter(
+                $result['checks'],
+                fn ($c) => !$c['pass'] && (($c['severity'] ?? 'error') !== 'warning')
+            );
+            $this->assertNotContains('screenshot_readiness', array_column($blocking, 'check'));
+        } finally {
+            putenv('PP_BROWSER_CMD');
+        }
+    }
+
     public function testReadinessProbeReflectsCaptureOutcome(): void
     {
         // --probe runs a real capture; a failing adapter must flip ready to false and
@@ -174,6 +348,9 @@ class ScreenshotTest extends TestCase
         try {
             $readiness = pp_screenshot_readiness(true);
             $this->assertFalse($readiness['ready'], 'A failing probe must report not-ready.');
+            // A configured-but-failing probe is the `broken` state (#497), distinct from
+            // `unavailable` (never configured).
+            $this->assertSame('broken', $readiness['state']);
             $this->assertIsArray($readiness['probe']);
             $this->assertFalse($readiness['probe']['ok'], 'The probe sub-result must record the failure.');
         } finally {


### PR DESCRIPTION
Closes #497

## Summary
Native screenshot readiness is now a definitive tri-state — **available** / **unavailable** / **broken** — instead of a single "PP_BROWSER_CMD not configured" warning that persisted forever and pushed operators onto external tooling. `wp pp screenshot doctor` is the in-band setup-and-diagnose surface: it probes by default (so "configured" means "actually captured a screenshot"), and when nothing is configured it lists candidate browser binaries found on `$PATH`. Preflight surfaces the same state as a non-blocking capability finding where `unavailable` and `broken` render distinctly.

## Scope (against #497 acceptance criteria)
- **Doctor command**: unconfigured → candidates + setup instruction; configured-valid → real probe capture (default); configured-broken → precise failure (binary missing, or probe error). `--no-probe` keeps the fast capability-only check.
- **Three states render distinctly in preflight/status** (per #496 classes): `screenshot_readiness` finding carries `state` (`unavailable` vs `broken`), each with `next_action: wp pp screenshot doctor`. No repeated ambient warning for a stable unconfigured install — it is a capability STATE.
- **Docs**: setup path documented in `docs/screenshot-setup.md`, `docs/running-an-ai-agent.md`, `docs/reference-apply-cli.md`, and `ai-instructions/operating-loop.md`.

## Design notes
- Preflight stays **read-only and never launches a browser**: it does a cheap stat-only resolve (`pp_screenshot_which`) and can report a binary-missing `broken` without exec. The real probe (doctor only) is the arbiter, so a working shell-form command (env-prefix, bare name on a different runtime `$PATH`) whose first token the cheap check can't resolve is verified rather than mislabeled `broken`.
- A zero-byte "successful" capture is treated as `broken`, so the operating loop can never claim native `VERIFIED` off a non-working browser.
- Builds on #496's classified `findings` seam; the screenshot finding remains `class: capability`, `next_action: wp pp screenshot doctor`.

## Validation
- PHP: `./vendor/bin/phpunit --configuration phpunit.xml` → **2423 tests green** (+9 new in ScreenshotTest.php; 3 warnings + 2 deprecations are pre-existing, identical on base).
- JS: `npm test` → **808 tests green**.
- `scripts/package.sh` validates the five-file version sync at 1.7.9 (zip deleted, CI builds the real one).
- Version bumped PATCH 1.7.8 → 1.7.9 across style.css, package.json, functions.php, README badge, readme.txt.

## Review
- `/plan-eng-review` (plan-stage) and `/review` (diff-scoped, with an independent adversarial subagent) both ran this session on this exact diff. The adversarial pass found and I fixed: the cheap `broken` short-circuit was firing even under `--probe` (would mislabel working shell-form configs); directory-as-binary false positive in `pp_screenshot_which` (now requires `is_file`); zero-byte-capture false success. A regression test pins the probe-arbitration fix.

## Accepted limitations
- This container has no browser, so `available`-with-a-real-browser was exercised via a fake PNG-writing adapter fixture; the live `unavailable` state is this environment's actual state. `broken` is exercised via injected failure.

Section 14.2: no new user-visible component; the "rendered artifact" here is the probe capture, inspected in-test via its byte count.