### PR TITLE
Release v1.11.0: hover & dark-band button contrast rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.11.0] — 2026-07-27 — hover & dark-band button contrast: every button state is brandable and legible (rollup)
+
+**v1.11.0 is the rollup release of the Hover & Dark-Band Button Contrast gate — three working versions (1.10.1–1.10.3) verified as one line. Per-instance hover fill slots finally paint on filled buttons, ending the premium gradient's mask over every hover recolour, with hover-state isolation across hero cta2 and cta button2 (#530); dark-band `outline`/`ghost` buttons and the filled button's separation ring route through the established on-inverted/on-overlay accent roles, taking them from sub-AA (3.23:1 / 1.17:1) to 8.33:1 / 4.59:1 with light bands byte-identical (#535); and the section panel CTA gains `--section-panel-cta-bg/-color/-shadow` fill slots mirroring the hero and cta conventions, closing the last button surface with an unreachable fill (#536).**
+
+No code changes in this release beyond the version bump — see the [v1.10.1]…[v1.10.3] entries below for the substance.
+
 ## [v1.10.3] — 2026-07-27 — a section's panel button can finally carry your brand colour (#536)
 
 **Set one slot and the section panel's call-to-action button turns a flat brand colour with a matching ring. Set none and it renders exactly as before.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.10.3-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.11.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.10.3');
+define('PP_VERSION', '1.11.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.10.3
+Stable tag: 1.11.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.10.3
+Version:          1.11.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Rollup release PR for the v1.11.0 "Hover & Dark-Band Button Contrast" gate.

Verified working versions folded into this line:
- **1.10.1** — #530: per-instance hover fill slots paint on filled buttons; hover-state isolation for hero cta2 / cta button2 (PR #537, b612dd2)
- **1.10.2** — #535: dark-band outline/ghost + filled-button separation ring routed through `--color-accent-on-inverted` / `--color-accent-on-overlay` (PR #544, e64505e)
- **1.10.3** — #536: `--section-panel-cta-bg/-color/-shadow` fill slots on the section panel CTA (PR #546, 482f741)

This PR contains only the five-file version bump to 1.11.0 and the rollup CHANGELOG entry. `scripts/package.sh` validates the sync.

Milestone v1.11.0: all 3 issues closed. Follow-ups deliberately outside this line: #538, #539, #540, #541, #542, #543, #545 (unmilestoned), #531/#508 design-dependent.