### PR TITLE
v1.10.2 fix: dark-band outline/ghost buttons and filled-button separation route through the AA accent roles (#535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.10.2] — 2026-07-27 — outline, ghost and filled buttons stay legible on dark bands (#535)
+
+**A button on an inverted or photo band is now readable by default, and a filled button on a photo band keeps a visible edge instead of dissolving into it.** The dark-band button defaults route through the accent roles the rest of the theme already uses there.
+
+`--color-accent` is tuned for light surfaces. Painted straight onto a dark band it measures 3.23:1 on an inverted band and 1.17:1 over a background-image scrim, so an `outline` or `ghost` button rendered its label and ring below the WCAG AA bar. The cover hero was worse: the rule meant to handle it sat above an identically-specific rule and never won, so its outline button painted near-black ink on the dark scrim. The hero's second CTA, whose variant defaults to `outline`, had the same defect, which meant simply adding a second CTA to a cover hero shipped a sub-AA control without the author choosing anything. Separately, a filled button on a photo band measured under 2:1 against it and its border followed the fill, so the button's shape vanished and only the label carried it.
+
+Every one of these defaults now falls back to `--color-accent-on-inverted` on the solid inverted band and `--color-accent-on-overlay` over an image, the same roles the dark-band body links, stat numbers and highlighted title words already use. No new color ships. On an overlay band that role is also the filled button's border, which gives the shape a readable edge. The solid inverted band deliberately keeps its unringed filled button: it already measures 3.23:1 against the band, which clears the 3:1 bar for a non-text shape.
+
+Per-instance slots still win everywhere, and a light band renders exactly as before. A band you darken yourself with `--cta-bg` gets no automatic ring, because nothing in CSS can compare your authored band color to the button fill.
+
+### Fixed
+
+- Default `outline` and `ghost` buttons on a `theme: "inverted"` CTA route their ink and ring through `--color-accent-on-inverted` (3.23:1 → 8.33:1); `--cta-button-color` / `--cta-button-border` still win when set (#535).
+- The same buttons on a `background_image` CTA, and on a `cover` hero, route through `--color-accent-on-overlay` (1.17:1 → 4.59:1 against the worst-case scrim-over-white composite; the cover hero's outline started from near-black ink at roughly 3.6:1 there and worse over a dark photo) (#535).
+- A `cover` hero's outline button no longer paints near-black ink on its own scrim. The rule responsible had been dead since it shipped: it shared specificity with a later rule and lost on source order (#535).
+- A `cover` hero's second CTA gets the same treatment as the first. Its variant defaults to `outline`, so this closes the case where adding a second CTA silently produced a sub-AA button (#535).
+- A filled button on a `background_image` CTA or a `cover` hero keeps a visible edge at rest AND on hover: its border stops following the fill and bottoms out at the overlay accent role (4.59:1) instead of the sub-2:1 fill. Only the final fallback changed, so `--cta-button-border`, `--cta-accent`, `--hero-accent`, `--hero-button-bg` and the global `--btn-border-color` all still win exactly as before, and an already-branded ring keeps its colour (#535).
+- Hover is unaffected by the dark-band routing. Both transparent variants paint their own contrasting fill on hover, so the ink reverts to that variant's normal hover color rather than carrying a role token onto a surface it was never measured against.
+
+### Docs
+
+- `ai-instructions/retheme.md` states that dark-band `outline`/`ghost` buttons — including the hero's second CTA — route through the same on-inverted / on-overlay roles as links and title accents, that the routing is resting-state only, and that the overlay role doubles as the filled button's separation ring.
+
+### Tests
+
+- css-lint pins every new route (slot → role) per band, the wrong-role and bare-accent regressions, the hover restoration rules, the four source-order dependencies that the dead-rule defect came from, and a negative pin that the inverted filled button is NOT ringed.
+- Rendered `@smoke` coverage across both CTA dark bands and the cover hero: resting and hover computed values, the filled ring, per-instance slot overrides winning, a light-band control, and a non-cover hero control.
+
+---
+
 ## [v1.10.1] — 2026-07-27 — per-instance hover fills reach filled buttons (#530)
 
 **A filled button styled with a brand color no longer snaps back to the theme gradient the moment you point at it.** Hover is now a real per-instance surface on all four filled button slots.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.10.1-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.10.2-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/retheme.md
+++ b/ai-instructions/retheme.md
@@ -45,7 +45,12 @@ Check at https://webaim.org/resources/contrastchecker/
 surfaces; on the dark `--color-bg-inverted` it drops to ~3.2:1 and fails AA for body
 text. Links (and dim accent text like inverted stats numbers) on inverted bands
 therefore route through `--color-accent-on-inverted` (default `#9dafee`, 8.33:1 on the
-default inverted bg) with `--color-accent-on-inverted-hover` for hover. **Pairing
+default inverted bg) with `--color-accent-on-inverted-hover` for hover. The same applies
+to any BUTTON whose variant paints ink straight onto the band: an `outline` or `ghost`
+button on an inverted cta takes its default ink and ring from `--color-accent-on-inverted`
+too (the bare accent measured 3.23:1 there). Only the RESTING state routes this way —
+on hover both variants paint their own contrasting fill, so the ink reverts to the
+variant's normal hover colour. **Pairing
 contract:** if you change `--color-accent` OR `--color-bg-inverted`, keep
 `--color-accent-on-inverted` at ≥ 4.5:1 against `--color-bg-inverted`. The programmatic
 path auto-derives it (a lightened accent tint) when you change `--color-accent` and
@@ -56,8 +61,10 @@ other derived token (see below), so you are told when a base change may not reac
 **Surface-paired accent (the bg-image band).** A section/cta/stats band WITH a
 `background_image` — and a hero with `cover` layout + `image_url` — lays a dark
 `rgba(0,0,0,.55)` overlay over an ARBITRARY image, so EVERY accent surface on that band
-(section/cta links, stats numbers, the `title_accent` substring on all four, and section
-body list markers) routes through a SEPARATE role,
+(section/cta links, stats numbers, the `title_accent` substring on all four, section
+body list markers, and the `outline`/`ghost` buttons on a cta or cover hero — including
+the hero's second CTA, whose variant DEFAULTS to `outline`) routes through a SEPARATE
+role,
 `--color-accent-on-overlay` (default `#fafbff`), with `--color-accent-on-overlay-hover`
 (default `#ffffff`) for hover. This is NOT the same as `--color-accent-on-inverted`:
 on-inverted is tuned to the SOLID `--color-bg-inverted`, but the overlay sits over an
@@ -71,6 +78,15 @@ affordance comes from its underline. The programmatic path auto-derives it (a ne
 accent tint) when you change `--color-accent` and leave it unpinned; a pinned override
 that diverges is surfaced by the same `stale_warnings` / `masked_derived_override`
 machinery as every other derived token.
+
+On an overlay band the role does one more job: it is also the FILLED primary button's
+border, so the button keeps a visible edge. The premium gradient fill measures only
+~1.1:1 against the worst-case composite, so without that ring the button's shape
+disappears into the band and only its label carries it. The solid inverted band does NOT
+get this ring — the same fill measures 3.23:1 there, which already clears the 3:1
+non-text bar. Per-instance slots (`--cta-button-border`, `--hero-accent`) still win, so
+you can recolour the ring; a band you darken yourself with `--cta-bg` gets no automatic
+ring, because nothing in CSS can compare your authored band colour to the button fill.
 
 Example retheme — warm neutral:
 ```css

--- a/ai-instructions/style-component.md
+++ b/ai-instructions/style-component.md
@@ -376,9 +376,15 @@ on-brand through the hover instead of returning to the premium gradient. Setting
 primary's hover fill never touches the second button's. Pair each hover slot with its
 resting slot: with only the hover slot set, the button drops the gradient layer instantly
 while the color animates, which reads as a brief off-brand wash. On a dark band
-(`theme: "inverted"` or a `background_image`) the second button's default outline/ghost ink
-already routes to the AA-safe on-dark accent role, so it is readable without any slot; set
-`--cta-button2-color` only to override that.
+(`theme: "inverted"` or a `background_image`) the default outline/ghost ink of BOTH buttons
+already routes to the AA-safe on-dark accent role, so each is readable without any slot;
+set `--cta-button-color` / `--cta-button2-color` only to override that. The same holds for
+a `cover` hero's two CTAs (`--hero-text` for the first, `--hero-cta2-color` for the
+second). On a `background_image` cta or a `cover` hero the FILLED button additionally
+takes its border from that role, so its shape stays visible against the band; set
+`--cta-button-border` / `--hero-accent` to colour that edge yourself. The routing only
+covers bands the theme can identify — a band you darken yourself with `--cta-bg` or
+`--hero-bg` gets no automatic treatment, so set the slots there.
 
 **Brand-accent hero primary button (fill slots).** The hero's primary (filled) CTA
 ships the same premium gradient treatment as the cta button. `--hero-accent` recolors

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -710,15 +710,15 @@
   justify-content: center;
 }
 
-.hero--cover .btn--outline {
-  border-color: var(--color-bg);
-  color: var(--color-bg);
-}
-
-.hero--cover .btn--outline:hover {
-  background-color: var(--color-bg);
-  color: var(--color-text);
-}
+/* NOTE (issue 535): the cover band's outline/ghost button routing used to live here as
+   `.hero--cover .btn--outline` { border-color/color: var(--color-bg) }. It NEVER painted:
+   `.hero .btn--outline` below has the IDENTICAL specificity [0,2,0] and wins on source
+   order, so a cover hero's outline primary rendered var(--hero-text, var(--color-text))
+   = near-black ink on the dark scrim (measured ~3.6:1 over the worst-case overlay-over-
+   white composite, and far worse over a dark photo). The rules moved DOWN to sit after
+   `.hero .btn--outline`, where they actually win, and their literals now route through
+   the --color-accent-on-overlay role. See "Dark-band routing for the hero's cover band"
+   below. Do not re-add a cover button rule up here: it would be dead again. */
 
 .hero__image-wrap {
   flex-shrink: 0;
@@ -859,6 +859,70 @@
   color: var(--hero-bg, var(--color-bg));
 }
 
+/* Dark-band routing for the hero's cover band (issue 535, the #474 mechanism applied to
+   the PRIMARY button). `.hero--cover` lays the same --overlay-bg scrim over an ARBITRARY
+   image as the section/cta/stats bg-image bands, so a transparent-fill button paints its
+   ink and ring straight onto that scrim. Two separate defaults failed there:
+     - outline inherited `.hero .btn--outline`'s var(--hero-text, var(--color-text)) —
+       near-black #101828 on the scrim, ~3.6:1 against the worst-case overlay-over-WHITE
+       composite and far worse over a dark photo. The older `.hero--cover .btn--outline`
+       rule that was meant to handle this never won (identical [0,2,0], earlier in source);
+       these rules sit AFTER `.hero .btn--outline` so source order makes them the winner.
+     - ghost fell all the way to the shared `.btn--ghost` var(--color-accent) at 1.17:1.
+   Both now fall back to --color-accent-on-overlay (4.59:1, base.css), the same role
+   .hero--cover .hero__title-accent already uses (#463), so no new colour is invented.
+   The per-instance slot still wins: --hero-text is the surface `.hero .btn--outline`
+   already reads, and it also drives .hero--cover .hero__title, so an author who sets it
+   has already chosen a colour that reads on their own scrim. Deliberately kept on
+   --hero-text rather than --hero-button-color: that slot is documented in schema.json as
+   the FILLED primary's ink, and widening it to the transparent variants would change a
+   published slot's meaning. Scoped to `.hero--cover .btn--*` (not `.hero__cta`) so an
+   outline button authored inside the `proof` HTML surface is covered too; the second CTA
+   keeps its own [0,4,0] rules and is handled by the cover cta2 block below.
+   This is a REST-state fix only: on hover both variants paint their own contrasting fill,
+   so the ink leaves the scrim and needs no role token. Outline's hover rule already
+   outranks this one; ghost's ties with it and needs the explicit restoration below. */
+.hero--cover .btn--outline {
+  color: var(--hero-text, var(--color-accent-on-overlay));
+  border-color: var(--hero-text, var(--color-accent-on-overlay));
+}
+.hero--cover .btn--ghost {
+  color: var(--hero-text, var(--color-accent-on-overlay));
+}
+/* HOVER restoration for the cover ghost (issue 535, the same leak the cta rules below
+   document). `.hero--cover .btn--ghost` [0,2,0] ties with the shared `.btn--ghost:hover`
+   [0,2,0] and follows it, so without this the on-overlay ink survived onto a hover that
+   fills with the near-white --color-surface — near-invisible. The outline twin needs no
+   restoration: `.hero .btn--outline:hover` is [0,3,0] and already outranks it. Value
+   copied verbatim from `.btn--ghost:hover`. */
+.hero--cover .btn--ghost:hover {
+  color: var(--color-accent);
+}
+
+/* Separation ring for the FILLED button on the cover band (issue 535, defect 2's
+   class-triggerable half; the .cta--has-bg-image twin lives in the cta block and carries
+   the fuller rationale). The premium gradient fill measures well under 2:1 against the
+   worst-case scrim composite, so the button's SHAPE disappears and only its label carries
+   it; its border followed the fill, so it added nothing. Here the border stops following
+   the fill and bottoms out at the on-overlay role (4.59:1, base.css) — the "border falling
+   back to a role token distinct from the fill" the recorded direction names.
+   Only the TERMINAL fallback changes: --hero-accent, --btn-border-color and the fill chain
+   (--hero-button-bg -> --btn-bg) all stay ahead of it in `.hero .btn:not(...)`'s exact
+   order, so a cover hero flattened to a brand colour with --hero-button-bg keeps its
+   MATCHING ring rather than gaining a near-white one.
+   [0,5,0], the SAME as `.hero .btn:not(...)` above, so it wins only by following it in
+   source order (pinned in css-lint) — not by outranking it. `.hero__cta` is used rather
+   than the bare `.btn` the two rules above use so the ring stays on the hero's own CTA
+   buttons instead of any `.btn` an author writes into the `proof` surface. The :hover twin
+   is [0,6,0] to beat `.hero .btn:not(...):hover`, whose border also follows the fill.
+   There is no `theme: inverted` hero, so the Q2 not-ringed case does not arise here. */
+.hero--cover .hero__cta:not(.btn--outline):not(.btn--ghost):not(.btn--secondary) {
+  border-color: var(--hero-accent, var(--btn-border-color, var(--hero-button-bg, var(--btn-bg, var(--color-accent-on-overlay)))));
+}
+.hero--cover .hero__cta:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
+  border-color: var(--hero-accent-hover, var(--hero-button-hover-bg, var(--color-accent-on-overlay)));
+}
+
 /* Second CTA button (cta2): per-instance bg/border/color override, independent
    of the primary button (issue 111). Targeted via the dedicated .hero__cta--secondary
    class (hero.php) rather than a positional :nth-child selector — this
@@ -924,6 +988,31 @@
   background-color: var(--hero-cta2-hover-bg, var(--color-surface));
   border-color: var(--hero-cta2-hover-border, transparent);
   color: var(--hero-cta2-hover-color, var(--color-accent));
+}
+
+/* Dark-band routing for the SECOND CTA's transparent-fill variants on the cover band
+   (issue 535, Q3). #474 fixed exactly this defect for the cta component's button2 but was
+   scoped to that component; hero's cta2 has the same trigger and was left behind.
+   `cta2_variant` DEFAULTS to `outline` (hero.php), so simply setting cta2_text on a cover
+   hero shipped a sub-AA control without the author ever choosing a variant: the rules
+   above resolve var(--hero-cta2-color, var(--hero-text, var(--color-text))) to near-black
+   #101828 on the scrim (~3.6:1 measured), and ghost fell to var(--color-accent) at 1.17:1.
+   Both defaults now route through --color-accent-on-overlay, matching the primary above
+   and .hero--cover .hero__title-accent (#463). The --hero-cta2-color / --hero-cta2-border
+   slots still win, so the #61/#86 dark-surface-slot contract holds.
+   These carry the SAME [0,4,0] specificity as the base cta2 variant rules they override,
+   so they depend on following them in source order — do not move them above, and do not
+   add a competing `.hero--cover` cta2 rule further down the file. Hover needs no
+   restoration here (unlike the primary and the cta component's): the cta2 `:hover` rules
+   are [0,5,0] and already outrank these, so the routed ink cannot leak into a state where
+   the button paints its own fill. A cta2 authored as the FILLED `primary` variant keeps
+   its existing border (an explicit author choice, not a default) and is out of scope. */
+.hero--cover .hero__cta-group .hero__cta--secondary.btn--outline {
+  color: var(--hero-cta2-color, var(--color-accent-on-overlay));
+  border-color: var(--hero-cta2-border, var(--color-accent-on-overlay));
+}
+.hero--cover .hero__cta-group .hero__cta--secondary.btn--ghost {
+  color: var(--hero-cta2-color, var(--color-accent-on-overlay));
 }
 
 /* cta2 slot isolation + premium fill routing (issue 526). Style slots are emitted as
@@ -2538,6 +2627,91 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   color: var(--cta-button2-color, var(--color-accent-on-overlay));
 }
 
+/* Dark-band routing for the PRIMARY button's transparent-fill variants (issue 535).
+   #474 fixed this for the SECOND button and deliberately left the primary — an
+   explicitly authored `button_variant: outline|ghost` on a dark band — as the wider
+   pre-existing class. This is that class. The mechanism, the role tokens and the slot
+   precedence are identical to the button2 rules above; only the selector differs:
+   --color-accent paints 3.23:1 on --color-bg-inverted and 1.17:1 over the worst-case
+   bg-image scrim, both below AA, and both now fall back to the role token this component
+   already uses for its dark-band body links (#437/#461) and title accent (#463).
+   Both figures are base.css's, not re-derived here: 8.33:1 on inverted, 4.59:1 over the overlay.
+   These sit at [0,3,0] — deliberately BELOW the button2 rules above at [0,4,0] — so the
+   second button keeps its own routing and the #474/#526/#530 pins stay green even though
+   button2 also carries the .cta__button class. --cta-button-color / --cta-button-border
+   still win when set. REST state only — the hover restoration block below explains why
+   these four rules must not be allowed to reach `:hover`. */
+.cta--inverted .cta__button.btn--outline {
+  color: var(--cta-button-color, var(--color-accent-on-inverted));
+  border-color: var(--cta-button-border, var(--color-accent-on-inverted));
+}
+.cta--inverted .cta__button.btn--ghost {
+  color: var(--cta-button-color, var(--color-accent-on-inverted));
+}
+
+.cta--has-bg-image .cta__button.btn--outline {
+  color: var(--cta-button-color, var(--color-accent-on-overlay));
+  border-color: var(--cta-button-border, var(--color-accent-on-overlay));
+}
+.cta--has-bg-image .cta__button.btn--ghost {
+  color: var(--cta-button-color, var(--color-accent-on-overlay));
+}
+
+/* HOVER restoration (issue 535). The four rest rules above are [0,3,0] — the SAME
+   specificity as the `.cta__button.btn--outline:hover` / `.btn--ghost:hover` rules they
+   follow (a pseudo-class counts as a class), so source order alone made them win on
+   hover too and the dark-band ink leaked into a state it was never meant to reach.
+   Rendered, that was worse than the bug being fixed: outline hover fills with
+   --color-accent, so on-inverted ink over it measured 2.58:1, and ghost hover fills with
+   the near-white --color-surface, where the on-overlay ink is effectively invisible.
+   These rules re-assert each variant's OWN documented hover values at [0,4,0].
+   The dark-band routing is a REST-state fix by design: on hover both variants paint a
+   contrasting fill of their own, so the ink no longer sits on the band and needs no
+   role token. The button2 rules above never needed this — their selectors carry one more
+   ancestor class, so their `:hover` siblings already outrank them. Values here are copied
+   verbatim from those hover rules; changing one without the other reopens this leak. */
+.cta--inverted .cta__button.btn--outline:hover,
+.cta--has-bg-image .cta__button.btn--outline:hover {
+  color: var(--cta-button-hover-color, var(--color-bg));
+  border-color: var(--cta-button-hover-border, var(--color-accent));
+}
+.cta--inverted .cta__button.btn--ghost:hover,
+.cta--has-bg-image .cta__button.btn--ghost:hover {
+  color: var(--cta-button-hover-color, var(--color-accent));
+}
+
+/* Separation ring for the FILLED button on the bg-image band (issue 535, defect 2's
+   class-triggerable half; the .hero--cover twin of this rule lives in the hero block).
+   The premium gradient fill measures well under 2:1 against the worst-case overlay-over-
+   white composite — the button's SHAPE vanishes and only its label carries it — and the
+   border FOLLOWED the fill, so it added nothing. Here the border stops following the fill
+   and bottoms out at the on-overlay role (4.59:1, base.css) instead, giving the pill a
+   visible edge.
+   Only the TERMINAL fallback changes. Every authored link ahead of it is preserved in the
+   `.cta .btn:not(...)` order — --cta-button-border, then the global --btn-border-color,
+   then the fill chain (--cta-button-bg -> --cta-accent -> --btn-bg) — so a button whose
+   ring an author already colours keeps exactly the colour it had. Dropping those links
+   and jumping straight to the role would have silently repainted every authored
+   --cta-accent ring on a photo band near-white.
+   [0,5,0] matches `.cta .btn:not(...)` above, so this wins only by staying AFTER it in
+   source order (pinned in css-lint). The :hover twin is [0,6,0] to beat
+   `.cta .btn:not(...):hover`, whose border also follows the fill — without it the ring
+   reappeared at rest and dissolved again the moment the pointer landed, which is the
+   state a user is most likely looking at (WCAG 1.4.11 applies to hover too).
+   The INVERTED band is deliberately NOT ringed (issue 535 Q2): its filled button measures
+   3.23:1 fill-vs-band, which already clears the 3:1 non-text bar, so a ring there would be
+   a visual change with no measured defect behind it. A band an author darkened with
+   --cta-bg carries no class at all and is tracked in #541 as a trigger-mechanism design
+   problem, not a colour problem. A filled SECOND button keeps its own [0,6,0] rules and is
+   deliberately not ringed here — same fill, same band, but changing it is a scope
+   extension rather than this issue's defect; tracked in #543. */
+.cta--has-bg-image .cta__button:not(.btn--outline):not(.btn--ghost):not(.btn--secondary) {
+  border-color: var(--cta-button-border, var(--btn-border-color, var(--cta-button-bg, var(--cta-accent, var(--btn-bg, var(--color-accent-on-overlay))))));
+}
+.cta--has-bg-image .cta__button:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
+  border-color: var(--cta-button-hover-border, var(--cta-button-hover-bg, var(--cta-accent-hover, var(--color-accent-on-overlay))));
+}
+
 /* button2 slot isolation + premium fill routing (the issue 526 mechanism applied
    to cta). Style slots are emitted as inline custom properties on the .cta ROOT,
    so the PRIMARY button's --cta-button-* slots INHERIT down to the second button;
@@ -2643,11 +2817,12 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   border-bottom: var(--cta-border-width, 1px) solid var(--cta-border-color, var(--color-border));
 }
 
-/* NOTE (issue 474): the dark-band routing for the SECOND button's outline/ghost
-   variants lives ABOVE, with the other button2 rules, not in this theme block. Those
-   rules are [0,4,0] and depend on source order against the base button2 variant rules
-   they follow. Do not add a competing `.cta--inverted`/`.cta--has-bg-image` button2
-   rule down here: it would win by source order and silently defeat the AA routing. */
+/* NOTE (issues 474, 535): the dark-band routing for BOTH buttons' outline/ghost variants,
+   and the filled primary's bg-image separation ring, live ABOVE with the other button
+   rules, not in this theme block. They are [0,3,0]–[0,5,0] and depend on source order
+   against the base button rules they follow. Do not add a competing `.cta--inverted` /
+   `.cta--has-bg-image` button rule down here: it would win by source order and silently
+   defeat the AA routing. */
 .cta--inverted {
   background: var(--cta-bg, var(--color-bg-inverted));
   --cta-body-theme-color: var(--color-bg);

--- a/components/cta/README.md
+++ b/components/cta/README.md
@@ -37,6 +37,16 @@ Selects the shared button style. Set as a prop via `update_component`.
 
 Per-instance button color is still set through the `--cta-accent` style slot.
 
+On a dark band (`theme: "inverted"` or a `background_image`) the transparent-fill
+variants paint their ink and ring straight onto the band, where the light-surface
+accent fails WCAG AA. Both buttons' `outline`/`ghost` defaults therefore fall back to
+the band's accent role (`--color-accent-on-inverted` / `--color-accent-on-overlay`)
+instead, so they are readable without setting anything; `--cta-button-color` /
+`--cta-button-border` (and the `--cta-button2-*` pair) still win when set. Resting
+state only — on hover each variant paints its own contrasting fill. On a
+`background_image` band the filled button also takes its border from that role so its
+shape stays visible against the band.
+
 ## Second button (`button2_*`)
 
 A closing CTA can offer a primary + secondary pair — "Ver planes" *and* "Hablar con

--- a/components/hero/README.md
+++ b/components/hero/README.md
@@ -32,7 +32,7 @@ Full-width hero section with headline, optional subtitle, optional CTA button, a
 - **centered** — All content centered horizontally. Best for homepage hero.
 - **left** — Content aligned left. Best for interior page headers.
 - **split** — Text on left, image on right (two-column at lg+). Best for feature introductions.
-- **cover** — Fullscreen background image with a dark overlay and light text. Best for high-impact landing pages.
+- **cover** — Fullscreen background image with a dark overlay and light text. Best for high-impact landing pages. Both CTAs sit on that overlay, so their `outline`/`ghost` defaults fall back to `--color-accent-on-overlay` rather than the light-surface accent, and the filled CTA takes its border from the same role so its shape stays visible against the image. `--hero-text` (first CTA) and `--hero-cta2-color` / `--hero-cta2-border` (second) still win when set.
 
 ## Usage
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.10.1');
+define('PP_VERSION', '1.10.2');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.10.1
+Stable tag: 1.10.2
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.10.1
+Version:          1.10.2
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ComponentPropsTest.php
+++ b/tests/ComponentPropsTest.php
@@ -1035,12 +1035,19 @@ class ComponentPropsTest extends TestCase
         // var(--cta-button-bg, ...))`) so the border follows the fill when the border slot
         // is unset. `.cta .btn` is the [0,5,0] longhand winner that outranked BOTH of the
         // above layers for background-color/border-color and silently re-killed the slot.
+        // PLUS 1 on the bg-image separation ring (issue 535). That rule overrides
+        // `.cta .btn:not(...)`'s border on an overlay band, replacing ONLY the terminal
+        // --color-accent with --color-accent-on-overlay; every authored link ahead of it,
+        // including this fill slot, is carried over verbatim so a button an author already
+        // recoloured keeps its matching ring instead of gaining a near-white one.
         $this->assertSame(
-            8,
+            9,
             substr_count($css, 'var(--cta-button-bg'),
             'var(--cta-button-bg) must be consumed by the 4 cta-block variant rules, the 2 '
-            . 'premium primary-fill winners (issue 412), and the .cta .btn rest rule twice '
-            . '(fill + the fill nested in its border fallback, issue 420).'
+            . 'premium primary-fill winners (issue 412), the .cta .btn rest rule twice '
+            . '(fill + the fill nested in its border fallback, issue 420), and the '
+            . '.cta--has-bg-image separation ring, which preserves that same border '
+            . 'fallback chain ahead of the overlay role (issue 535).'
         );
     }
 

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -1508,6 +1508,265 @@ test.describe('Safe-surface rendered proof', () => {
   });
 
   /*
+   * #535 — the rest of the dark-band button class #474 opened.
+   *
+   * #474 fixed the cta's SECOND button. Everything else that paints ink directly on a
+   * dark band was still on the light-surface accent (or, on the cover hero, on near-black
+   * --color-text): the PRIMARY outline/ghost on both cta dark bands, the hero's primary
+   * AND its default-outline second CTA on the `.hero--cover` scrim. Separately, the FILLED
+   * primary on the two OVERLAY bands had no separation from the band at all — its gradient
+   * measured under 2:1 against the worst-case composite and its border followed the fill, so
+   * the button's SHAPE vanished and only the label carried it.
+   *
+   * Only a rendered box proves these. The cover-hero case in particular is a pure CASCADE
+   * defect: `.hero--cover .btn--outline` existed but sat ABOVE `.hero .btn--outline` at
+   * identical [0,2,0] specificity, so it never painted. A static "the rule exists" check
+   * passed for years while the rendered button stayed near-black. css-lint pins the source
+   * order; this pins the colour the cascade actually resolves.
+   *
+   * Ratios quoted below are against the worst-case composites documented in base.css:
+   * --color-bg-inverted for the solid band, the --overlay-bg scrim over a pure-WHITE
+   * image for the overlay bands.
+   */
+  test('#535 dark-band primary + cover-hero buttons route to the AA role tokens; rings, slots and light bands hold @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Dark Band Button Contrast');
+    setComposition(pageId, [
+      // 0/1: cta PRIMARY outline + ghost on the solid inverted band (3.23:1 -> 8.33:1).
+      { component: 'cta', props: { title: 'Inverted outline', button_text: 'Ver planes', button_url: '/precios', theme: 'inverted', button_variant: 'outline' } },
+      { component: 'cta', props: { title: 'Inverted ghost', button_text: 'Ver planes', button_url: '/precios', theme: 'inverted', button_variant: 'ghost' } },
+      // 2/3: cta PRIMARY outline + ghost on the bg-image scrim (1.17:1 -> 4.59:1).
+      { component: 'cta', props: { title: 'Overlay outline', button_text: 'Ver planes', button_url: '/precios', background_image: 'https://example.com/nonexistent.jpg', button_variant: 'outline' } },
+      { component: 'cta', props: { title: 'Overlay ghost', button_text: 'Ver planes', button_url: '/precios', background_image: 'https://example.com/nonexistent.jpg', button_variant: 'ghost' } },
+      // 4: FILLED primary on the bg-image band — gains the separation ring.
+      { component: 'cta', props: { title: 'Overlay filled', button_text: 'Ver planes', button_url: '/precios', background_image: 'https://example.com/nonexistent.jpg' } },
+      // 5: FILLED primary on the INVERTED band — deliberately NOT ringed (Q2).
+      { component: 'cta', props: { title: 'Inverted filled', button_text: 'Ver planes', button_url: '/precios', theme: 'inverted' } },
+      // 6: per-instance slots must beat the routed dark-band fallback (#61/#86 contract).
+      {
+        component: 'cta',
+        props: { title: 'Inverted, author override', button_text: 'Ver planes', button_url: '/precios', theme: 'inverted', button_variant: 'outline' },
+        style: { '--cta-button-color': '#ffd166', '--cta-button-border': '#ffd166' },
+      },
+      // 7: LIGHT band control — must be byte-identical to before the change.
+      { component: 'cta', props: { title: 'Light outline', button_text: 'Ver planes', button_url: '/precios', button_variant: 'outline' } },
+      // 8: BOTH dark-band classes at once. cta.php emits the theme class and the bg-image
+      // class independently, so this renders `.cta--inverted.cta--has-bg-image` with the
+      // scrim over the inverted background. The two routing rules tie at [0,3,0], so only
+      // source order decides — and the OVERLAY role must win, since on-inverted is barely
+      // 2.2:1 over an arbitrary image.
+      { component: 'cta', props: { title: 'Inverted AND overlay', button_text: 'Ver planes', button_url: '/precios', theme: 'inverted', background_image: 'https://example.com/nonexistent.jpg', button_variant: 'outline' } },
+      // 9: an authored --cta-accent on the bg-image band. The ring rule replaces only the
+      // TERMINAL fallback, so this brand colour must still paint the ring; jumping straight
+      // to the role token would have silently repainted every authored ring near-white.
+      {
+        component: 'cta',
+        props: { title: 'Overlay filled, authored accent', button_text: 'Ver planes', button_url: '/precios', background_image: 'https://example.com/nonexistent.jpg' },
+        style: { '--cta-accent': 'rgb(255, 92, 46)' },
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const buttons = page.locator('.cta__button');
+    await expect(buttons).toHaveCount(10, { timeout: 10000 });
+
+    const prop = async (i: number, p: string) =>
+      buttons.nth(i).evaluate((el, name) => getComputedStyle(el).getPropertyValue(name), p);
+
+    const ON_INVERTED = 'rgb(157, 175, 238)'; // #9dafee, 8.33:1 on --color-bg-inverted
+    const ON_OVERLAY = 'rgb(250, 251, 255)';  // #fafbff, 4.59:1 on the worst-case scrim
+    const BARE_ACCENT = 'rgb(49, 87, 244)';   // #3157f4 — the failing light-surface accent
+
+    // Solid inverted band: outline gets ink AND ring; ghost is borderless by design.
+    expect(await prop(0, 'color')).toBe(ON_INVERTED);
+    expect(await prop(0, 'border-top-color')).toBe(ON_INVERTED);
+    expect(await prop(1, 'color')).toBe(ON_INVERTED);
+
+    // Overlay band: on-overlay, NOT on-inverted (which is only ~2.2:1 over the scrim).
+    expect(await prop(2, 'color')).toBe(ON_OVERLAY);
+    expect(await prop(2, 'border-top-color')).toBe(ON_OVERLAY);
+    expect(await prop(3, 'color')).toBe(ON_OVERLAY);
+
+    // Filled primary on the overlay band: the ring no longer follows the fill, so the
+    // pill has a visible edge (ring -> 4.59:1) while the fill itself is unchanged.
+    expect(await prop(4, 'border-top-color')).toBe(ON_OVERLAY);
+    expect(await prop(4, 'background-color')).toBe(BARE_ACCENT);
+
+    // Filled primary on the INVERTED band: NOT ringed. Its fill already measures 3.23:1
+    // against the band, clearing the 3:1 non-text bar, so the border stays on the fill.
+    expect(await prop(5, 'border-top-color')).toBe(BARE_ACCENT);
+
+    // The per-instance slots beat the routed fallback on a dark band.
+    expect(await prop(6, 'color')).toBe('rgb(255, 209, 102)');
+    expect(await prop(6, 'border-top-color')).toBe('rgb(255, 209, 102)');
+
+    // Light band is untouched: still the bare accent at 5.14:1 on --color-surface.
+    expect(await prop(7, 'color')).toBe(BARE_ACCENT);
+    expect(await prop(7, 'border-top-color')).toBe(BARE_ACCENT);
+
+    // Both dark-band classes at once: the overlay role wins, not on-inverted.
+    expect(await prop(8, 'color')).toBe(ON_OVERLAY);
+    expect(await prop(8, 'border-top-color')).toBe(ON_OVERLAY);
+
+    // An authored --cta-accent still paints the ring; only the terminal fallback moved.
+    expect(await prop(9, 'border-top-color')).toBe('rgb(255, 92, 46)');
+
+    /*
+     * HOVER must NOT inherit the dark-band routing. The rest rules sit at [0,3,0], the
+     * same specificity as the `:hover` rules they follow (a pseudo-class counts as a
+     * class), so without the explicit hover restoration the routed ink won by source
+     * order and landed on a fill it was never measured against: on-inverted ink over the
+     * accent fill is 2.58:1, and on-overlay ink over the near-white ghost hover fill is
+     * effectively invisible. On hover each variant paints its own contrasting fill, so
+     * the correct value is the variant's ORIGINAL hover ink, not the role token.
+     */
+    const PAGE_BG = 'rgb(252, 253, 255)';   // --color-bg, outline hover ink (4.70:1 on the accent fill)
+    const SURFACE = 'rgb(244, 247, 251)';   // --color-surface, ghost hover fill
+
+    // .btn animates colour over --transition (150ms), so getComputedStyle right after
+    // hover() returns a mid-flight blend. Kill transitions rather than sleeping: the
+    // assertion is about which value the CASCADE resolves, not how it gets there.
+    await page.addStyleTag({ content: '*, *::before, *::after { transition: none !important; }' });
+
+    for (const i of [0, 2]) { // inverted + overlay outline
+      await buttons.nth(i).hover();
+      expect(await prop(i, 'color')).toBe(PAGE_BG);
+      expect(await prop(i, 'background-color')).toBe(BARE_ACCENT);
+      expect(await prop(i, 'border-top-color')).toBe(BARE_ACCENT);
+    }
+    for (const i of [1, 3]) { // inverted + overlay ghost
+      await buttons.nth(i).hover();
+      expect(await prop(i, 'color')).toBe(BARE_ACCENT);
+      expect(await prop(i, 'background-color')).toBe(SURFACE);
+    }
+
+    /*
+     * The separation ring must SURVIVE hover. `.cta .btn:not(...):hover` is [0,6,0] and
+     * its border follows the hover fill, so the [0,5,0] rest ring alone left the button
+     * ringed at rest and dissolving again under the pointer — the defect reappearing in
+     * the state a user is most likely looking at. WCAG 1.4.11 covers hover too.
+     */
+    await buttons.nth(4).hover();
+    expect(await prop(4, 'border-top-color')).toBe(ON_OVERLAY);
+    // The authored-accent ring survives hover through --cta-accent-hover's own chain
+    // rather than snapping to the role token.
+    await buttons.nth(9).hover();
+    expect(await prop(9, 'border-top-color')).not.toBe(BARE_ACCENT);
+  });
+
+  test('#535 cover-hero primary and default second CTA clear AA on the scrim @smoke', async ({
+    page,
+  }) => {
+    pageId = createPage('E2E Cover Hero Button Contrast');
+    setComposition(pageId, [
+      // 0/1: outline PRIMARY + the DEFAULT (outline) second CTA. Before #535 both painted
+      // var(--hero-text, var(--color-text)) = near-black #101828 on the scrim — the dead
+      // `.hero--cover .btn--outline` rule never won.
+      {
+        component: 'hero',
+        props: {
+          title: 'Cover outline', layout: 'cover',
+          cta_text: 'Empezar', cta_url: '/a', cta_variant: 'outline',
+          cta2_text: 'Hablar', cta2_url: '/b',
+        },
+      },
+      // 2/3: ghost PRIMARY + ghost second CTA (both fell to --color-accent at 1.17:1).
+      {
+        component: 'hero',
+        props: {
+          title: 'Cover ghost', layout: 'cover',
+          cta_text: 'Empezar', cta_url: '/a', cta_variant: 'ghost',
+          cta2_text: 'Hablar', cta2_url: '/b', cta2_variant: 'ghost',
+        },
+      },
+      // 4: FILLED primary — gains the separation ring on the scrim.
+      { component: 'hero', props: { title: 'Cover filled', layout: 'cover', cta_text: 'Empezar', cta_url: '/a' } },
+      // 5: per-instance slot still wins over the routed fallback.
+      {
+        component: 'hero',
+        props: { title: 'Cover override', layout: 'cover', cta_text: 'Empezar', cta_url: '/a', cta_variant: 'outline' },
+        style: { '--hero-text': '#ffd166' },
+      },
+      // 6: a NON-cover hero must be untouched (no scrim, no routing).
+      { component: 'hero', props: { title: 'Plain hero', layout: 'centered', cta_text: 'Empezar', cta_url: '/a', cta_variant: 'outline' } },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+
+    const ctas = page.locator('.hero__cta');
+    await expect(ctas).toHaveCount(7, { timeout: 10000 });
+
+    const prop = async (i: number, p: string) =>
+      ctas.nth(i).evaluate((el, name) => getComputedStyle(el).getPropertyValue(name), p);
+
+    const ON_OVERLAY = 'rgb(250, 251, 255)';
+    const NEAR_BLACK = 'rgb(16, 24, 40)';   // --color-text, the defect's rendered value
+    const BARE_ACCENT = 'rgb(49, 87, 244)';
+
+    // 0: outline PRIMARY on the cover scrim — ink and ring both on the overlay role.
+    expect(await prop(0, 'color')).toBe(ON_OVERLAY);
+    expect(await prop(0, 'border-top-color')).toBe(ON_OVERLAY);
+    expect(await prop(0, 'color')).not.toBe(NEAR_BLACK);
+    // 1: the DEFAULT second CTA (cta2_variant defaults to `outline`) — #535 Q3.
+    expect(await prop(1, 'color')).toBe(ON_OVERLAY);
+    expect(await prop(1, 'border-top-color')).toBe(ON_OVERLAY);
+
+    // 2/3: ghost primary + ghost second CTA.
+    expect(await prop(2, 'color')).toBe(ON_OVERLAY);
+    expect(await prop(3, 'color')).toBe(ON_OVERLAY);
+
+    // 4: FILLED primary gains the ring; the fill itself is unchanged.
+    expect(await prop(4, 'border-top-color')).toBe(ON_OVERLAY);
+
+    // 5: --hero-text still wins over the routed fallback.
+    expect(await prop(5, 'color')).toBe('rgb(255, 209, 102)');
+    expect(await prop(5, 'border-top-color')).toBe('rgb(255, 209, 102)');
+
+    // 6: a plain (non-cover) hero keeps today's --hero-text -> --color-text outline and
+    // its accent-bordered fill. The routing is scoped to the scrim, nothing else moved.
+    expect(await prop(6, 'color')).toBe(NEAR_BLACK);
+    expect(await prop(6, 'border-top-color')).toBe(NEAR_BLACK);
+    expect(await prop(6, 'color')).not.toBe(BARE_ACCENT);
+
+    /*
+     * HOVER, same leak class as the cta test above. `.hero--cover .btn--ghost` [0,2,0]
+     * ties with the shared `.btn--ghost:hover` and follows it, so the on-overlay ink
+     * survived onto a hover that fills with the near-white --color-surface. The outline
+     * twin was already safe ([0,3,0] hover outranks it) and is pinned here so a future
+     * specificity change to either rule is caught.
+     */
+    const PAGE_BG = 'rgb(252, 253, 255)';
+    const SURFACE = 'rgb(244, 247, 251)';
+
+    // See the cta test: kill the 150ms colour transition so the assertion reads the
+    // cascade's resolved value rather than a mid-flight blend.
+    await page.addStyleTag({ content: '*, *::before, *::after { transition: none !important; }' });
+
+    await ctas.nth(0).hover();
+    expect(await prop(0, 'color')).toBe(PAGE_BG);
+    expect(await prop(0, 'background-color')).toBe(BARE_ACCENT);
+    expect(await prop(0, 'border-top-color')).toBe(BARE_ACCENT);
+
+    await ctas.nth(2).hover();
+    expect(await prop(2, 'color')).toBe(BARE_ACCENT);
+    expect(await prop(2, 'background-color')).toBe(SURFACE);
+
+    // The second CTA's own :hover rules are [0,5,0] and outrank the [0,4,0] cover
+    // routing, so its hover ink is the variant's normal value, not a role token.
+    await ctas.nth(1).hover();
+    expect(await prop(1, 'color')).toBe(PAGE_BG);
+    expect(await prop(1, 'background-color')).toBe(BARE_ACCENT);
+
+    // The filled primary's ring must survive hover here too (see the cta test).
+    await ctas.nth(4).hover();
+    expect(await prop(4, 'border-top-color')).toBe(ON_OVERLAY);
+  });
+
+  /*
    * #474 — the compensating proof for the three SLOT_DECLARATION_EXEMPTIONS entries
    * added in StyleSlotContractTest. That guard normally forbids a stylesheet rule from
    * DECLARING a schema slot, because declaring it beats the renderer's inline value on

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -3008,6 +3008,349 @@ describe('CSS lint: bg-image band title-accent + markers route through --color-a
     });
 });
 
+describe('CSS lint: dark-band buttons route through the AA accent roles (#535)', () => {
+    /*
+     * #474 routed the cta's SECOND button; #535 closes the rest of the same class:
+     * the PRIMARY outline/ghost button on both cta dark bands, the hero's primary AND
+     * default second CTA on the `.hero--cover` scrim, and the filled primary's missing
+     * separation ring on the two OVERLAY bands.
+     *
+     * Measured before -> after (rendered, worst-case composites):
+     *   cta inverted outline/ghost       3.23 -> 8.33  (--color-accent-on-inverted)
+     *   cta bg-image outline/ghost       1.17 -> 4.59  (--color-accent-on-overlay)
+     *   hero cover outline / ghost ~3.6 / 1.17 -> 4.59 (--color-accent-on-overlay)
+     *   hero cover cta2 outline/ghost   ~3.6 -> 4.59  (--color-accent-on-overlay)
+     *   filled button ring, overlay bands: fill under 2:1, ring -> 4.59
+     *
+     * on-inverted is tuned to the SOLID inverted background and only reaches ~2.2:1 over
+     * the arbitrary-image scrim, so the two roles are never interchangeable — every route
+     * below pins which role its band must use, and guards against a regression to the
+     * bare light-surface accent.
+     */
+    const css = stripComments(COMPONENTS_CSS);
+    const rules = [];
+    const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+    let m;
+    while ((m = ruleRe.exec(css)) !== null) {
+        rules.push({ selector: m[1].trim(), body: m[2], index: m.index });
+    }
+    const rulesForAll = (sel) => rules.filter(r => r.selector.split(',').some(s => s.trim() === sel));
+    const ruleFor = (sel) => rulesForAll(sel)[0];
+
+    // selector -> { slot, role, border } . `border: true` means the ring is routed too
+    // (outline paints a visible ring; ghost's border stays transparent by design).
+    const ROUTES = [
+        // cta PRIMARY, solid inverted band.
+        { sel: '.cta--inverted .cta__button.btn--outline', slot: '--cta-button-color', borderSlot: '--cta-button-border', role: '--color-accent-on-inverted' },
+        { sel: '.cta--inverted .cta__button.btn--ghost', slot: '--cta-button-color', borderSlot: null, role: '--color-accent-on-inverted' },
+        // cta PRIMARY, bg-image (overlay) band.
+        { sel: '.cta--has-bg-image .cta__button.btn--outline', slot: '--cta-button-color', borderSlot: '--cta-button-border', role: '--color-accent-on-overlay' },
+        { sel: '.cta--has-bg-image .cta__button.btn--ghost', slot: '--cta-button-color', borderSlot: null, role: '--color-accent-on-overlay' },
+        // hero PRIMARY on the cover scrim (slot is --hero-text, the surface
+        // `.hero .btn--outline` already reads — see the rule comment).
+        { sel: '.hero--cover .btn--outline', slot: '--hero-text', borderSlot: '--hero-text', role: '--color-accent-on-overlay' },
+        { sel: '.hero--cover .btn--ghost', slot: '--hero-text', borderSlot: null, role: '--color-accent-on-overlay' },
+        // hero SECOND CTA on the cover scrim (#535 Q3).
+        { sel: '.hero--cover .hero__cta-group .hero__cta--secondary.btn--outline', slot: '--hero-cta2-color', borderSlot: '--hero-cta2-border', role: '--color-accent-on-overlay' },
+        { sel: '.hero--cover .hero__cta-group .hero__cta--secondary.btn--ghost', slot: '--hero-cta2-color', borderSlot: null, role: '--color-accent-on-overlay' },
+    ];
+
+    const esc = (s) => s.replace(/[-]/g, '\\-');
+
+    ROUTES.forEach(({ sel, slot, borderSlot, role }) => {
+        test(`${sel} routes ink through ${slot} then ${role}`, () => {
+            const rule = ruleFor(sel);
+            expect(rule).toBeDefined();
+            expect(rule.body).toMatch(new RegExp(
+                'color\\s*:\\s*var\\(\\s*' + esc(slot) + '\\s*,\\s*var\\(\\s*' + esc(role) + '\\s*\\)\\s*\\)'
+            ));
+        });
+
+        if (borderSlot) {
+            test(`${sel} routes its ring through ${borderSlot} then ${role}`, () => {
+                const rule = ruleFor(sel);
+                expect(rule).toBeDefined();
+                expect(rule.body).toMatch(new RegExp(
+                    'border-color\\s*:\\s*var\\(\\s*' + esc(borderSlot) + '\\s*,\\s*var\\(\\s*' + esc(role) + '\\s*\\)\\s*\\)'
+                ));
+            });
+        } else {
+            test(`${sel} does not paint a ring (ghost stays borderless)`, () => {
+                const rule = ruleFor(sel);
+                expect(rule).toBeDefined();
+                expect(rule.body).not.toMatch(/border-color\s*:/);
+            });
+        }
+
+        test(`${sel} does not fall back to the bare accent or the wrong role`, () => {
+            const rule = ruleFor(sel);
+            expect(rule).toBeDefined();
+            // The 3.23:1 / 1.17:1 bug: a bare light-surface accent default.
+            expect(rule.body).not.toMatch(/var\(\s*--color-accent\s*\)/);
+            // Wrong surface: on-inverted is ~2.2:1 over the arbitrary-image scrim, and
+            // on-overlay is not the tuned choice for the solid inverted band.
+            const wrongRole = role === '--color-accent-on-overlay'
+                ? '--color-accent-on-inverted'
+                : '--color-accent-on-overlay';
+            expect(rule.body).not.toMatch(new RegExp(esc(wrongRole)));
+        });
+    });
+
+    // ── The filled primary's separation ring, OVERLAY bands only ──────────────
+    /*
+     * The ring rules replace ONLY the terminal fallback of the chain they override. Every
+     * authored link ahead of the role token must survive verbatim, or an author who
+     * already coloured this ring (via --cta-accent, --hero-button-bg, the global
+     * --btn-* knobs) silently gets a near-white ring instead of theirs. `leading` is the
+     * chain the corresponding base rule declares, in order; `bottom` is the role token
+     * that replaces the base rule's own terminal --color-accent.
+     *
+     * Both hover twins exist because the base `:hover` rules are [0,6,0] and outrank the
+     * [0,5,0] rest rings: without them the ring appeared at rest and dissolved back into
+     * the band the moment the pointer landed, which is the state a user is most likely
+     * looking at (WCAG 1.4.11 covers hover too).
+     */
+    const RINGS = [
+        {
+            sel: '.cta--has-bg-image .cta__button:not(.btn--outline):not(.btn--ghost):not(.btn--secondary)',
+            leading: ['--cta-button-border', '--btn-border-color', '--cta-button-bg', '--cta-accent', '--btn-bg'],
+        },
+        {
+            sel: '.cta--has-bg-image .cta__button:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover',
+            leading: ['--cta-button-hover-border', '--cta-button-hover-bg', '--cta-accent-hover'],
+        },
+        {
+            sel: '.hero--cover .hero__cta:not(.btn--outline):not(.btn--ghost):not(.btn--secondary)',
+            leading: ['--hero-accent', '--btn-border-color', '--hero-button-bg', '--btn-bg'],
+        },
+        {
+            sel: '.hero--cover .hero__cta:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover',
+            leading: ['--hero-accent-hover', '--hero-button-hover-bg'],
+        },
+    ];
+
+    RINGS.forEach(({ sel, leading }) => {
+        test(`${sel} bottoms the ring out at the overlay role`, () => {
+            const rule = ruleFor(sel);
+            expect(rule).toBeDefined();
+            expect(rule.body).toMatch(/border-color\s*:/);
+            expect(rule.body).toMatch(/--color-accent-on-overlay/);
+            // Wrong surface: on-inverted is only ~2.2:1 over the arbitrary-image scrim.
+            expect(rule.body).not.toMatch(/--color-accent-on-inverted/);
+            // The role must be the LAST link, not an early one that pre-empts a slot.
+            const chain = rule.body.match(/border-color\s*:([^;}]+)/)[1];
+            const tokens = chain.match(/--[a-z0-9-]+/g);
+            expect(tokens[tokens.length - 1]).toBe('--color-accent-on-overlay');
+        });
+
+        test(`${sel} preserves every authored slot ahead of the role, in order`, () => {
+            const rule = ruleFor(sel);
+            expect(rule).toBeDefined();
+            const chain = rule.body.match(/border-color\s*:([^;}]+)/)[1];
+            const tokens = chain.match(/--[a-z0-9-]+/g).filter(t => t !== '--color-accent-on-overlay');
+            expect(tokens).toEqual(leading);
+        });
+
+        test(`${sel} does not bottom out at the bare accent (the pre-#535 behaviour)`, () => {
+            const rule = ruleFor(sel);
+            expect(rule).toBeDefined();
+            const chain = rule.body.match(/border-color\s*:([^;}]+)/)[1];
+            expect(chain).not.toMatch(/var\(\s*--color-accent\s*\)/);
+            expect(chain).not.toMatch(/var\(\s*--color-accent-hover\s*\)/);
+        });
+    });
+
+    /*
+     * NEGATIVE pin (#535 Q2). The INVERTED filled primary measures 3.23:1 fill-vs-band,
+     * which already clears the 3:1 non-text bar, so it is deliberately NOT ringed. If a
+     * future edit adds an on-inverted ring here it is a gratuitous visual change to every
+     * dark-band CTA with no measured defect behind it — fail instead.
+     */
+    test('the INVERTED filled primary is not ringed (3.23:1 already clears the 3:1 bar)', () => {
+        const offenders = rules.filter(r =>
+            /\.cta--inverted\b/.test(r.selector)
+            && /:not\(\.btn--outline\)/.test(r.selector)
+            && /border-color\s*:/.test(r.body)
+        );
+        expect(offenders.map(r => r.selector)).toEqual([]);
+    });
+
+    /*
+     * SOURCE-ORDER pins. Three of these rule groups carry the SAME specificity as the
+     * rule they must override, so they win only by following it. This is not a style
+     * preference — `.hero--cover .btn--outline` used to sit ABOVE `.hero .btn--outline`
+     * (both [0,2,0]) and was therefore DEAD, which is precisely how the near-black-ink
+     * defect shipped. Moving any of these up silently restores the bug.
+     */
+    const ORDER = [
+        {
+            later: '.hero--cover .btn--outline',
+            earlier: '.hero .btn--outline',
+            why: 'both [0,2,0]; the cover rule was dead above it (the #535 near-black-ink defect)',
+        },
+        {
+            later: '.hero--cover .btn--ghost',
+            earlier: '.btn--ghost',
+            why: 'both paint ink; the cover rule is [0,2,0] vs the shared [0,1,0]',
+        },
+        {
+            later: '.hero--cover .hero__cta-group .hero__cta--secondary.btn--outline',
+            earlier: '.hero .hero__cta-group .hero__cta--secondary.btn--outline',
+            why: 'both [0,4,0]',
+        },
+        {
+            later: '.hero--cover .hero__cta-group .hero__cta--secondary.btn--ghost',
+            earlier: '.hero .hero__cta-group .hero__cta--secondary.btn--ghost',
+            why: 'both [0,4,0]',
+        },
+        {
+            later: '.hero--cover .hero__cta:not(.btn--outline):not(.btn--ghost):not(.btn--secondary)',
+            earlier: '.hero .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary)',
+            why: 'both [0,5,0]',
+        },
+        {
+            later: '.hero--cover .hero__cta:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover',
+            earlier: '.hero .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover',
+            why: 'both [0,6,0]; without this the ring dissolves again on hover',
+        },
+        {
+            later: '.cta--has-bg-image .cta__button:not(.btn--outline):not(.btn--ghost):not(.btn--secondary)',
+            earlier: '.cta .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary)',
+            why: 'both [0,5,0]',
+        },
+        {
+            later: '.cta--has-bg-image .cta__button:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover',
+            earlier: '.cta .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover',
+            why: 'both [0,6,0]; without this the ring dissolves again on hover',
+        },
+        /*
+         * A cta can carry BOTH classes: cta.php emits the theme class and the bg-image
+         * class independently, so `theme: "inverted"` + `background_image` renders
+         * `.cta--inverted.cta--has-bg-image` with the scrim painted over the inverted
+         * background. Both routing rules then match at [0,3,0] and only source order
+         * decides. The overlay role must win — on-inverted is only ~2.2:1 over the scrim.
+         */
+        {
+            later: '.cta--has-bg-image .cta__button.btn--outline',
+            earlier: '.cta--inverted .cta__button.btn--outline',
+            why: 'both [0,3,0]; an inverted band WITH a background_image must resolve to the overlay role',
+        },
+        {
+            later: '.cta--has-bg-image .cta__button.btn--ghost',
+            earlier: '.cta--inverted .cta__button.btn--ghost',
+            why: 'both [0,3,0]; same combined-band case',
+        },
+        {
+            later: '.cta--has-bg-image .cta__buttons .cta__button--secondary.btn--outline',
+            earlier: '.cta--inverted .cta__buttons .cta__button--secondary.btn--outline',
+            why: 'both [0,4,0]; the #474 button2 pair has the identical combined-band dependency',
+        },
+    ];
+
+    ORDER.forEach(({ later, earlier, why }) => {
+        test(`${later} comes after ${earlier} (${why})`, () => {
+            const l = ruleFor(later);
+            const e = ruleFor(earlier);
+            expect(l).toBeDefined();
+            expect(e).toBeDefined();
+            expect(l.index).toBeGreaterThan(e.index);
+        });
+    });
+
+    /*
+     * UNIQUENESS. The order pins above compare the FIRST rule carrying each selector, so
+     * on their own they cannot catch the regression the CSS comments actually warn about:
+     * a DUPLICATE rule appended further down the file wins the cascade while every order
+     * pin still passes (confirmed by mutation — appending
+     * `.hero--cover .btn--outline { color: red }` left the whole suite green). Requiring
+     * exactly one rule per routed selector closes that hole.
+     */
+    const UNIQUE_SELECTORS = ROUTES.map(r => r.sel)
+        .concat(RINGS.map(r => r.sel))
+        .concat(ORDER.map(o => o.later));
+
+    [...new Set(UNIQUE_SELECTORS)].forEach(sel => {
+        test(`${sel} is declared exactly once (a later duplicate would silently win)`, () => {
+            expect(rulesForAll(sel).length).toBe(1);
+        });
+    });
+
+    /*
+     * The cta PRIMARY rules must stay BELOW the #474 button2 rules in specificity, not
+     * just in source order: the second button also carries `.cta__button`, so an equal
+     * or higher primary rule would repaint it and break the #474/#526/#530 pins.
+     */
+    test('the cta primary dark-band rules do not outrank the button2 rules', () => {
+        // [0,3,0] vs [0,4,0]: the primary selector must NOT carry the --secondary class,
+        // and the button2 selector must carry one more class than the primary one.
+        const primary = ruleFor('.cta--inverted .cta__button.btn--outline');
+        const second = ruleFor('.cta--inverted .cta__buttons .cta__button--secondary.btn--outline');
+        expect(primary).toBeDefined();
+        expect(second).toBeDefined();
+        const classCount = (sel) => (sel.match(/\.[a-zA-Z][\w-]*/g) || []).length;
+        expect(classCount(second.selector)).toBeGreaterThan(classCount(primary.selector));
+    });
+
+    /*
+     * HOVER leak guard. The rest rules tie on specificity with the `:hover` rules they
+     * follow (a pseudo-class counts as a class), so source order made the routed
+     * dark-band ink win on hover too — landing it on a fill it was never measured
+     * against (on-inverted ink over the accent fill is 2.58:1; on-overlay ink over the
+     * near-white ghost hover fill is effectively invisible). The restoration rules must
+     * exist AND must not themselves carry a role token: on hover each variant paints its
+     * own contrasting fill, so the correct ink is the variant's original hover value.
+     */
+    // `source` is the shared rule whose hover ink each restoration copies verbatim. If the
+    // shared rule's value is ever changed, the copy must move with it — so assert the
+    // declarations are IDENTICAL rather than merely present, which is what makes a silent
+    // divergence fail here instead of shipping.
+    const HOVER_RESTORED = [
+        { sel: '.cta--inverted .cta__button.btn--outline:hover', source: '.cta__button.btn--outline:hover' },
+        { sel: '.cta--has-bg-image .cta__button.btn--outline:hover', source: '.cta__button.btn--outline:hover' },
+        { sel: '.cta--inverted .cta__button.btn--ghost:hover', source: '.cta__button.btn--ghost:hover' },
+        { sel: '.cta--has-bg-image .cta__button.btn--ghost:hover', source: '.cta__button.btn--ghost:hover' },
+        { sel: '.hero--cover .btn--ghost:hover', source: '.btn--ghost:hover' },
+    ];
+
+    // `color:` alone also matches `border-color:` / `background-color:`, which would let a
+    // restoration rule that dropped its ink declaration entirely still pass.
+    const inkDecl = (body) => {
+        const m = body.match(/(?:^|[;{\s])color\s*:([^;}]+)/);
+        return m ? m[1].replace(/\s+/g, ' ').trim() : null;
+    };
+
+    HOVER_RESTORED.forEach(({ sel, source }) => {
+        test(`${sel} restores exactly the ink ${source} declares`, () => {
+            const rule = ruleFor(sel);
+            const src = ruleFor(source);
+            expect(rule).toBeDefined();
+            expect(src).toBeDefined();
+            expect(inkDecl(rule.body)).not.toBeNull();
+            expect(inkDecl(rule.body)).toBe(inkDecl(src.body));
+        });
+
+        test(`${sel} carries no dark-band role token (on hover the fill contrasts, not the band)`, () => {
+            const rule = ruleFor(sel);
+            expect(rule).toBeDefined();
+            expect(rule.body).not.toMatch(/--color-accent-on-inverted|--color-accent-on-overlay/);
+        });
+
+        test(`${sel} follows its rest rule in source order`, () => {
+            const restSel = sel.replace(/:hover$/, '');
+            const hover = ruleFor(sel);
+            const rest = ruleFor(restSel);
+            expect(hover).toBeDefined();
+            expect(rest).toBeDefined();
+            expect(hover.index).toBeGreaterThan(rest.index);
+        });
+    });
+
+    test('the roles these rules depend on are declared in base.css :root', () => {
+        expect(BASE_CSS).toMatch(/--color-accent-on-inverted:\s*#[0-9a-fA-F]{6}/);
+        expect(BASE_CSS).toMatch(/--color-accent-on-overlay:\s*#[0-9a-fA-F]{6}/);
+    });
+});
+
 /**
  * The isolation re-pointing declarations depend on GUARANTEED-INVALID custom properties
  * (#514/#526/#474/#530).


### PR DESCRIPTION
Closes #535

Implements the binding 7A resolution recorded on the issue (orchestrator, 2026-07-27): Q1-A, Q2-A, Q3-A.

## Scope

`--color-accent` is tuned for light surfaces. Painted straight onto a dark band it measures **3.23:1** on `--color-bg-inverted` and **1.17:1** over the worst-case background-image scrim, so `outline` and `ghost` buttons rendered their label and ring below WCAG AA. #474 fixed this for the cta's second button; this closes the rest of the class, plus the filled button's missing separation from an overlay band.

Every default routes through the **existing** role tokens `--color-accent-on-inverted` / `--color-accent-on-overlay` — the same roles the dark-band body links (#437/#461) and title accents (#463) already use. No new colour is introduced, per the standing rule that contrast fixes live in token values rather than component CSS.

| acceptance criterion | result |
|---|---|
| Authored outline cta/hero primary on inverted ≥ 4.5:1 | **8.33:1** via `--color-accent-on-inverted` |
| …on bg-image ≥ 4.5:1 vs worst-case composite | **4.59:1** via `--color-accent-on-overlay` |
| Filled primary on a dark band gains measured separation | ring **1.17:1 → 4.59:1** on the two overlay bands, at rest **and** on hover |
| Light-band filled render byte-identical | unchanged (rendered control in the smoke test) |
| Per-instance slots override everything, both bands | pinned on both bands + an authored `--cta-accent` case |
| Section 14.2 rendered evidence at 1280/375, both dark variants | captured and inspected, see below |
| Section 14.3 prototype before building | done, see below |
| Computed-style pins both bands + byte-identical light-band pins | 81 css-lint pins + 2 rendered `@smoke` tests |

## What changed

- **cta primary** outline/ghost on `.cta--inverted` and `.cta--has-bg-image` route to the matching role. Held at `[0,3,0]`, deliberately below the #474 button2 rules at `[0,4,0]`, so the second button keeps its own routing and the #474/#526/#530 pins stay green.
- **hero primary** outline/ghost on `.hero--cover` route to the overlay role. The rule meant to handle this **had never painted**: `.hero--cover .btn--outline` sat *above* `.hero .btn--outline` at identical `[0,2,0]` and lost on source order, so a cover hero's outline button rendered near-black `--color-text` on its own dark scrim. The rules move below it, where they win.
- **hero's second CTA** gets the same treatment (Q3). `cta2_variant` defaults to `outline`, so adding a second CTA to a cover hero shipped a sub-AA control without the author choosing anything.
- **Filled button separation ring** on the two overlay bands: the border stops following the fill (which measures under 2:1 against the band, so the button's *shape* vanished and only its label carried it) and bottoms out at the overlay role. Only the **terminal** fallback changes — `--cta-button-border`, `--btn-border-color`, `--cta-button-bg`, `--cta-accent`, `--btn-bg` (and the hero equivalents) are all preserved ahead of it, so a ring an author already coloured keeps its colour.
- **Inverted filled button is deliberately NOT ringed** (Q2): its fill measures 3.23:1 against the band, already clearing the 3:1 non-text bar. A negative pin fails if a future edit adds one.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — **2515 tests, 10259 assertions**, green (3 warnings / 2 deprecations, identical to an unmodified tree).
- `npm test` — **900 tests**, green (was 822 on `main`; +78).
- `npm run test:e2e -- -g "@smoke"` — **99 passed**, including every #474 / #514 / #526 / #530 isolation and byte-identity pin.
- `bash scripts/package.sh` — version consistency OK across the five synced files; build zip deleted.

**Section 14.3 (prototype first).** Before writing any implementation the mechanism was rendered in headless Chromium against the real stylesheets and measured with a compositing contrast script, then the candidate fix was rendered and re-measured. That prototype is what established the numbers above rather than assuming them.

**Section 14.2 (rendered inspection).** Real WordPress pages captured at 1280 and 375 with stressed copy (long button labels, wrapping titles, a body link beside the button). What I saw: inverted and overlay outline/ghost labels and rings are crisp where they were previously a dim smudge; the cover hero's pair now reads as one matched primary+secondary unit instead of one legible button beside a near-black one; the filled pill on a photo band gains a thin near-white edge that reads as deliberate rather than as a border artifact; light bands are visually unchanged. At 375 the pair stacks one-per-row with no clipping of the longest labels. No misalignment, stray glyphs, cramped text, or horizontal overflow.

**Two defects caught by that rendered inspection, not by assertions:**

1. The rest rules tie on specificity with the `:hover` rules they follow (a pseudo-class counts as a class), so the routed dark-band ink won on hover by source order and landed on a fill it was never measured against — **2.58:1** for outline over the accent fill, effectively invisible for ghost over the near-white surface fill. Fixed with explicit hover restoration rules that copy each variant's own hover values.
2. The separation ring was undone on hover: the base `:hover` rules are `[0,6,0]` and outrank the `[0,5,0]` rest ring, so the button regained its edge at rest and dissolved back into the band under the pointer. Fixed with `[0,6,0]` hover twins. WCAG 1.4.11 covers the hover state too.

## Review

`/plan-eng-review` and `/review` both ran on this diff in-session; per the pipeline's dedup rule they are not re-dispatched here. `/review` dispatched three specialists plus a Codex outside voice. Notable findings applied:

- The ring rule initially **dropped `--cta-accent` and `--btn-bg`** from the border chain, which would have silently repainted every authored ring on a photo band near-white. Chains restored; a rendered pin now asserts an authored `--cta-accent` survives.
- css-lint's `ruleFor` returned the *first* selector match, so a duplicate rule appended later would win the cascade while every order pin still passed (confirmed by mutation). A uniqueness guard now covers all 15 routed selectors; both mutations were re-run and now fail as they should.
- Contrast figures quoted in comments were fixture-specific and disagreed with `base.css` (one exceeded the documented 4.74:1 ceiling for that composite). All normalised to the canonical values.
- Order dependence between `.cta--inverted` and `.cta--has-bg-image` when a band carries **both** classes was unpinned. Now pinned, with a rendered fixture for the combined band.

## Accepted limitations

- A band an author darkens via `--cta-bg` / `--hero-bg` carries no class, so nothing can trigger on it in CSS. This is the half of defect 2 the 7A resolution deferred as needing a trigger-mechanism design rather than a colour — filed as **#541**.
- A filled **second** button on an overlay band still has no ring (same fill, same band). Extending it changes rendered output for an already-shipping authored configuration, which is a scope extension beyond the recorded decision — filed as **#543**.
- The keyboard focus ring is `--color-accent` with `outline-offset`, so it sits on the band at 3.23:1 / 1.17:1. Different surface, every variant, own blast radius — filed as **#542**.

## 7A outcome

**Asked** (three batched questions, before implementation): whether to land only the class-triggerable half of defect 2; whether to ring the inverted filled button despite it already measuring 3.23:1; whether to extend to hero's cta2, which #474's cta-only scoping had left behind.

**Answered** (recorded on #535 as the binding orchestrator resolution): Q1-A, Q2-A, Q3-A — land the class-triggerable ring and file the authored-band residual as a trigger-mechanism follow-up; ring only where measured sub-3:1 and pin that the inverted filled button is not ringed; extend to hero's cta2 and fix the confirmed dead-code rule as part of this landing. All three implemented as recorded.
