### PR TITLE
Release v1.10.0 — Button & Brand Parity gate (rollup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.10.0] — 2026-07-27 — button & brand parity: every button surface behaves per-instance and consistently (rollup)
+
+**v1.10.0 is the rollup release of the Button & Brand Parity gate — three working versions (1.9.1–1.9.3) verified as one line. The hero's second CTA no longer inherits the primary's per-instance slots, and its own fill slot finally paints (with the border following the fill, matching #514's convention) (#526); stats numbers gain `--stats-number-font` / `--stats-number-weight` so figures can match a serif heading system (#472); and the cta component gains an optional second button (`button2_*`, mirroring hero's `cta2_*`) with leak-proof slot isolation and dark-band contrast routed through the established on-inverted/on-overlay role tokens (#474).**
+
+No code changes in this release beyond the version bump — see the [v1.9.1]…[v1.9.3] entries below for the substance.
+
 ## [v1.9.3] — 2026-07-27 — a closing CTA can offer a primary + secondary button pair (#474)
 
 **A page-closing CTA had one button, so a band that wanted "Ver planes" AND "Hablar con nosotros" had to drop one of them or switch to a `hero`, which is a styling change nobody asked for. The `cta` component now takes an optional second button — `button2_text` / `button2_url` / `button2_variant` — rendered beside the primary as a secondary action. Leave `button2_text` unset and the band renders byte for byte as it always has.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.9.3-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.10.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.9.3');
+define('PP_VERSION', '1.10.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.9.3
+Stable tag: 1.10.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.9.3
+Version:          1.10.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Rollup release PR: bumps the working line 1.9.3 → 1.10.0 (five synced version files + CHANGELOG rollup entry). No code changes.

Covers working versions 1.9.1–1.9.3:
- #526 hero cta2 slot-leak fix + `--hero-cta2-bg` fill routing with border-follows-fill (v1.9.1)
- #472 stats number typography slots `--stats-number-font` / `--stats-number-weight` (v1.9.2)
- #474 cta second button `button2_*` with slot isolation + dark-band role-token contrast (v1.9.3)

Suites at head: 2512 PHP / 818 JS green. Follow-ups filed during the gate, unmilestoned: #530 (hover fill slots dead on filled buttons), #531 (font-family slot grammar, needs-design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)