### PR TITLE
v1.11.4 feat: global --btn-hover-bg / --btn-hover-border-color tier (#539)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -372,7 +372,8 @@ Spacing:    --space-xs, --space-sm, --space-md, --space-lg, --space-xl, --space-
 Typography: --font-body, --font-heading, --font-weight-heading, --line-height-body, --line-height-heading,
             --letter-spacing-heading, --font-mono
 Button:     --btn-padding-y, --btn-padding-x, --btn-radius,
-            --btn-bg, --btn-text, --btn-border-color, --btn-shadow
+            --btn-bg, --btn-text, --btn-border-color, --btn-shadow,
+            --btn-hover-bg, --btn-hover-border-color
 Shape:      --radius, --max-width, --measure-body, --measure-body-wide, --measure-centered,
             --transition, --overlay-bg
 Elevation:  --shadow-none, --shadow-sm, --shadow-md, --shadow-lg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.11.4] — 2026-07-27 — a site-wide button retheme now survives the pointer (#539)
+
+**Recolour every button on the site and they stay recoloured when someone hovers them. Until now the theme's accent gradient came straight back the moment a pointer landed.**
+
+`--btn-bg` and `--btn-border-color` are the knobs that restyle every button at once. They only ever governed the resting state, so a brand-coloured site looked right until a visitor moved the mouse, and then every button flashed back to the stock accent gradient. The only way out was to set a hover fill on each button individually, which defeats the point of a site-wide token. Two new tokens close the gap: `--btn-hover-bg` and `--btn-hover-border-color`, the hover twins of the two resting knobs. Set them alongside their resting counterparts and the brand holds through the whole interaction, on the hero button, the CTA block's buttons, the section panel CTA, and plain buttons in the header and footer alike.
+
+Both are unset by default, so nothing about an existing site changes until you set them. Per-instance slots still win where a component has been individually styled: `--hero-button-hover-bg` and friends override the global knob exactly as they always overrode the resting one.
+
+### The chains that changed
+
+Threading a global token into a hover chain is not a matter of appending one fallback. The rule that paints a button's gradient and the rule that paints its colour are different rules with different specificity, and only one of them owns the gradient:
+
+| Rule | Specificity | Owns |
+|---|---|---|
+| `.hero .btn:not(...):hover`, `.cta .btn:not(...):hover` | `[0,6,0]` | `background-color` |
+| `main .btn:not(...):hover` | `[0,5,1]` | `background-image` (the gradient) |
+
+Adding the knob to the gradient rule alone clears the gradient and then loses to the colour rule, which still resolves the stock accent. So the token was threaded into every hover chain whose resting twin already routes the resting knob, at the same position: ten chains in all.
+
+### Known limits
+
+The hero's **second** CTA is the one filled surface the global tokens do not paint, in either state. Its chains route `--hero-cta2-*` and never routed `--btn-bg` either. Set `--hero-cta2-bg` and `--hero-cta2-hover-bg` on that button when you retheme site-wide.
+
+There is still no global hover **ink** or hover **elevation** token. Hover label ink falls back to the page background on the primaries, so when picking a `--btn-hover-bg`, check it for contrast against `--color-bg` rather than against `--btn-text`.
+
+### Itemized changes
+
+### Added
+- `--btn-hover-bg` and `--btn-hover-border-color` design tokens in `assets/css/base.css`, both registered `initial` and settable through `update_design_token`.
+
+### Fixed
+- The global button tokens no longer revert to the theme's premium accent gradient on hover, on the hero primary, the CTA primary and second button, the section panel CTA, and bare buttons outside `main` (#539).
+
+### Docs
+- `ai-instructions/retheme.md` documents the hover pair, the exact per-property precedence, the hover-contrast hazard, the `outline` variant's ring, and the hero second CTA exception.
+- `ai-instructions/style-component.md`, `AI_CONTEXT.md`, and `components/cta/README.md` list the new tokens.
+
+### Tests
+- Authoring-path coverage through `update_design_token` for both tokens (registration, `initial` default, accept and reject).
+- Rendered hover pins for all five filled surfaces at 1280 and 375, covering byte-identity when unset, global reach when set, and per-instance precedence for both fill and border.
+- Two new lint guards for `:root` docblock hazards: a comment that closes early and leaves prose as raw CSS, and `--token: value` prose that the design-token registry regex would register as a phantom token.
+
+---
+
 ## [v1.11.3] — 2026-07-27 — a filled pair of buttons on a photo band now matches (#543)
 
 **Put two filled buttons side by side on a background-image band and both keep a visible edge. Until now only the first one did, and the second dissolved into the picture.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.11.3-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.11.4-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/retheme.md
+++ b/ai-instructions/retheme.md
@@ -205,9 +205,9 @@ renders byte-identically to today.
 
 | Token | Set it to… | Reaches | Effective default when unset |
 |-------|-----------|---------|------------------------------|
-| `--btn-bg` | recolor every button fill | bare `.btn`, `.cta`/`.hero` primary, a filled cta second button, premium `main .btn` primary | `--color-accent` (bare) / accent gradient (composed primary) |
+| `--btn-bg` | recolor every button fill | bare `.btn`, `.cta`/`.hero` primary, a filled cta second button, the section-panel CTA, premium `main .btn` primary | `--color-accent` (bare) / accent gradient (composed primary) |
 | `--btn-text` | recolor every button label ink | every button ink rule | `var(--color-bg)` (registered, the inversion coupling below) |
-| `--btn-border-color` | recolor every button border | bare `.btn`, `.cta`/`.hero`, premium primary | `--color-accent` (bare/`.cta`/`.hero`) / `--color-accent-strong` (premium) |
+| `--btn-border-color` | recolor every button border | bare `.btn` (incl. the `outline` variant), `.cta`/`.hero`, the section-panel CTA, premium primary | `--color-accent` (bare/`.cta`/`.hero`) / `--color-accent-strong` (premium) |
 | `--btn-shadow` | change every button's elevation (a `--shadow-*` preset, or `none` to flatten) | bare `.btn`, premium primary | `none` (bare) / premium bevel (composed primary) |
 
 **Per-component slots still win.** `--btn-*` sits BETWEEN the per-component slots
@@ -219,15 +219,70 @@ been individually restyled.
 / `--hero-button-color` / `--hero-button-shadow`; `--hero-accent` recolors only its border. A
 cta or hero SECOND button has its own family — `--cta-button2-*` / `--hero-cta2-*` — which the
 primary's slots never reach in rest OR hover, so restyling the primary alone leaves the second
-button on the global token. The section's `text-panel` CTA has its own family too —
+button on the global token. That last part holds for the CTA block's second button, whose own
+chains do route `--btn-bg` / `--btn-hover-bg`; the HERO's second CTA is the exception and does
+not — see the hover section below. The section's `text-panel` CTA has its own family too —
 `--section-panel-cta-bg` / `--section-panel-cta-color` / `--section-panel-cta-shadow` — which
 is the only way to give one section's panel button a flat brand fill without moving the
 site-wide token. See `ai-instructions/style-component.md`.)
 
-**There is no global hover-fill token.** `--btn-bg` is resting-state only: there is no
-`--btn-hover-bg`, so a site-wide fill retheme still returns to the theme's premium gradient on
-hover. Hover fill is per-instance only — `--hero-button-hover-bg`, `--cta-button-hover-bg`,
-`--hero-cta2-hover-bg`, `--cta-button2-hover-bg` — and each pairs with its resting slot.
+**The global tier has hover twins for fill and border.** `--btn-hover-bg` and
+`--btn-hover-border-color` are the hover counterparts of `--btn-bg` and `--btn-border-color`,
+and they sit at the same place in the hover chains that the resting knobs occupy at rest:
+below every per-instance hover slot, above the literal. Set them alongside the resting pair
+whenever you recolour buttons site-wide, or the retheme reverts to the theme's premium accent
+gradient the moment a pointer lands.
+
+| Token | Set it to… | Reaches | Effective default when unset |
+|-------|-----------|---------|------------------------------|
+| `--btn-hover-bg` | recolor every button's hover fill | bare `.btn`, `.cta`/`.hero` primary, a filled cta second button, the section-panel CTA, premium `main .btn` primary | `--color-accent-hover` (bare) / the premium hover gradient (composed primary) |
+| `--btn-hover-border-color` | recolor every button's hover border | same surfaces as above | `--color-accent-hover` (bare/`.cta`/`.hero`) / `--color-accent` (premium) |
+
+Per-instance hover slots still win **for their own property**: `--hero-button-hover-bg`,
+`--cta-button-hover-bg`, `--hero-cta2-hover-bg`, `--cta-button2-hover-bg` beat
+`--btn-hover-bg` for the fill; `--cta-button-hover-border`, `--hero-cta2-hover-border`,
+`--cta-button2-hover-border` beat `--btn-hover-border-color` for the border.
+
+One cross-property note, same as at rest: `--btn-hover-border-color` outranks the per-instance
+hover FILL slots inside a border chain. An explicit global ring beats a ring merely inferred
+from someone's fill. So a component that sets only `--cta-button-hover-bg` keeps its matching
+ring until you set a global `--btn-hover-border-color`, at which point it takes the global
+ring. Set that component's `--cta-button-hover-border` to opt back out.
+
+The **section-panel CTA** has no per-instance hover fill slot of its own
+(`--section-panel-cta-bg` is resting-state only), so the global knob is the only way to move
+its hover fill. That is intended, not an oversight.
+
+**The hero's second CTA is the exception — set its own slots.** Its chains route
+`--hero-cta2-*` / `--hero-accent` / `--color-accent` and never routed `--btn-bg` either, so
+the global tier does not paint it. Be aware of the halfway state, because it is visible: the
+global knob still reaches that button through the shared premium rule, where a flat value
+clears the theme gradient, while the cta2's own higher-specificity rule keeps painting
+`--color-accent` / `--color-accent-hover`. So a site-wide button retheme renders a filled hero
+cta2 flat-accent rather than brand-coloured. `--btn-bg` already does this to its resting state
+today; `--btn-hover-bg` does the same to hover, which at least keeps the two states matching.
+**Always set `--hero-cta2-bg` and `--hero-cta2-hover-bg` when you retheme buttons site-wide
+and a hero has a filled second CTA.**
+
+**Watch hover contrast: there is no global hover INK token.** `--btn-text` sets label ink at
+rest, but the bare `.btn` and the premium primary hard-code hover ink to `--color-bg` (only
+the two SECOND buttons fall back through `--btn-text` on hover). So if you pin a custom
+`--btn-text`, hover ink still reverts to `--color-bg`. When choosing `--btn-hover-bg`, check
+it against **`--color-bg`**, not against `--btn-text` (≥ 4.5:1) — or pin the per-instance
+hover ink slots (`--cta-button-hover-color`, `--hero-cta2-hover-color`,
+`--cta-button2-hover-color`).
+
+**There is no global hover ELEVATION token either.** `--btn-shadow: none` flattens rest and
+the premium bevel returns on hover. Use the per-instance shadow slots
+(`--hero-button-shadow` / `--cta-button-shadow` / `--section-panel-cta-shadow`), which each
+cover rest AND hover.
+
+**`--btn-hover-border-color` also rings the `outline` variant.** `.btn--outline:hover` paints
+its own fill but declares no border, so the global hover ring reaches it — exactly as
+`--btn-border-color` reaches its resting border. Its hover FILL is not routed by any global
+knob, so an outline button hovers to the theme accent wearing your ring. Set
+`--cta-button-hover-border` / `--hero-cta2-hover-border` per instance if that pairing matters
+on a given button.
 
 **Fill and border are independent knobs.** `--btn-bg` recolors the fill; `--btn-border-color`
 recolors the border. On `.cta`/`.hero` primaries an unset border follows the fill (so a

--- a/ai-instructions/style-component.md
+++ b/ai-instructions/style-component.md
@@ -342,7 +342,10 @@ flat-button capability, not a new default.
 
 > **Per-instance vs site-wide.** The `--cta-button-*` slots above restyle ONE
 > component's button. The global `--btn-bg` / `--btn-text` / `--btn-border-color` /
-> `--btn-shadow` tokens (base.css, set via `update_design_token`) restyle EVERY composed
+> `--btn-shadow` tokens — plus the hover pair `--btn-hover-bg` /
+> `--btn-hover-border-color` (#539), which keep a site-wide fill or border retheme from
+> reverting to the theme gradient under the pointer — (base.css, set via
+> `update_design_token`) restyle EVERY composed
 > primary button at once: the premium `main .btn` primary cascade routes its
 > fill/border/ink/shadow fallbacks through them (#458), so setting `--btn-bg` at `:root`
 > recolors the section-panel CTA, the CTA-block button, and the hero button together.

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -64,11 +64,53 @@
      rule: --btn-bg = --color-accent on the bare .btn / accent gradient on the composed
      primary; --btn-border-color = --color-accent (bare/.cta/.hero) / --color-accent-strong
      (premium); --btn-shadow = none (bare) / premium bevel (composed primary). See the .btn and
-     `main .btn` rules in components.css and ai-instructions/retheme.md. */
+     `main .btn` rules in components.css and ai-instructions/retheme.md.
+
+     HOVER (issue 539). --btn-hover-bg / --btn-hover-border-color are the hover twins of
+     --btn-bg / --btn-border-color, and complete #530's rest/hover parity at the GLOBAL tier:
+     before them, a site-wide fill or border retheme reverted to the theme's premium accent
+     gradient the moment a pointer touched any button. They sit in the hover chains at exactly
+     the position their resting counterparts occupy in the rest chains, and above the literal.
+     Both are `initial`, so an unset button is byte-identical.
+
+     Precedence, stated exactly, because "below the per-instance slots" is only half true.
+     Each knob sits below the per-instance slots FOR ITS OWN PROPERTY and above everything
+     else, mirroring rest:
+       fill    --hero-button-hover-bg / --cta-button-hover-bg / --cta-button2-hover-bg
+               -> --btn-hover-bg -> literal
+       border  --*-hover-border (the per-instance BORDER slots) -> --btn-hover-border-color
+               -> the border-follows-fill link -> literal
+     So --btn-hover-border-color DOES outrank the per-instance hover FILL slots in a border
+     chain. That is deliberate and matches --btn-border-color at rest: an explicitly authored
+     global ring should beat a ring merely INFERRED from someone's fill. The visible
+     consequence is worth knowing — a component that sets only --cta-button-hover-bg loses its
+     matching hover ring once a global --btn-hover-border-color is set, and takes the global
+     ring instead. Set the per-instance --*-hover-border to opt back out.
+
+     Deliberately NOT mirrored: hover INK and hover ELEVATION. --btn-shadow reaches no hover
+     rule at all, so setting it to `none` flattens rest and the premium bevel grows back under
+     the pointer. --btn-text is reachable on hover only on the two SECOND buttons (their
+     [0,7,0] hover ink rules fall back through it); the bare .btn and premium primary hover ink
+     are literals. Both are the same class of gap as this one, but routing --btn-shadow into
+     hover would change rendered output for sites that already set it, so they are tracked as
+     their own issues rather than riding along here.
+
+     The hero's SECOND cta gets no hover link here because its own chains never routed --btn-bg
+     either. Be precise about what that does and does not mean: the global knob still reaches
+     that button through the SHARED premium rule, where it resolves the `background` shorthand
+     to a flat colour and so CLEARS the gradient — while the cta2's own [0,7,0]
+     background-color rule keeps painting --color-accent-hover. So a site-wide hover fill turns
+     a filled hero cta2 flat-accent rather than brand-coloured. That is not new and not this
+     tier's doing: --btn-bg already does exactly this to the cta2's REST state today. Mirroring
+     it onto hover makes the button consistent with itself (both states flat) instead of
+     stripped at rest and gradient on hover. The real fix is to route the global tier through
+     the cta2's own chains in BOTH states, which is tracked separately. */
   --btn-bg:           initial;         /* color: Global button fill. Unset = each rule's own default (bare .btn: --color-accent; composed primary: the accent gradient). Set to recolor every button fill. */
   --btn-text:         var(--color-bg); /* color: Button label ink. Defaults to the PAGE BACKGROUND token, not a text token — buttons invert: a light page yields light text on the accent fill. Change --color-bg and button text follows unless pinned here. */
   --btn-border-color: initial;         /* color: Global button border. Unset = each rule's own default (--color-accent, or --color-accent-strong on the premium primary). Set to recolor every button border. */
   --btn-shadow:       initial;         /* shadow: Global button elevation. Unset = each rule's own default (bare .btn flat; composed primary keeps its premium bevel). Set a shadow preset (e.g. --shadow-md) or none to change every button's elevation. */
+  --btn-hover-bg:           initial;   /* color: Global button HOVER fill — the hover twin of --btn-bg. Unset = each rule's own default (bare .btn: --color-accent-hover; composed primary: the premium hover gradient). Set alongside --btn-bg so a site-wide fill retheme survives the pointer. */
+  --btn-hover-border-color: initial;   /* color: Global button HOVER border — the hover twin of --btn-border-color. Unset = each rule's own default (--color-accent-hover, or --color-accent on the premium primary). Set alongside --btn-border-color so a site-wide border retheme survives the pointer. */
 
   /* Shape & motion */
   --radius:     0.375rem;   /* length: 6px — increase for rounder corners */

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -12,14 +12,16 @@
    SHARED: Button
    .btn is the shared base; variants .btn--secondary / .btn--outline / .btn--ghost
    (primary = bare .btn) are selected per-instance via the `button_variant` prop.
-   The --btn-* color tokens (--btn-bg / --btn-text / --btn-border-color / --btn-shadow)
+   The --btn-* color tokens (--btn-bg / --btn-text / --btn-border-color / --btn-shadow,
+   plus the HOVER pair --btn-hover-bg / --btn-hover-border-color added by #539)
    are registered design tokens in base.css and are the site-wide GLOBAL button surface.
    The premium `main .btn:not(...)` primary cascade and the `.cta .btn` / `.hero .btn`
    primary rules route their fill/border/ink/shadow fallbacks through --btn-* (#458), so
    setting --btn-bg / --btn-text / --btn-border-color / --btn-shadow at :root restyles
    EVERY composed primary button. --btn-bg / --btn-border-color / --btn-shadow register as
    `initial` (unset), so each consuming rule resolves its own literal until the token is
-   set and an unset button is byte-identical; --btn-text keeps a concrete --color-bg
+   set and an unset button is byte-identical; the two hover knobs register `initial` for the
+   same reason; --btn-text keeps a concrete --color-bg
    default (its value equals the universal ink literal). Per-component slots
    (--cta-button-* / --cta-accent / --hero-button-* / --hero-accent) still win over the
    global tokens when set — --btn-* sits between those slots and the literal fallback. These tokens are NOT
@@ -44,9 +46,20 @@
   line-height: 1.4;
 }
 
+/* Hover twin of the .btn rest rule above: the global hover knobs (issue 539) sit exactly
+   where --btn-bg / --btn-border-color sit at rest — first, ahead of the literal, since the
+   bare primitive has no per-instance slots. This rule is the live hover winner only OUTSIDE
+   `main` (inside it the premium `main .btn:not(...):hover` cascade wins on specificity), so
+   it is what carries a site-wide retheme onto header/footer buttons. Unset, both fall to
+   --color-accent-hover and the button is byte-identical.
+   Note the border reaches .btn--outline too: `.btn--outline:hover` sets no border-color, so
+   this declaration is its hover ring. That mirrors REST exactly (`.btn--outline` sets no
+   border-color either, so --btn-border-color already rings it), which is the point — the
+   global border knob should not change which variants it reaches between the two states.
+   .btn--ghost and .btn--secondary set their own hover border and are unaffected. */
 .btn:hover {
-  background-color: var(--color-accent-hover);
-  border-color: var(--color-accent-hover);
+  background-color: var(--btn-hover-bg, var(--color-accent-hover));
+  border-color: var(--btn-hover-border-color, var(--color-accent-hover));
   color: var(--color-bg);
 }
 
@@ -823,12 +836,21 @@
    This in-block consumption is the slot-contract keystone (StyleSlotContractTest) — the
    VISIBLE win happens in the premium rule, exactly as --hero-button-bg does at rest.
    Unset it falls to --hero-accent-hover then the literal, so an unset button is
-   byte-identical. Border mirrors the REST chain's ordering above (--hero-accent first,
-   then FOLLOWS the fill) with each knob swapped for its hover equivalent; there is no
-   --btn-hover-border-color token, so that link is simply absent. */
+   byte-identical. Border mirrors the REST chain's ordering above (--hero-accent first, then
+   its own global knob, then FOLLOWS the fill) with each knob swapped for its hover equivalent.
+   The global hover tier (issue 539) completes that mirror: --btn-hover-bg and
+   --btn-hover-border-color take the positions --btn-bg and --btn-border-color hold at rest.
+   Routing the fill HERE is not redundant with the premium rule — it is load-bearing. This
+   rule is [0,6,0] and the premium hover winner is [0,5,1], so background-COLOR is decided
+   here while background-IMAGE is decided there. Today the gradient image masks whatever this
+   rule computes; the moment --btn-hover-bg clears that image to `none` in the premium rule,
+   THIS declaration becomes the visible pixel. Insert the tier only in the premium rule and a
+   site-wide hover retheme computes correctly, clears the gradient, and is then overridden
+   right back to --color-accent-hover by this line — the knob would be dead on every hero
+   primary. Same reason --btn-bg is in the rest chain above. */
 .hero .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
-  background-color: var(--hero-button-hover-bg, var(--hero-accent-hover, var(--color-accent-hover)));
-  border-color: var(--hero-accent-hover, var(--hero-button-hover-bg, var(--color-accent-hover)));
+  background-color: var(--hero-button-hover-bg, var(--hero-accent-hover, var(--btn-hover-bg, var(--color-accent-hover))));
+  border-color: var(--hero-accent-hover, var(--btn-hover-border-color, var(--hero-button-hover-bg, var(--btn-hover-bg, var(--color-accent-hover)))));
 }
 /* Ink + elevation slots for the hero primary button (issue 514, the --cta-button-color /
    --cta-button-shadow idiom scoped to .cta__button). Kept at [0,4,0] — BELOW the premium
@@ -920,7 +942,11 @@
   border-color: var(--hero-accent, var(--btn-border-color, var(--hero-button-bg, var(--btn-bg, var(--color-accent-on-overlay)))));
 }
 .hero--cover .hero__cta:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
-  border-color: var(--hero-accent-hover, var(--hero-button-hover-bg, var(--color-accent-on-overlay)));
+  /* Global hover tier (issue 539) in the same slot its resting counterpart holds in the rest
+     twin directly above: --btn-hover-border-color after --hero-accent-hover, --btn-hover-bg
+     at the tail of the border-follows-fill link. Only the terminal on-overlay fallback stays
+     last, exactly as at rest. */
+  border-color: var(--hero-accent-hover, var(--btn-hover-border-color, var(--hero-button-hover-bg, var(--btn-hover-bg, var(--color-accent-on-overlay)))));
 }
 
 /* Second CTA button (cta2): per-instance bg/border/color override, independent
@@ -2534,8 +2560,16 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   border-color: var(--cta-button-border, var(--btn-border-color, var(--cta-button-bg, var(--cta-accent, var(--btn-bg, var(--color-accent))))));
 }
 .cta .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
-  background-color: var(--cta-button-hover-bg, var(--cta-accent-hover, var(--color-accent-hover)));
-  border-color: var(--cta-button-hover-border, var(--cta-button-hover-bg, var(--cta-accent-hover, var(--color-accent-hover))));
+  /* Global hover tier (issue 539) mirrors the rest chain above: --btn-hover-bg last before
+     the literal in the fill, --btn-hover-border-color straight after this rule's own hover
+     border slot. As on the hero, routing the fill here is load-bearing rather than
+     decorative — this rule is [0,6,0] and decides background-COLOR, while the premium
+     [0,5,1] hover rule decides background-IMAGE; once the global knob clears the gradient
+     there, this declaration is what actually paints. The pre-existing order quirk (this
+     chain keeps the hover FILL ahead of --cta-accent-hover, where button2 keeps #538's
+     Option-3 order) is untouched — see issue 548. */
+  background-color: var(--cta-button-hover-bg, var(--cta-accent-hover, var(--btn-hover-bg, var(--color-accent-hover))));
+  border-color: var(--cta-button-hover-border, var(--btn-hover-border-color, var(--cta-button-hover-bg, var(--cta-accent-hover, var(--btn-hover-bg, var(--color-accent-hover))))));
 }
 
 /* CTA button (single button): per-instance bg/border/color override,
@@ -2651,7 +2685,7 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   color: var(--cta-button2-color, var(--btn-text, var(--color-bg)));
 }
 .cta .cta__buttons .cta__button--secondary:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
-  background-color: var(--cta-button2-hover-bg, var(--cta-accent-hover, var(--color-accent-hover)));
+  background-color: var(--cta-button2-hover-bg, var(--cta-accent-hover, var(--btn-hover-bg, var(--color-accent-hover))));
   /* Border follows the hover fill from the LAST fallback position (issue 538, Option 3 —
      the recorded decision), the exact twin of the hero's cta2 hover ring above. #530 left
      the fill out entirely because the hover BORDER, unlike the hover FILL, was never masked
@@ -2685,7 +2719,11 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
      Not mirrored onto the outline/ghost/secondary button2 hover rules — see the hero cta2
      comment above for the two separate reasons (ghost bottoms out at `transparent`;
      outline/secondary don't follow the fill in either state). */
-  border-color: var(--cta-button2-hover-border, var(--cta-accent-hover, var(--cta-button2-hover-bg, var(--color-accent-hover))));
+  /* Global hover tier (issue 539) takes the position --btn-border-color holds in this
+     button's rest chain: after its own hover border slot, ahead of #538's Option-3
+     accent-then-fill link, which is preserved verbatim. --btn-hover-bg joins the tail of
+     that link so a site-wide hover fill still rings itself. */
+  border-color: var(--cta-button2-hover-border, var(--btn-hover-border-color, var(--cta-accent-hover, var(--cta-button2-hover-bg, var(--btn-hover-bg, var(--color-accent-hover))))));
   color: var(--cta-button2-hover-color, var(--btn-text, var(--color-bg)));
 }
 
@@ -2845,7 +2883,7 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   border-color: var(--cta-button-border, var(--btn-border-color, var(--cta-button-bg, var(--cta-accent, var(--btn-bg, var(--color-accent-on-overlay))))));
 }
 .cta--has-bg-image .cta__button:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
-  border-color: var(--cta-button-hover-border, var(--cta-button-hover-bg, var(--cta-accent-hover, var(--color-accent-on-overlay))));
+  border-color: var(--cta-button-hover-border, var(--btn-hover-border-color, var(--cta-button-hover-bg, var(--cta-accent-hover, var(--btn-hover-bg, var(--color-accent-on-overlay))))));
 }
 
 /* The SAME separation ring for the filled SECOND button (issue 543). #535 scoped its ring
@@ -2886,7 +2924,7 @@ main > .grid:not(.grid--steps):not(.grid--uniform) .grid__item:first-child::befo
   border-color: var(--cta-button2-border, var(--btn-border-color, var(--cta-button2-bg, var(--cta-accent, var(--btn-bg, var(--color-accent-on-overlay))))));
 }
 .cta--has-bg-image .cta__buttons .cta__button--secondary:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
-  border-color: var(--cta-button2-hover-border, var(--cta-accent-hover, var(--cta-button2-hover-bg, var(--color-accent-on-overlay))));
+  border-color: var(--cta-button2-hover-border, var(--btn-hover-border-color, var(--cta-accent-hover, var(--cta-button2-hover-bg, var(--btn-hover-bg, var(--color-accent-on-overlay))))));
 }
 
 /* button2 slot isolation + premium fill routing (the issue 526 mechanism applied
@@ -4428,10 +4466,11 @@ main .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary) {
 main .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
   border-color: var(--cta-button-hover-border, var(--color-accent));
   /* Superseded for background by the later "True final cascade" block; --hero-button-hover-bg
-     leads the chain here too (issue 530) so both hover primary-fill rules stay uniform, the
-     way #514 kept both REST rules uniform. */
-  background: var(--hero-button-hover-bg, var(--cta-button-hover-bg,
-    linear-gradient(180deg, var(--color-accent) 0%, var(--color-accent-hover) 100%)));
+     leads the chain here too (issue 530) and the global --btn-hover-bg closes it (issue 539)
+     so both hover primary-fill rules stay uniform, the way #514 kept both REST rules
+     uniform. */
+  background: var(--hero-button-hover-bg, var(--cta-button-hover-bg, var(--btn-hover-bg,
+    linear-gradient(180deg, var(--color-accent) 0%, var(--color-accent-hover) 100%))));
   box-shadow: var(--cta-button-shadow,
     inset 0 1px 0 rgba(255, 255, 255, 0.2),
     0 14px 30px color-mix(in srgb, var(--color-accent-strong) 22%, transparent));
@@ -4511,7 +4550,14 @@ main .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary) {
 }
 
 main .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
-  border-color: var(--cta-button-hover-border, var(--cta-accent-hover, var(--color-accent)));
+  /* Global hover BORDER (issue 539) mirrors the rest twin's ordering above: after
+     --cta-button-hover-border and --cta-accent-hover, ahead of the literal. Border stays
+     INDEPENDENT of the fill in this rule exactly as at rest, so --btn-hover-bg is
+     deliberately absent here. The rest chain's --section-panel-cta-bg link has no hover
+     counterpart because the panel CTA has no per-instance hover fill slot (#536 shipped it
+     resting-state-only), so that one link is simply absent — the same way
+     --btn-hover-border-color used to be. */
+  border-color: var(--cta-button-hover-border, var(--cta-accent-hover, var(--btn-hover-border-color, var(--color-accent))));
   /* Hero per-instance HOVER fill slot (issue 530): --hero-button-hover-bg is the visible
      hover fill winner for a hero primary, exactly as --hero-button-bg is at rest. A FLAT
      color here resolves the shorthand to `background: <color>`, which resets background-image
@@ -4523,9 +4569,17 @@ main .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover {
      inherit it), and re-pointed at --hero-cta2-hover-bg on .hero__cta--secondary (and
      --cta-button-hover-bg at --cta-button2-hover-bg on .cta__button--secondary) by the
      issue 530 isolation declarations — which is how a filled SECOND button gets its OWN
-     gradient-clearing hover fill here, isolated from the primary's. */
-  background: var(--hero-button-hover-bg, var(--cta-button-hover-bg,
-    linear-gradient(180deg, var(--color-accent) 0%, var(--color-accent-strong) 100%)));
+     gradient-clearing hover fill here, isolated from the primary's.
+     The global --btn-hover-bg closes the chain (issue 539), in the position --btn-bg holds in
+     the rest twin above. It is deliberately NOT re-pointed by any isolation declaration: a
+     global knob is meant to move both buttons of a pair together, exactly as --btn-bg does at
+     rest. This is also the panel CTA's only hover fill winner — .section__panel-cta has no
+     .hero/.cta ancestor and no hover rule of its own — so the global tier reaches it here even
+     though #536 gave it no per-instance hover slot. That asymmetry is intended: the global
+     tier is site-wide by definition, and a knob that skipped one filled surface would be the
+     surprising behaviour. */
+  background: var(--hero-button-hover-bg, var(--cta-button-hover-bg, var(--btn-hover-bg,
+    linear-gradient(180deg, var(--color-accent) 0%, var(--color-accent-strong) 100%))));
   /* --hero-button-shadow flattens hover too (issue 514, matching --cta-button-shadow's
      rest+hover contract): set `none` and both rest and hover lose the bevel. Unset falls
      to --cta-button-shadow then the hover bevel literal (byte-identical).

--- a/components/cta/README.md
+++ b/components/cta/README.md
@@ -91,7 +91,11 @@ Hover is a separate surface, isolated the same way (issue 530): `--cta-button-ho
 addresses the primary only and `--cta-button2-hover-bg` the second only, and on a filled
 button each replaces the shared premium hover gradient with a flat fill. A resting slot
 governs the resting state only, so pair each with its hover counterpart when a button
-should stay on-brand through the hover; left unset, hover keeps the premium gradient.
+should stay on-brand through the hover; left unset, hover falls through to the global
+`--btn-hover-bg` (issue 539) and then to the premium gradient. That global knob is the
+site-wide hover twin of `--btn-bg`, so a theme-level button retheme now survives the
+pointer on both of this component's buttons without per-instance slots; the per-instance
+slots above still win wherever they are set.
 
 On the filled SECOND button the hover BORDER follows that hover fill when neither
 `--cta-button2-hover-border` nor `--cta-accent-hover` is set, so a hover-fill-only recolor

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.11.3');
+define('PP_VERSION', '1.11.4');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.11.3
+Stable tag: 1.11.4
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.11.3
+Version:          1.11.4
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ApplyTest.php
+++ b/tests/ApplyTest.php
@@ -2265,6 +2265,68 @@ class ApplyTest extends TestCase
         $this->assertEquals('invalid_length', $result->get_error_code());
     }
 
+    // ── Global button HOVER tier (issue 539) ──────────────────────────────
+    // #458 gave the theme four site-wide button knobs; #530 gave every filled
+    // surface a per-instance hover fill slot. The global tier stopped at rest,
+    // so a site-wide fill/border retheme reverted to the theme's premium accent
+    // gradient on hover. --btn-hover-bg / --btn-hover-border-color close that.
+    //
+    // These are AUTHORING-PATH tests, not render pins. pp_design_tokens() derives
+    // every token's type from the `/* type: ... */` comment beside its :root
+    // declaration, so a token declared without (or with a wrong) annotation is
+    // registered with a null type and update_design_token refuses to validate it.
+    // A CSS chain that routes a token no operator can actually SET is an inert
+    // feature — exactly the schema-vs-render incoherence raw fixtures never catch.
+
+    public function testGlobalButtonHoverTokensAreRegisteredAsColorTokens(): void
+    {
+        $tokens = pp_design_tokens();
+
+        $this->assertArrayHasKey('--btn-hover-bg', $tokens);
+        $this->assertSame('color', $tokens['--btn-hover-bg']['type']);
+
+        $this->assertArrayHasKey('--btn-hover-border-color', $tokens);
+        $this->assertSame('color', $tokens['--btn-hover-border-color']['type']);
+    }
+
+    public function testGlobalButtonHoverTokensRegisterUnsetSoRenderIsByteIdentical(): void
+    {
+        // Both must register `initial` (the guaranteed-invalid value), the same way
+        // --btn-bg / --btn-border-color do. That is what makes every consuming hover
+        // chain fall through to its own literal until an operator sets the token, so
+        // an untouched site renders exactly as before. A concrete default here would
+        // repaint every button hover on every existing install.
+        $tokens = pp_design_tokens();
+        $this->assertSame('initial', $tokens['--btn-hover-bg']['value']);
+        $this->assertSame('initial', $tokens['--btn-hover-border-color']['value']);
+    }
+
+    public function testUpdateDesignTokenAcceptsGlobalButtonHoverColors(): void
+    {
+        // The point of the issue: an operator rethemes hover site-wide through the
+        // SAME shared colour engine (_pp_validate_token_value) used by every other
+        // colour token, with no surface-specific validator.
+        $this->assertTrue(
+            pp_validate_apply('update_design_token', ['token' => '--btn-hover-bg', 'value' => '#b45309'])
+        );
+        $this->assertTrue(
+            pp_validate_apply('update_design_token', ['token' => '--btn-hover-border-color', 'value' => '#b45309'])
+        );
+    }
+
+    public function testUpdateDesignTokenRejectsInvalidGlobalButtonHoverColors(): void
+    {
+        // Same colour grammar as every other colour token — rejection comes from the
+        // shared engine, so the new knobs cannot drift into a laxer surface.
+        $bg = pp_validate_apply('update_design_token', ['token' => '--btn-hover-bg', 'value' => 'burnt-sienna']);
+        $this->assertInstanceOf(WP_Error::class, $bg);
+        $this->assertEquals('invalid_color', $bg->get_error_code());
+
+        $border = pp_validate_apply('update_design_token', ['token' => '--btn-hover-border-color', 'value' => 'burnt-sienna']);
+        $this->assertInstanceOf(WP_Error::class, $border);
+        $this->assertEquals('invalid_color', $border->get_error_code());
+    }
+
     // ── Font apply tests ─────────────────────────────────────────────────
 
     public function testEnqueueFontValid(): void

--- a/tests/StyleSlotContractTest.php
+++ b/tests/StyleSlotContractTest.php
@@ -823,7 +823,12 @@ class StyleSlotContractTest extends TestCase
         $this->assertHoverBorderChain(
             $block,
             '.cta .cta__buttons .cta__button--secondary',
-            ['--cta-button2-hover-border', '--cta-accent-hover', '--cta-button2-hover-bg', '--color-accent-hover'],
+            // The global hover tier (issue 539) takes the position --btn-border-color holds in
+            // this button's REST chain — straight after its own hover border slot, ahead of
+            // #538's Option-3 accent-then-fill link, which is preserved verbatim between them.
+            // --btn-hover-bg closes the border-follows-fill link so a site-wide hover fill
+            // still rings itself, exactly as --btn-bg does at rest.
+            ['--cta-button2-hover-border', '--btn-hover-border-color', '--cta-accent-hover', '--cta-button2-hover-bg', '--btn-hover-bg', '--color-accent-hover'],
             'button2'
         );
     }
@@ -1074,18 +1079,19 @@ class StyleSlotContractTest extends TestCase
         // consumption (the slot-contract keystone). Its VISIBLE win is the premium hover
         // rule; this declaration is what makes the slot discoverable in the hero block.
         $this->assertStringContainsString(
-            'background-color: var(--hero-button-hover-bg, var(--hero-accent-hover, var(--color-accent-hover)))',
+            'background-color: var(--hero-button-hover-bg, var(--hero-accent-hover, var(--btn-hover-bg, var(--color-accent-hover))))',
             $block,
-            'The hero primary hover rule must consume --hero-button-hover-bg (issue 530).'
+            'The hero primary hover rule must consume --hero-button-hover-bg (issue 530), then the global --btn-hover-bg (issue 539).'
         );
         // The hero primary's hover border DOES follow the new fill slot, mirroring its rest
         // sibling. Safe because --hero-button-hover-bg is new in #530: no shipped composition
         // can already set it, so no existing render changes.
         $this->assertStringContainsString(
-            'border-color: var(--hero-accent-hover, var(--hero-button-hover-bg, var(--color-accent-hover)))',
+            'border-color: var(--hero-accent-hover, var(--btn-hover-border-color, var(--hero-button-hover-bg, var(--btn-hover-bg, var(--color-accent-hover)))))',
             $block,
-            'The hero primary hover border must FOLLOW --hero-button-hover-bg when '
-            . '--hero-accent-hover is unset (issue 530, mirroring the rest chain).'
+            'The hero primary hover border must honour the global --btn-hover-border-color '
+            . '(issue 539) and then FOLLOW --hero-button-hover-bg when --hero-accent-hover is '
+            . 'unset (issue 530) — the same shape its REST sibling has carried since #458.'
         );
     }
 

--- a/tests/e2e/style-render.spec.ts
+++ b/tests/e2e/style-render.spec.ts
@@ -4970,6 +4970,327 @@ test.describe('#458 the global button surface is a real one-knob (real WP)', () 
 });
 
 /**
+ * #539 — the global button surface survives a HOVER.
+ *
+ * #458 (above) made `--btn-*` a real one-knob at REST. #530 gave every filled surface a
+ * per-instance HOVER fill slot. Between them sat this gap: the global tier was
+ * resting-state only, so an operator who rethemed every button with `--btn-bg` /
+ * `--btn-border-color` got their brand at rest and the theme's premium accent gradient
+ * back the moment a pointer touched any button on the site. `--btn-hover-bg` /
+ * `--btn-hover-border-color` close it.
+ *
+ * Why this is an E2E and not a computed-chain unit pin: the bug lives in the CASCADE, not
+ * in any single chain. The premium `main .btn:not(...):hover` rule [0,5,1] owns
+ * background-IMAGE, while the component hover rules [0,6,0] own background-COLOR. Adding
+ * the tier only to the premium rule computes correctly, clears the gradient, and is then
+ * overridden right back to `--color-accent-hover` by the component rule — a knob that
+ * looks wired in every unit assertion and is dead in a browser. Only a real hover on a
+ * real composed page catches that, which is why all five filled surfaces are hovered here.
+ *
+ * Proven three ways, mirroring the #458 block:
+ *   (a) UNSET is byte-identical on hover — the hovered button matches the browser's own
+ *       resolution of the historical premium hover gradient, at 1280 AND 375.
+ *   (b) SET reaches every filled surface, including the section-panel CTA (which #536 gave
+ *       no per-instance hover slot, so the global tier is its ONLY hover fill authority).
+ *   (c) per-instance hover slots still outrank the global knobs.
+ */
+test.describe('#539 the global button surface survives a hover (real WP)', () => {
+  let pageId = 0;
+
+  test.afterEach(async () => {
+    if (pageId) {
+      deletePage(pageId);
+      pageId = 0;
+    }
+  });
+
+  // All FIVE filled surfaces on one page: hero primary, hero cta2, cta primary, cta
+  // button2, section panel CTA. Both second buttons use `primary` variants so they are
+  // FILLED (an outline/ghost second button takes a different rule and would not exercise
+  // the gradient-clearing path at all).
+  function buildHoverPage(): number {
+    const id = createPage('E2E btn hover tier #539');
+    setComposition(id, [
+      {
+        component: 'hero',
+        props: {
+          id: 'btn539-hero',
+          title: 'Ship faster',
+          cta_text: 'Primary',
+          cta_url: '/start',
+          cta2_text: 'Secondary',
+          cta2_url: '/learn',
+          cta2_variant: 'primary',
+        },
+      },
+      {
+        component: 'cta',
+        props: {
+          id: 'btn539-cta',
+          title: 'Join us',
+          button_text: 'Sign up',
+          button_url: '/join',
+          button2_text: 'Talk to us',
+          button2_url: '/contact',
+          button2_variant: 'primary',
+        },
+      },
+      {
+        component: 'section',
+        props: {
+          id: 'btn539-section',
+          title: 'Details',
+          layout: 'text-panel',
+          panel_heading: 'Panel',
+          panel_cta_text: 'Learn more',
+          panel_cta_url: '/more',
+        },
+      },
+    ]);
+    return id;
+  }
+
+  const SEL = {
+    heroPrimary: '.hero__cta:not(.hero__cta--secondary)',
+    heroCta2: '.hero__cta--secondary',
+    ctaPrimary: '.cta__button:not(.cta__button--secondary)',
+    ctaButton2: '.cta__button--secondary',
+    panelCta: '.section__panel-cta',
+  };
+
+  // Transitions animate colour over 150ms, so every read below must happen with them off or
+  // getComputedStyle samples an intermediate frame (the #458 block's lesson).
+  const NO_TRANSITION =
+    '*,*::before,*::after{transition:none !important;animation:none !important;}';
+
+  for (const width of [1280, 375]) {
+    test(`unset global hover knobs keep every filled surface byte-identical on hover (${width}px) @smoke`, async ({
+      page,
+    }) => {
+      pageId = buildHoverPage();
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`/?page_id=${pageId}`);
+      await expect(page.locator(SEL.panelCta)).toBeVisible({ timeout: 10000 });
+      await page.addStyleTag({ content: NO_TRANSITION });
+
+      // The historical values, resolved by the BROWSER through throwaway probes that inherit
+      // :root — so this compares against the theme's own resolution rather than brittle
+      // hardcoded hex. The gradient alone is not enough: this diff changed the BORDER chain on
+      // six rules and the background-color chain on four, and a reordering that repaints an
+      // unset button while leaving background-image untouched would slip straight through.
+      const probe = await page.evaluate(() => {
+        const resolve = (prop: string, value: string) => {
+          const el = document.createElement('div');
+          el.style.setProperty(prop, value);
+          document.body.appendChild(el);
+          const v = getComputedStyle(el).getPropertyValue(prop);
+          el.remove();
+          return v;
+        };
+        return {
+          gradient: resolve(
+            'background-image',
+            'linear-gradient(180deg, var(--color-accent) 0%, var(--color-accent-strong) 100%)',
+          ),
+          accentHover: resolve('background-color', 'var(--color-accent-hover)'),
+          accent: resolve('background-color', 'var(--color-accent)'),
+        };
+      });
+
+      // Each surface's hover border resolves a DIFFERENT literal when unset, so the expected
+      // value is named per surface rather than asserted loosely. A bare truthiness check here
+      // would pass through a reordered chain, a wrong literal, or an accidental repaint —
+      // which is the whole failure class this test exists to catch.
+      const expectedBorder: Record<string, string> = {
+        heroPrimary: probe.accentHover,
+        heroCta2: probe.accentHover,
+        ctaPrimary: probe.accentHover,
+        ctaButton2: probe.accentHover,
+        // The generic panel CTA is governed by the premium rule, which bottoms out at
+        // --color-accent rather than --color-accent-hover.
+        panelCta: probe.accent,
+      };
+
+      for (const [name, sel] of Object.entries(SEL)) {
+        await page.locator(sel).first().hover();
+        const got = await page
+          .locator(sel)
+          .first()
+          .evaluate((el) => {
+            const cs = getComputedStyle(el);
+            return { bgImage: cs.backgroundImage, border: cs.borderTopColor };
+          });
+        // Unset, the chain bottoms out at the premium hover gradient on every surface —
+        // the gradient is still THERE, which is precisely the behaviour #539 complains
+        // about when the operator HAS set a global fill, and must preserve when they have not.
+        expect(got.bgImage, `${name} bgImage @${width}px`).toBe(probe.gradient);
+        // The border chains gained a tier too: six rules changed. Unset, each must still
+        // resolve the exact literal it resolved before.
+        expect(got.border, `${name} border @${width}px`).toBe(expectedBorder[name]);
+      }
+    });
+  }
+
+  test('setting --btn-hover-bg / --btn-hover-border-color reaches every filled surface @smoke', async ({
+    page,
+  }) => {
+    pageId = buildHoverPage();
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+    await expect(page.locator(SEL.panelCta)).toBeVisible({ timeout: 10000 });
+
+    // Sentinels no theme token resolves to, so a match proves the global knob reached.
+    await page.addStyleTag({
+      content:
+        NO_TRANSITION +
+        ':root{--btn-hover-bg:rgb(1,2,3);--btn-hover-border-color:rgb(7,8,9);}',
+    });
+
+    // The hero's SECOND cta is NOT in this group — see the dedicated assertion below, which
+    // pins the halfway outcome rather than skipping the surface.
+    const covered = ['heroPrimary', 'ctaPrimary', 'ctaButton2', 'panelCta'] as const;
+
+    for (const name of covered) {
+      await page.locator(SEL[name]).first().hover();
+      const got = await page
+        .locator(SEL[name])
+        .first()
+        .evaluate((el) => {
+          const cs = getComputedStyle(el);
+          return { bgColor: cs.backgroundColor, bgImage: cs.backgroundImage, border: cs.borderTopColor };
+        });
+
+      // A flat colour resolves the premium `background` SHORTHAND to `background: <color>`,
+      // which resets background-image to `none` and CLEARS the gradient that used to mask
+      // every hover fill. Both halves matter: the colour AND the absence of the gradient.
+      expect(got.bgColor, `${name} hover fill`).toBe('rgb(1, 2, 3)');
+      expect(got.bgImage, `${name} hover gradient cleared`).toBe('none');
+      expect(got.border, `${name} hover border`).toBe('rgb(7, 8, 9)');
+    }
+
+    /*
+     * The hero's SECOND cta: pin the ACCEPTED halfway outcome, do not skip it.
+     *
+     * Its own [0,7,0] rules never routed the global tier (rest or hover), but the SHARED
+     * premium rule still resolves `background: var(--btn-hover-bg, ...)` to a flat colour for
+     * it, which clears the gradient background-IMAGE. Its own background-COLOR keeps winning.
+     * Net: gradient gone, fill still the theme accent-hover, not the operator's colour.
+     *
+     * This is pre-existing, not introduced here: --btn-bg alone already does exactly this to
+     * the cta2's REST state. The hover knob mirrors it so the button is consistent with itself.
+     * Pinning it means the day someone routes the global tier through the cta2's own chains,
+     * this assertion fails and gets updated on purpose instead of the behaviour drifting.
+     */
+    const accentHover = await page.evaluate(() => {
+      const el = document.createElement('div');
+      el.style.setProperty('background-color', 'var(--color-accent-hover)');
+      document.body.appendChild(el);
+      const v = getComputedStyle(el).backgroundColor;
+      el.remove();
+      return v;
+    });
+
+    await page.locator(SEL.heroCta2).first().hover();
+    const cta2 = await page
+      .locator(SEL.heroCta2)
+      .first()
+      .evaluate((el) => {
+        const cs = getComputedStyle(el);
+        return { bgColor: cs.backgroundColor, bgImage: cs.backgroundImage };
+      });
+    expect(cta2.bgColor, 'hero cta2 keeps its own accent fill, NOT the global knob').toBe(
+      accentHover,
+    );
+    expect(cta2.bgImage, 'hero cta2 gradient is cleared by the shared premium rule').toBe('none');
+  });
+
+  test('a per-instance hover slot still beats the global --btn-hover-bg @smoke', async ({
+    page,
+  }) => {
+    pageId = buildHoverPage();
+
+    // Style ONLY the hero's own hover fill slot (component index 0), then set a conflicting
+    // global knob. The per-instance slot must win on that button; the cta primary, which has
+    // no per-instance hover slot set, must still take the global one.
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    const res = await styleComponent(
+      page,
+      pageId,
+      { '--hero-button-hover-bg': 'rgb(20,30,40)' },
+      undefined,
+      0,
+    );
+    expect(res.success).toBeTruthy();
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+    await expect(page.locator(SEL.ctaPrimary)).toBeVisible({ timeout: 10000 });
+    await page.addStyleTag({
+      content: NO_TRANSITION + ':root{--btn-hover-bg:rgb(1,2,3);}',
+    });
+
+    await page.locator(SEL.heroPrimary).first().hover();
+    const heroFill = await page
+      .locator(SEL.heroPrimary)
+      .first()
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    // Per-instance slot wins over the global knob.
+    expect(heroFill).toBe('rgb(20, 30, 40)');
+
+    await page.locator(SEL.ctaPrimary).first().hover();
+    const ctaFill = await page
+      .locator(SEL.ctaPrimary)
+      .first()
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    // ...and the global knob still governs the surface that set no slot of its own.
+    expect(ctaFill).toBe('rgb(1, 2, 3)');
+  });
+
+  test('a per-instance hover BORDER slot still beats the global --btn-hover-border-color @smoke', async ({
+    page,
+  }) => {
+    pageId = buildHoverPage();
+
+    // --btn-hover-border-color was threaded into six border chains at six different positions.
+    // Chain-order string pins catch a text edit, but only a rendered hover proves the
+    // PRECEDENCE actually holds in the cascade — the exact distinction that makes this whole
+    // block an E2E rather than a unit test.
+    await page.goto('/wp-admin/admin.php?page=pp-ai-chat');
+    const res = await styleComponent(
+      page,
+      pageId,
+      { '--cta-button-hover-border': 'rgb(60,70,80)' },
+      undefined,
+      1,
+    );
+    expect(res.success).toBeTruthy();
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/?page_id=${pageId}`);
+    await expect(page.locator(SEL.ctaPrimary)).toBeVisible({ timeout: 10000 });
+    await page.addStyleTag({
+      content: NO_TRANSITION + ':root{--btn-hover-border-color:rgb(7,8,9);}',
+    });
+
+    await page.locator(SEL.ctaPrimary).first().hover();
+    const authored = await page
+      .locator(SEL.ctaPrimary)
+      .first()
+      .evaluate((el) => getComputedStyle(el).borderTopColor);
+    // The authored per-instance ring wins over the global knob.
+    expect(authored).toBe('rgb(60, 70, 80)');
+
+    await page.locator(SEL.panelCta).first().hover();
+    const global = await page
+      .locator(SEL.panelCta)
+      .first()
+      .evaluate((el) => getComputedStyle(el).borderTopColor);
+    // ...and a surface with no per-instance ring still takes the global one.
+    expect(global).toBe('rgb(7, 8, 9)');
+  });
+});
+
+/**
  * Computed-rhythm proof for the shared section-band spacing model (issue 431).
  *
  * The band-level components used to hard-code their own vertical-padding literals

--- a/tests/js/css-lint.test.js
+++ b/tests/js/css-lint.test.js
@@ -447,7 +447,7 @@ describe('CSS lint: premium primary-button fill routes through the fill-slot cha
         surfaceRules.forEach(r => {
             const isHover = /:hover\b/.test(r.selector);
             const requiredSlots = isHover
-                ? ['--hero-button-hover-bg', '--cta-button-hover-bg']
+                ? ['--hero-button-hover-bg', '--cta-button-hover-bg', '--btn-hover-bg']
                 : ['--section-panel-cta-bg', '--hero-button-bg', '--cta-button-bg'];
             r.decls.forEach(d => {
                 // Leading slot must be the outermost required slot.
@@ -502,6 +502,18 @@ describe('CSS lint: premium primary-button fill routes through the fill-slot cha
         const hover = ['--hero-button-hover-bg', '--cta-button-hover-bg'];
         const preFix = 'main .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover { background: var(--cta-button-hover-bg, linear-gradient(red, blue)); }';
         const fixed = 'main .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover { background: var(--hero-button-hover-bg, var(--cta-button-hover-bg, linear-gradient(red, blue))); }';
+        expect(scanWithRequiredSlots(preFix, hover).length).toBe(1);
+        expect(scanWithRequiredSlots(fixed, hover).length).toBe(0);
+    });
+
+    // Issue 539 added the GLOBAL tier to the hover branch's requiredSlots. Its own proof:
+    // a chain carrying both per-instance hover slots but no --btn-hover-bg is precisely the
+    // pre-#539 shape (a site-wide fill retheme reverting to the theme gradient on hover) and
+    // MUST now be caught — otherwise dropping the global tier from the chain goes unnoticed.
+    test('detector flags a hover chain missing the global --btn-hover-bg tier', () => {
+        const hover = ['--hero-button-hover-bg', '--cta-button-hover-bg', '--btn-hover-bg'];
+        const preFix = 'main .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover { background: var(--hero-button-hover-bg, var(--cta-button-hover-bg, linear-gradient(red, blue))); }';
+        const fixed = 'main .btn:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover { background: var(--hero-button-hover-bg, var(--cta-button-hover-bg, var(--btn-hover-bg, linear-gradient(red, blue)))); }';
         expect(scanWithRequiredSlots(preFix, hover).length).toBe(1);
         expect(scanWithRequiredSlots(fixed, hover).length).toBe(0);
     });
@@ -641,8 +653,12 @@ describe('CSS lint: primary-button background-color routes through --cta-button-
     test('hover rule: fill routes through --cta-button-hover-bg, border through --cta-button-hover-border then the fill, accent-hover chain as fallback', () => {
         const body = bodyOf(HOVER_SEL);
         expect(body).not.toBeNull();
-        expect(body).toMatch(/background-color:\s*var\(--cta-button-hover-bg,\s*var\(--cta-accent-hover,\s*var\(--color-accent-hover\)\)\)/);
-        expect(body).toMatch(/border-color:\s*var\(--cta-button-hover-border,\s*var\(--cta-button-hover-bg,\s*var\(--cta-accent-hover,\s*var\(--color-accent-hover\)\)\)\)/);
+        // #539 completes the rest chain's shape above at the hover tier: --btn-hover-bg and
+        // --btn-hover-border-color take exactly the positions --btn-bg and --btn-border-color
+        // hold at rest — between the per-component slots and the --color-accent-hover literal.
+        // Border still FOLLOWS the fill chain after honouring its own global knob.
+        expect(body).toMatch(/background-color:\s*var\(--cta-button-hover-bg,\s*var\(--cta-accent-hover,\s*var\(--btn-hover-bg,\s*var\(--color-accent-hover\)\)\)\)/);
+        expect(body).toMatch(/border-color:\s*var\(--cta-button-hover-border,\s*var\(--btn-hover-border-color,\s*var\(--cta-button-hover-bg,\s*var\(--cta-accent-hover,\s*var\(--btn-hover-bg,\s*var\(--color-accent-hover\)\)\)\)\)\)/);
     });
 });
 
@@ -2870,6 +2886,97 @@ describe('CSS lint: #441 global button token contract (consumed ⊆ registered�
         expect(root).toMatch(/--btn-shadow:\s*initial/);
     });
 
+    test('the global HOVER knobs register as unset-by-default too (#539)', () => {
+        // #539 completed #530's rest/hover parity at the GLOBAL tier. Both hover knobs must
+        // register `initial` for the same reason their resting counterparts do: unset, every
+        // consuming hover rule resolves its own literal and the button renders byte-identically;
+        // set, they override. A concrete default here would repaint every hover on every site.
+        const root = firstRootBlock(BASE_CSS);
+        expect(root).toMatch(/--btn-hover-bg:\s*initial/);
+        expect(root).toMatch(/--btn-hover-border-color:\s*initial/);
+    });
+
+    /*
+     * PARSER TRAP GUARD — a COMMENT inside :root must never contain `--token: value` syntax.
+     *
+     * The design-token registry is derived by regex (_pp_read_tokens_from_file in lib/apply.php
+     * and pp_design_tokens in lib/wp.php) running `/(--[\w-]+)\s*:\s*([^;]+);/` over the raw
+     * :root block with comments NOT stripped. So prose like "set --btn-shadow: none to flatten"
+     * inside a comment registers a phantom token whose "value" is the rest of the sentence.
+     * It is invisible when the real declaration happens to come later (last-wins overwrites it)
+     * and corrupts the registry when it does not — the token then reports a garbage value and
+     * update_design_token validates against it.
+     *
+     * That is why every token comment in this file writes `--btn-shadow = none`, with an equals
+     * sign, not a colon. #539 broke the convention and this guard exists so the next one cannot.
+     */
+    test('no :root comment contains --token: syntax that the registry regex would eat', () => {
+        const root = firstRootBlock(BASE_CSS);
+        const comments = root.match(/\/\*[\s\S]*?\*\//g) || [];
+        const offenders = [];
+        comments.forEach(c => {
+            const hits = c.match(/--[\w-]+\s*:\s*[^;\n]+;/g);
+            if (hits) offenders.push(...hits.map(h => h.trim()));
+        });
+        expect(offenders).toEqual([]);
+    });
+
+    /*
+     * STRUCTURAL GUARD — comment delimiters must balance, and :root must contain only
+     * declarations once comments are stripped.
+     *
+     * The trap this catches is a premature `*​/` in the middle of one of this file's long
+     * docblocks: everything after it becomes RAW CSS inside :root, the browser's error
+     * recovery swallows whatever declaration follows, and a token silently stops existing.
+     * A text-matching lint sees nothing wrong, because the prose it was checking is simply no
+     * longer inside a comment. It happened once during #539 and was caught by an outside
+     * reviewer rather than by this suite, so the suite gets the guard.
+     */
+    test('base.css and components.css have balanced comment delimiters', () => {
+        [['base.css', BASE_CSS], ['components.css', COMPONENTS_CSS]].forEach(([name, css]) => {
+            const stripped = css.replace(/\/\*[\s\S]*?\*\//g, '');
+            expect(stripped.includes('*/'), `${name} has a stray */ (comment closed early)`).toBe(false);
+            expect(stripped.includes('/*'), `${name} has an unclosed /*`).toBe(false);
+            expect(css.split('{').length, `${name} brace balance`).toBe(css.split('}').length);
+        });
+    });
+
+    test(':root contains only declarations once comments are stripped', () => {
+        const bare = firstRootBlock(BASE_CSS).replace(/\/\*[\s\S]*?\*\//g, '');
+        const stray = bare
+            .split(';')
+            .map(s => s.trim())
+            .filter(Boolean)
+            // A real declaration is `prop: value` (custom property or otherwise).
+            .filter(s => !/^[-a-zA-Z][\w-]*\s*:/.test(s));
+        expect(stray).toEqual([]);
+    });
+
+    test('detector catches prose left raw in :root by an early comment close', () => {
+        // Anti-vacuity for the guard above: the exact #539 shape must be caught.
+        const broken = ':root {\n  /* explains a thing */\n  Deliberately NOT mirrored: hover ink\n  and elevation. */\n  --btn-bg: initial;\n}';
+        const stripped = broken.replace(/\/\*[\s\S]*?\*\//g, '');
+        expect(stripped.includes('*/')).toBe(true);
+    });
+
+    test('detector catches a --token: colon form planted inside a :root comment', () => {
+        // Anti-vacuity: prove the guard above actually fires, so a regex slip can't make it
+        // silently pass on a file that really does carry the trap.
+        const planted = ':root {\n  /* set --btn-shadow: none; to flatten */\n  --btn-bg: initial;\n}';
+        const comments = firstRootBlock(planted).match(/\/\*[\s\S]*?\*\//g) || [];
+        const hits = comments.flatMap(c => c.match(/--[\w-]+\s*:\s*[^;\n]+;/g) || []);
+        expect(hits).toHaveLength(1);
+        expect(hits[0]).toContain('--btn-shadow');
+    });
+
+    test('the global hover knobs carry their annotated type comment (#539)', () => {
+        // Same contract as the resting knobs: pp_design_tokens() derives the type from the
+        // `/* type: ... */` comment, and without it update_design_token cannot validate an
+        // authored value. This is the annotation the PHP authoring-path test exercises.
+        expect(BASE_CSS).toMatch(/--btn-hover-bg:[^;]*;\s*\/\*\s*color:/);
+        expect(BASE_CSS).toMatch(/--btn-hover-border-color:[^;]*;\s*\/\*\s*color:/);
+    });
+
     test('the registered button color tokens carry their annotated type comment', () => {
         // pp_design_tokens() derives each token's type from a `/* type: ... */` comment;
         // without it the token exposes a null type and the AI cannot validate authored values.
@@ -3124,7 +3231,9 @@ describe('CSS lint: dark-band buttons route through the AA accent roles (#535)',
         },
         {
             sel: '.cta--has-bg-image .cta__button:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover',
-            leading: ['--cta-button-hover-border', '--cta-button-hover-bg', '--cta-accent-hover'],
+            // --btn-hover-border-color / --btn-hover-bg join at the positions their resting
+            // counterparts hold in the rest twin above (#539).
+            leading: ['--cta-button-hover-border', '--btn-hover-border-color', '--cta-button-hover-bg', '--cta-accent-hover', '--btn-hover-bg'],
         },
         {
             sel: '.hero--cover .hero__cta:not(.btn--outline):not(.btn--ghost):not(.btn--secondary)',
@@ -3132,7 +3241,9 @@ describe('CSS lint: dark-band buttons route through the AA accent roles (#535)',
         },
         {
             sel: '.hero--cover .hero__cta:not(.btn--outline):not(.btn--ghost):not(.btn--secondary):hover',
-            leading: ['--hero-accent-hover', '--hero-button-hover-bg'],
+            // --btn-hover-border-color / --btn-hover-bg join at the positions their resting
+            // counterparts hold in the rest twin above (#539).
+            leading: ['--hero-accent-hover', '--btn-hover-border-color', '--hero-button-hover-bg', '--btn-hover-bg'],
         },
     ];
 
@@ -3461,7 +3572,11 @@ describe('CSS lint: the filled second button is ringed on overlay bands (#543)',
         { sel: CTA2_RING, base: CTA2_BASE, terminal: '--color-accent',
           leading: ['--cta-button2-border', '--btn-border-color', '--cta-button2-bg', '--cta-accent', '--btn-bg'] },
         { sel: CTA2_RING + ':hover', base: CTA2_BASE + ':hover', terminal: '--color-accent-hover',
-          leading: ['--cta-button2-hover-border', '--cta-accent-hover', '--cta-button2-hover-bg'] },
+          // #539's global hover tier joins at the positions the resting knobs hold in the rest
+          // row above: --btn-hover-border-color right after the button's own hover border slot,
+          // --btn-hover-bg at the tail of the border-follows-fill link. #538's Option-3 order
+          // (--cta-accent-hover ahead of the hover fill) is preserved verbatim between them.
+          leading: ['--cta-button2-hover-border', '--btn-hover-border-color', '--cta-accent-hover', '--cta-button2-hover-bg', '--btn-hover-bg'] },
         { sel: HERO2_RING, base: HERO2_BASE, terminal: '--color-accent',
           leading: ['--hero-cta2-border', '--hero-accent', '--hero-cta2-bg'] },
         { sel: HERO2_RING + ':hover', base: HERO2_BASE + ':hover', terminal: '--color-accent-hover',
@@ -3801,5 +3916,219 @@ describe('CSS lint: dark-band focus ring routes through the AA accent roles (#54
     test('the roles these rules depend on are declared in base.css :root', () => {
         expect(BASE_CSS).toMatch(/--color-accent-on-inverted:\s*#[0-9a-fA-F]{6}/);
         expect(BASE_CSS).toMatch(/--color-accent-on-overlay:\s*#[0-9a-fA-F]{6}/);
+    });
+});
+
+/**
+ * CSS lint: the GLOBAL button hover tier (#539).
+ *
+ * #458 gave the theme four site-wide button knobs; #530 gave every filled surface a
+ * per-instance HOVER fill slot. Between them sat the gap this issue closes: the global tier
+ * was resting-state only, so an operator who rethemed every button with --btn-bg /
+ * --btn-border-color got their brand at rest and the theme's premium accent gradient back the
+ * moment a pointer touched any button on the site.
+ *
+ * The fix is deliberately NOT "add the tier to the two shared premium hover rules". That
+ * would not work. The premium hover rule owns background-IMAGE, but the component hover
+ * rules outrank it on background-COLOR:
+ *
+ *     .hero .btn:not(x):not(y):not(z):hover          [0,6,0]  <- decides background-color
+ *     .cta  .btn:not(x):not(y):not(z):hover          [0,6,0]  <- decides background-color
+ *     main  .btn:not(x):not(y):not(z):hover          [0,5,1]  <- decides background-image
+ *
+ * Today the gradient image masks whatever the component rules compute. The instant
+ * --btn-hover-bg resolves the premium shorthand to a flat colour, background-image becomes
+ * `none` and the component declaration becomes the visible pixel — still resolving to
+ * --color-accent-hover if the tier is missing there. So the knob must appear in EVERY hover
+ * chain whose resting twin routes the global resting tier, at the SAME relative position.
+ * These are exact-value pins: the whole contract is chain ORDER, so a reorder must fail.
+ */
+describe('CSS lint: global button hover tier (#539)', () => {
+    // Comments are stripped first: several of these rules carry long docblocks directly
+    // above them, which defeats a "preceded by } or start-of-file" selector match.
+    const NO_COMMENTS = COMPONENTS_CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+    const bodiesFor = (sel) => {
+        const want = sel.replace(/\s+/g, ' ').trim();
+        const out = [];
+        const re = /([^{}]+)\{([^{}]*)\}/g;
+        let m;
+        while ((m = re.exec(NO_COMMENTS)) !== null) {
+            if (m[1].replace(/\s+/g, ' ').trim() === want) out.push(m[2]);
+        }
+        return out;
+    };
+    // Several selectors (notably the premium primary) are declared TWICE — a superseded rule
+    // and the "true final cascade" winner. `last` is the live winner in every such pair.
+    const bodyFor = (sel) => {
+        const all = bodiesFor(sel);
+        return all.length ? all[all.length - 1] : null;
+    };
+    const NOT3 = ':not(.btn--outline):not(.btn--ghost):not(.btn--secondary)';
+
+    // Each entry: the hover rule, and the EXACT chains it must declare. Written out in full
+    // rather than assembled, so the pin is readable as the contract itself.
+    const CHAINS = [
+        {
+            what: 'bare .btn (the live hover winner OUTSIDE main — header/footer buttons)',
+            sel: '.btn:hover',
+            decls: [
+                'background-color: var(--btn-hover-bg, var(--color-accent-hover));',
+                'border-color: var(--btn-hover-border-color, var(--color-accent-hover));',
+            ],
+        },
+        {
+            what: 'hero primary (background-COLOR winner at [0,6,0])',
+            sel: '.hero .btn' + NOT3 + ':hover',
+            decls: [
+                'background-color: var(--hero-button-hover-bg, var(--hero-accent-hover, var(--btn-hover-bg, var(--color-accent-hover))));',
+                'border-color: var(--hero-accent-hover, var(--btn-hover-border-color, var(--hero-button-hover-bg, var(--btn-hover-bg, var(--color-accent-hover)))));',
+            ],
+        },
+        {
+            what: 'cta primary (background-COLOR winner at [0,6,0])',
+            sel: '.cta .btn' + NOT3 + ':hover',
+            decls: [
+                'background-color: var(--cta-button-hover-bg, var(--cta-accent-hover, var(--btn-hover-bg, var(--color-accent-hover))));',
+                'border-color: var(--cta-button-hover-border, var(--btn-hover-border-color, var(--cta-button-hover-bg, var(--cta-accent-hover, var(--btn-hover-bg, var(--color-accent-hover))))));',
+            ],
+        },
+        {
+            what: 'cta second button (isolated from the primary since #530)',
+            sel: '.cta .cta__buttons .cta__button--secondary' + NOT3 + ':hover',
+            decls: [
+                'background-color: var(--cta-button2-hover-bg, var(--cta-accent-hover, var(--btn-hover-bg, var(--color-accent-hover))));',
+            ],
+        },
+        {
+            what: 'the shared premium hover rule (background-IMAGE winner; the panel CTA\'s only fill winner)',
+            sel: 'main .btn' + NOT3 + ':hover',
+            decls: [
+                'var(--hero-button-hover-bg, var(--cta-button-hover-bg, var(--btn-hover-bg,',
+            ],
+        },
+    ];
+
+    CHAINS.forEach(({ what, sel, decls }) => {
+        test(`${what}: routes the global hover tier below every per-instance slot`, () => {
+            const body = bodyFor(sel);
+            expect(body).not.toBeNull();
+            decls.forEach(d => expect(body.replace(/\s+/g, ' ')).toContain(d.replace(/\s+/g, ' ')));
+        });
+    });
+
+    /*
+     * Cross-property precedence, pinned in the LOSING direction (red-team finding).
+     *
+     * In every border chain --btn-hover-border-color sits below the per-instance hover BORDER
+     * slot and ABOVE the per-instance hover FILL slot. That asymmetry is deliberate — an
+     * explicitly authored global ring beats a ring merely inferred from someone's fill, and it
+     * mirrors --btn-border-color at rest — but it is exactly the kind of ordering a later
+     * "make the globals sit below every per-instance slot" tidy-up would silently invert,
+     * which would hand authored fills their ring back and change shipped renders.
+     */
+    const BORDER_ORDER = [
+        { sel: '.cta .btn' + NOT3 + ':hover', fill: '--cta-button-hover-bg', own: '--cta-button-hover-border' },
+        { sel: '.cta .cta__buttons .cta__button--secondary' + NOT3 + ':hover', fill: '--cta-button2-hover-bg', own: '--cta-button2-hover-border' },
+        { sel: '.hero .btn' + NOT3 + ':hover', fill: '--hero-button-hover-bg', own: null },
+    ];
+
+    BORDER_ORDER.forEach(({ sel, fill, own }) => {
+        test(`${sel}: the global hover ring outranks the per-instance hover FILL link`, () => {
+            const body = bodyFor(sel);
+            expect(body).not.toBeNull();
+            const chain = body.match(/border-color\s*:([^;]+)/)[1];
+            const order = chain.match(/--[a-z0-9-]+/g);
+            const iGlobal = order.indexOf('--btn-hover-border-color');
+            const iFill = order.indexOf(fill);
+            expect(iGlobal).toBeGreaterThan(-1);
+            expect(iFill).toBeGreaterThan(-1);
+            // Global ring BEFORE the border-follows-fill link.
+            expect(iGlobal).toBeLessThan(iFill);
+            // ...but AFTER the button's own hover border slot, where it has one.
+            if (own) {
+                const iOwn = order.indexOf(own);
+                expect(iOwn).toBeGreaterThan(-1);
+                expect(iOwn).toBeLessThan(iGlobal);
+            }
+        });
+    });
+
+    test('BOTH premium hover rules carry the tier, so the superseded one cannot drift', () => {
+        // #514/#530 keep the superseded and the live premium rules uniform on purpose: the
+        // superseded one is the shape a reader hits first, so a drifted copy teaches the wrong
+        // chain. Two `background:` declarations must route --btn-hover-bg.
+        // Matched against the comment-stripped source: these rules carry docblocks that quote
+        // chain shapes verbatim, so counting against the raw file would trip on documentation.
+        const hits = NO_COMMENTS.match(/background:\s*var\(--hero-button-hover-bg,\s*var\(--cta-button-hover-bg,\s*var\(--btn-hover-bg,/g);
+        expect(hits).not.toBeNull();
+        expect(hits.length).toBe(2);
+    });
+
+    /*
+     * The global hover RING reaches the outline variant, and that is load-bearing to pin.
+     * `.btn--outline:hover` repaints background-color and color but declares NO border-color,
+     * so `.btn:hover`'s border-color is its ring. That mirrors REST exactly (`.btn--outline`
+     * also declares no border-color, so --btn-border-color already rings it), which is the
+     * whole justification for putting the knob in the shared rule. If someone gives
+     * `.btn--outline:hover` its own border-color, or moves it ABOVE `.btn:hover`, the global
+     * ring silently stops reaching outline buttons site-wide and no other assertion notices.
+     */
+    test('the outline variant inherits the global hover ring from .btn:hover', () => {
+        const outlineHover = bodyFor('.btn--outline:hover');
+        expect(outlineHover).not.toBeNull();
+        // It must NOT declare its own border-color, or it would shadow the global ring.
+        expect(outlineHover).not.toMatch(/border-color\s*:/);
+        // ...and it must FOLLOW `.btn:hover` in source order (equal specificity [0,2,0]).
+        const iBase = NO_COMMENTS.indexOf('.btn:hover');
+        const iOutline = NO_COMMENTS.indexOf('.btn--outline:hover');
+        expect(iBase).toBeGreaterThan(-1);
+        expect(iOutline).toBeGreaterThan(iBase);
+    });
+
+    test('the global hover fill NEVER enters a border chain in the premium rule', () => {
+        // Border is INDEPENDENT of the fill in `main .btn:not(...)` at rest (it routes
+        // --btn-border-color but deliberately does not follow --btn-bg, matching the bare .btn
+        // primitive). The hover twin must keep that independence, or a fill-only site retheme
+        // silently starts moving the premium ring too.
+        const body = bodyFor('main .btn' + NOT3 + ':hover');
+        expect(body).not.toBeNull();
+        const border = body.match(/border-color\s*:([^;]+)/)[1];
+        expect(border).toContain('--btn-hover-border-color');
+        expect(border).not.toContain('--btn-hover-bg');
+    });
+
+    /*
+     * NEGATIVE PIN — the hero's SECOND cta's OWN chains stay out of the global tier, in BOTH
+     * states.
+     *
+     * Read this pin precisely, because the rendered behaviour is NOT "the global tier does not
+     * reach that button". It does reach it, through the SHARED premium rule, where a flat
+     * value resolves the `background` shorthand and clears the gradient background-IMAGE —
+     * while this button's own [0,7,0] background-COLOR rule keeps painting --color-accent /
+     * --color-accent-hover. Net: a site-wide retheme renders a filled hero cta2 flat-accent,
+     * not brand-coloured. Verified in a browser, both states.
+     *
+     * That is pre-existing and not this tier's doing: --btn-bg alone already strips the cta2's
+     * REST gradient today. What the hover knob adds is the same treatment on hover, so the
+     * button is at least consistent with itself instead of stripped at rest and gradient on
+     * hover. The real fix routes the global tier through the cta2's OWN chains in BOTH states
+     * and is tracked separately; when it lands, this pin must be updated deliberately.
+     *
+     * So what is asserted here is chain MEMBERSHIP, not rendered isolation: hover must not
+     * gain a global link while rest lacks one, which would make a site setting both knobs
+     * render --color-accent at rest and flash to the operator's colour on hover.
+     */
+    test('hero cta2 own chains stay free of the global tier while their rest twins are', () => {
+        const restBody = bodyFor('.hero .hero__cta-group .hero__cta--secondary' + NOT3);
+        const hoverBody = bodyFor('.hero .hero__cta-group .hero__cta--secondary' + NOT3 + ':hover');
+        expect(restBody).not.toBeNull();
+        expect(hoverBody).not.toBeNull();
+
+        // Premise: the REST twin routes neither global resting knob.
+        expect(restBody).not.toContain('--btn-bg');
+        expect(restBody).not.toContain('--btn-border-color');
+        // Therefore the hover twin routes neither global hover knob.
+        expect(hoverBody).not.toContain('--btn-hover-bg');
+        expect(hoverBody).not.toContain('--btn-hover-border-color');
     });
 });


### PR DESCRIPTION
Closes #539

## Scope

Adds the two global button HOVER tokens and threads them into every hover chain whose resting twin already routes the resting equivalents.

- `--btn-hover-bg` and `--btn-hover-border-color` in `assets/css/base.css`, both `initial`, both settable via `update_design_token`.
- Ten chains in `assets/css/components.css` gain the tier at the same relative position their resting counterparts hold in that rule's own rest twin. No chain reordered.

**Why not just the two shared premium hover rules** (the issue's suggested direction): that alone produces a knob that is dead on the hero and cta primaries. `main .btn:not(...):hover` is `[0,5,1]` and owns `background-image`; `.hero .btn:not(...):hover` and `.cta .btn:not(...):hover` are `[0,6,0]` and own `background-color`. The gradient currently masks whatever those component rules compute. Clear it from the premium rule only, and the component declaration becomes the visible pixel while still resolving `--color-accent-hover`. Verified in a browser before implementing.

## 7A question

**Asked:** what is the knob set — `--btn-hover-bg` alone, or the full hover mirror of #458's four global knobs? All four resting knobs die on hover, not just fill.

**Answered (orchestrator, binding, [issuecomment-5096679003](https://github.com/FJCF76/PromptingPress/issues/539#issuecomment-5096679003)):** Option 2, `--btn-hover-bg` + `--btn-hover-border-color`. Ink and shadow are out of scope and filed separately (#555, #556). Panel CTA gets global hover coverage; no chain reordering. Implemented exactly as resolved.

## Validation

- PHP `./vendor/bin/phpunit --configuration phpunit.xml` — **2532 pass** (baseline 2528; 3 warnings / 2 deprecations, identical to an unmodified tree).
- JS `npm test` — **981 pass** (baseline 961).
- E2E: 5 new specs in `tests/e2e/style-render.spec.ts`, all collect and typecheck. Not run locally (wp-env); they run on post-merge main.
- Rendered verification in Chromium against the real stylesheets, all five filled surfaces plus bare buttons, rest and hover, at 1280 and 375 including a wrapped-copy stress variant.

**Byte-identity when unset** — patched vs unpatched, every surface, both states, identical:

| surface | unset hover fill | unset hover gradient |
|---|---|---|
| hero primary / cta primary / cta button2 | `rgb(36,71,223)` | present |
| panel CTA | `rgba(0,0,0,0)` | present |
| bare `.btn` | `rgb(36,71,223)` | n/a |

**Precedence per tier**, with `--btn-hover-bg: rgb(1,2,3)` / `--btn-hover-border-color: rgb(7,8,9)` and per-instance slots set on hero + cta:

| surface | per-instance set | global only |
|---|---|---|
| hero primary | `rgb(200,0,0)` | `rgb(1,2,3)` |
| cta primary | fill `rgb(0,200,0)`, border `rgb(60,70,80)` | `rgb(1,2,3)` / `rgb(7,8,9)` |
| cta button2 | — | `rgb(1,2,3)` / `rgb(7,8,9)` |
| panel CTA | — | `rgb(1,2,3)` / `rgb(7,8,9)` |

In every set case the gradient is cleared (`background-image: none`), which is the mechanism that makes the knob visible.

## Accepted limitations

- **The hero's second CTA is not painted by the global tier, in either state.** Its own chains route `--hero-cta2-*` and never routed `--btn-bg`. It IS reached through the shared premium rule, where a flat value clears its gradient while its own `[0,7,0]` rule keeps painting the accent — so a site-wide retheme renders it flat-accent rather than brand. This is pre-existing: `--btn-bg` alone already does exactly this to its resting state on `main` today. Mirroring it onto hover leaves the button consistent with itself instead of stripped at rest and gradient on hover. Documented, pinned in both the CSS lint and the E2E, and evidence added to #554 which tracks the real fix.
- **No global hover ink** (#555), so hover label ink reverts to `--color-bg` on the primaries. `retheme.md` tells authors to check `--btn-hover-bg` contrast against `--color-bg`.
- **No global hover elevation** (#556): `--btn-shadow: none` flattens rest and the bevel returns on hover.
- `--btn-hover-border-color` rings the `outline` variant (whose `:hover` declares no border), mirroring `--btn-border-color` at rest. Its hover fill is unrouted, so an outline button hovers to the theme accent wearing the operator's ring. Documented and pinned.

## Review

`/plan-eng-review` and `/review` both ran on this content. `/review` dispatched 4 specialists + red team + a Codex adversarial pass: 16 findings, all resolved. Three were serious and all three are fixed in the feature commit:

1. **Codex** caught a premature `*/` I introduced in `base.css` during a review fix, which left ~10 lines of prose as raw CSS inside `:root`. Fixed; browser-verified that every token after the block still resolves. A balanced-delimiter lint guard now exists.
2. **Red team** caught that a comment containing literal `--btn-shadow: none` registers a phantom design token, because the registry regex (`lib/apply.php:973`) runs over the raw `:root` block with comments un-stripped. Reproduced with the real regex, fixed, and guarded.
3. **Two specialists independently** caught that the hero cta2 is reached by the premium rule (see limitations above); the claim was corrected everywhere and the real outcome is now pinned rather than skipped.
