### PR TITLE
Release v1.9.0 — Write-Path Trust gate (rollup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.9.0] — 2026-07-26 — write-path trust: accepted writes render as authored, the patch surface derives from schemas, and no read command mutates (rollup)
+
+**v1.9.0 is the rollup release of the Write-Path Trust gate — four working versions (1.8.1–1.8.4) verified as one line. The theme: what the write layer accepts is what the page shows. Write-time enforcement of schema-declared prop types and a link-URL format family ends the dead-button `ok:true` class (#507); the semantic patch surface is derived from component schemas instead of a hand-maintained 6-of-10 registry, inheriting that enforcement everywhere (#509); a branded hero can carry a filled accent primary button through per-instance style slots without a global token override (#514); and plain `wp pp sync check` no longer silently creates a baseline manifest on a read — baselines are established only by the explicit commands (#522).**
+
+No code changes in this release beyond the version bump — see the [v1.8.1]…[v1.8.4] entries below for the substance.
+
 ## [v1.8.4] — 2026-07-26 — `wp pp sync check` is now truly read-only: it no longer secretly records a baseline the first time you run it (#522)
 
 **Running `wp pp sync check` on an install that had never been baselined used to silently write the current theme files in as the deployment baseline. On a drifted install that meant the drift got recorded as "normal" and every later check reported clean against a poisoned baseline, hiding the exact change the command exists to surface. Plain `sync check` now writes nothing when there is no manifest: it reports that there is no baseline and points you at the two explicit commands that create one, so a baseline only ever exists because you asked for it.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.8.4-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.9.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.8.4');
+define('PP_VERSION', '1.9.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.8.4",
+  "version": "1.9.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.8.4
+Stable tag: 1.9.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.8.4
+Version:          1.9.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Rollup release PR: bumps the working line 1.8.4 → 1.9.0 (five synced version files + CHANGELOG rollup entry). No code changes.

Covers working versions 1.8.1–1.8.4:
- #507 write-time schema type + link-URL format enforcement — accepted writes render as authored (v1.8.1)
- #509 schema-derived semantic patch surface — hand-maintained registry retired, all 10 components covered (v1.8.2)
- #514 hero per-instance filled-button slots `--hero-button-bg/-color/-shadow` (v1.8.3)
- #522 plain `wp pp sync check` performs zero writes — baselines only via explicit commands (v1.8.4)

Suites at head: 2471 PHP / 812 JS green. Known follow-up filed: #526 (cta2 slot-leak edge + pre-existing cta2 masking, unmilestoned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)