### PR TITLE
v1.9.3 feat: cta component supports an optional second button (#474)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -117,7 +117,7 @@ site-customization permission.
 | faq       | components/faq/faq.php         | Native details/summary accordion. Zero JS. Auto-emits FAQPage JSON-LD. | items[] (req) {question, answer}, title, title_accent, eyebrow, theme, id |
 | grid      | components/grid/grid.php       | Responsive card grid for real content objects    | items[] (req) {number, title, text, text_role, bullets[], image_url, image_alt, link_url, link_text, style (per-card style overrides — card-scoped grid slots, set in composition not style_component)}, title, title_accent, eyebrow, subheading, heading_align, layout, card_emphasis, theme, columns, image_treatment, id |
 | table     | components/table/table.php     | Data/comparison table, horizontal scroll mobile  | headers[] (req), rows[][] (req), title, caption    |
-| cta       | components/cta/cta.php         | Call-to-action block. Layout + color + bg-image  | title, title_accent, eyebrow, button_text (req), button_url (req), button_variant, text, layout, theme, background_image, id |
+| cta       | components/cta/cta.php         | Call-to-action block. Layout + color + bg-image  | title, title_accent, eyebrow, button_text (req), button_url (req), button_variant, button2_text, button2_url, button2_variant, text, layout, theme, background_image, id |
 | stats     | components/stats/stats.php     | Horizontal row of large-number metrics + labels  | items[] (req) {number, label}, title, title_accent, theme, background_image, id |
 | logos     | components/logos/logos.php     | Flex-wrap image grid — logo strips or icon tiles | items[] (req) {image_url, image_alt, image_id?, label?}, title, theme, id |
 | embed     | components/embed/embed.php     | WP shortcode / plugin content wrapper            | content (req), title, theme, id                    |
@@ -394,7 +394,7 @@ Token overrides survive theme updates — `base.css` is overwritten on update, b
 
 Style slots allow per-instance visual customization of components without CSS edits. Each component declares allowed CSS custom properties in its `schema.json` under `styling.style_slots`. Only declared slots are accepted — arbitrary CSS is rejected.
 
-**222 style slots** across 10 components: hero (44), section (40), grid (37), cta (31), testimonials (26), faq (18), stats (14), embed (4), logos (4), table (4).
+**228 style slots** across 10 components: hero (44), section (40), cta (37), grid (37), testimonials (26), faq (18), stats (14), embed (4), logos (4), table (4).
 
 **How it works:**
 1. Composition entries gain an optional `style` key alongside `props`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.9.3] — 2026-07-27 — a closing CTA can offer a primary + secondary button pair (#474)
+
+**A page-closing CTA had one button, so a band that wanted "Ver planes" AND "Hablar con nosotros" had to drop one of them or switch to a `hero`, which is a styling change nobody asked for. The `cta` component now takes an optional second button — `button2_text` / `button2_url` / `button2_variant` — rendered beside the primary as a secondary action. Leave `button2_text` unset and the band renders byte for byte as it always has.**
+
+The prop trio mirrors the hero's `cta2_*` exactly, so the two components stay learnable as one pattern, and `button2_variant` defaults to `outline` so a pair reads as one filled action and one outlined action without the author choosing a variant. `button2_url` picks up the `link_url` format check for free, so a `javascript:` destination is rejected at write time instead of rendering as a dead button. The pair sits in its own flex row that wraps to one button per row on mobile; the wrapper is emitted only when a second button exists, which is what keeps the single-button render unchanged down to the whitespace. Six `--cta-button2-*` slots give the second button per-instance colour independent of the primary: flattening the primary to a brand fill leaves the second button on the default premium treatment, and recolouring the second leaves the primary alone. The one place the two buttons could not simply mirror the hero is contrast. `outline` is the DEFAULT here, and an outline button paints its ink straight onto the band, where the light-surface accent measures 3.23:1 on an inverted band and 1.17:1 over a background image — both below AA. Rather than invent a colour, the second button's outline and ghost defaults route through the same `--color-accent-on-inverted` and `--color-accent-on-overlay` roles this component already uses for its dark-band body links, which lands them at 8.33:1 and 4.59:1. The per-instance slots still win, so an author can override either.
+
+### Added
+- `cta` accepts `button2_text`, `button2_url` (with the #507 `link_url` format check) and `button2_variant` (`primary`/`secondary`/`outline`/`ghost`, default `outline`). Only `button2_text` gates the render, matching the hero's `cta2_text`; unset renders no wrapper and no second anchor (#474).
+- Six per-instance slots — `--cta-button2-bg`, `-border`, `-color`, `-hover-bg`, `-hover-border`, `-hover-color` — address the second button independently of the primary's `--cta-button-*` family, using the #526 isolation mechanism so neither button's resting fill, ink or elevation reaches the other. Style-slot totals 222 to 228 (cta 31 to 37) (#474).
+- On a dark band (`theme: "inverted"` or a `background_image`), the second button's default `outline`/`ghost` ink and ring route through the `--color-accent-on-inverted` / `--color-accent-on-overlay` roles, so the default pair meets AA without the author setting a slot; `--cta-button2-color` / `--cta-button2-border` still win when set (#474).
+
+### Fixed
+- The second button's fill and border chains route the site-wide `--btn-bg` / `--btn-border-color` tokens in the primary's exact order, so a `primary` + `primary` pair renders one colour rather than two on a site that rethemes the global button surface (#474).
+- A non-scalar or `false` `button2_text` reaching the renderer from a raw or legacy composition snapshot renders nothing instead of an unlabelled button or the literal text `Array`; a `"0"` label still renders (#474).
+
+### Docs
+- `components/cta/README.md`, `ai-instructions/composition.md` and `ai-instructions/style-component.md` document the pair, the two slot families, the mobile stacking, and the two hover caveats shared with the hero.
+- `AI_CONTEXT.md`, `README.md`, `docs/reference-apply-cli.md` and the `link_url` prop inventory in `lib/admin.php` list the new props and the updated slot totals.
+
+### Tests
+- `tests/ComponentPropsTest.php` (14 new): the pair renders both anchors inside one wrapper, variant-to-modifier mapping for all four values, the `outline` default and the invalid-value coercion, escaping of both new props, the title-less standalone pair, and a whitespace-exact pin that the unset render keeps its pre-#474 indentation — the false branch must emit zero bytes.
+- `tests/ActionsTest.php` (4 new): authoring-path proofs through `pp_execute_action` — `create_page` accepts and persists a pair, `update_component` adds a second button to an existing single-button CTA, a `javascript:` `button2_url` is rejected with `invalid_prop_value`, and an out-of-enum variant is accept-and-coerced like its siblings.
+- `tests/StyleSlotContractTest.php` pins the isolation rule's selector and all three declarations (the compensating static guard for its three exemption entries), and `tests/js/css-lint.test.js` extends the #420 fill guard to the second button's own slot family.
+- `tests/e2e/style-render.spec.ts` (3 new): computed-style proof that both dark bands route to the AA role tokens and the per-instance slot still wins, that the primary's slots do not repaint a filled second button and `--cta-button2-bg` clears the premium gradient, and that the pair sits on one row at 1280 and stacks at 375.
+
+---
+
 ## [v1.9.2] — 2026-07-27 — stats display numbers can follow the heading system instead of the body font (#472)
 
 **A brand on a serif display face could style the biggest text in the `stats` band every way except the two that mattered: the numbers took the page BODY font because no `font-family` was ever declared, and their weight was a hardcoded `700`. Two per-instance slots fix that — `--stats-number-font` and `--stats-number-weight`. Set them and the figures join the heading system; leave them unset and the band renders exactly as it did before, down to the byte.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.9.2-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.9.3-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -135,7 +135,7 @@ No blocks. No shortcodes. No visual-builder serialization. AI can read, write, d
 | section | Text + optional image; 4 `layout`s (text-only, image-left, image-right, centered) + `theme` (default, muted, inverted) | one of `body` / `body_items` / panel content |
 | grid | Responsive card grid; `layout` (cards, steps) + `theme` (default, muted, inverted) + `card_emphasis` (featured, uniform) + `columns` (1-4, force desktop column count) + `image_treatment` (banner, icon) | `items[]` |
 | faq | Native `details/summary` accordion, zero JavaScript | `items[]` |
-| cta | Call-to-action block with layout, color axis, and background image; `title` optional (omit for a standalone button row) | `button_text`, `button_url` |
+| cta | Call-to-action block with layout, color axis, and background image; `title` optional (omit for a standalone button row); optional second button for a primary + secondary pair | `button_text`, `button_url` |
 | stats | Large-number metrics with labels and optional background image | `items[]` |
 | logos | Flex-wrap image strip for partner/client logos | `items[]` |
 | table | Data/comparison table, horizontal scroll on mobile | `headers[]`, `rows[][]` |
@@ -171,7 +171,7 @@ No build step. No transpilation. No bundler. What you write is what ships.
 
 A single layer of CSS custom properties controls the entire visual system: colors, typography (including mono/meta/label/kicker roles), spacing, borders, shadows, measures. Product defaults live in `assets/css/base.css`. Site-specific overrides are stored in the database and **survive theme updates** — no file to lose when the theme ZIP gets replaced.
 
-222 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
+228 per-instance style slots let AI make this page's hero dark and spacious while that page's hero is tight, accent-bordered, and lifted with a drop shadow — all through composition data, no CSS edits. 11 named recipes (like `dark-spacious` or `compact`) expand to multiple slot values at once.
 
 ```bash
 # Preview a token change without applying
@@ -424,7 +424,7 @@ PromptingPress is in active development by a single developer. It is not yet pac
 See [CHANGELOG.md](CHANGELOG.md) for a detailed release history from v0.0.1 through v1.7.0.
 
 **What exists today (v1.7.0):**
-- 12 components with schema contracts and 222 per-instance style slots, plus named recipes
+- 12 components with schema contracts and 228 per-instance style slots, plus named recipes
 - A contract-test suite that enforces the style-slot contract: every declared slot must be consumed by the CSS, and literal re-declarations that would defeat a slot fail the build — including cross-stylesheet clobbers, where an automatic-match rule in `base.css`/`utilities.css` outranks a component slot (issue [#342](https://github.com/FJCF76/PromptingPress/issues/342)). Known exceptions live in shrink-only ledgers (issues [#309](https://github.com/FJCF76/PromptingPress/issues/309), [#342](https://github.com/FJCF76/PromptingPress/issues/342)); the static guards account for every clobber candidate, and the rendered computed-style checks own the true cascade proof
 - Typed action/apply layer with validation, preview, and rollback
 - Bounded presentation controls — button variants, typography roles, shadow/border/radius slots

--- a/ai-instructions/composition.md
+++ b/ai-instructions/composition.md
@@ -48,7 +48,7 @@ See `AI_CONTEXT.md` → Component index for the current list. As of last update:
 | faq     | items[] {question, answer}              | title, title_accent, eyebrow, theme, id                 |
 | grid    | items[] {title, text, ...}              | title, title_accent, eyebrow, subheading, heading_align, layout, card_emphasis, theme, columns, image_treatment |
 | table   | headers[], rows[][]                     | title, caption                                          |
-| cta     | button_text, button_url                 | title, title_accent, eyebrow, text, layout, theme, background_image, button_variant |
+| cta     | button_text, button_url                 | title, title_accent, eyebrow, text, button2_text, button2_url, button2_variant, layout, theme, background_image, button_variant |
 | stats   | items[] {number, label}                 | title, title_accent, theme, background_image            |
 | logos   | items[] {image_url, image_alt, image_id?, label?} | title, theme                                  |
 | embed   | content                                 | title, theme                                            |
@@ -64,7 +64,7 @@ next. The rule (#439):
 |----------|-------|--------------------|
 | **Rich HTML** (`wp_kses_post`) | `section.body`, `faq.items[].answer` | Block markup: paragraphs, lists, headings, links, `strong`/`em`. These are the main prose surfaces. |
 | **Inline HTML** (`a, strong, em, br`) | `cta.text`, `grid.items[].text`, `testimonials.items[].quote` | Supporting copy with a link or light emphasis, e.g. `Read our <a href="/terms">terms</a>.` No block elements — `<p>`, `<ul>`, `<h2>` are stripped. |
-| **Plain text** (escaped) | Titles, eyebrows, subheadings, `button_text`, `stats.items[].label`, `stats.items[].number`, `grid.items[].title`, `testimonials.items[].author`, `faq.items[].question`, and all URLs | Text only. Any `<...>` renders as visible characters, not markup. |
+| **Plain text** (escaped) | Titles, eyebrows, subheadings, `button_text`, `button2_text`, `stats.items[].label`, `stats.items[].number`, `grid.items[].title`, `testimonials.items[].author`, `faq.items[].question`, and all URLs | Text only. Any `<...>` renders as visible characters, not markup. |
 
 Both HTML contracts are allowlist-sanitized: `script`, `style`, `iframe`, event
 handlers (`onclick`), and `javascript:` URLs are always stripped, whoever authored
@@ -79,6 +79,30 @@ plain-text prop (it will show as literal `<a href=...>` text on the page).
 ```json
 { "component": "cta", "props": { "button_text": "Get started free →", "button_url": "/signup" } }
 ```
+
+### cta: primary + secondary button pair
+
+A closing CTA can offer two actions instead of forcing a choice between them. Set
+`button2_text` (and `button2_url`) alongside the primary button props; `button2_variant`
+defaults to `outline`, so the pair reads as one filled action and one outlined
+action without setting it. This is the `cta` equivalent of the hero's `cta2_text` / `cta2_url`,
+so a closing band does not have to become a `hero` just to offer a secondary action.
+
+```json
+{ "component": "cta", "props": {
+  "title": "Listo para empezar",
+  "button_text": "Ver planes",   "button_url": "/precios",
+  "button2_text": "Hablar con nosotros", "button2_url": "/contacto"
+} }
+```
+
+Omit `button2_text` and the CTA renders exactly as it always has — one button, no
+wrapper element. The two buttons take independent per-instance RESTING colors
+(`--cta-button-bg` / `-color` / `-shadow` for the primary, `--cta-button2-*` for the
+second); neither reaches the other. Hover is not isolated: setting the primary's
+`--cta-button-hover-bg` also clears the second button's hover gradient, so set
+`--cta-button2-hover-bg` too when the pair needs distinct hover fills. At mobile
+widths the pair stacks one button per row.
 
 ### section.theme
 

--- a/ai-instructions/retheme.md
+++ b/ai-instructions/retheme.md
@@ -166,18 +166,21 @@ renders byte-identically to today.
 
 | Token | Set it to… | Reaches | Effective default when unset |
 |-------|-----------|---------|------------------------------|
-| `--btn-bg` | recolor every button fill | bare `.btn`, `.cta`/`.hero` primary, premium `main .btn` primary | `--color-accent` (bare) / accent gradient (composed primary) |
+| `--btn-bg` | recolor every button fill | bare `.btn`, `.cta`/`.hero` primary, a filled cta second button, premium `main .btn` primary | `--color-accent` (bare) / accent gradient (composed primary) |
 | `--btn-text` | recolor every button label ink | every button ink rule | `var(--color-bg)` (registered, the inversion coupling below) |
 | `--btn-border-color` | recolor every button border | bare `.btn`, `.cta`/`.hero`, premium primary | `--color-accent` (bare/`.cta`/`.hero`) / `--color-accent-strong` (premium) |
 | `--btn-shadow` | change every button's elevation (a `--shadow-*` preset, or `none` to flatten) | bare `.btn`, premium primary | `none` (bare) / premium bevel (composed primary) |
 
 **Per-component slots still win.** `--btn-*` sits BETWEEN the per-component slots
-(`--cta-button-*`, `--cta-accent`, `--hero-button-*`, `--hero-accent`) and the literal
-fallback. A component that sets its own slot keeps overriding the global token, so a
-site-wide `--btn-bg` recolors every button that has not been individually restyled.
+(`--cta-button-*`, `--cta-button2-*`, `--cta-accent`, `--hero-button-*`, `--hero-cta2-*`,
+`--hero-accent`) and the literal fallback. A component that sets its own slot keeps
+overriding the global token, so a site-wide `--btn-bg` recolors every button that has not
+been individually restyled.
 (The hero's per-instance FILLED-primary slots are `--hero-button-bg` / `--hero-button-color`
-/ `--hero-button-shadow`; `--hero-accent` recolors only its border. See
-`ai-instructions/style-component.md`.) (Resting state only — hover keeps its
+/ `--hero-button-shadow`; `--hero-accent` recolors only its border. A cta or hero SECOND
+button has its own family — `--cta-button2-*` / `--hero-cta2-*` — which the primary's slots
+never reach, so restyling the primary alone leaves the second button on the global token.
+See `ai-instructions/style-component.md`.) (Resting state only — hover keeps its
 own `--*-hover-*` slots and its accent-derived default; set those to control hover.)
 
 **Fill and border are independent knobs.** `--btn-bg` recolors the fill; `--btn-border-color`
@@ -188,7 +191,10 @@ the section-panel CTA) keeps its own `--color-accent-strong` border until you se
 Set both when recoloring buttons site-wide so every context stays consistent. The same
 border-follows-fill idiom applies to the hero's per-instance slots: a filled second CTA
 recolored with `--hero-cta2-bg` alone keeps a matching ring (`--hero-cta2-border` and
-`--hero-accent` still win where set).
+`--hero-accent` still win where set). The cta's own second button works the same way
+through `--cta-button2-bg` / `--cta-button2-border`, and its chain routes `--btn-bg` and
+`--btn-border-color` in the primary's exact order, so a site-wide recolor moves both
+buttons of a pair together.
 
 **The `--btn-text` → `--color-bg` inversion coupling.** Button text defaults to the PAGE
 BACKGROUND token, not to `--color-text`. Buttons invert on purpose: the accent fill is

--- a/ai-instructions/style-component.md
+++ b/ai-instructions/style-component.md
@@ -351,6 +351,32 @@ flat-button capability, not a new default.
 > has not individually restyled. See `ai-instructions/retheme.md` for the full global
 > button surface.
 
+**A cta with a second button (`button2_text`) has TWO button surfaces.** The
+`--cta-button-*` slots above address the PRIMARY button only; the second button has its
+own `--cta-button2-bg` / `-border` / `-color` / `-hover-bg` / `-hover-border` /
+`-hover-color`. Restyling the primary alone therefore leaves the second button on the
+default treatment, which is usually what you want for a filled + outlined pair. To
+recolor both, set both families:
+```bash
+wp pp action execute style_component --run-id=<uuid> --params='{
+  "post_id": 19,
+  "component_id": "pp-a1b2c3d4",
+  "style": {
+    "--cta-button-bg": "#7c3aed",
+    "--cta-button-color": "#ffffff",
+    "--cta-button2-color": "#7c3aed",
+    "--cta-button2-border": "#7c3aed"
+  }
+}'
+```
+Two caveats, both shared with the hero's second CTA: a flat per-instance fill reverts to
+the shared premium gradient on hover, and hover is NOT isolated between the two buttons
+— setting the primary's `--cta-button-hover-bg` also clears the second button's hover
+gradient, so set `--cta-button2-hover-bg` alongside it when the pair needs distinct hover
+fills. On a dark band (`theme: "inverted"` or a `background_image`) the second button's
+default outline/ghost ink already routes to the AA-safe on-dark accent role, so it is
+readable without any slot; set `--cta-button2-color` only to override that.
+
 **Brand-accent hero primary button (fill slots).** The hero's primary (filled) CTA
 ships the same premium gradient treatment as the cta button. `--hero-accent` recolors
 the button's BORDER (and the outline CTA's hover fill) but NOT the filled primary's

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2380,6 +2380,178 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   color: var(--cta-button-hover-color, var(--color-accent));
 }
 
+/* Second CTA button (issue 474): the pair row + its own per-instance slots.
+   The wrapper is rendered ONLY when button2_text is set (cta.php), so a
+   single-button cta keeps today's markup and computed styles byte-for-byte.
+   flex-wrap + the shared `main .btn { width: 100% }` mobile rule is what makes
+   the pair stack one-per-row under 768px with no mobile-specific rule here —
+   the same mechanism .hero__cta-group relies on (confirmed by rendering at
+   375px). justify-content is STATED rather than inherited from the flexbox
+   initial value, per the issue 338 lesson: the packing only becomes visible
+   once the buttons wrap, so leaving it implicit ships a silently left-packed
+   row on a centered band. */
+.cta__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+  justify-content: flex-start;
+  /* Deliberately NO flex-shrink: 0 here (matching .hero__cta-group). The individual
+     buttons keep their own flex-shrink from .cta__button, so they never squash; making
+     the WRAPPER rigid instead would pin it at both buttons' min-width (~432px) in the
+     inline layout's `space-between` row, which both prevents the flex-wrap above from
+     ever firing there AND crushes the text block. Measured at 768px: rigid wrapper
+     forces the title to 3 lines, shrinkable wrapper wraps the pair to two rows and
+     keeps the title at the 2 lines a single-button inline cta renders. */
+}
+
+.cta--full-width .cta__buttons {
+  justify-content: center;
+}
+
+/* Per-instance bg/border/color override for the SECOND button, independent of
+   the primary (the issue 111 idiom the primary already has, mirrored from the
+   hero's cta2 rules). Targeted via the dedicated .cta__button--secondary class
+   rather than a positional :nth-child selector — this codebase's CSS lint guard
+   forbids nth-child/nth-of-type entirely, and button_text/button2_text are
+   fixed named props (not a reorderable array), so a dedicated class is both
+   safe and simpler. Three classes + the :not() chain puts these at [0,6,0],
+   above `.cta .btn:not(...)` at [0,5,0] (the primary's fill winner), so the
+   primary's accent chain cannot repaint the second button. One rule per
+   variant, each falling back to THAT variant's own existing default, so an
+   unset override renders byte-identically to the matching single button. */
+.cta .cta__buttons .cta__button--secondary:not(.btn--outline):not(.btn--ghost):not(.btn--secondary) {
+  /* Fill chain mirrors the PRIMARY's winner (`.cta .btn:not(...)` above) exactly,
+     including the site-wide --btn-bg token from #458. Dropping --btn-bg here would
+     make a `primary` + `primary` pair render two DIFFERENT fills on any site that
+     rethemes the global button surface: the primary would paint --btn-bg while the
+     second fell through to --color-accent. Unset, both bottom out identically. */
+  background-color: var(--cta-button2-bg, var(--cta-accent, var(--btn-bg, var(--color-accent))));
+  /* Border FOLLOWS the fill when its own knobs are unset (the #514/#526 idiom, in the
+     PRIMARY's exact order): --cta-button2-border wins, then the global
+     --btn-border-color knob, then the fill chain — so a filled second button recolored
+     with the fill slot alone keeps a MATCHING ring rather than an --cta-accent one
+     around a brand-colored button. Unset, the chain still bottoms out at
+     --color-accent, byte-identical. */
+  border-color: var(--cta-button2-border, var(--btn-border-color, var(--cta-button2-bg, var(--cta-accent, var(--btn-bg, var(--color-accent))))));
+  color: var(--cta-button2-color, var(--btn-text, var(--color-bg)));
+}
+.cta .cta__buttons .cta__button--secondary:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
+  background-color: var(--cta-button2-hover-bg, var(--cta-accent-hover, var(--color-accent-hover)));
+  border-color: var(--cta-button2-hover-border, var(--cta-accent-hover, var(--color-accent-hover)));
+  color: var(--cta-button2-hover-color, var(--btn-text, var(--color-bg)));
+}
+
+.cta .cta__buttons .cta__button--secondary.btn--outline {
+  background-color: var(--cta-button2-bg, transparent);
+  color: var(--cta-button2-color, var(--color-accent));
+  border-color: var(--cta-button2-border, var(--color-accent));
+}
+.cta .cta__buttons .cta__button--secondary.btn--outline:hover {
+  background-color: var(--cta-button2-hover-bg, var(--color-accent));
+  border-color: var(--cta-button2-hover-border, var(--color-accent));
+  color: var(--cta-button2-hover-color, var(--color-bg));
+}
+
+.cta .cta__buttons .cta__button--secondary.btn--secondary {
+  background-color: var(--cta-button2-bg, var(--color-surface));
+  color: var(--cta-button2-color, var(--color-text));
+  border-color: var(--cta-button2-border, var(--color-border));
+}
+.cta .cta__buttons .cta__button--secondary.btn--secondary:hover {
+  background-color: var(--cta-button2-hover-bg, var(--color-border));
+  border-color: var(--cta-button2-hover-border, var(--color-border));
+  color: var(--cta-button2-hover-color, var(--color-text));
+}
+
+.cta .cta__buttons .cta__button--secondary.btn--ghost {
+  background-color: var(--cta-button2-bg, transparent);
+  color: var(--cta-button2-color, var(--color-accent));
+  border-color: var(--cta-button2-border, transparent);
+}
+.cta .cta__buttons .cta__button--secondary.btn--ghost:hover {
+  background-color: var(--cta-button2-hover-bg, var(--color-surface));
+  border-color: var(--cta-button2-hover-border, transparent);
+  color: var(--cta-button2-hover-color, var(--color-accent));
+}
+
+/* Dark-band routing for the SECOND button's transparent-fill variants (issue 474,
+   7A decision). outline/ghost paint their ink and ring DIRECTLY on the band, and
+   the light-surface --color-accent measures 3.23:1 on --color-bg-inverted and
+   1.17:1 over the worst-case bg-image scrim — both below AA. `outline` is the
+   DEFAULT for the second button, so simply setting button2_text on an inverted
+   closing CTA would otherwise ship a sub-AA control without the author ever
+   choosing a variant. Route the FALLBACK through the same named role tokens this
+   component already uses on its sibling dark-band elements — .cta--inverted
+   .cta__body a (#437), .cta--has-bg-image .cta__body a (#461), and
+   .cta--has-bg-image .cta__title-accent (#463) — so no new color is invented and
+   the #61/#86 dark-surface-slot contract holds: --cta-button2-color /
+   --cta-button2-border still win when set, and unset falls to the AA tint.
+   Same [0,4,0] specificity as the base variant rules above, so these must stay
+   AFTER them in source order. Scoped to the second button: the primary's
+   explicitly-authored outline/ghost on a dark band is the pre-existing, wider
+   class and is deliberately untouched here. Hover is unchanged — it fills with
+   the accent (outline) or the light surface (ghost), so the hover ink already
+   sits on its own contrasting fill rather than on the band. */
+.cta--inverted .cta__buttons .cta__button--secondary.btn--outline {
+  color: var(--cta-button2-color, var(--color-accent-on-inverted));
+  border-color: var(--cta-button2-border, var(--color-accent-on-inverted));
+}
+.cta--inverted .cta__buttons .cta__button--secondary.btn--ghost {
+  color: var(--cta-button2-color, var(--color-accent-on-inverted));
+}
+
+.cta--has-bg-image .cta__buttons .cta__button--secondary.btn--outline {
+  color: var(--cta-button2-color, var(--color-accent-on-overlay));
+  border-color: var(--cta-button2-border, var(--color-accent-on-overlay));
+}
+.cta--has-bg-image .cta__buttons .cta__button--secondary.btn--ghost {
+  color: var(--cta-button2-color, var(--color-accent-on-overlay));
+}
+
+/* button2 slot isolation + premium fill routing (the issue 526 mechanism applied
+   to cta). Style slots are emitted as inline custom properties on the .cta ROOT,
+   so the PRIMARY button's --cta-button-* slots INHERIT down to the second button;
+   when button2 is authored as a filled `primary` variant it also matches the
+   shared premium `main .btn:not(...)` winner, and the primary's fill, ink and
+   elevation repaint it. A declaration ON the button2 element beats the inherited
+   value regardless of source order, so this one rule fixes it:
+     - `--cta-button-bg: var(--cta-button2-bg)` — a var() that fails to substitute
+       makes the custom property GUARANTEED-INVALID, so with --cta-button2-bg unset
+       every downstream var(--cta-button-bg, <fallback>) takes its fallback (the
+       premium chain's own --btn-bg -> gradient literal): unset stays byte-identical
+       and the leak is killed. With --cta-button2-bg SET, the flat color resolves the
+       premium `background:` SHORTHAND to `background: <color>`, which resets
+       background-image to none and CLEARS the gradient that would otherwise MASK the
+       slot — the same mechanism #514/#526 used for the hero.
+     - `--cta-button-color` / `--cta-button-shadow: initial` — `initial` IS the
+       guaranteed-invalid value for a custom property, so button2 falls back to its own
+       ink rule above and to the premium bevel instead of the primary's ink/elevation.
+       The ink half is DEFENSIVE today rather than load-bearing: button2's own rules sit
+       at [0,6,0]/[0,7,0] and already outrank every current --cta-button-color consumer
+       (.cta__button:not(...) at [0,4,0], the variant rules at [0,2,0], and the premium
+       `main .btn:not(...)` at [0,4,1]). The shadow half IS load-bearing, since button2
+       has no elevation rule of its own. Both are kept so the isolation holds even if a
+       future rule wires the slots more widely.
+       Consequence, accepted with the fix: flattening the PRIMARY with
+       --cta-button-shadow: none no longer flattens button2 with it. button2 has no
+       elevation slot of its own today; a --cta-button2-shadow slot is the follow-up
+       if a flat pair is wanted.
+   Applied to EVERY button2 variant on purpose. The transparent-fill variants DO reach
+   --cta-button-* consumers (`.cta__button.btn--outline` and its --secondary/--ghost
+   siblings read --cta-button-bg/-color/-border at [0,2,0], and button2 carries the
+   .cta__button class too), so they are not immune by construction — they are covered
+   because button2's own variant rules at [0,4,0] outrank those. Resetting the slots on
+   every variant keeps the isolation true on its own terms rather than resting on that
+   specificity margin, which a future edit could shift. Hover is deliberately
+   unchanged: a flat per-instance fill reverts to the premium hover gradient, the same
+   shipped trait the primary carries since #514 (tracked in #530). */
+.cta .cta__buttons .cta__button--secondary {
+  --cta-button-bg: var(--cta-button2-bg);
+  --cta-button-color: initial;
+  --cta-button-shadow: initial;
+}
+
 /* Full-width: centered block with surface background */
 .cta--full-width {
   background: var(--cta-bg, var(--color-surface));
@@ -2434,6 +2606,11 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   border-bottom: var(--cta-border-width, 1px) solid var(--cta-border-color, var(--color-border));
 }
 
+/* NOTE (issue 474): the dark-band routing for the SECOND button's outline/ghost
+   variants lives ABOVE, with the other button2 rules, not in this theme block. Those
+   rules are [0,4,0] and depend on source order against the base button2 variant rules
+   they follow. Do not add a competing `.cta--inverted`/`.cta--has-bg-image` button2
+   rule down here: it would win by source order and silently defeat the AA routing. */
 .cta--inverted {
   background: var(--cta-bg, var(--color-bg-inverted));
   --cta-body-theme-color: var(--color-bg);

--- a/components/cta/README.md
+++ b/components/cta/README.md
@@ -13,6 +13,9 @@ Call-to-action block. Place at the bottom of a page or between sections to drive
 | `text`        | string | No       | `''`           | Supporting body text. Inline HTML allowed: a, strong, em, br. |
 | `button_text` | string | Yes      | —              | Button label |
 | `button_url`  | string | Yes      | —              | Button URL |
+| `button2_text` | string | No      | `''`           | Optional SECOND button label. Empty (default) renders no second button |
+| `button2_url` | string | No       | `'#'`          | Second button URL |
+| `button2_variant` | enum | No     | `'outline'`    | Second button style: `primary` / `secondary` / `outline` / `ghost` |
 | `layout`     | enum   | No       | `'full-width'` | Structural layout: `full-width` / `inline` |
 | `theme`       | enum   | No       | `'default'`    | Background color: `default` / `muted` (light tinted surface band) / `inverted` (genuinely dark band) (independent of `layout`) |
 | `background_image` | string | No | `''`           | Optional background image URL with dark overlay for text readability |
@@ -33,6 +36,39 @@ Selects the shared button style. Set as a prop via `update_component`.
 - **ghost** — Borderless text-style button for tertiary actions.
 
 Per-instance button color is still set through the `--cta-accent` style slot.
+
+## Second button (`button2_*`)
+
+A closing CTA can offer a primary + secondary pair — "Ver planes" *and* "Hablar con
+nosotros" — instead of forcing a choice between them. Set `button2_text` (and
+`button2_url`); `button2_variant` defaults to `outline` so the pair reads as one
+filled action and one outlined action.
+
+```php
+pp_get_component('cta', [
+    'title'        => 'Listo para empezar',
+    'button_text'  => 'Ver planes',
+    'button_url'   => '/precios',
+    'button2_text' => 'Hablar con nosotros',
+    'button2_url'  => '/contacto',
+]);
+```
+
+Leave `button2_text` unset and the CTA renders exactly as a single-button CTA always
+has — no wrapper element, no second anchor, no style change.
+
+The two buttons are styled independently in their RESTING state: `--cta-button-bg`,
+`--cta-button-color` and `--cta-button-shadow` address the primary only, and the
+`--cta-button2-*` slots address the second only, so flattening the primary to a brand
+color leaves the second button on the default premium treatment. `--cta-accent` still
+reaches both by design.
+
+Two hover caveats, both shared with the hero: a flat per-instance fill reverts to the
+shared premium gradient on hover, and the primary's `--cta-button-hover-bg` is NOT
+isolated, so setting it also clears the second button's hover gradient. Set
+`--cta-button2-hover-bg` alongside it when the pair needs distinct hover fills.
+
+At mobile widths the pair stacks one button per row.
 
 ## Usage
 

--- a/components/cta/cta.php
+++ b/components/cta/cta.php
@@ -15,22 +15,45 @@ $eyebrow          = $props['eyebrow']          ?? '';
 $text             = $props['text']             ?? '';
 $button_text      = $props['button_text']      ?? 'Get Started';
 $button_url       = $props['button_url']       ?? '#';
+$button2_text     = $props['button2_text']     ?? '';
+$button2_url      = $props['button2_url']      ?? '#';
 $layout           = $props['layout']           ?? 'full-width';
 $theme            = $props['theme']            ?? 'default';
 $background_image = $props['background_image'] ?? '';
 $button_variant   = $props['button_variant']   ?? 'primary';
+$button2_variant  = $props['button2_variant']  ?? 'outline';
 
 $allowed_layouts = ['full-width', 'inline'];
 if (!in_array($layout, $allowed_layouts, true)) {
     $layout = 'full-width';
 }
 
+// Shared 4-variant button primitive (same list as components/hero/hero.php).
 $allowed_button_variants = ['primary', 'secondary', 'outline', 'ghost'];
 if (!in_array($button_variant, $allowed_button_variants, true)) {
     $button_variant = 'primary';
 }
+if (!in_array($button2_variant, $allowed_button_variants, true)) {
+    $button2_variant = 'outline';
+}
 // primary is the bare .btn; other variants add a .btn--{variant} modifier.
-$button_variant_class = $button_variant !== 'primary' ? ' btn--' . $button_variant : '';
+$button_variant_class  = $button_variant !== 'primary' ? ' btn--' . $button_variant : '';
+$button2_variant_class = $button2_variant !== 'primary' ? ' btn--' . $button2_variant : '';
+
+// Optional second button (issue 474), the hero's cta2 pattern scoped to cta.
+// The pair needs a flex row of its own: .cta__inner is a flex COLUMN on
+// full-width (two bare sibling anchors would stack, separated by the full
+// --cta-inner-gap) and a `space-between` ROW on inline (they would be flung to
+// opposite ends of the band). Both were confirmed by rendering the no-wrapper
+// alternative. The wrapper is therefore emitted ONLY when a second button
+// exists, so a single-button cta keeps today's markup byte-for-byte.
+// is_scalar guard: the write path rejects a non-scalar string prop, but
+// restore_composition deliberately never blocks on validation (#233), so an array or
+// boolean CAN reach the renderer from a legacy/raw-written history snapshot. A bare
+// `!== ''` would treat `false` as a label and emit a button with an empty accessible
+// name, and an array would render the literal text "Array" plus a PHP warning. Casting
+// after the guard keeps a legitimate "0" label working, which a truthy check would drop.
+$has_button2 = is_scalar($button2_text) && (string) $button2_text !== '';
 
 // theme coercion + the deprecated 'dark' -> 'muted' alias live in pp_theme_class() (#442).
 $theme_class    = pp_theme_class($theme, 'cta');
@@ -76,9 +99,25 @@ $style_attr = $inline_styles ? ' style="' . implode('; ', $inline_styles) . ';"'
             </div>
             <?php endif; ?>
 
+<?php // The wrapper control tags below start at column 0 ON PURPOSE. PHP emits
+      // everything outside its tags verbatim, so an INDENTED control tag still
+      // prints its own leading spaces even when the branch is false. At column 0
+      // there is no leading whitespace to print, and the closing tag eats the
+      // trailing newline, so an unset second button adds ZERO bytes and the
+      // single-button render stays byte-for-byte identical to pre-474 output
+      // (pinned by ComponentPropsTest::testCtaWithoutButton2IsByteIdenticalToBefore). ?>
+<?php if ($has_button2) : ?>
+            <div class="cta__buttons">
+<?php endif; ?>
             <a href="<?php echo esc_url($button_url); ?>" class="cta__button btn<?php echo esc_attr($button_variant_class); ?>">
                 <?php echo esc_html($button_text); ?>
             </a>
+<?php if ($has_button2) : ?>
+                <a href="<?php echo esc_url($button2_url); ?>" class="cta__button cta__button--secondary btn<?php echo esc_attr($button2_variant_class); ?>">
+                    <?php echo esc_html($button2_text); ?>
+                </a>
+            </div>
+<?php endif; ?>
         </div>
     </div>
 </section>

--- a/components/cta/schema.json
+++ b/components/cta/schema.json
@@ -43,6 +43,26 @@
       "format": "link_url",
       "description": "Button destination URL. Accepts an absolute URL (https://...), a site-relative path (/path), an anchor (#id), mailto:, or tel:; a disallowed protocol (javascript:, data:) is rejected at write time because it would render as a dead link."
     },
+    "button2_text": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Optional SECOND button label, rendered beside the primary button as a secondary action (the hero's cta2_text pattern). Leave empty (the default) and no second button is rendered — the CTA is byte-identical to a single-button one. Plain text — HTML is escaped."
+    },
+    "button2_url": {
+      "type": "string",
+      "required": false,
+      "default": "#",
+      "format": "link_url",
+      "description": "Second button destination URL. Accepts an absolute URL (https://...), a site-relative path (/path), an anchor (#id), mailto:, or tel:; a disallowed protocol (javascript:, data:) is rejected at write time because it would render as a dead link."
+    },
+    "button2_variant": {
+      "type": "enum",
+      "values": ["primary", "secondary", "outline", "ghost"],
+      "required": false,
+      "default": "outline",
+      "description": "Second button style — defaults to 'outline' so a primary + secondary pair reads as one filled action and one outlined action. 'primary' = filled accent. 'secondary' = muted surface fill. 'outline' = accent border, transparent fill. 'ghost' = borderless text button. Set via update_component (a prop, not a style slot). Only rendered when button2_text is set."
+    },
     "layout": {
       "type": "enum",
       "values": ["full-width", "inline"],
@@ -101,6 +121,12 @@
       "--cta-button-hover-border": { "type": "color", "default": "(varies by button_variant)", "description": "Button hover border color." },
       "--cta-button-hover-color": { "type": "color", "default": "(varies by button_variant)", "description": "Button hover text color." },
       "--cta-button-shadow": { "type": "shadow", "default": "(premium bevel)", "description": "Button box shadow on the DEFAULT (primary) variant. Set to `none` for a FLAT button (removes the gradient bevel/drop shadow on rest AND hover); pair with --cta-button-bg (a flat color) and --cta-button-color (ink) for a flat primary." },
+      "--cta-button2-bg": { "type": "color", "default": "(varies by button2_variant)", "description": "SECOND button background color, independent of the primary button (the primary's RESTING slots --cta-button-bg / -color / -shadow never reach this button; hover is not isolated — see --cta-button2-hover-bg). Applies whatever button2_variant is set to: on a filled (primary) button2 it replaces the premium gradient with a flat fill, exactly as --cta-button-bg does for the primary button, and reverts to the gradient on hover unless left unset." },
+      "--cta-button2-border": { "type": "color", "default": "(varies by button2_variant)", "description": "Second button border color, independent of the primary button. The chain mirrors the primary button's exactly: this slot wins, then the site-wide --btn-border-color token, then the fill chain (--cta-button2-bg, then --cta-accent, then --btn-bg) — so with no global border token set, a fill-only recolor keeps a matching ring. Set this slot when the ring should differ from the fill, or when a site-wide --btn-border-color is in play and this button needs its own ring." },
+      "--cta-button2-color": { "type": "color", "default": "(varies by button2_variant)", "description": "Second button text color, independent of the primary button. This is the safe surface for fixing the second button's contrast on a dark band." },
+      "--cta-button2-hover-bg": { "type": "color", "default": "(varies by button2_variant)", "description": "Second button hover background color. Two shared-with-hero caveats: on a filled (primary) button2 the shared premium hover gradient covers a flat --cta-button2-bg, which reverts to that gradient on hover (the same shipped behaviour --cta-button-bg has on the primary button); and hover is NOT isolated between the two buttons, so setting the primary's --cta-button-hover-bg also clears this button's hover gradient. Set this slot alongside it when the pair needs distinct hover fills." },
+      "--cta-button2-hover-border": { "type": "color", "default": "(varies by button2_variant)", "description": "Second button hover border color." },
+      "--cta-button2-hover-color": { "type": "color", "default": "(varies by button2_variant)", "description": "Second button hover text color." },
       "--cta-border-color": { "type": "color", "default": "transparent", "description": "Top and bottom border color" },
       "--cta-border-width": { "type": "length", "default": "0", "description": "Top and bottom border width" },
       "--cta-radius": { "type": "length", "default": "0", "description": "Border radius" },

--- a/docs/reference-apply-cli.md
+++ b/docs/reference-apply-cli.md
@@ -184,7 +184,7 @@ A page whose stored composition already carries a collision (written before this
 
 **Unknown component props (#147).** Each component declares its full prop contract in `components/<name>/schema.json` under `props`. A composition whose component carries a prop key not in that contract is rejected at write time by `pp_validate_composition()`, so `create_page`, `update_composition`, `add_component`, `update_component`, and the dashboard editor's save all fail with:
 
-> `Component "cta" has no prop "not_a_real_prop". Available props: id, title, title_accent, eyebrow, text, button_text, button_url, layout, theme, background_image, button_variant [unknown_prop]`
+> `Component "cta" has no prop "not_a_real_prop". Available props: id, title, title_accent, eyebrow, text, button_text, button_url, button2_text, button2_url, button2_variant, layout, theme, background_image, button_variant [unknown_prop]`
 
 The source of truth is the component's full schema `props`, not the narrower schema-derived scalar-patch set (`pp_get_component_fields()`, which exposes only scalar props for `operate patch`), so real props like `cta.theme` and `cta.background_image` are accepted while a misspelled or invented key is not — closing the "phantom field" hole where an unknown key would persist behind an `ok:true` while the renderer silently ignored it. Unlike template-owned chrome and duplicate ids, this rule has no composition-smell counterpart: a stored composition that already carries an unknown prop (from a legacy write or a raw non-action path) is surfaced by `restore_composition`, which never blocks undo and instead reports the `unknown_prop` finding (#233), rather than by `wp pp check page`.
 
@@ -192,7 +192,7 @@ The source of truth is the component's full schema `props`, not the narrower sch
 
 > `Component "cta" prop "title" must be a string; got array. [invalid_prop_value]`
 
-**Link-URL format (#507).** A prop that declares `format: "link_url"` (today `cta.button_url`, `hero.cta_url` / `cta2_url`, `section.panel_cta_url`, and `grid.items[].link_url`) is validated so the write cannot report `ok:true` for a value that `esc_url()` would silently neuter into an empty `href` — a dead button. The bar is "what survives `esc_url()` renders as authored": a site-relative path (`/pricing`), an anchor (`#booking`), a protocol-relative URL (`//cdn.example.com/x`), `mailto:`, `tel:`, and any other `wp_allowed_protocols()` scheme are accepted; a value carrying a disallowed protocol (`javascript:`, `data:`, `vbscript:`, ...) is rejected:
+**Link-URL format (#507).** A prop that declares `format: "link_url"` (today `cta.button_url` / `cta.button2_url`, `hero.cta_url` / `cta2_url`, `section.panel_cta_url`, and `grid.items[].link_url`) is validated so the write cannot report `ok:true` for a value that `esc_url()` would silently neuter into an empty `href` — a dead button. The bar is "what survives `esc_url()` renders as authored": a site-relative path (`/pricing`), an anchor (`#booking`), a protocol-relative URL (`//cdn.example.com/x`), `mailto:`, `tel:`, and any other `wp_allowed_protocols()` scheme are accepted; a value carrying a disallowed protocol (`javascript:`, `data:`, `vbscript:`, ...) is rejected:
 
 > `Component "cta" prop "button_url" is not a usable link URL: "javascript:alert(1)" uses a disallowed protocol and would render as a dead link. Use an absolute URL (https://...), a site-relative path (/path), an anchor (#id), mailto:, or tel:. [invalid_prop_value]`
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.9.2');
+define('PP_VERSION', '1.9.3');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -1063,7 +1063,7 @@ function pp_validate_composition_errors(array $items): array {
 
         // Link-URL format family (issue 507). A prop MAY declare `format: "link_url"`
         // (the #154 media-URL annotation pattern, applied to the destination-URL
-        // props: cta.button_url, hero.cta_url/cta2_url, section.panel_cta_url,
+        // props: cta.button_url/button2_url, hero.cta_url/cta2_url, section.panel_cta_url,
         // grid.items[].link_url). The renderer runs esc_url() on these, which
         // SILENTLY neuters a disallowed-protocol value (javascript:, data:, ...) into
         // an empty href — a dead button — while still reporting ok:true. This rejects

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.9.2
+Stable tag: 1.9.3
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.9.2
+Version:          1.9.3
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -612,6 +612,97 @@ class ActionsTest extends TestCase
         }
     }
 
+    // ── CTA second button, through the REAL write surface (issue 474) ──────
+    //
+    // Section 14.1 authoring-path proofs. Raw _pp_composition meta writes bypass
+    // validation entirely, so the authoring CONTRACT for each new prop is exercised
+    // once here through pp_execute_action: the pair is accepted and persisted, the
+    // enum is enforced, and button2_url inherits the #507 link_url family.
+
+    public function testCreatePageAcceptsCtaSecondButtonPair(): void
+    {
+        $result = pp_execute_action('create_page', [
+            'title'       => 'Closing CTA with a pair',
+            'composition' => [['component' => 'cta', 'props' => [
+                'button_text'     => 'Ver planes',
+                'button_url'      => '/precios',
+                'button2_text'    => 'Hablar con nosotros',
+                'button2_url'     => '/contacto',
+                'button2_variant' => 'outline',
+            ]]],
+        ]);
+
+        $this->assertTrue($result['ok'], 'the primary+secondary pair must be accepted: ' . ($result['error'] ?? ''));
+        $props = pp_get_composition((int) $result['target']['post_id'])[0]['props'];
+        $this->assertSame('Hablar con nosotros', $props['button2_text']);
+        $this->assertSame('/contacto', $props['button2_url']);
+        $this->assertSame('outline', $props['button2_variant']);
+    }
+
+    public function testUpdateComponentAddsSecondButtonToAnExistingCta(): void
+    {
+        // The reported symptom: an existing single-button closing CTA gains a
+        // secondary action through a targeted edit.
+        $id = pp_create_page('Existing closing CTA', 'draft');
+        pp_update_composition($id, [['component' => 'cta', 'props' => [
+            'button_text' => 'Ver planes', 'button_url' => '/precios',
+        ]]]);
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 0,
+            'props'           => ['button2_text' => 'Hablar', 'button2_url' => '/contacto'],
+        ]);
+
+        $this->assertTrue($result['ok'], $result['error'] ?? '');
+        $props = pp_get_composition($id)[0]['props'];
+        $this->assertSame('Hablar', $props['button2_text']);
+        $this->assertSame('Ver planes', $props['button_text'], 'the primary button is untouched');
+    }
+
+    public function testCreatePageRejectsDeadButton2LinkUrl(): void
+    {
+        // #507 link_url family applies to button2_url exactly as to button_url:
+        // esc_url() would neuter this into an empty href — a dead second button.
+        $result = pp_execute_action('create_page', [
+            'title'       => 'Dead second button',
+            'composition' => [['component' => 'cta', 'props' => [
+                'button_text'  => 'Click',
+                'button_url'   => '/ok',
+                'button2_text' => 'Also click',
+                'button2_url'  => 'javascript:alert(1)',
+            ]]],
+        ]);
+
+        $this->assertFalse($result['ok'], 'a javascript: button2_url must not persist behind ok:true');
+        $this->assertSame('invalid_prop_value', $result['error_code']);
+        $this->assertStringContainsString('button2_url', $result['error']);
+        $this->assertStringContainsString('dead link', $result['error']);
+    }
+
+    public function testUpdateComponentCoercesOutOfEnumButton2Variant(): void
+    {
+        // button2_variant mirrors button_variant (and hero's cta2_variant): neither
+        // declares `strict`, so the enum is accept-and-COERCE, not reject. The write
+        // is accepted and the renderer falls back to the secondary default, so the
+        // authored page still renders a real button rather than being locked out.
+        $id = pp_create_page('Out-of-enum second variant', 'draft');
+        pp_update_composition($id, [['component' => 'cta', 'props' => [
+            'button_text' => 'Go', 'button_url' => '/',
+        ]]]);
+
+        $result = pp_execute_action('update_component', [
+            'post_id'         => $id,
+            'component_index' => 0,
+            'props'           => ['button2_text' => 'Second', 'button2_variant' => 'neon'],
+        ]);
+
+        $this->assertTrue($result['ok'], 'a non-strict enum is coerced at render, not rejected at write');
+        $this->assertSame('neon', pp_get_composition($id)[0]['props']['button2_variant']);
+        // The render-side coercion to `outline` is pinned in
+        // ComponentPropsTest::testCtaButton2VariantInvalidFallsBackToOutline.
+    }
+
     public function testUpdateComponentRejectsNonScalarStringProp(): void
     {
         $id = pp_create_page('Non-scalar title', 'draft');

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -589,6 +589,203 @@ class ComponentPropsTest extends TestCase
         $this->assertStringNotContainsString('btn--', $html);
     }
 
+    // ── CTA second button (issue 474) ──────────────────────────────────────
+    //
+    // A closing CTA can offer a primary + secondary pair, the hero's cta2 pattern
+    // scoped to cta. The hard contract is that an UNSET second button renders the
+    // component byte-for-byte as before: no wrapper element, no extra anchor.
+
+    public function testCtaWithoutButton2IsByteIdenticalToBefore(): void
+    {
+        $baseline = $this->render('cta', $this->ctaProps());
+
+        // Structural: no wrapper element, no second anchor.
+        $this->assertStringNotContainsString('cta__buttons', $baseline, 'no pair wrapper on a single-button cta');
+        $this->assertStringNotContainsString('cta__button--secondary', $baseline);
+        $this->assertSame(1, substr_count($baseline, '<a href='), 'exactly one button anchor');
+
+        // WHITESPACE-EXACT: the guarantee documented in schema.json/README/composition.md
+        // is byte-for-byte, and the obvious implementation breaks it invisibly — an
+        // INDENTED `if`/`endif` control tag prints its own leading spaces even when the
+        // branch is false, which silently added 24 bytes ahead of the primary anchor.
+        // Pin the exact indentation so a future re-indent of those tags fails here
+        // instead of quietly widening the diff on every existing page.
+        $this->assertMatchesRegularExpression(
+            '/\n {12}<a href="#" class="cta__button btn">/',
+            $baseline,
+            'the primary anchor must keep exactly its pre-474 indentation — the false '
+            . 'button2 branch must emit no bytes at all'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/\n {13,}<a href="#" class="cta__button btn">/',
+            $baseline,
+            'stray indentation leaked from the unset second button branch'
+        );
+
+        // An explicit empty button2_text behaves exactly like the prop being absent.
+        $this->assertSame(
+            $baseline,
+            $this->render('cta', $this->ctaProps(['button2_text' => ''])),
+            'an explicit empty button2_text must not change a single byte of the render'
+        );
+    }
+
+    /** @dataProvider button2NonLabelProvider */
+    public function testCtaButton2NonScalarOrEmptyLabelRendersNoSecondButton($label): void
+    {
+        // restore_composition never blocks on validation (#233), so a legacy/raw-written
+        // snapshot can put a boolean or array here. Neither may render a button with an
+        // empty accessible name or the literal text "Array".
+        $html = $this->render('cta', $this->ctaProps([
+            'button2_text' => $label,
+            'button2_url'  => '/contacto',
+        ]));
+        $this->assertStringNotContainsString('cta__buttons', $html);
+        $this->assertStringNotContainsString('cta__button--secondary', $html);
+        $this->assertStringNotContainsString('Array', $html);
+        $this->assertSame(1, substr_count($html, '<a href='), 'exactly one button anchor');
+    }
+
+    public static function button2NonLabelProvider(): array
+    {
+        return [
+            'empty string' => [''],
+            'false'        => [false],
+            'null'         => [null],
+            'array'        => [['a' => 'b']],
+        ];
+    }
+
+    public function testCtaButton2ZeroLabelStillRenders(): void
+    {
+        // "0" is a legitimate label; the is_scalar guard must not drop it the way a
+        // bare truthy check would.
+        $html = $this->render('cta', $this->ctaProps(['button2_text' => '0', 'button2_url' => '/x']));
+        $this->assertStringContainsString('cta__button--secondary', $html);
+        $this->assertSame(2, substr_count($html, '<a href='));
+    }
+
+    public function testCtaButton2UrlWithoutTextRendersNoSecondButton(): void
+    {
+        // button2_text is the gate (mirroring hero, where cta2_text gates cta2_url), so
+        // a URL authored without a label is a silent no-op rather than an empty button.
+        $html = $this->render('cta', $this->ctaProps(['button2_url' => '/contacto']));
+        $this->assertStringNotContainsString('cta__buttons', $html);
+        $this->assertStringNotContainsString('/contacto', $html);
+        $this->assertSame(1, substr_count($html, '<a href='), 'exactly one button anchor');
+    }
+
+    public function testCtaButton2RendersPairInsideWrapper(): void
+    {
+        $html = $this->render('cta', $this->ctaProps([
+            'button2_text' => 'Hablar con nosotros',
+            'button2_url'  => '/contacto',
+        ]));
+
+        $this->assertStringContainsString('<div class="cta__buttons">', $html, 'the pair needs its own flex row');
+        $this->assertStringContainsString('class="cta__button btn"', $html, 'primary keeps the bare .btn');
+        $this->assertStringContainsString('class="cta__button cta__button--secondary btn btn--outline"', $html);
+        $this->assertStringContainsString('href="/contacto"', $html);
+        $this->assertStringContainsString('Hablar con nosotros', $html);
+        $this->assertSame(2, substr_count($html, '<a href='), 'exactly two button anchors');
+    }
+
+    public function testCtaButton2DefaultsToOutline(): void
+    {
+        // Mirrors hero's cta2_variant default: the pair reads as one filled action
+        // and one outlined action without the author selecting a variant.
+        $html = $this->render('cta', $this->ctaProps(['button2_text' => 'Secondary']));
+        $this->assertStringContainsString('cta__button--secondary btn btn--outline', $html);
+    }
+
+    public function testCtaButton2VariantPrimaryIsBareBtn(): void
+    {
+        $html = $this->render('cta', $this->ctaProps([
+            'button2_text'    => 'Secondary',
+            'button2_variant' => 'primary',
+        ]));
+        $this->assertStringContainsString('class="cta__button cta__button--secondary btn"', $html);
+    }
+
+    /** @dataProvider button2VariantProvider */
+    public function testCtaButton2VariantMapsToModifier(string $variant, string $expected): void
+    {
+        $html = $this->render('cta', $this->ctaProps([
+            'button2_text'    => 'Secondary',
+            'button2_variant' => $variant,
+        ]));
+        $this->assertStringContainsString('cta__button--secondary btn ' . $expected, $html);
+    }
+
+    public static function button2VariantProvider(): array
+    {
+        return [
+            'secondary' => ['secondary', 'btn--secondary'],
+            'outline'   => ['outline', 'btn--outline'],
+            'ghost'     => ['ghost', 'btn--ghost'],
+        ];
+    }
+
+    public function testCtaButton2VariantInvalidFallsBackToOutline(): void
+    {
+        // Unlike the primary (which falls back to `primary`), an unrecognized
+        // second-button variant falls back to the secondary default.
+        $html = $this->render('cta', $this->ctaProps([
+            'button2_text'    => 'Secondary',
+            'button2_variant' => 'neon',
+        ]));
+        $this->assertStringContainsString('cta__button--secondary btn btn--outline', $html);
+    }
+
+    public function testCtaButton2TextAndUrlAreEscaped(): void
+    {
+        $html = $this->render('cta', $this->ctaProps([
+            'button2_text' => 'Tom & Jerry <script>',
+            'button2_url'  => '/a?b=1&c=2',
+        ]));
+        $this->assertStringNotContainsString('<script>', $html, 'button2_text is plain text');
+        $this->assertStringContainsString('Tom &amp; Jerry &lt;script&gt;', $html);
+        // The href must carry the esc_url()-processed value, not the raw prop. Comparing
+        // against esc_url() itself keeps this honest under the test bootstrap's stub
+        // while still failing if esc_url() is dropped from the anchor.
+        $this->assertStringContainsString('href="' . esc_url('/a?b=1&c=2') . '"', $html);
+    }
+
+    public function testCtaButton2UrlActuallyPassesThroughEscUrl(): void
+    {
+        // Non-tautological on purpose: a space is one of the few characters BOTH the
+        // test bootstrap's esc_url() stub (FILTER_SANITIZE_URL strips it) and real
+        // WordPress esc_url() (encodes it as %20) transform. Asserting the raw value is
+        // ABSENT is what fails if esc_url() is ever dropped from the anchor; asserting
+        // against esc_url() itself keeps the expectation correct under either engine.
+        // (Quote-stripping is deliberately NOT asserted here — real esc_url() strips
+        // `"`, but the stub does not, so such a test would fail against safe code.)
+        $raw  = '/a b?c=1';
+        $html = $this->render('cta', $this->ctaProps([
+            'button2_text' => 'Secondary',
+            'button2_url'  => $raw,
+        ]));
+
+        $this->assertStringContainsString('href="' . esc_url($raw) . '"', $html);
+        $this->assertStringNotContainsString('href="' . $raw . '"', $html, 'button2_url must be escaped, not emitted raw');
+    }
+
+    public function testCtaButton2RendersOnTitlelessStandaloneRow(): void
+    {
+        // The pair must also work as the sanctioned heading-less button row (#294),
+        // where the wrapper is the ONLY child of .cta__inner.
+        $html = $this->render('cta', [
+            'button_text'  => 'Ver planes',
+            'button_url'   => '/precios',
+            'button2_text' => 'Hablar',
+            'button2_url'  => '/contacto',
+        ]);
+        $this->assertStringContainsString('cta__buttons', $html);
+        $this->assertStringNotContainsString('cta__text', $html);
+        $this->assertStringNotContainsString('<h2', $html);
+        $this->assertSame(2, substr_count($html, '<a href='));
+    }
+
     // ── Title-less CTA = standalone button row (issue 294) ─────────────────
 
     public function testCtaTitlelessRendersNoHeading(): void

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -248,7 +248,7 @@ class SchemaValidationTest extends TestCase
             'hero'    => 44,
             'section' => 40,
             'grid'    => 37,
-            'cta'     => 31,
+            'cta'     => 37,
         ];
 
         foreach ($expected as $component => $count) {
@@ -2264,7 +2264,7 @@ class SchemaValidationTest extends TestCase
      * intentionally ADD a prop, append it here in the same change.
      */
     private const PINNED_PROP_BASELINE = [
-        'cta'          => ['id', 'title', 'title_accent', 'eyebrow', 'text', 'button_text', 'button_url', 'layout', 'theme', 'background_image', 'button_variant'],
+        'cta'          => ['id', 'title', 'title_accent', 'eyebrow', 'text', 'button_text', 'button_url', 'button2_text', 'button2_url', 'button2_variant', 'layout', 'theme', 'background_image', 'button_variant'],
         'embed'        => ['id', 'title', 'content', 'theme'],
         'faq'          => ['id', 'title', 'title_accent', 'eyebrow', 'theme', 'items'],
         'footer'       => ['location', 'show_logo', 'logo_text', 'logo_id', 'logo_alt', 'bg', 'text', 'link_color', 'blurb', 'contact', 'copyright', 'menu_label', 'contact_label', 'secondary_location', 'secondary_label', 'note', 'social'],

--- a/tests/StyleSlotContractTest.php
+++ b/tests/StyleSlotContractTest.php
@@ -674,6 +674,59 @@ class StyleSlotContractTest extends TestCase
      * swapping the var() form for `initial` on --hero-button-bg would kill the leak but
      * leave --hero-cta2-bg masked again (the pre-existing half).
      */
+    /**
+     * Issue 474 — the cta's own second button carries the #526 isolation mechanism, and
+     * three SLOT_DECLARATION_EXEMPTIONS entries were added to permit it. Those exemptions
+     * switch OFF the slot-deadening guard for this rule, so this is the compensating
+     * STATIC pin (the hero equivalent below is the precedent): dropping any one of the
+     * three declarations, or qualifying the selector with a variant, silently restores
+     * half the #514-class leak while every other check here stays green. The rendered
+     * proof lives in tests/e2e/style-render.spec.ts, but that needs a live WP env — this
+     * one runs in the unit suite on every push.
+     */
+    public function testIssue474CtaButton2SlotIsolationAndFillRouting(): void
+    {
+        $block = $this->stripComments($this->componentBlock('cta'));
+
+        $selector = '/(?:^|\})\s*\.cta\s+\.cta__buttons\s+\.cta__button--secondary\s*\{([^}]*)\}/';
+        $this->assertMatchesRegularExpression(
+            $selector,
+            $block,
+            'The issue 474 button2 isolation rule is missing, or its selector gained a '
+            . 'variant qualifier — it must stay an unqualified .cta__button--secondary rule '
+            . 'so the primary button slots are unreachable on every button2 variant.'
+        );
+        preg_match($selector, $block, $m);
+        $isolation = $m[1] ?? '';
+
+        $this->assertMatchesRegularExpression(
+            '/--cta-button-bg:\s*var\(--cta-button2-bg\)\s*;/',
+            $isolation,
+            'The isolation rule must re-point --cta-button-bg at --cta-button2-bg (issue 474): '
+            . 'that single declaration both kills the slot leak (unset -> guaranteed-invalid -> '
+            . 'premium fallback) AND routes the button2 fill into the gradient-clearing chain. '
+            . 'Plain `initial` here would fix the leak but leave --cta-button2-bg masked again.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/--cta-button-color:\s*initial\s*;/',
+            $isolation,
+            'The isolation rule must reset --cta-button-color on button2 (issue 474).'
+        );
+        $this->assertMatchesRegularExpression(
+            '/--cta-button-shadow:\s*initial\s*;/',
+            $isolation,
+            'The isolation rule must reset --cta-button-shadow on button2 (issue 474).'
+        );
+
+        // The button2 rest rule still consumes --cta-button2-bg directly (background-color),
+        // so the slot stays author-reachable on the element the isolation rule targets.
+        $this->assertMatchesRegularExpression(
+            '/background-color:\s*var\(--cta-button2-bg,/',
+            $block,
+            'The button2 rest rule must still consume --cta-button2-bg as a background-color.'
+        );
+    }
+
     public function testIssue526HeroCta2SlotIsolationAndFillRouting(): void
     {
         $block = $this->stripComments($this->componentBlock('hero'));
@@ -1323,6 +1376,18 @@ class StyleSlotContractTest extends TestCase
         '.hero .hero__cta-group .hero__cta--secondary declares --hero-button-bg',
         '.hero .hero__cta-group .hero__cta--secondary declares --hero-button-color',
         '.hero .hero__cta-group .hero__cta--secondary declares --hero-button-shadow',
+        // issue 474 — the SAME isolation mechanism for the cta component's own second
+        // button, and exempt for the same reason. .cta__button--secondary is a
+        // descendant of the .cta root, so it inherits the PRIMARY button's
+        // --cta-button-* slots; a filled (`primary`) button2 sits in the shared premium
+        // button cascade and would be repainted by them. Nothing an author can set on
+        // the second button is deadened: its own author-facing slots are --cta-button2-*,
+        // none of which is declared here. --cta-button-bg is re-pointed at
+        // --cta-button2-bg (routing the button2 fill into the premium gradient-clearing
+        // chain); the other two are reset to the guaranteed-invalid `initial`.
+        '.cta .cta__buttons .cta__button--secondary declares --cta-button-bg',
+        '.cta .cta__buttons .cta__button--secondary declares --cta-button-color',
+        '.cta .cta__buttons .cta__button--secondary declares --cta-button-shadow',
     ];
 
     public function testNoStylesheetRuleDeclaresASchemaSlot(): void

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -1423,6 +1423,226 @@ test.describe('Safe-surface rendered proof', () => {
   });
 
   /*
+   * #474 — the cta's optional SECOND button.
+   *
+   * Two things only a rendered box can prove. (1) The dark-band routing: outline is
+   * the DEFAULT second-button variant, and outline paints its ink and ring directly
+   * on the band, so on `theme: inverted` and on a background_image band the
+   * light-surface --color-accent (#3157f4) rendered at 3.23:1 and 1.17:1 — both
+   * below AA. The fallback now routes through the same role tokens this component
+   * already uses for its dark-band body links (#437/#461). (2) The per-instance slot
+   * must still WIN over that routed fallback, or the #61/#86 dark-surface-slot
+   * contract is broken. The static StyleSlotContractTest proves the var() is
+   * consumed; only getComputedStyle proves which value the cascade actually paints.
+   */
+  test('#474 second button outline routes to the AA role token on both dark bands; the slot still wins @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E CTA Second Button Dark Bands');
+    setComposition(pageId, [
+      // 0: inverted band, default (outline) second button.
+      {
+        component: 'cta',
+        props: {
+          title: 'Inverted closing band',
+          button_text: 'Ver planes',
+          button_url: '/precios',
+          button2_text: 'Hablar con nosotros',
+          button2_url: '/contacto',
+          theme: 'inverted',
+        },
+      },
+      // 1: background-image band, default (outline) second button.
+      {
+        component: 'cta',
+        props: {
+          title: 'Overlay closing band',
+          button_text: 'Ver planes',
+          button_url: '/precios',
+          button2_text: 'Hablar con nosotros',
+          button2_url: '/contacto',
+          background_image: 'https://example.com/nonexistent.jpg',
+        },
+      },
+      // 2: inverted band with an explicit per-instance override — the slot must beat
+      // the routed fallback (the safe-surface contract).
+      {
+        component: 'cta',
+        props: {
+          title: 'Inverted, author override',
+          button_text: 'Ver planes',
+          button_url: '/precios',
+          button2_text: 'Hablar con nosotros',
+          button2_url: '/contacto',
+          theme: 'inverted',
+        },
+        style: { '--cta-button2-color': '#ffd166', '--cta-button2-border': '#ffd166' },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const secondaries = page.locator('.cta__button--secondary');
+    await expect(secondaries).toHaveCount(3, { timeout: 10000 });
+
+    const colorOf = async (i: number, prop: string) =>
+      secondaries.nth(i).evaluate(
+        (el, p) => getComputedStyle(el).getPropertyValue(p),
+        prop,
+      );
+
+    // --color-accent-on-inverted (#9dafee) = 8.33:1 on --color-bg-inverted,
+    // replacing --color-accent's failing 3.23:1.
+    expect(await colorOf(0, 'color')).toBe('rgb(157, 175, 238)');
+    expect(await colorOf(0, 'border-top-color')).toBe('rgb(157, 175, 238)');
+
+    // --color-accent-on-overlay (#fafbff) = 4.59:1 over the worst-case
+    // overlay-over-white composite, replacing --color-accent's 1.17:1.
+    expect(await colorOf(1, 'color')).toBe('rgb(250, 251, 255)');
+    expect(await colorOf(1, 'border-top-color')).toBe('rgb(250, 251, 255)');
+
+    // The per-instance slot beats the routed dark-band fallback.
+    expect(await colorOf(2, 'color')).toBe('rgb(255, 209, 102)');
+    expect(await colorOf(2, 'border-top-color')).toBe('rgb(255, 209, 102)');
+  });
+
+  /*
+   * #474 — the compensating proof for the three SLOT_DECLARATION_EXEMPTIONS entries
+   * added in StyleSlotContractTest. That guard normally forbids a stylesheet rule from
+   * DECLARING a schema slot, because declaring it beats the renderer's inline value on
+   * every descendant. The cta2-style isolation rule is exempt, so the guard can no
+   * longer catch a regression here — this test is what replaces it. It pins both halves
+   * of the mechanism that the exemption exists to enable, which is exactly the #514/#526
+   * leak class: the primary's slots must not repaint a filled second button, and the
+   * second button's own fill slot must resolve the premium `background` SHORTHAND so the
+   * gradient is cleared rather than masking the flat color.
+   */
+  test('#474 primary button slots do not leak into a filled second button; --cta-button2-bg clears the gradient @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E CTA Button2 Slot Isolation');
+    setComposition(pageId, [
+      // 0: the PRIMARY is flattened to a brand color. button2 is the filled `primary`
+      // variant, so it matches the same premium cascade and would be repainted too.
+      {
+        component: 'cta',
+        props: {
+          title: 'Isolation',
+          button_text: 'Primary',
+          button_url: '/a',
+          button2_text: 'Second',
+          button2_url: '/b',
+          button2_variant: 'primary',
+        },
+        style: {
+          '--cta-button-bg': 'rgb(185, 28, 28)',
+          '--cta-button-color': 'rgb(0, 255, 0)',
+          '--cta-button-shadow': 'none',
+        },
+      },
+      // 1: the SECOND button is recolored on its own slot; the primary must stay default.
+      {
+        component: 'cta',
+        props: {
+          title: 'Flat second',
+          button_text: 'Primary',
+          button_url: '/a',
+          button2_text: 'Second',
+          button2_url: '/b',
+          button2_variant: 'primary',
+        },
+        style: { '--cta-button2-bg': 'rgb(21, 128, 61)' },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const bands = page.locator('section.cta');
+    await expect(bands).toHaveCount(2, { timeout: 10000 });
+
+    const boxOf = (loc: any) =>
+      loc.evaluate((el: Element) => {
+        const cs = getComputedStyle(el);
+        return {
+          bg: cs.backgroundColor,
+          img: cs.backgroundImage,
+          color: cs.color,
+          shadow: cs.boxShadow,
+        };
+      });
+
+    // Band 0 — the primary's per-instance slots must NOT reach the second button.
+    const primary0 = await boxOf(bands.nth(0).locator('.cta__button').nth(0));
+    const second0 = await boxOf(bands.nth(0).locator('.cta__button--secondary'));
+    expect(primary0.bg).toBe('rgb(185, 28, 28)');
+    expect(primary0.img).toBe('none'); // flat fill cleared the gradient
+    expect(primary0.shadow).toBe('none');
+    expect(second0.bg).not.toBe('rgb(185, 28, 28)');
+    expect(second0.color).not.toBe('rgb(0, 255, 0)');
+    expect(second0.shadow).not.toBe('none'); // keeps the premium bevel
+    expect(second0.img).not.toBe('none'); // keeps the premium gradient
+
+    // Band 1 — the reverse direction: button2's fill slot must resolve the premium
+    // `background` shorthand (clearing the gradient) and must not touch the primary.
+    const primary1 = await boxOf(bands.nth(1).locator('.cta__button').nth(0));
+    const second1 = await boxOf(bands.nth(1).locator('.cta__button--secondary'));
+    expect(second1.bg).toBe('rgb(21, 128, 61)');
+    expect(second1.img).toBe('none');
+    expect(primary1.bg).not.toBe('rgb(21, 128, 61)');
+    expect(primary1.img).not.toBe('none'); // primary keeps its gradient
+  });
+
+  test('#474 an unset second button leaves the cta byte-identical; a set one renders the pair', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E CTA Second Button Presence');
+    setComposition(pageId, [
+      {
+        component: 'cta',
+        props: { title: 'Single', button_text: 'Ver planes', button_url: '/precios' },
+      },
+      {
+        component: 'cta',
+        props: {
+          title: 'Pair',
+          button_text: 'Ver planes',
+          button_url: '/precios',
+          button2_text: 'Hablar',
+          button2_url: '/contacto',
+        },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const bands = page.locator('section.cta');
+    await expect(bands).toHaveCount(2, { timeout: 10000 });
+
+    // Unset: no wrapper, no second anchor — the pre-#474 shape exactly.
+    await expect(bands.nth(0).locator('.cta__buttons')).toHaveCount(0);
+    await expect(bands.nth(0).locator('.cta__button')).toHaveCount(1);
+
+    // Set: the pair sits in one wrapper, side by side on desktop (same row).
+    await expect(bands.nth(1).locator('.cta__buttons')).toHaveCount(1);
+    await expect(bands.nth(1).locator('.cta__button')).toHaveCount(2);
+
+    const primaryBox = (await bands.nth(1).locator('.cta__button').nth(0).boundingBox())!;
+    const secondBox = (await bands.nth(1).locator('.cta__button').nth(1).boundingBox())!;
+    expect(Math.abs(primaryBox.y - secondBox.y)).toBeLessThan(2);
+    expect(secondBox.x).toBeGreaterThan(primaryBox.x);
+
+    // Mobile: the pair stacks one button per row (the shared `main .btn` width rule
+    // plus flex-wrap, the mechanism .hero__cta-group relies on).
+    await page.setViewportSize({ width: 375, height: 800 });
+    const mPrimary = (await bands.nth(1).locator('.cta__button').nth(0).boundingBox())!;
+    const mSecond = (await bands.nth(1).locator('.cta__button').nth(1).boundingBox())!;
+    expect(mSecond.y).toBeGreaterThan(mPrimary.y + mPrimary.height - 2);
+  });
+
+  /*
    * #305 — slot-contract rendered proof, one pin per dead-slot axis that shipped.
    *
    * The static guard (StyleSlotContractTest) proves every consumed slot survives the

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -328,8 +328,8 @@ describe('CSS lint: style slot fallback patterns', () => {
         });
     });
 
-    test('hero/section/grid/cta schemas declare 152 style slots (subset of the total)', () => {
-        expect(allSlots.length).toBe(152);
+    test('hero/section/grid/cta schemas declare 158 style slots (subset of the total)', () => {
+        expect(allSlots.length).toBe(158);
     });
 
     allSlots.forEach(({ component, slotName }) => {
@@ -509,6 +509,13 @@ describe('CSS lint: primary-button background-color routes through --cta-button-
             const s = sel.trim();
             return /(^|\s)\.cta\s+\.btn:not\(\.btn--outline\)/.test(s)
                 || /(^|\s)\.cta__button:not\(\.btn--outline\)/.test(s)
+                // The cta's SECOND button (issue 474) is its own composed-primary fill
+                // surface in CTA context: it sets a background-color longhand and routes
+                // --cta-button2-bg. The `.cta__button` alternative above cannot match it
+                // (that pattern needs `:not(` immediately after the class, and this
+                // selector carries the `--secondary` modifier there), so without this
+                // line the #420 guard has a hole exactly where the newest fill rule is.
+                || /(^|\s)\.cta__button--secondary:not\(\.btn--outline\)/.test(s)
                 || /(^|\s)main\s+\.btn:not\(\.btn--outline\)/.test(s);
         });
     }
@@ -535,7 +542,14 @@ describe('CSS lint: primary-button background-color routes through --cta-button-
         const offenders = [];
         surfaceRules.forEach(r => {
             const isHover = /:hover\b/.test(r.selector);
-            const slot = isHover ? '--cta-button-hover-bg' : '--cta-button-bg';
+            // The cta's SECOND button (issue 474) is the same fill surface but owns a
+            // SEPARATE slot family: --cta-button2-* is what an author sets there, and
+            // routing it through --cta-button-* would re-couple it to the primary (the
+            // exact leak the isolation rule exists to kill). Expect the slot that
+            // actually belongs to the surface, so the guard polices both buttons.
+            const isSecond = /\.cta__button--secondary\b/.test(r.selector);
+            const family = isSecond ? '--cta-button2' : '--cta-button';
+            const slot = isHover ? `${family}-hover-bg` : `${family}-bg`;
             r.decls.forEach(d => {
                 if (!new RegExp('background-color\\s*:\\s*var\\(\\s*' + slot + '\\b').test(d)) {
                     offenders.push(`${r.selector} { ${d} }`);


### PR DESCRIPTION
Closes #474

## Scope

A page-closing CTA had exactly one button, so a band that wanted "Ver planes" AND "Hablar con nosotros" had to drop one or switch to a `hero` (a styling change nobody asked for). The `cta` component now takes an optional second button.

- **Props:** `button2_text` / `button2_url` / `button2_variant`, mirroring hero's `cta2_*`. `button2_variant` defaults to `outline`. `button2_url` inherits the #507 `link_url` validation, so a `javascript:` destination is rejected at write time rather than rendering as a dead button.
- **Render:** `button2_text` gates it. Set, the pair renders in its own flex row that wraps to one button per row on mobile. Unset, the CTA renders **byte for byte** as before — no wrapper, no second anchor (the control tags sit at column 0 so the false branch emits zero bytes; verified against the pre-change renderer, 455 bytes both sides).
- **Styling:** six `--cta-button2-*` slots address the second button independently of the primary's `--cta-button-*` family, using the #526 isolation mechanism. Flattening the primary to a brand fill leaves the second button on the default premium treatment, and vice versa.
- **Contrast:** `outline` is the *default* here and paints its ink straight onto the band, where the light-surface accent measures **3.23:1** on an inverted band and **1.17:1** over a background image (both below AA). The second button's `outline`/`ghost` defaults now route through the `--color-accent-on-inverted` / `--color-accent-on-overlay` roles this component already uses for its dark-band body links: **8.33:1** and **4.59:1**. The per-instance slots still win.

## 7A question (asked and answered)

**Asked:** should the second button's default outline/ghost get a dark-band contrast fallback, or ship with the component's existing outline colors (identical to today's explicitly-authored `button_variant: outline`)?

**Answered:** Option B — route through the existing role tokens, scoped to the **second button only**, with `--cta-button2-color` / `--cta-button2-border` winning first. Rationale: this change is what makes an outline button reachable *by default* on a dark band, the same trigger that produced #437 / #461 / #463 in this very component, and it reuses named role tokens rather than inventing a colour. The wider pre-existing class (primary outline/ghost explicitly authored on dark bands) stays out of scope.

## Accepted limitations

Both are faithful to the hero's shipped behaviour and documented in the schema and README:

- A flat per-instance fill reverts to the shared premium gradient on hover (documented shipped trait, tracked in #530).
- Hover is not isolated between the two buttons: setting the primary's `--cta-button-hover-bg` also clears the second button's hover gradient. Set `--cta-button2-hover-bg` alongside it when the pair needs distinct hover fills.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — **2512 tests / 10226 assertions, green**. Warning counts (3 warnings, 2 deprecations) match an unmodified tree.
- `npm test` — **818 tests / 20 files, green**.
- `npx playwright test -g "#474"` — **4 passed** against wp-env, including computed-style assertions on both dark bands.
- Byte-identity of the unset render diffed directly against the pre-change renderer.
- Rendered at 1280 and 375 in stressed states (long copy, title-less pair, all four variants, inverted, background-image, both isolation directions).

## Review

`/plan-eng-review` (with a CSS prototype and rendered evidence before implementation), `/review` (testing + maintainability specialists, an adversarial pass, a red-team pass, and a Codex cross-model outside voice), and `/document-generate`. Eleven findings were raised and resolved, including four that changed shipped behaviour:

1. Stray indentation from indented control tags broke the byte-identical guarantee (24 bytes).
2. `--btn-bg` was missing from the second button's fill chain, so a `primary` + `primary` pair rendered two different fills on a site with a rethemed global button surface.
3. `flex-shrink: 0` on the pair wrapper stopped `flex-wrap` from ever firing in the inline layout and crushed the text block at 768px.
4. A non-scalar or `false` `button2_text` reaching the renderer rendered an unlabelled button or the literal text `Array`.

Also closed two test-guard gaps found by the red team: the #420 css-lint fill guard did not cover the new selector, and the three new `SLOT_DECLARATION_EXEMPTIONS` entries had no compensating static pin (hero's equivalent has one).
