### PR TITLE
Release v1.8.0 — Live Safe-Edit Readiness gate (rollup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.8.0] — 2026-07-26 — live safe-edit readiness: targeted edits on long-lived sites are safe, explained, and evidence-backed (rollup)
+
+**v1.8.0 is the rollup release of the Live Safe-Edit Readiness gate plus the Starter Presentation gate — seven working versions (1.7.4–1.7.10) verified as one line. The theme: an operator (human or AI) doing a targeted safe edit on a long-lived live site gets a clean preview and apply even when the stored composition predates 1.0 (#495), a render path that never destroys data no matter how corrupt the stored state is (#506), preflight output where every warning is classified and either actionable or explicitly acknowledgeable (#496), screenshot evidence readiness reported as a definitive available/unavailable/broken state (#497), and an authorable alignment lever for wrapped inline strips (#510). It also ships the Starter Presentation pair: a real branded theme-card `screenshot.png` with a package guard (#511) and a six-band branded starter homepage seeded on fresh activation (#512).**
+
+The gate closed against a rehearsal bar executed end-to-end: a targeted `update_component` on a legacy-shaped (pre-1.0 props) composition previews and applies cleanly, healing only the touched component; a corrupt-meta front page renders its safe fallback with zero writes while `inspect` still reports the corruption honestly; preflight contains zero unexplained warnings; screenshot readiness reports its definitive tri-state. No code changes in this release beyond the version bump — see the [v1.7.4]…[v1.7.10] entries below for the substance.
+
 ## [v1.7.10] — 2026-07-26 — a wrapped trust strip can now be centered per line, not just left-packed (#510)
 
 **A `body_items` trust strip that fits one line on desktop reads centered, but the moment it wraps at mobile widths it silently became a left-packed ragged block — a different composition than the one that was authored, with no lever to restore it. The new `--section-inline-items-align` style slot (`start` | `center`) gives the author that lever. `start` is the default and is byte-identical to today: left-packed wrapped lines with no separator ever dangling at the start of a line. `center` centers every wrapped line, so a brand strip whose art direction wants a centered row keeps it at every width, mobile included.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.7.10-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.8.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.7.10');
+define('PP_VERSION', '1.8.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.7.10",
+  "version": "1.8.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.7.10
+Stable tag: 1.8.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.7.10
+Version:          1.8.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Rollup release PR: bumps the working line 1.7.10 → 1.8.0 (five synced version files + CHANGELOG rollup entry). No code changes.

Covers working versions 1.7.4–1.7.10:
- #511 branded theme-card screenshot + package guard (v1.7.4)
- #512 six-band branded starter homepage seed (v1.7.5)
- #495 bounded legacy-prop alias map + schema-rename drift-catcher (v1.7.6)
- #506 front-page classify-before-seed — corrupt compositions never destroyed (v1.7.7)
- #496 classified/actionable/acknowledgeable readiness findings + `wp pp readiness` group (v1.7.8)
- #497 screenshot doctor + definitive available/unavailable/broken tri-state (v1.7.9)
- #510 `--section-inline-items-align` enum style slot (v1.7.10)

Gate-close rehearsal (wp-env): ALL 4 LEGS PASS — legacy-shaped targeted edit previews/applies cleanly with touched-only healing; corrupt front page renders safe with zero writes and honest inspect; zero unexplained preflight warnings (acknowledge round-trip demonstrated); definitive screenshot tri-state. Suites: 2437 PHP / 809 JS green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)