### PR TITLE
v1.8.4 fix: wp pp sync check no longer creates a baseline manifest on read (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.8.4] — 2026-07-26 — `wp pp sync check` is now truly read-only: it no longer secretly records a baseline the first time you run it (#522)
+
+**Running `wp pp sync check` on an install that had never been baselined used to silently write the current theme files in as the deployment baseline. On a drifted install that meant the drift got recorded as "normal" and every later check reported clean against a poisoned baseline, hiding the exact change the command exists to surface. Plain `sync check` now writes nothing when there is no manifest: it reports that there is no baseline and points you at the two explicit commands that create one, so a baseline only ever exists because you asked for it.**
+
+`sync check` is a drift-reporting command, and reporting must not establish state. With no deployment manifest there is nothing to compare against, so the command now prints the no-baseline state and exits without hashing-and-saving anything. To record a baseline you run one of the two sanctioned writers, unchanged: `wp pp sync check --save-manifest` (snapshot the current files) or `wp pp readiness rebaseline` (snapshot and record the installed release version, so later drift reads as "changed since <release>"). The drift computation, `--save-manifest`, and `readiness rebaseline` all behave exactly as before.
+
+### Fixed
+- `wp pp sync check` with no deployment manifest no longer creates one as a side effect of the read (lib/cli.php). It reports the no-baseline state and names `wp pp sync check --save-manifest` and `wp pp readiness rebaseline` as the explicit ways to establish a baseline, then exits 0. Only those two commands write the manifest (#522).
+
+### Docs
+- The `pp_check_drift` doc comment (lib/operate.php) no longer tells operators to establish a baseline by running plain `wp pp sync check`; it names the explicit `--save-manifest` / `readiness rebaseline` commands (#522).
+
+### Tests
+- `tests/ReadinessFindingsTest.php`: a real-CLI assertion that plain `sync check` on a manifest-less install writes nothing (manifest still absent afterward), reports the no-baseline state, and names both explicit baseline commands; plus a companion test that `--save-manifest` still writes the manifest. The shared WP_CLI test stub (`tests/CliGateTest.php`, `tests/ReadinessFindingsTest.php`) now captures `warning()` output so advisory state reports are assertable (#522).
+
 ## [v1.8.3] — 2026-07-26 — a hero can now carry a filled brand-accent primary button through composition style slots alone (#514)
 
 **A dark, brand-recolored hero used to be stuck with the theme's default blue premium button, because the primary button's visible fill lives in a shared cascade that painted a gradient over the hero's own color. The hero now exposes three per-instance fill slots — `--hero-button-bg`, `--hero-button-color`, `--hero-button-shadow` — analogous to the cta button's, so a site-builder AI can set a solid brand fill (and flat ink / no bevel) on a fresh install without overriding the site-wide accent token. Set none of them and the hero renders exactly as before.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.8.3-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.8.4-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.8.3');
+define('PP_VERSION', '1.8.4');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -1752,6 +1752,11 @@ class PP_Sync_Command extends WP_CLI_Command {
      * Reports modified, added (live-only), and deleted files.
      * Exit 0 if clean, exit 1 if drift detected.
      *
+     * Read-only: with no deployment manifest there is no baseline to compare
+     * against, so this reports the no-baseline state and exits WITHOUT creating
+     * one. Establish a baseline explicitly with `--save-manifest` or
+     * `wp pp readiness rebaseline`.
+     *
      * ## OPTIONS
      *
      * [--force]
@@ -1791,19 +1796,25 @@ class PP_Sync_Command extends WP_CLI_Command {
 
         // Load manifest
         $manifest = _pp_load_deployment_manifest();
-        $current_hashes = _pp_hash_theme_files($theme_path);
 
         if ($manifest === null) {
-            WP_CLI::warning('No previous deployment manifest found. Run wp pp sync check --save-manifest after your next sync to establish a baseline.');
-            // Save current state as baseline
-            $saved = _pp_save_deployment_manifest($theme_path, $current_hashes);
-            if (!$saved) {
-                WP_CLI::error('Failed to save baseline manifest. Check permissions on ' . dirname(_pp_deployment_manifest_path()));
-            }
-            WP_CLI::line(sprintf('Baseline manifest created: %d files.', count($current_hashes)));
+            // Read-only invariant: `check` REPORTS drift, it never establishes
+            // state. With no baseline there is nothing to compare against, so we
+            // report the no-baseline state and return WITHOUT writing a manifest.
+            // Recording the current (possibly already-drifted) files here would
+            // silently poison the baseline — the drift this command exists to
+            // detect would be masked as "clean" on every subsequent check, with
+            // no operator intent expressed. Establishing a baseline is the job of
+            // the explicit `--save-manifest` / `wp pp readiness rebaseline`
+            // commands, never a side effect of reading state (issue #522).
+            WP_CLI::warning('No deployment manifest found — no baseline to check drift against. `wp pp sync check` reports drift; it does not create a baseline.');
+            WP_CLI::line('To establish a baseline explicitly, run one of:');
+            WP_CLI::line('  - `wp pp sync check --save-manifest` — snapshot the current theme files as the baseline.');
+            WP_CLI::line('  - `wp pp readiness rebaseline` — snapshot AND record the installed release version (drift then reads as "changed since <release>").');
             return;
         }
 
+        $current_hashes = _pp_hash_theme_files($theme_path);
         $manifest_hashes = $manifest['file_hashes'];
 
         // Compute drift

--- a/lib/operate.php
+++ b/lib/operate.php
@@ -71,8 +71,10 @@ function pp_operate_loop_steps(): array {
  * Checks for drift between live theme files and the deployment manifest.
  *
  * READ-ONLY: does NOT auto-create a baseline manifest when none exists.
- * If no manifest is found, returns no-drift. An agent that wants to
- * establish a baseline must run `wp pp sync check` explicitly.
+ * If no manifest is found, returns no-drift. Establishing a baseline is the
+ * job of the explicit `wp pp sync check --save-manifest` or
+ * `wp pp readiness rebaseline` commands (#522) — never a side effect of a
+ * read.
  *
  * @return array{has_drift: bool, modified: string[], added: string[], deleted: string[]}
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.8.3
+Stable tag: 1.8.4
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.8.3
+Version:          1.8.4
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/CliGateTest.php
+++ b/tests/CliGateTest.php
@@ -51,10 +51,12 @@ if (!class_exists('WP_CLI')) {
     class WP_CLI {
         /** @var string[] Captured line() output — the machine-readable stdout channel. */
         public static array $lines = [];
+        /** @var string[] Captured warning() output — the advisory stderr channel. */
+        public static array $warnings = [];
         public static function error($message, $exit = true): void { throw new WpCliExitException((string) $message); }
         public static function add_command($name, $handler, $args = []): void {}
         public static function line($message = ''): void { self::$lines[] = (string) $message; }
-        public static function warning($message = ''): void {}
+        public static function warning($message = ''): void { self::$warnings[] = (string) $message; }
         public static function success($message = ''): void {}
         public static function debug($message = '', $group = false): void {}
         public static function log($message = ''): void {}

--- a/tests/ReadinessFindingsTest.php
+++ b/tests/ReadinessFindingsTest.php
@@ -37,10 +37,11 @@ if (!class_exists('WP_CLI_Command')) {
 if (!class_exists('WP_CLI')) {
     class WP_CLI {
         public static array $lines = [];
+        public static array $warnings = [];
         public static function error($message, $exit = true): void { throw new WpCliExitException((string) $message); }
         public static function add_command($name, $handler, $args = []): void {}
         public static function line($message = ''): void { self::$lines[] = (string) $message; }
-        public static function warning($message = ''): void {}
+        public static function warning($message = ''): void { self::$warnings[] = (string) $message; }
         public static function success($message = ''): void {}
         public static function debug($message = '', $group = false): void {}
         public static function log($message = ''): void {}
@@ -83,6 +84,7 @@ class ReadinessFindingsTest extends TestCase
 
         $this->clearManifest();
         WP_CLI::$lines = [];
+        WP_CLI::$warnings = [];
     }
 
     protected function tearDown(): void
@@ -372,6 +374,51 @@ class ReadinessFindingsTest extends TestCase
         (new PP_Sync_Command())->check([], []);
         $report = $this->lastJson();
         $this->assertSame(PP_VERSION, $report['manifest_release_version']);
+    }
+
+    /**
+     * Read-only invariant (#522): plain `sync check` with NO manifest must not
+     * create one. Driven through the real CLI surface (Section 14.1). Asserts
+     * both the no-write (manifest still absent afterward) and that the emitted
+     * guidance names the two explicit baseline commands.
+     */
+    public function testCliSyncCheckWithNoManifestWritesNothing(): void
+    {
+        // Precondition: setUp() already cleared the manifest.
+        $this->assertFileDoesNotExist(_pp_deployment_manifest_path(), 'no manifest before check');
+
+        // Plain check (no flags) on a manifest-less install must not throw
+        // (exit 0 — no baseline is neither drift nor a failure).
+        (new PP_Sync_Command())->check([], []);
+
+        // The heart of the fix: still no manifest — the read command wrote nothing.
+        $this->assertFileDoesNotExist(
+            _pp_deployment_manifest_path(),
+            'plain sync check must NOT create a baseline manifest'
+        );
+
+        // It REPORTS the no-baseline state (the advisory warning names it).
+        $warnings = implode("\n", WP_CLI::$warnings);
+        $this->assertStringContainsString('No deployment manifest found', $warnings);
+        $this->assertStringContainsString('does not create a baseline', $warnings);
+
+        // And the operator is pointed at the explicit baseline commands.
+        $output = implode("\n", WP_CLI::$lines);
+        $this->assertStringContainsString('--save-manifest', $output);
+        $this->assertStringContainsString('readiness rebaseline', $output);
+    }
+
+    /**
+     * The explicit save path (#522 non-goal: unchanged) still creates a manifest.
+     */
+    public function testCliSyncCheckSaveManifestStillWrites(): void
+    {
+        $this->assertFileDoesNotExist(_pp_deployment_manifest_path(), 'no manifest before save');
+        (new PP_Sync_Command())->check([], ['save-manifest' => true]);
+        $this->assertFileExists(
+            _pp_deployment_manifest_path(),
+            '--save-manifest must create the deployment manifest'
+        );
     }
 
     public function testOverlappingDriftIsBlockingIntegrityFinding(): void


### PR DESCRIPTION
Closes #522

## Problem

`wp pp sync check` is a drift-*reporting* command, but its no-manifest branch (lib/cli.php) silently called `_pp_save_deployment_manifest()` and printed "Baseline manifest created" the first time it ran. That violates the project's read-only CLI semantics rule (status/check commands must not mutate). On a drifted install, the very first `sync check` recorded the *drifted* state as the baseline, permanently masking the drift — subsequent checks reported clean against a poisoned baseline. The warning was also self-contradictory: it told the operator to run `--save-manifest` to "establish a baseline" while the command had already established one.

## Change (narrow, per the issue's recorded decision)

- Removed the implicit save in the `$manifest === null` branch of `PP_Sync_Command::check()`. Plain `sync check` with no manifest now performs **zero writes**: it reports the no-baseline state (advisory `WP_CLI::warning`) and names the two sanctioned writers via `WP_CLI::line` — `wp pp sync check --save-manifest` and `wp pp readiness rebaseline` — then exits **0** (no-baseline is neither drift nor failure; preserves the prior exit code).
- Moved the theme-file hashing below the no-baseline return so the read-only path does no file hashing at all.
- Updated the `pp_check_drift` docblock (lib/operate.php), which still told agents to establish a baseline via plain `wp pp sync check`.

**No changes** to drift computation, `--save-manifest`, or `wp pp readiness rebaseline`. No new preflight/readiness finding was added: `pp_check_drift` already returns no-drift/no-write on a null manifest, so preflight does not surface the no-baseline state, and the issue's finding criterion is conditional ("IF preflight/readiness reports it").

## Acceptance criteria

- [x] Plain `sync check` with no manifest writes nothing (asserted: manifest still absent afterward) and exits with an accurate message naming the explicit baseline commands.
- [x] `--save-manifest` and `readiness rebaseline` still create/update the manifest exactly as before (companion test).
- [x] Tested through the real CLI surface (Section 14.1), including the no-manifest → no-write assertion.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — **2471 passing** (added 2 tests; assertions 10007 → 10009). Warnings (3) and PHPUnit deprecations (2) are pre-existing (verified against a clean tree).
- `npm test` — **812 passing** (includes the five-file version-sync check at 1.8.4).
- `bash scripts/package.sh` — version consistency OK across the five synced files; generated zip deleted.

## Before / after (no-manifest case)

- **Before:** warns, then `_pp_save_deployment_manifest(...)` → prints "Baseline manifest created: N files." (a write on a read).
- **After:** warns "No deployment manifest found — no baseline to check drift against. `wp pp sync check` reports drift; it does not create a baseline.", prints the two explicit baseline commands, writes nothing, exits 0.

## Accepted limitations

- Exit code for the no-baseline case is **0** (rule-3 disclosure): the issue is silent on exit code; this preserves the prior behavior and matches the command's convention (0 = clean, 1 = drift). No-baseline is reported via an advisory warning.

## Reviews

`/plan-eng-review` and `/review` (Claude adversarial + testing specialist) ran this session on this exact diff. Two findings, both folded in: the stale `pp_check_drift` docblock, and making the no-baseline state report directly assertable by having the shared WP_CLI test stub capture `warning()` output. No critical findings.