### PR TITLE
v1.12.17 fix: remove the unbounded Levenshtein style-slot repair in the AI chat preview path (#607)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -695,7 +695,6 @@ On Apply, all of a proposal's steps execute in a single request to `wp_ajax_pp_a
 | `pp_ai_get_connector_models($provider_id)` | Queries WP 7.0 `ProviderRegistry` for text-generation models of a provider |
 | `pp_ai_get_provider_models($provider_id)` | Models for a provider, falling back to the hardcoded default when the registry is empty |
 | `pp_ai_parse_error_response($code, $body)` | Parses an HTTP error into a user-facing message with a "Settings → Connectors" hint |
-| `_pp_attempt_style_repair(string $error_code, array $params)` | Levenshtein-based fuzzy match for misspelled slot names (threshold ≤ 3). Returns repair suggestion array or null |
 | `_pp_build_friendly_error(WP_Error $error, array $params)` | Structured error builder returning `{error_code, user_message, alternatives, cross_component_hints, raw_error}` |
 | (cross-component slot search) | Inline logic in `_pp_build_friendly_error()` that searches all registered components for slots matching invalid names. Produces `cross_component_hints` in the error response |
 | `_pp_suggest_alternative_value(string $type, string $description, string $default)` | CSS keyword detection with contextual alternative suggestions. Returns suggestion string or null |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.12.17] — 2026-08-09 — a misspelled style slot is rejected by name instead of silently swapped for another one (#607)
+
+**The AI chat preview no longer guesses what you meant. When a `style_component` proposal named a style slot the component does not declare, the preview path used to rewrite the name to the nearest declared slot by Levenshtein distance — up to 40% of the name's length, so a 20-character slot admitted an 8-character rewrite — and return a preview of that DIFFERENT slot flagged only `repaired: true`. It is removed. An undeclared slot name is now `invalid_style_slot`, the same verdict every other surface in the theme reports, and the error names the slot you actually wrote alongside the ones that exist.**
+
+This was the loosest normalization mechanism left in the theme, and the only one with no closed vocabulary behind it: the accepted set was "whatever is within 40% edit distance and unambiguous", which is a guess, not a contract. It also ran in the one place where guessing is most expensive. The author asked for slot A, was shown a rendered preview of slot B, and got a bare boolean saying something had been repaired — no rejected name, no substituted name, no way to learn the real vocabulary. The better mechanism was already sitting on the same code path: `_pp_build_friendly_error()` returns the rejected name, the declared names, and a cross-component hint when the slot lives on a different component. That is the one that teaches. The repair was the one that hid.
+
+Nothing that worked stops working. The substitution never survived the preview: `executeProposal` sends the proposal's original params, so an Apply that followed a "repaired" preview re-sent the misspelled slot and failed at execute time anyway. The old path showed a preview that could not be applied. This release moves that failure earlier and makes it honest.
+
+Fresh generation is unaffected, and was never the beneficiary. The runtime catalog advertises each component's declared slots verbatim and already instructed the model that the slot it targets must exist on the component's schema, so a correct proposal never reached the repair. Nothing in `AI_CONTEXT.md`, `AI_RULES.md`, `ai-instructions/` or the runtime context ever promised typo repair to an author or to the model — the behaviour was undocumented, which is part of why it could drift this far.
+
+**What breaks, stated plainly.** A `style_component` proposal carrying a near-miss slot name (`--hero-bgs` for `--hero-bg`) previously previewed successfully against the corrected slot; it now fails preview with `invalid_style_slot`. In a multi-step proposal that failure blocks the Apply button for every step, as any failed preview always has. Validators are untouched, the #330 render boundary is untouched, and no stored composition changes meaning.
+
+### Removed
+
+- `_pp_attempt_style_repair()` (`lib/ai-chat.php`) and its `── Style Repair Helper ──` banner: the `levenshtein()` sweep over every declared slot, the `max(3, ceil(strlen($slot) * 0.4))` threshold, the tie guard, and the substituted-params return.
+- The repair-and-retry block in the `wp_ajax_pp_ai_preview` handler, including the second `pp_preview_action`/`pp_preview_apply` call and the `repaired` flag it set on the retried preview. No preview response carries that key on any path now.
+- The `_pp_attempt_style_repair` row from `AI_CONTEXT.md`'s AI-chat function reference.
+
+### Fixed
+
+- The `style_component` error branch in the preview handler now ends in an explicit `return`, so the structured error and the plain-message fallback below it stay mutually exclusive without depending on `wp_send_json_error()` terminating through `wp_die()`.
+
+### Kept, deliberately
+
+- `_pp_resolve_component_index_for_error()` stays. The repair was one of its callers; `_pp_build_friendly_error()` is the other three, and it still owns the #123 rule that `component_id` beats `component_index`.
+
+### Docs
+
+- The raw-params docblock in `lib/ai-chat.php` and its cross-file twin on `_pp_resolve_component_id_to_index()` (`lib/actions.php`) name a single chat-side error helper instead of a plural "error/repair helpers".
+- The `_pp_component_target_not_found()` docblock no longer sends the reader toward a "repair attempt" that no longer exists, and the preview handler records why the structured payload stays scoped to `style_component`.
+- `assets/js/pp-ai-chat.js` labels the structured error by its actual producer, `_pp_build_friendly_error`. The client never read the `repaired` flag, so no rendering changed.
+
+### Tests
+
+- The removal is pinned structurally, not by symbol name. The preview handler is a closure registered through `add_action`, which is a no-op in the test bootstrap, so its body is unreachable from PHPUnit; the test slices the `style_component` branch out of the source and asserts both what must be there (`wp_send_json_error`, `_pp_build_friendly_error`) and what must not (`wp_send_json_success`, any re-preview call, any `repaired` key, case-insensitive). A repair hop reintroduced under a different name or with different quoting fails it. Verified by restoring the pre-change file and confirming the test goes red.
+- An undeclared slot is pinned through the real surface — `pp_preview_action('style_component', ...)`, through the validator — as `invalid_style_slot` whose message names the slot the author wrote, and the friendly error's `alternatives` is asserted equal to the component's full declared slot set.
+- The happy path is pinned: a declared slot still previews, and the preview array has no `repaired` key.
+- The eight tests that pinned the Levenshtein heuristic are gone with it. The one contract among them not already covered elsewhere — `component_id` winning over a stale, conflicting `component_index` — is re-pinned twice: directly on `_pp_resolve_component_index_for_error()`, and through `_pp_build_friendly_error()`.
+
+---
+
 ## [v1.12.16] — 2026-08-09 — the `theme: "dark"` input value is gone; the emitted `--dark` class stays (#605)
 
 **`dark` was the last legacy VALUE any prop accepted at write, and the only one whose name mispredicted its own output: `theme: "dark"` rendered a LIGHT band. It is removed. `theme` now accepts exactly `default | muted | inverted`, the strict-enum gate (#579) rejects everything else, and the value an agent writes matches the values the catalog advertises with no footnote. The CSS class `<root>--dark` that `theme: "muted"` emits is KEPT and unchanged — that is an output name, not a value anyone can write (#570 DG-4).**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-1936+_passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.12.16-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.12.17-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/js/pp-ai-chat.js
+++ b/assets/js/pp-ai-chat.js
@@ -305,7 +305,7 @@ function ppChatCompositionUndoTarget(steps) {
  * Handles structured errors (from _pp_build_friendly_error) and plain strings.
  */
 function ppChatRenderPreviewError(diffArea, data) {
-    // Structured error from style_component repair path.
+    // Structured error from _pp_build_friendly_error (style_component failures).
     if (data && typeof data === 'object' && data.user_message) {
         var msgEl = document.createElement('div');
         msgEl.className = 'pp-ai-preview-error-message';

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.12.16');
+define('PP_VERSION', '1.12.17');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/actions.php
+++ b/lib/actions.php
@@ -3142,8 +3142,8 @@ function _pp_reject_auto_draft(int $post_id) {
  *
  * Shared by _pp_resolve_id_param() below (mutates $params for action
  * validate callables) and _pp_resolve_component_index_for_error() in
- * lib/ai-chat.php (the chat-side error/repair helpers, which run on raw
- * AI-submitted params and never see the mutation the former makes) — one
+ * lib/ai-chat.php (the chat-side error helper, which runs on raw
+ * AI-submitted params and never sees the mutation the former makes) — one
  * source of truth for the id-to-index lookup so the two never drift (#123).
  *
  * @param int    $post_id      Post ID to read composition from.

--- a/lib/ai-chat.php
+++ b/lib/ai-chat.php
@@ -300,8 +300,8 @@ function pp_ai_coerce_params(string $type, string $name, array $params): array {
 // ── Component Index Resolver (chat-side error helpers) ────────────────────
 
 /**
- * Resolves the target component index for chat-side error-analysis helpers
- * (_pp_attempt_style_repair, _pp_build_friendly_error). These run on the raw
+ * Resolves the target component index for the chat-side error-analysis helper
+ * (_pp_build_friendly_error). It runs on the raw
  * AI-submitted $params — pp_validate_action()'s own component_id resolution
  * (_pp_resolve_id_param() in lib/actions.php) mutates a local copy of $params
  * inside the validate call, which never propagates back to the caller here,
@@ -320,7 +320,7 @@ function _pp_resolve_component_index_for_error(array $params): int {
         return is_wp_error($index) ? -1 : $index;
     }
     // Defense in depth: pp_validate_action() already type-checks
-    // component_index as a real int on every path that reaches these helpers
+    // component_index as a real int on every path that reaches this helper
     // today, but blindly (int)-casting here would silently coerce a garbage
     // value (e.g. a non-numeric string) to 0 — a real component — for any
     // future direct caller that skips that validation. Preserve the old
@@ -337,80 +337,10 @@ function _pp_resolve_component_index_for_error(array $params): int {
  * (both of which also produce an empty availability list). Without this
  * distinction, a typo'd component_id silently looks identical to "this
  * component genuinely has nothing configurable," misleading the calling
- * agent into the wrong repair attempt (#123 adversarial review).
+ * agent into retargeting a component that isn't there (#123 adversarial review).
  */
 function _pp_component_target_not_found(array $params, int $resolved_index): bool {
     return isset($params['component_id']) && $params['component_id'] !== '' && $resolved_index < 0;
-}
-
-// ── Style Repair Helper ───────────────────────────────────────────────────
-// When the LLM proposes an invalid style slot name, attempt to find the
-// closest match via Levenshtein distance. Returns repaired params or null.
-
-function _pp_attempt_style_repair(string $error_code, array $params): ?array {
-    if ($error_code !== 'invalid_style_slot') {
-        return null;
-    }
-
-    $style = $params['style'] ?? [];
-    if (empty($style) || !is_array($style)) {
-        return null;
-    }
-
-    $post_id         = $params['post_id'] ?? 0;
-    $component_index = _pp_resolve_component_index_for_error($params);
-    $composition     = pp_get_composition($post_id);
-    $component_name  = $composition[$component_index]['component'] ?? '';
-    $available_slots = pp_get_style_slots($component_name);
-
-    if (empty($available_slots)) {
-        return null;
-    }
-
-    $available_names = array_keys($available_slots);
-    $repaired        = [];
-    $did_repair      = false;
-
-    foreach ($style as $slot_name => $slot_value) {
-        if ($slot_name === '__recipe' || isset($available_slots[$slot_name])) {
-            $repaired[$slot_name] = $slot_value;
-            continue;
-        }
-
-        // Find closest match by Levenshtein distance.
-        $best_match    = null;
-        $best_distance = PHP_INT_MAX;
-        $tie_count     = 0;
-        foreach ($available_names as $candidate) {
-            $dist = levenshtein($slot_name, $candidate);
-            if ($dist < $best_distance) {
-                $best_distance = $dist;
-                $best_match    = $candidate;
-                $tie_count     = 1;
-            } elseif ($dist === $best_distance) {
-                $tie_count++;
-            }
-        }
-
-        // Accept repair only if distance is reasonable (≤ 40% of slot name length)
-        // AND the match is unambiguous (no tie with another slot at the same distance).
-        $threshold = max(3, (int) ceil(strlen($slot_name) * 0.4));
-        if ($best_match !== null && $best_distance <= $threshold && $tie_count === 1) {
-            $repaired[$best_match] = $slot_value;
-            $did_repair = true;
-        } else {
-            // No close match, or ambiguous tie — repair fails.
-            return null;
-        }
-    }
-
-    if (!$did_repair) {
-        return null;
-    }
-
-    $repaired_params          = $params;
-    $repaired_params['style'] = $repaired;
-    return $repaired_params;
 }
 
 /**
@@ -834,24 +764,19 @@ add_action('wp_ajax_pp_ai_preview', function () {
     }
 
     if (is_wp_error($result)) {
-        // For style_component errors, attempt repair before giving up.
+        // Scoped to style_component because that is the action whose validator
+        // rejections carry a slot vocabulary worth structuring (available slots,
+        // cross-component hints). Every other action reports its message as-is below.
         if ($name === 'style_component') {
-            $repaired_params = _pp_attempt_style_repair($result->get_error_code(), $params);
-            if ($repaired_params !== null) {
-                $retry = $type === 'action'
-                    ? pp_preview_action($name, $repaired_params)
-                    : pp_preview_apply($name, $repaired_params);
-
-                if (!is_wp_error($retry)) {
-                    // Repair succeeded — return preview with a repair note.
-                    $retry['repaired'] = true;
-                    wp_send_json_success($retry);
-                }
-                // Repair attempt also failed — fall through to friendly error.
-            }
-
-            // Return structured error for style_component failures.
+            // A style_component failure reports the validator's own verdict, structured
+            // for the chat UI (#607). There is deliberately no repair-and-retry hop: a
+            // slot name the component doesn't declare is invalid_style_slot, the same
+            // answer every other surface gives. The response carries the rejected name
+            // (raw_error) and the declared names (alternatives) rather than a preview of
+            // a slot the author never asked for. The explicit return keeps the two
+            // wp_send_json_error calls mutually exclusive without relying on wp_die().
             wp_send_json_error(_pp_build_friendly_error($result, $params));
+            return;
         }
 
         wp_send_json_error($result->get_error_message());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.12.16",
+  "version": "1.12.17",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.12.16
+Stable tag: 1.12.17
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.12.16
+Version:          1.12.17
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -4664,173 +4664,165 @@ class ActionsTest extends TestCase
         $this->assertSame('dark-spacious', $result[0]['available_recipes'][0]['name']);
     }
 
-    // ── Style Repair Helper ──────────────────────────────────────────────
+    // ── Misspelled Style Slots Are Rejected, Never Repaired (#607) ────────
+    //
+    // The chat preview path used to intercept invalid_style_slot and substitute
+    // the nearest declared slot by Levenshtein distance (40% of the rejected
+    // name's length), returning a preview of a DIFFERENT slot flagged only
+    // `repaired: true`. #607 removed it: a slot the component doesn't declare is
+    // invalid_style_slot, the same verdict every other surface reports.
+    //
+    //   style_component proposal
+    //     └─ pp_preview_action -> pp_validate_action
+    //          ├─ declared slot   -> preview array (NO 'repaired' key)
+    //          └─ undeclared slot -> WP_Error invalid_style_slot
+    //                                  └─ _pp_build_friendly_error
+    //                                       ├─ raw_error     names the REJECTED slot
+    //                                       └─ alternatives  names the DECLARED slots
 
-    public function testStyleRepairFixesCloseSlotName(): void
+    public function testUndeclaredStyleSlotIsRejectedNamingTheSlotTheAuthorWrote(): void
     {
-        $post_id = pp_create_page('Repair test');
+        $post_id = pp_create_page('Reject test');
         pp_update_composition($post_id, [
             ['component' => 'hero', 'props' => ['title' => 'Hi']],
         ]);
 
-        // --hero-backgroud (typo) should be repaired to --hero-bg.
-        // Levenshtein distance is too large for that example.
-        // Use a closer typo: --hero-bgs → --hero-bg (distance 1).
-        $repaired = _pp_attempt_style_repair('invalid_style_slot', [
+        // --hero-bgs is one edit from --hero-bg: exactly the case the removed
+        // repair used to substitute silently. It is now simply invalid.
+        $result = pp_preview_action('style_component', [
             'post_id'         => $post_id,
             'component_index' => 0,
             'style'           => ['--hero-bgs' => '#1a1a2e'],
         ]);
 
-        $this->assertNotNull($repaired, 'Repair should succeed for close typo.');
-        $this->assertArrayHasKey('--hero-bg', $repaired['style']);
-        $this->assertSame('#1a1a2e', $repaired['style']['--hero-bg']);
+        $this->assertInstanceOf(WP_Error::class, $result, 'A misspelled slot must not preview.');
+        $this->assertSame('invalid_style_slot', $result->get_error_code());
+        $this->assertStringContainsString(
+            '--hero-bgs',
+            $result->get_error_message(),
+            'The validator names the slot the author actually wrote.'
+        );
     }
 
-    public function testStyleRepairRejectsDistantSlotName(): void
+    public function testFriendlyErrorForMisspelledSlotNamesRejectedSlotAndKeepsAlternatives(): void
     {
-        $post_id = pp_create_page('Repair test');
+        // The chat preview handler's whole style_component error branch after
+        // #607: the validator's verdict, structured for the UI. raw_error is the
+        // teaching surface (it carries the rejected name); alternatives is
+        // unchanged by the removal.
+        $post_id = pp_create_page('Reject test');
         pp_update_composition($post_id, [
             ['component' => 'hero', 'props' => ['title' => 'Hi']],
         ]);
 
-        // --hero-display is not close to any hero slot.
-        $repaired = _pp_attempt_style_repair('invalid_style_slot', [
-            'post_id'         => $post_id,
-            'component_index' => 0,
-            'style'           => ['--hero-display' => 'none'],
-        ]);
-
-        $this->assertNull($repaired, 'Repair should fail for distant slot name.');
-    }
-
-    public function testStyleRepairRejectsAmbiguousTie(): void
-    {
-        // Hero has --hero-padding-top and --hero-padding-bottom.
-        // Both are distance 3 from --hero-padding-boxxx (via replace + insert).
-        // But real slots are too well-separated for a natural tie.
-        // Verify the guard structurally: the Levenshtein loop tracks tie_count
-        // and rejects when > 1. We confirm by testing with --hero-padding-,
-        // which is distance 3 from both --hero-padding-top and --hero-padding-bottom.
-        $post_id = pp_create_page('Repair test');
-        pp_update_composition($post_id, [
-            ['component' => 'hero', 'props' => ['title' => 'Hi']],
-        ]);
-
-        $top_dist    = levenshtein('--hero-padding-', '--hero-padding-top');
-        $bottom_dist = levenshtein('--hero-padding-', '--hero-padding-bottom');
-        // top=3, bottom=6 — not tied. Use a different input.
-        // --hero-padding-bop: top=2, bottom=4. Still not tied.
-        // The real slots are too well-separated for accidental ties.
-        // Assert that the tie_count guard code path exists by inspecting the
-        // function's behavior: unambiguous match succeeds, distant name fails.
-        // The guard prevents silent ambiguous repair in edge cases that would
-        // arise if new similarly-named slots are added later.
-
-        // Verify unambiguous repair still succeeds (no false positive from guard).
-        $repaired = _pp_attempt_style_repair('invalid_style_slot', [
+        $params = [
             'post_id'         => $post_id,
             'component_index' => 0,
             'style'           => ['--hero-bgs' => '#1a1a2e'],
-        ]);
-        $this->assertNotNull($repaired, 'Unambiguous repair should succeed.');
-        $this->assertArrayHasKey('--hero-bg', $repaired['style']);
+        ];
+        $error  = pp_preview_action('style_component', $params);
+        $this->assertInstanceOf(WP_Error::class, $error);
+
+        $friendly = _pp_build_friendly_error($error, $params);
+
+        $this->assertSame('invalid_style_slot', $friendly['error_code']);
+        $this->assertStringContainsString(
+            '--hero-bgs',
+            $friendly['raw_error'],
+            'The rejected slot name must reach the author verbatim.'
+        );
+        $this->assertSame(
+            array_keys(pp_get_style_slots('hero')),
+            $friendly['alternatives'],
+            'The alternatives list is the declared slot set, unchanged by #607.'
+        );
+        $this->assertContains('--hero-bg', $friendly['alternatives']);
     }
 
-    public function testStyleRepairIgnoresNonSlotErrors(): void
+    public function testDeclaredStyleSlotStillPreviews(): void
     {
-        $repaired = _pp_attempt_style_repair('invalid_style_value', [
-            'post_id'         => 1,
-            'component_index' => 0,
-            'style'           => ['--hero-bg' => 'bad'],
-        ]);
-
-        $this->assertNull($repaired, 'Repair should only handle invalid_style_slot errors.');
-    }
-
-    public function testStyleRepairPreservesValidSlots(): void
-    {
-        $post_id = pp_create_page('Repair test');
+        // AC#4: the happy path is untouched by the removal. The no-'repaired'
+        // assertion here documents the preview array's shape; it is NOT the
+        // regression guard for #607, because pp_preview_action never set that key
+        // on any path — only the deleted AJAX retry branch did. The guard for the
+        // removal itself lives in
+        // testPreviewStyleComponentBranchOnlyReportsTheValidatorVerdict.
+        $post_id = pp_create_page('Happy path test');
         pp_update_composition($post_id, [
             ['component' => 'hero', 'props' => ['title' => 'Hi']],
         ]);
 
-        // Mix of valid slot + typo.
-        $repaired = _pp_attempt_style_repair('invalid_style_slot', [
+        $preview = pp_preview_action('style_component', [
             'post_id'         => $post_id,
             'component_index' => 0,
-            'style'           => [
-                '--hero-bg'           => '#ffffff',
-                '--hero-heading-colr' => '#000000', // typo for --hero-heading-color
-            ],
+            'style'           => ['--hero-bg' => '#1a1a2e'],
         ]);
 
-        $this->assertNotNull($repaired);
-        $this->assertArrayHasKey('--hero-bg', $repaired['style']);
-        $this->assertArrayHasKey('--hero-heading-color', $repaired['style']);
-        $this->assertSame('#ffffff', $repaired['style']['--hero-bg']);
-        $this->assertSame('#000000', $repaired['style']['--hero-heading-color']);
+        $this->assertNotInstanceOf(WP_Error::class, $preview, 'A declared slot must still preview.');
+        $this->assertIsArray($preview);
+        $this->assertArrayNotHasKey('repaired', $preview);
     }
 
-    public function testStyleRepairResolvesComponentIdNotJustIndexZero(): void
+    public function testPreviewStyleComponentBranchOnlyReportsTheValidatorVerdict(): void
     {
-        // #123 regression: composition [0]=nav (no style slots), [1]=hero
-        // (id pp-a1b2c3d4). An id-targeted proposal with a typo'd hero slot
-        // must repair against the hero component, not silently look up nav
-        // at index 0 and fail with "no available slots".
-        $post_id = pp_create_page('Id Repair test');
+        // The preview AJAX handler is a closure registered through add_action,
+        // which is a no-op in this bootstrap, so its body is unreachable from
+        // PHPUnit. Pin it at the source level instead (same technique as the
+        // lib/cli.php gate invariant, tests/CliGateTest.php).
+        //
+        // Assert on the style_component BRANCH, not on the whole file, and assert
+        // the POSITIVE shape as well as the negative one. A tripwire that only
+        // greps for the old helper's name is defeated by a repair hop reintroduced
+        // under any other name (similar_text/soundex/inline), or by a flag written
+        // with double quotes. What must stay true is structural: this branch
+        // reports an error and never returns a preview.
+        $src = file_get_contents(dirname(__DIR__) . '/lib/ai-chat.php');
+        $this->assertNotFalse($src);
+
+        $start = strpos($src, "if (\$name === 'style_component') {");
+        $this->assertNotFalse($start, 'The style_component error branch must exist.');
+        $end = strpos($src, "\n        }\n", $start);
+        $this->assertNotFalse($end, 'The style_component error branch must be closed.');
+        $branch = substr($src, $start, $end - $start);
+
+        // Positive: the branch's whole job is to report the validator's verdict.
+        $this->assertStringContainsString('_pp_build_friendly_error(', $branch);
+        $this->assertStringContainsString('wp_send_json_error(', $branch);
+
+        // Negative, name- and quote-agnostic: no repair-and-retry hop may re-run the
+        // preview and hand back a slot the author never asked for (#607).
+        $this->assertStringNotContainsString('wp_send_json_success', $branch);
+        $this->assertStringNotContainsString('pp_preview_action', $branch);
+        $this->assertStringNotContainsString('pp_preview_apply', $branch);
+        $this->assertDoesNotMatchRegularExpression('/repaired/i', $branch);
+
+        // The helper itself is gone, and nothing in lib/ reintroduced the heuristic.
+        $this->assertFalse(
+            function_exists('_pp_attempt_style_repair'),
+            'The Levenshtein slot repair was removed in #607.'
+        );
+        foreach (glob(dirname(__DIR__) . '/lib/*.php') as $lib_file) {
+            $lib_src = file_get_contents($lib_file);
+            $this->assertStringNotContainsString('_pp_attempt_style_repair', $lib_src, basename($lib_file));
+            $this->assertDoesNotMatchRegularExpression('/levenshtein\s*\(/i', $lib_src, basename($lib_file));
+        }
+    }
+
+    public function testResolveComponentIndexForErrorPrefersComponentIdOverStaleIndex(): void
+    {
+        // The precedence contract itself, pinned directly on the helper that
+        // owns it rather than only through a caller.
+        $post_id = pp_create_page('Direct precedence test');
         pp_update_composition($post_id, [
             ['component' => 'nav', 'props' => []],
             ['component' => 'hero', 'props' => ['id' => 'pp-a1b2c3d4', 'title' => 'Hi']],
         ]);
 
-        $repaired = _pp_attempt_style_repair('invalid_style_slot', [
-            'post_id'      => $post_id,
-            'component_id' => 'pp-a1b2c3d4',
-            'style'        => ['--hero-bgs' => '#1a1a2e'],
-        ]);
-
-        $this->assertNotNull($repaired, 'Repair should resolve the id-targeted hero component, not index 0 (nav).');
-        $this->assertArrayHasKey('--hero-bg', $repaired['style']);
-        $this->assertSame('#1a1a2e', $repaired['style']['--hero-bg']);
-    }
-
-    public function testStyleRepairReturnsNullForUnresolvableComponentId(): void
-    {
-        $post_id = pp_create_page('Bad Id Repair test');
-        pp_update_composition($post_id, [
-            ['component' => 'hero', 'props' => ['id' => 'pp-a1b2c3d4', 'title' => 'Hi']],
-        ]);
-
-        $repaired = _pp_attempt_style_repair('invalid_style_slot', [
-            'post_id'      => $post_id,
-            'component_id' => 'pp-doesnotexist',
-            'style'        => ['--hero-bgs' => '#1a1a2e'],
-        ]);
-
-        $this->assertNull($repaired, 'An unresolvable component_id must bail gracefully, not fall back to index 0.');
-    }
-
-    public function testStyleRepairPrefersComponentIdOverStaleComponentIndex(): void
-    {
-        // Proves precedence, not just presence: a stale/mismatched
-        // component_index (e.g. echoed back from a prior turn) must NOT win
-        // over an explicit component_id in the same params.
-        $post_id = pp_create_page('Precedence test');
-        pp_update_composition($post_id, [
-            ['component' => 'nav', 'props' => []],
-            ['component' => 'hero', 'props' => ['id' => 'pp-a1b2c3d4', 'title' => 'Hi']],
-        ]);
-
-        $repaired = _pp_attempt_style_repair('invalid_style_slot', [
+        $this->assertSame(1, _pp_resolve_component_index_for_error([
             'post_id'         => $post_id,
             'component_id'    => 'pp-a1b2c3d4',
-            'component_index' => 0, // stale: points at nav, id points at hero
-            'style'           => ['--hero-bgs' => '#1a1a2e'],
-        ]);
-
-        $this->assertNotNull($repaired, 'component_id must win over a conflicting component_index.');
-        $this->assertArrayHasKey('--hero-bg', $repaired['style']);
+            'component_index' => 0,
+        ]));
     }
 
     public function testResolveComponentIndexForErrorReturnsNegativeOneWithNoTarget(): void
@@ -4931,6 +4923,35 @@ class ActionsTest extends TestCase
         $this->assertStringContainsString('hero', $result['user_message']);
         $this->assertNotEmpty($result['alternatives'], 'Should list hero slots, not fail as if nav (index 0) had none.');
         $this->assertContains('--hero-bg', $result['alternatives']);
+    }
+
+    public function testFriendlyErrorPrefersComponentIdOverStaleComponentIndex(): void
+    {
+        // Proves precedence, not just presence (the sibling test above covers
+        // presence). #607 re-pinned this case here: it used to live only in the
+        // deleted style-repair block, so removing that block would otherwise have
+        // dropped the #123 guarantee that a stale/mismatched component_index —
+        // echoed back from a prior turn — never wins over an explicit component_id.
+        $post_id = pp_create_page('Precedence test');
+        pp_update_composition($post_id, [
+            ['component' => 'nav', 'props' => []],
+            ['component' => 'hero', 'props' => ['id' => 'pp-a1b2c3d4', 'title' => 'Hi']],
+        ]);
+
+        $error  = new WP_Error('invalid_style_slot', 'Component "hero" has no style slot "--hero-bgs". Available: --hero-bg, ...');
+        $result = _pp_build_friendly_error($error, [
+            'post_id'         => $post_id,
+            'component_id'    => 'pp-a1b2c3d4',
+            'component_index' => 0, // stale: points at nav, id points at hero
+            'style'           => ['--hero-bgs' => '#1a1a2e'],
+        ]);
+
+        $this->assertSame('invalid_style_slot', $result['error_code']);
+        $this->assertContains(
+            '--hero-bg',
+            $result['alternatives'],
+            'component_id must win over a conflicting component_index.'
+        );
     }
 
     public function testFriendlyErrorForUnresolvableComponentIdReportsNotFoundNotEmpty(): void


### PR DESCRIPTION
Closes #607

Removes `_pp_attempt_style_repair()`, the unbounded Levenshtein style-slot repair in the AI chat preview path. When a `style_component` proposal named a slot the component does not declare, it rewrote the name to the nearest declared slot (threshold `max(3, ceil(strlen($slot) * 0.4))`, so a 20-character slot admitted an 8-character rewrite), re-ran the preview, and returned a preview of that **different** slot flagged only `repaired: true`. An undeclared slot is now `invalid_style_slot` — the same verdict every other surface reports — and `_pp_build_friendly_error()` names the rejected slot and lists the declared ones.

Applies the governing ruling verbatim (**default REMOVE**): the mechanism fails all three retention tests. It does not make current generation more reliable, it makes *invalid* generation produce a plausible-but-different result; the accepted set is "within 40% edit distance and unambiguous", which is a guess rather than a canonicalization into one contract; and a preview of a slot the caller never asked for, labelled with a bare boolean, is strictly harder to inspect than a rejection that names the right slot.

## The audit's test-pin caveat, resolved

The issue flagged that its sweep did **not** verify this subsystem and told me to grep before editing. It was right to: **eight tests pinned the helper**, all in `tests/ActionsTest.php` under the `── Style Repair Helper ──` banner.

| Test | Disposition |
|---|---|
| `testStyleRepairFixesCloseSlotName` | Removed — pins the removed heuristic |
| `testStyleRepairRejectsDistantSlotName` | Removed — pins the removed threshold |
| `testStyleRepairRejectsAmbiguousTie` | Removed — pins the removed tie guard |
| `testStyleRepairIgnoresNonSlotErrors` | Removed — pins the removed error-code gate |
| `testStyleRepairPreservesValidSlots` | Removed — pins the removed merge behaviour |
| `testStyleRepairResolvesComponentIdNotJustIndexZero` | Removed — #123 case **already** re-covered at `testFriendlyErrorForInvalidSlotResolvesComponentIdNotIndexZero` |
| `testStyleRepairReturnsNullForUnresolvableComponentId` | Removed — #123 case **already** re-covered at `testFriendlyErrorForUnresolvableComponentIdReportsNotFoundNotEmpty` |
| `testStyleRepairPrefersComponentIdOverStaleComponentIndex` | **Re-pinned twice** — this contract (`component_id` beats a *stale, conflicting* `component_index`) lived ONLY here. Now pinned directly on `_pp_resolve_component_index_for_error()` and through `_pp_build_friendly_error()`. |
| `testResolveComponentIndexForErrorReturnsNegativeOneWithNoTarget` | **Kept** — pins the surviving resolver, filed under the banner but not about repair |

`_pp_resolve_component_index_for_error()` was checked before removal as instructed and **kept**: `_pp_build_friendly_error()` calls it in three places.

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | `_pp_attempt_style_repair` gone; `invalid_style_slot` goes direct to the friendly error | DONE |
| 2 | Misspelled slot returns a structured error naming the rejected slot, alternatives unchanged, + test | DONE |
| 3 | No validator changed (`_pp_validate_style_slot_map`, #330 boundary untouched) | DONE — the `lib/actions.php` edit is a docblock only |
| 4 | Valid slot previews identically, + regression test | DONE |
| 5 | Full PHPUnit + JS suites green | DONE |

## Client-side and documentation surfaces

`assets/js/pp-ai-chat.js` **never read** the `repaired` flag — the only trace was a stale comment, now corrected to name `_pp_build_friendly_error`. No rendering changed.

**No doc surface ever promised typo repair**, to an author or to the model. `AI_CONTEXT.md`, `AI_RULES.md`, `README.md`, `ai-instructions/*` and `lib/ai-context.php` were all swept. The runtime catalog advertises each component's declared slots verbatim (`lib/ai-context.php:98`) and already instructs the model *"**Slot exists**: The style slot you want to change actually exists on the target component's schema"* (`:233`). The behaviour was undocumented — itself part of the case for removal, as the issue anticipated. The only stale reference was the `AI_CONTEXT.md` function-table row, now removed. `readme.txt:122` and `CHANGELOG.md:4880/4905` mention the original feature but sit inside changelog history and are correctly left untouched.

## How the removal is pinned

The preview handler is a closure registered through `add_action`, a no-op in this test bootstrap, so its body is unreachable from PHPUnit. A first pass grepped the file for the old symbol name — and review proved that insufficient: **restoring the old code left 5 of 6 new tests green**, and the 6th was defeated by any rename or by a double-quoted key.

The pin now slices the `style_component` branch out of the source (same technique as `tests/CliGateTest.php:498`) and asserts both directions:

- **must contain** `wp_send_json_error(`, `_pp_build_friendly_error(`
- **must not contain** `wp_send_json_success`, `pp_preview_action`, `pp_preview_apply`, `/repaired/i`
- plus a `lib/*.php` sweep for the helper name and `levenshtein(`

**Verified by simulation:** restoring `lib/ai-chat.php` to `529c0a5` makes this test FAIL; current code passes. Name- and quote-agnostic.

## Behaviour change, stated plainly

A near-miss slot name (`--hero-bgs` for `--hero-bg`) previously previewed successfully against the corrected slot; it now fails preview with `invalid_style_slot`. In a multi-step proposal that blocks Apply for every step, as any failed preview always has.

This regresses nothing that worked. `executeProposal` sends the proposal's original `step.params` (`assets/js/pp-ai-chat.js:1044`) and nothing writes preview results back, so an Apply following a "repaired" preview re-sent the **misspelled** slot and failed at execute. The old path showed a preview that could not be applied. The failure now happens earlier and truthfully.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — **2973 tests, 13518 assertions, green.** 4 warnings / 2 deprecations, identical to an unmodified tree (`git stash` baseline), so not attributable to this change. Test count 2975 to 2973 = 8 heuristic pins removed, 6 added.
- `npm test` — **1113 tests / 19 files, green.**
- `bash scripts/package.sh` — "Version consistency: OK" across all five synced files; the zip it builds was deleted.
- Bisectability confirmed: the suite is green at the first commit alone (`c32e2fb`).
- No `/qa`: backend + validation-layer only, nothing browser-observable. No `assets/css/` change, so Section 14.5 does not apply.

## Reviews

`/plan-eng-review` (9 findings, 0 unresolved, Codex outside voice) and `/review` (15 findings across 5 specialists + red team + Claude/Codex adversarial) both ran on this exact content. One CRITICAL finding (the defeatable tripwire) was fixed and verified; the rest were auto-fixed or routed out of scope. `/document-generate` found nothing to update beyond the row already removed.

## Accepted limitations

The preview closure has no behavioural test coverage, before or after this change, because `add_action` is stubbed out. Extracting `_pp_ai_preview_response()` to mirror the existing `_pp_ai_execute_response()` (`lib/ai-chat.php`, extracted for exactly this reason per the #387 lesson) would replace the source-level pin with a real behavioural one. That is a production refactor beyond this issue's recorded decision, so it is **not** done here and is flagged for the maintainer.

## Found while working on this (filed, not fixed)

- **#625** — the chat labels a fixable slot typo "impossible" while the correct name sits in `alternatives`. Pre-existing, but this change raises its reachability sharply.
- **#626** — `_pp_build_friendly_error()` re-reads the composition (TOCTOU) and computes its invalid-slot set without recipe expansion.
- **#627** — dead `.pp-ai-preview-error-alternatives` CSS pinned by a vacuously-passing JS test.

No 7A decision was needed: every review finding either fell inside the recorded decision or was routed to one of the issues above.
