### PR TITLE
Release v1.12.0: button interaction & accessibility rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.12.0] — 2026-07-28 — button interaction & accessibility: every button state is consistent, legible, and honest (rollup)
+
+**v1.12.0 is the rollup release of the Button Interaction & Accessibility gate — nine working versions (1.11.1–1.11.9) verified as one line.** The second buttons' hover ring follows their hover fill (#538) and the cta primary's hover chain now agrees with every sibling (#548); the keyboard focus ring routes through the dark-band accent roles, taking it from sub-3:1 to 8.33:1 / 4.59:1 (#542); the filled second button gains the same overlay separation ring as its primary, rest and hover (#543); the global tier gains `--btn-hover-bg` / `--btn-hover-border-color` so a site-wide retheme survives hover (#539), and the hero's cta2 chains carry the global links its siblings already had (#554); the outline/ghost/secondary panel CTA is legible on dark bands (~1.02:1 → 5.14:1, #551); author-written `.btn` markup inside rich-text props no longer inherits component fill slots (#545); and a hover-only fill no longer flashes an off-brand colour mid-transition — fill and ring snap on filled premium buttons while shadow, ink and lift keep animating (#540).
+
+No code changes in this release beyond the version bump — see the [v1.11.1]…[v1.11.9] entries below for the substance.
+
 ## [v1.11.9] — 2026-07-28 — a hover fill no longer flashes a colour you never picked (#540)
 
 **Give a filled button a brand hover colour and, for about an eighth of a second, it rendered something else: a violet on the way to red, a muddy slate on the way from teal. A colour nobody chose, on the way to the one you did.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.11.9-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.12.0-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.11.9');
+define('PP_VERSION', '1.12.0');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.11.9",
+  "version": "1.12.0",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.11.9
+Stable tag: 1.12.0
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.11.9
+Version:          1.12.0
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later


### PR DESCRIPTION
Rollup release PR for the v1.12.0 "Button Interaction & Accessibility" gate.

Verified working versions folded into this line:
- **1.11.1** — #538: hover border follows hover fill on second buttons, Option 3 (PR #550, 7c94122)
- **1.11.2** — #542: keyboard focus ring routed through dark-band accent roles, WCAG 1.4.11 (PR #552, 69aaa31)
- **1.11.3** — #543: separation ring on filled second buttons, rest+hover twins (PR #553, 3173625)
- **1.11.4** — #539: global `--btn-hover-bg` + `--btn-hover-border-color` tier (PR #557, c2b47b6)
- **1.11.5** — #548: cta primary hover chain aligned with Option-3 sibling order (PR #558, 3a05630)
- **1.11.6** — #551: panel CTA band-ink carve-out, ~1.02:1 → ≥5.14:1 (PR #559, 1c05644)
- **1.11.7** — #554: hero cta2 global-tier parity, rest+hover (PR #560, d0ad158)
- **1.11.8** — #545: nested-button fill-slot isolation via neutralisation rule (PR #561, 1943c7b)
- **1.11.9** — #540: hover fill/ring snap on filled premium buttons, zero off-brand frames (PR #562, 3ae1c63)

This PR contains only the five-file version bump to 1.12.0 and the rollup CHANGELOG entry. `scripts/package.sh` validates the sync.

Milestone v1.12.0: all 9 issues closed (three maintainer decisions + two orchestrator 7A resolutions recorded on their issues). Follow-ups deliberately outside this line: #549/#541/#531/#508 (design-first), #555, #556 (unmilestoned).