### PR TITLE
v1.13.2 fix: editor form-sync robustness

### DIFF
--- a/AI_RULES.md
+++ b/AI_RULES.md
@@ -106,6 +106,10 @@ The logic under test is in `assets/js/pp-editor-logic.js`. When editing `escapeH
 
 The read-back path carries the opposite rule: it puts nothing dynamic into a selector at all. Field names are raw composition keys, so a name can contain characters that are structural in a selector; `syncAccordionToJson` therefore resolves fields by comparing `data-comp` and `data-field` attribute values (`findByCompField`) rather than interpolating them into one. `tests/js/pp-editor-field-lookup.test.js` drives a real edit through the real debounced sync to pin that.
 
+That pair does not identify a control on its own. Prop names and array sub-keys are separate namespaces that may collide, and a shipped schema does collide (`grid` declares a top-level `title` and an `items[].title`), so a card can hold several controls answering to the same pair. A top-level prop resolves through `findScalarControl`, which delegates to `findByCompField` and then drops candidates sitting inside an array row, making the winner explicit rather than a consequence of the order props happen to be declared in.
+
+Two more rules hold on the same path. Values reach the markup through `esc(value)` and are never pre-coerced with `String(value || '')`: that idiom is falsy-based, so it blanks a stored `0` or `false`, and the next read-back takes the blank as the value. And anything that reads the JSON buffer and then re-renders from it — the six structural row handlers — calls `syncAccordionToJson.flush()` first, because the sync is debounced and an edit made inside that window is otherwise still in the DOM, unwritten, when the buffer is read. `tests/js/pp-editor-form-sync.test.js` pins all three.
+
 ## E2E tests
 
 Playwright tests in `tests/e2e/` run against a live WordPress instance via wp-env (Docker).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.13.2] — 2026-08-12 — editor: form-sync robustness
+
+**Values that are numbers or booleans now survive the composition editor's accordion, fields resolve to the control the author typed into, and an edit made a moment before a row operation is no longer dropped.** Three properties of the accordion-to-JSON sync are involved, all on the path that reads edited values back out of the DOM. A stored `0` or `false` rendered as an empty field and was read back as the empty string. A top-level prop and an array row's sub-field can carry the same name — `grid` ships a `title` and an `items[].title` — and which one answered for the prop depended on the order the schema happened to declare them in. And the sync is debounced, so an edit made within that window was still sitting in the DOM, unwritten, when a move, delete, or add read the buffer and re-rendered from it.
+
+The value fix is a deliberate correction rather than a widening. Values reach the markup through the shared escaper, which already treats only `null` and `undefined` as absent; the previous `String(value || '')` wrapper was falsy-based, so it could not tell "no value" from "the value zero". Strings render exactly as before. Field resolution now excludes controls inside an array row when resolving a top-level prop, which selects the same element document order already selected on every shipped schema — the resolution becomes a stated rule instead of a consequence of declaration order. Pending edits are settled before any handler that rebuilds the composition reads it, so the edit and the structural change both land; a handler with no edit pending settles nothing and leaves the composition byte-identical.
+
+### Fixed
+
+- **Numeric and boolean values round-trip (`assets/js/pp-admin-editor.js`).** `buildFieldHtml` renders `esc(field.value)` in both value-bearing branches, and `buildArrayFieldHtml` passes row values through unchanged, so `0` renders as `0` and `false` as `false` at both levels. Absent values still render empty.
+- **Deterministic field resolution for nested rows.** `findScalarControl` delegates to `findByCompField` and drops candidates inside a `.pp-accordion-array`, so a sub-key never answers for a top-level prop of the same name. A prop whose own control is absent is now reported and left alone rather than taking a row's value. The array-container and row lookups are unchanged.
+- **Pending edits survive row operations.** `debounce` gained a `flush` handle, and the six handlers that rebuild the composition from the buffer — component insert, move up, move down, delete, array row add, array row remove — settle any pending edit first. `flush` disarms the timer before running, so the trailing edge cannot fire a second time against the re-rendered DOM, and it does nothing when no edit is pending. A failure while settling is contained so it cannot abort the operation.
+- **The insert dropdown is no longer treated as a field.** It sits inside the accordion and matched the generic field-change handler, so choosing a component to add left a sync pending and rewrote the whole composition, marking every resolved control touched and writing schema defaults into bands the author never opened.
+- **Array guard reads item presence, not item shape (`assets/js/pp-editor-logic.js`).** `wouldLoseArrayData` asked `Object.keys(orig).length > 0` of each original, a question only an object answers, so a stored `[1, 2, 3]` read as empty and stood the guard down. Any non-empty stored array now counts. The documented limit is stated in place: the guard sees only arrays that render no row controls, so an array whose schema declares sub-keys is outside its reach.
+
+### Docs
+
+- `AI_RULES.md` records the three read-path rules alongside the existing lookup rule: prop names and sub-keys are separate namespaces that can collide, values are never pre-coerced with a falsy default, and a handler that reads the buffer settles pending edits first.
+- `README.md` lists form sync in the JS unit-test coverage summary.
+
+### Tests
+
+- `tests/js/pp-editor-form-sync.test.js` (new, 52 cases) boots the real `pp-admin-editor.js` under jsdom and drives real events through the real debounced sync, asserting on the JSON the editor actually serialized. Field resolution is asserted against two registries differing only in declaration order, with identical expectations, so a resolution that depended on order fails one of them. Value cases cover `0`, `false`, non-zero numbers, `true`, empty string, plain strings, absent and `null`, across text inputs, textareas and array rows. Row-operation cases cover all six handlers plus a row sub-field edit, and pin that an operation with nothing pending leaves the composition unchanged. Write counts distinguish one settled sync from two.
+- `tests/js/pp-editor-field-lookup.test.js` follows the scalar lookup through `findScalarControl`, pinning both ends of the indirection.
+
+---
+
 ## [v1.13.1] — 2026-08-12 — editor: robust field lookup during form sync
 
 **Field names with CSS-selector-significant characters now resolve correctly in the composition editor's accordion.** `syncAccordionToJson` read every edited value back out of the DOM by building a jQuery attribute selector around the field's name. Field names are raw composition keys — `buildAccordionData` passes `Object.keys(props)` straight through for any prop the schema does not declare — so a name may contain `"`, `]`, `\` or `.`, which are structure in a selector and merely characters in a name. Those names now resolve by comparing `data-comp` and `data-field` attribute values instead, so nothing about a name is ever parsed as syntax. Behavior is unchanged for every field name the shipped schemas declare.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.13.1-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.13.2-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>
@@ -415,7 +415,7 @@ Enforced by `AI_RULES.md` and verified by automated tests:
 composer install && composer test
 ```
 
-**JS unit tests** — JSON context, composition validator, accordion data, insert position, data-loss guard, DOM selector alignment, attribute-context escaping (rendered against the real editor), field lookup for names with selector-significant characters, serialization invariant (deep diff + round-trip gate), CSS lint, docs lint, packaging, proposal card, guided error card, page targeting, post-apply validation, shared PHP/JS validation contract, server-driven warning lookup:
+**JS unit tests** — JSON context, composition validator, accordion data, insert position, data-loss guard, DOM selector alignment, attribute-context escaping (rendered against the real editor), field lookup for names with selector-significant characters, form sync (numeric and boolean round-trip, scalar-vs-array-row field resolution, pending edits across row operations), serialization invariant (deep diff + round-trip gate), CSS lint, docs lint, packaging, proposal card, guided error card, page targeting, post-apply validation, shared PHP/JS validation contract, server-driven warning lookup:
 
 ```bash
 npm install && npm test

--- a/assets/js/pp-admin-editor.js
+++ b/assets/js/pp-admin-editor.js
@@ -40,13 +40,45 @@
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
+    // Debounced call with a `flush` handle, so a caller that is about to read the
+    // state the debounced function WRITES can settle it first.
+    //
+    //   trailing edge (normal)   ...call, call, call ──300ms──> fn()
+    //   flush()                  ...call, call, flush ─────────> fn() immediately
+    //
+    // `scheduled` tracks pendency explicitly rather than testing the timer handle:
+    // setTimeout returns a number in browsers and an object in Node, and a falsy
+    // handle would silently make flush a no-op.
+    //
+    // flush() clears the timer BEFORE invoking, so the trailing edge cannot also
+    // fire afterwards — a second run would land after the caller re-rendered and
+    // read a DOM that no longer matches what it captured. Args are dropped once
+    // invoked, so a later flush can never replay a stale call.
     function debounce(fn, ms) {
-        var timer;
-        return function () {
-            var args = arguments;
+        var timer = null, pendingArgs = null, scheduled = false;
+
+        function invoke() {
+            var args = pendingArgs;
+            scheduled = false; timer = null; pendingArgs = null;
+            fn.apply(null, args);
+        }
+
+        function debounced() {
+            pendingArgs = arguments;
+            if (scheduled) clearTimeout(timer);
+            timer = setTimeout(invoke, ms);
+            scheduled = true;
+        }
+
+        // No-op when nothing is pending: the structural handlers below call this
+        // unconditionally, and a click with no pending edit must not rewrite JSON.
+        debounced.flush = function () {
+            if (!scheduled) return;
             clearTimeout(timer);
-            timer = setTimeout(function () { fn.apply(null, args); }, ms);
+            invoke();
         };
+
+        return debounced;
     }
 
     // Attribute-safe escaping for the markup this file builds by concatenation.
@@ -203,6 +235,14 @@
         var h = '<div class="pp-accordion-field' + reqClass + '">';
         h += '<label for="' + idAttr + '">' + nameAttr + '</label>';
 
+        // The two value-bearing branches below (textarea, text input) hand the
+        // value straight to esc(), rather than through String(value || '').
+        // The `|| ''` in that idiom is falsy-based, so it does not mean "default
+        // when absent" — it also swallows the values 0 and false, which then
+        // render as empty and are read back off the DOM as the empty string by
+        // the next sync. esc() coerces only null/undefined to '' (see escapeHtml
+        // in pp-editor-logic.js), which is the rule this wants: absent renders
+        // empty, present renders its own text. Strings are unaffected either way.
         if (field.type === 'enum' && field.values) {
             h += '<select id="' + idAttr + '" data-comp="' + compIdx + '" data-field="' + nameAttr + '">';
             // The <select> is built from the advertised `values` and nothing else
@@ -223,10 +263,10 @@
         } else if (field.multiline) {
             h += '<textarea id="' + idAttr + '" rows="4" data-comp="' + compIdx + '" data-field="' + nameAttr + '"';
             h += ' placeholder="' + esc(field.description || '') + '"';
-            h += '>' + esc(String(field.value || '')) + '</textarea>';
+            h += '>' + esc(field.value) + '</textarea>';
         } else if (field.type === 'string') {
             h += '<input type="text" id="' + idAttr + '" data-comp="' + compIdx + '" data-field="' + nameAttr + '"';
-            h += ' value="' + esc(String(field.value || '')) + '"';
+            h += ' value="' + esc(field.value) + '"';
             h += ' placeholder="' + esc(field.description || '') + '"';
             h += ' />';
         }
@@ -256,7 +296,12 @@
                     name: sk,
                     type: 'string',
                     required: !!(subSchema[sk] && subSchema[sk].required),
-                    value: item[sk] || '',
+                    // Same rule as the scalar branch of buildFieldHtml: coercing
+                    // here with `|| ''` would blank a stored 0 or false before the
+                    // renderer ever sees it, so fixing only that branch would still
+                    // leave row values of those types rendering empty. esc() applies
+                    // the null/undefined rule once, at the point of render.
+                    value: item[sk],
                     description: (subSchema[sk] && subSchema[sk].description) || '',
                     multiline: ['body', 'content', 'answer'].indexOf(sk) !== -1
                 };
@@ -380,9 +425,40 @@
     // An array row's sub-field control carries the same data-comp and a data-field
     // equal to its SUB-KEY, which lives in a different namespace from the prop
     // names and can equal one (grid ships a top-level `title` and an `items[].title`).
-    // The scalar lookup therefore keeps the previous selector's exact match set,
-    // first-in-document-order included — see the scalar call site below.
     var FIELD_CONTROLS = 'input, textarea, select';
+
+    // A top-level scalar prop resolves to the card's OWN control, never to a
+    // control inside one of the card's array rows.
+    //
+    //   .pp-accordion-card [data-comp-idx=0]
+    //     ├── <input data-comp=0 data-field="title">      ← the scalar. Wins.
+    //     └── .pp-accordion-array [data-field="items"]
+    //           └── .pp-accordion-array-item
+    //                 └── <input data-comp=0 data-field="title">   ← a row sub-key
+    //
+    // Sub-keys and prop names are different namespaces that can collide, and the
+    // shipped grid schema does collide (`title` and `items[].title`). Resolution
+    // used to fall out of document order — .val() returns the first match — which
+    // happens to pick the scalar only because grid declares `title` above `items`.
+    // Ordering is a property of the schema file, not a rule the sync enforced, so
+    // the same collision under a different declaration order resolved a top-level
+    // prop to a ROW's value. Excluding array descendants makes the winner explicit
+    // and order-independent; on every shipped schema it selects the same element
+    // document order already did, so the resolved set does not move.
+    //
+    // A prop whose scalar control is absent now resolves to nothing and takes the
+    // "no control resolved" branch, which leaves the stored value alone — the
+    // deliberate choice over adopting an unrelated row's value.
+    //
+    // Native closest() rather than jQuery's: this runs once per candidate inside
+    // the component x field loops, the same reason findByCompField reads raw
+    // attributes. Only array rows nest controls (buildArrayFieldHtml renders row
+    // sub-fields through buildFieldHtml, which never emits a nested array
+    // container), so one ancestor test is the whole rule.
+    function findScalarControl($scope, compIdx, fieldName) {
+        return findByCompField($scope, compIdx, fieldName, FIELD_CONTROLS)
+            .filter(function () { return !this.closest('.pp-accordion-array'); });
+    }
 
     var syncAccordionToJson = debounce(function () {
         if (!cm) return;
@@ -437,12 +513,7 @@
                     field.value = items;
                     field.userTouched = true;
                 } else {
-                    // Card-wide, so an array row's sub-field control is a candidate
-                    // whenever a sub-key equals this prop's name. .val() then takes
-                    // the first in document order, which is the scalar's own input
-                    // for every schema that declares the prop before the array. That
-                    // is the pre-existing resolution rule, preserved here unchanged.
-                    var $input = findByCompField($scope, compIdx, field.name, FIELD_CONTROLS);
+                    var $input = findScalarControl($scope, compIdx, field.name);
                     if ($input.length) {
                         field.value = $input.val();
                         field.userTouched = true;
@@ -500,6 +571,39 @@
     function initAccordionEvents() {
         var $container = $('#pp-accordion-view');
 
+        // The six structural handlers below (insert, move up, move down, delete,
+        // array-row add, array-row remove) rebuild the composition from
+        // cm.getValue() and then re-render the accordion from it. A field edit
+        // reaches that buffer only through syncAccordionToJson, which is debounced
+        // — so an edit made inside the debounce window is still sitting in the
+        // DOM, unwritten, when such a handler reads the buffer:
+        //
+        //   type ──> [sync pending, 300ms] ──> click move/delete/add
+        //                                        │
+        //             reads cm (edit absent) ────┤
+        //             re-renders from it   ──────┘   ← DOM value replaced
+        //
+        // The re-render replaces the control, so the edit is gone from the DOM as
+        // well and the later trailing-edge run has nothing to recover. Settling the
+        // sync first makes the buffer current before it is read, which keeps the
+        // edit and the structural change both. Settling rather than discarding is
+        // the point — the edit is the user's, so it has to land, not be dropped.
+        // The throw is contained deliberately. Before the flush existed, the sync
+        // ran from a timer, so a failure inside it could not reach the click that
+        // happened to precede it — a delete still deleted. Calling it inline puts
+        // it on the handler's own stack, where an exception would abort the
+        // structural action and read to the user as a button that does nothing.
+        // A failed sync should cost the pending edit, not the operation.
+        function flushPendingFieldEdits() {
+            try {
+                syncAccordionToJson.flush();
+            } catch (e) {
+                if (window.console) {
+                    console.error('pp-editor: could not settle pending edits before this operation.', e);
+                }
+            }
+        }
+
         // Expand/collapse
         $container.on('click', '.pp-accordion-toggle', function () {
             var $header = $(this);
@@ -529,8 +633,18 @@
             }
         });
 
-        // Field change
+        // Field change.
+        //
+        // The insert dropdown is excluded because it is chrome, not a field: it
+        // carries no data-comp/data-field, holds no composition value, and its
+        // own handler rebuilds the buffer from scratch. Letting a `change` on it
+        // schedule a sync meant choosing a component to add always left one
+        // pending, so the flush below could never be the no-op it is meant to be
+        // and an insert rewrote the whole composition — marking every resolved
+        // control touched, which writes schema defaults into bands the author
+        // never opened. Selecting from it now schedules nothing.
         $container.on('input change', 'input, textarea, select', function () {
+            if ($(this).hasClass('pp-accordion-insert')) return;
             syncAccordionToJson();
         });
 
@@ -558,6 +672,7 @@
 
         // Component insert
         $container.on('change', '.pp-accordion-insert', function () {
+            flushPendingFieldEdits();
             var name = $(this).val();
             if (!name) return;
             $(this).val(''); // reset dropdown
@@ -601,6 +716,7 @@
 
         // Move up
         $container.on('click', '.pp-move-up', function () {
+            flushPendingFieldEdits();
             var idx = parseInt($(this).data('idx'), 10);
             if (idx <= 0) return;
             var parsed;
@@ -632,6 +748,7 @@
 
         // Move down
         $container.on('click', '.pp-move-down', function () {
+            flushPendingFieldEdits();
             var idx = parseInt($(this).data('idx'), 10);
             var parsed;
             try { parsed = JSON.parse(cm.getValue()); } catch (e) { return; }
@@ -659,6 +776,7 @@
 
         // Delete
         $container.on('click', '.pp-delete-btn', function () {
+            flushPendingFieldEdits();
             var idx = parseInt($(this).data('idx'), 10);
             var parsed;
             try { parsed = JSON.parse(cm.getValue()); } catch (e) { return; }
@@ -689,6 +807,7 @@
 
         // Array item add
         $container.on('click', '.pp-array-add-btn', function () {
+            flushPendingFieldEdits();
             var compIdx = parseInt($(this).data('comp'), 10);
             var fieldName = $(this).data('field');
             var parsed;
@@ -714,6 +833,7 @@
 
         // Array item remove
         $container.on('click', '.pp-array-remove-btn', function () {
+            flushPendingFieldEdits();
             var compIdx = parseInt($(this).data('comp'), 10);
             var fieldName = $(this).data('field');
             var itemIdx = parseInt($(this).data('item'), 10);

--- a/assets/js/pp-editor-logic.js
+++ b/assets/js/pp-editor-logic.js
@@ -373,8 +373,37 @@ function serializeAccordionData(components) {
 
 /**
  * Detect when DOM-read array items would lose content compared to originals.
- * Returns true if all new items are empty objects but at least one original
- * had content — indicating a sync bug, not a legitimate user edit.
+ * Returns true when every DOM-read item came back as an empty object while the
+ * stored value was a non-empty array — the shape of a failed read, not of an
+ * edit the user could have performed.
+ *
+ * A read item is `{}` only when NONE of the sub-key lookups resolved a control:
+ * syncAccordionToJson assigns `item[sk]` for every sub-key whose control it
+ * finds, and an emptied text field still yields `{sk: ''}`. So "all items empty"
+ * is unreachable through editing, and always means the row controls were not
+ * there to read — which is the permanent state of a pass-through array, whose
+ * items have no schema `items` spec and therefore render no sub-field controls
+ * at all.
+ *
+ * The originals are deliberately NOT inspected item by item. Doing so asked
+ * `Object.keys(orig).length > 0`, which is a question only an object can answer:
+ * `Object.keys(1)` and `Object.keys(true)` are both `[]`, so a stored `[1,2,3]`
+ * read as "no content", stood the guard down, and was written back as
+ * `[{},{},{}]`. Item type is not what makes an array worth protecting; having
+ * any items at all is. Where the originals really were empty objects, both
+ * answers write the same value, so the simpler rule gives up nothing.
+ *
+ * WHAT THIS DOES NOT COVER. The guard keys on the read coming back EMPTY, so it
+ * only sees arrays that render no sub-field controls — those whose schema
+ * declares no `items` spec. An array whose schema DOES declare sub-keys renders
+ * a control per sub-key, and if a stored item is a scalar rather than an object,
+ * each control reads back as `''` and the item arrives as `{sub: ''}` — not
+ * empty, so the guard stays down and the scalar is still overwritten. Detecting
+ * that needs a comparison against the ORIGINAL item's type, which is a different
+ * question from the one this function asks.
+ *
+ * Structural row changes do not pass through here — add/remove rewrite the JSON
+ * buffer directly — so a skipped sync never blocks one.
  *
  * @param {Array<Object>} newItems  - Items read from the DOM
  * @param {*}             origItems - Original field value (from CodeMirror JSON)
@@ -383,8 +412,7 @@ function serializeAccordionData(components) {
 function wouldLoseArrayData(newItems, origItems) {
     return newItems.length > 0 &&
         Array.isArray(origItems) && origItems.length > 0 &&
-        newItems.every(function (item) { return Object.keys(item).length === 0; }) &&
-        origItems.some(function (orig) { return orig && Object.keys(orig).length > 0; });
+        newItems.every(function (item) { return Object.keys(item).length === 0; });
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.13.1');
+define('PP_VERSION', '1.13.2');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.13.1
+Stable tag: 1.13.2
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.13.1
+Version:          1.13.2
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/pp-editor-field-lookup.test.js
+++ b/tests/js/pp-editor-field-lookup.test.js
@@ -478,7 +478,14 @@ describe('the shipped editor builds no selector from a field name', () => {
         expect(src.match(/findByCompField\(/g).length).toBeGreaterThanOrEqual(4);
         expect(src).toContain("findByCompField($scope, compIdx, field.name, '.pp-accordion-array')");
         expect(src).toContain('findByCompField($item, compIdx, sk, FIELD_CONTROLS)');
-        expect(src).toContain('findByCompField($scope, compIdx, field.name, FIELD_CONTROLS)');
+
+        // The scalar lookup reaches the helper one step removed: findScalarControl
+        // delegates to it and then drops candidates inside an array row, so a
+        // sub-key that shares a prop's name cannot answer for the prop. Both ends
+        // of that indirection are pinned, so neither can be bypassed silently.
+        expect(src).toContain('function findScalarControl(');
+        expect(src).toContain('findByCompField($scope, compIdx, fieldName, FIELD_CONTROLS)');
+        expect(src).toContain('findScalarControl($scope, compIdx, field.name)');
     });
 
     it('keeps the array data-loss guard', () => {

--- a/tests/js/pp-editor-form-sync.test.js
+++ b/tests/js/pp-editor-form-sync.test.js
@@ -1,0 +1,831 @@
+/**
+ * Form-sync robustness pins for the accordion editor.
+ *
+ * Three properties of the accordion <-> JSON sync are pinned here:
+ *
+ *   1. FIELD RESOLUTION   a top-level scalar prop resolves to the card's own
+ *                         control, not to an array row's sub-field control that
+ *                         happens to carry the same name.
+ *   2. VALUE ROUND-TRIP   a stored value renders as itself and reads back as
+ *                         itself. Numeric and boolean values are the interesting
+ *                         case: they are falsy, and a falsy-based default would
+ *                         render them as empty.
+ *   3. PENDING EDITS      a field edit made inside the sync's debounce window
+ *                         survives a structural row operation (move/delete/add).
+ *
+ * Every test boots the REAL assets/js/pp-admin-editor.js under jsdom and drives
+ * real events through the real debounced sync, then asserts on the JSON the
+ * editor actually serialized. The sibling pp-editor-dom.test.js re-implements
+ * parts of the lookup in its own test body; a re-implementation stays green
+ * while the shipped code regresses, so no ASSERTION here is made against a
+ * re-implementation. The `scalarControl` locator below does repeat the
+ * array-descendant rule, because a test has to pick a control without going
+ * through the construction it is pinning — but it only chooses what to type
+ * into. What is asserted is always the JSON the shipped editor produced.
+ *
+ *   edit a control ──trigger('input')──> syncAccordionToJson (300ms debounce)
+ *                                              │
+ *                                     cm.setValue(serialized JSON)
+ *                                              │
+ *                                       assert the round-trip
+ *
+ * @vitest-environment jsdom
+ */
+
+const path = require('path');
+
+const LOGIC_PATH  = path.join(__dirname, '..', '..', 'assets', 'js', 'pp-editor-logic.js');
+const EDITOR_PATH = path.join(__dirname, '..', '..', 'assets', 'js', 'pp-admin-editor.js');
+
+const { wouldLoseArrayData } = require(LOGIC_PATH);
+
+// ─── Registries ─────────────────────────────────────────────────────────────
+//
+// `card` mirrors the shape components/grid/schema.json ships: a top-level
+// `title` prop AND an `items[].title` sub-key. Both controls end up carrying
+// data-comp="0" data-field="title", so the pair is the collision under test.
+// `subheading` is declared but left out of every fixture below — it is the
+// probe for a sync that ran when it should not have, since a sync marks every
+// control it resolves as touched and would add the prop to the output.
+
+const SCALAR_FIRST = [
+    {
+        name: 'card',
+        templateOwned: false,
+        schema: {
+            props: {
+                title:      { type: 'string', required: false, description: 'Heading' },
+                subheading: { type: 'string', required: false, description: 'Supporting line' },
+                items: {
+                    type: 'array', required: false,
+                    items: {
+                        title: { type: 'string', required: false },
+                        body:  { type: 'string', required: false },
+                    },
+                },
+            },
+        },
+    },
+];
+
+/**
+ * The same collision with the array declared FIRST. Nothing but key order
+ * differs, which is exactly the point: declaration order decides document
+ * order, and resolution must not depend on it.
+ */
+const ARRAY_FIRST = [
+    {
+        name: 'card',
+        templateOwned: false,
+        schema: {
+            props: {
+                items: {
+                    type: 'array', required: false,
+                    items: {
+                        title: { type: 'string', required: false },
+                        body:  { type: 'string', required: false },
+                    },
+                },
+                title:      { type: 'string', required: false, description: 'Heading' },
+                subheading: { type: 'string', required: false, description: 'Supporting line' },
+            },
+        },
+    },
+];
+
+/** A component with a multiline field, to cover the <textarea> render branch. */
+const MULTILINE_REGISTRY = [
+    {
+        name: 'card',
+        templateOwned: false,
+        schema: {
+            props: {
+                title: { type: 'string', required: false },
+                body:  { type: 'string', required: false },
+            },
+        },
+    },
+];
+
+// ─── Harness ────────────────────────────────────────────────────────────────
+
+/** The markup pp-admin-editor.js expects to find on the page. */
+function installDom() {
+    // jsdom implements no layout, so it ships no scrollIntoView. The insert
+    // handler scrolls the new card into view from a timer, which would otherwise
+    // throw AFTER the test that triggered it had already returned — an unhandled
+    // rejection attributed to whichever test happened to be running next.
+    if (!window.Element.prototype.scrollIntoView) {
+        window.Element.prototype.scrollIntoView = function () {};
+    }
+    document.body.innerHTML = [
+        '<div id="pp-error-bar"></div>',
+        '<div id="pp-save-status"></div>',
+        '<div id="pp-preview-status"></div>',
+        '<div id="pp-accordion-live"></div>',
+        '<div id="pp-accordion-view"></div>',
+        '<div id="pp-json-view"></div>',
+        '<button id="pp-view-toggle">JSON</button>',
+        '<div class="pp-pane pp-pane--editor">',
+        '<div class="pp-pane-header"></div>',
+        '<div class="pp-pane-body">',
+        '<textarea id="pp-composition-editor"></textarea>',
+        '</div></div>',
+        '<iframe id="pp-preview-frame"></iframe>',
+    ].join('');
+}
+
+/**
+ * Boot the real editor over `json` with every card expanded.
+ * Returns the jQuery handle plus a reader for the editor's current buffer.
+ */
+async function bootEditor(json, components) {
+    installDom();
+
+    const jquery = require('jquery');
+    global.jQuery = jquery;
+    global.$ = jquery;
+
+    // The sync path ends in runPreview(), which POSTs to admin-ajax. Stub it to
+    // a chainable no-op so the test never opens a socket.
+    const chainable = { done() { return this; }, fail() { return this; }, always() { return this; } };
+    jquery.post = () => chainable;
+
+    let buffer = json;
+    // Counting writes, not just reading the final buffer: a sync that runs a
+    // second time usually lands on the same text, so the buffer alone cannot
+    // tell one settled sync from two.
+    let writes = 0;
+    const cm = {
+        getValue:  () => buffer,
+        setValue:  (v) => { writes += 1; buffer = v; },
+        getRange:  () => '',
+        getCursor: () => ({ line: 0, ch: 0 }),
+        on:        () => {},
+        refresh:   () => {},
+        setSize:   () => {},
+    };
+
+    global.wp = window.wp = {
+        CodeMirror: {
+            fromTextArea:   () => cm,
+            registerHelper: () => {},
+            showHint:       () => {},
+            Pos:            (line, ch) => ({ line, ch }),
+        },
+    };
+
+    global.ppAdminEditor = window.ppAdminEditor = {
+        components,
+        ajaxUrl: '/wp-admin/admin-ajax.php',
+        nonce: 'test-nonce',
+        postId: 1,
+        postStatus: 'draft',
+        compositionVersion: 1,
+        codeEditorSettings: { codemirror: {} },
+    };
+
+    // Both files are IIFEs whose whole effect is the side effect of running, and
+    // they sit in Node's CJS require.cache, which vi.resetModules() does not
+    // clear. Without deleting the cache entry the second and later boots in this
+    // file silently no-op and the accordion never renders.
+    delete require.cache[require.resolve(LOGIC_PATH)];
+    delete require.cache[require.resolve(EDITOR_PATH)];
+    require(LOGIC_PATH);
+    require(EDITOR_PATH);
+
+    // The boot block runs from jQuery's document-ready queue, which dispatches
+    // asynchronously even on a complete document. Poll for the observable
+    // result, bounded so a genuine boot failure fails fast instead of hanging.
+    let settled = false;
+    for (let i = 0; i < 50; i++) {
+        const rendered = document.getElementById('pp-accordion-view').innerHTML !== '';
+        const blocked  = document.querySelector('.pp-serialization-error') !== null;
+        if (rendered || blocked) { settled = true; break; }
+        await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    if (!settled) {
+        throw new Error('editor never booted: #pp-accordion-view is empty and no serialization notice was posted');
+    }
+    if (document.querySelector('.pp-serialization-error')) {
+        throw new Error('the serialization-invariant gate blocked the accordion; this fixture cannot exercise sync');
+    }
+
+    jquery('#pp-accordion-view .pp-accordion-toggle').each(function () {
+        if (jquery(this).attr('aria-expanded') === 'false') jquery(this).trigger('click');
+        const panel = document.getElementById(jquery(this).attr('aria-controls'));
+        if (!panel) throw new Error('toggle aria-controls resolved to no element');
+        if (panel.getAttribute('aria-hidden') === 'true') {
+            throw new Error('toggle did not reveal its panel');
+        }
+    });
+
+    return { $: jquery, getBuffer: () => buffer, getWrites: () => writes };
+}
+
+/**
+ * Controls carrying `fieldName`, without going through a selector — the test
+ * must not depend on the very construction it is pinning.
+ */
+function controls($, fieldName, $scope) {
+    return ($scope || $('#pp-accordion-view')).find('input, textarea, select').filter(function () {
+        return $(this).attr('data-field') === fieldName;
+    });
+}
+
+/** The scalar control: the one carrying `fieldName` outside any array row. */
+function scalarControl($, fieldName, $scope) {
+    return controls($, fieldName, $scope).filter(function () {
+        return !this.closest('.pp-accordion-array');
+    });
+}
+
+/** The control for `subKey` inside array row `rowIdx`. */
+function rowControl($, subKey, rowIdx) {
+    const $row = $('#pp-accordion-view .pp-accordion-array-item').eq(rowIdx);
+    return controls($, subKey, $row);
+}
+
+/**
+ * Edit a control and wait for the debounced sync to publish a new buffer.
+ * Bounded: a sync that never lands fails here rather than hanging the suite.
+ */
+async function editAndSync($, $input, value, getBuffer) {
+    const before = getBuffer();
+    $input.val(value).trigger('input');
+    for (let i = 0; i < 200; i++) {
+        if (getBuffer() !== before) return JSON.parse(getBuffer());
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error('sync never published a new buffer within the bound');
+}
+
+/**
+ * Type into a control and IMMEDIATELY run `act`, without waiting — the edit is
+ * still inside the 300ms debounce window when `act` fires. Then let every timer
+ * drain so a trailing-edge sync, if one were still scheduled, would land before
+ * the assertion reads the buffer.
+ */
+async function editThen($input, value, act) {
+    $input.val(value).trigger('input');
+    act();
+    await new Promise((resolve) => setTimeout(resolve, 600));
+}
+
+afterEach(() => {
+    // Unconditionally, not at the end of each test body: a console spy left in
+    // place by a failing assertion would silence warnings for every test after
+    // it, turning one failure into a run whose later results cannot be trusted.
+    vi.restoreAllMocks();
+
+    const jquery = require('jquery');
+    jquery(document).off();
+    jquery(window).off();
+
+    // Cancel any debounce still in flight. A test that returns before its timer
+    // fires would otherwise leave it to land during the NEXT test, against that
+    // test's DOM but the previous boot's closure — order-dependent flake that
+    // only shows up once some test stops changing the buffer. The editor keeps
+    // its timer handles private, so sweep the id space instead; ids are small
+    // integers in jsdom.
+    const highest = setTimeout(function () {}, 0);
+    for (let id = 0; id <= highest; id++) clearTimeout(id);
+
+    document.body.innerHTML = '';
+    delete global.ppAdminEditor; delete window.ppAdminEditor;
+    delete global.wp;            delete window.wp;
+    delete global.jQuery;        delete global.$;
+});
+
+// ─── 1. Field resolution for nested rows ────────────────────────────────────
+
+describe('a top-level prop and an array sub-key of the same name resolve independently', () => {
+    const FIXTURE = JSON.stringify([
+        {
+            component: 'card',
+            props: {
+                title: 'Section heading',
+                items: [
+                    { title: 'Row one', body: 'First body' },
+                    { title: 'Row two', body: 'Second body' },
+                ],
+            },
+        },
+    ]);
+
+    // Both orders are asserted with the SAME expectations. That pairing is the
+    // test: if resolution still depended on document order, exactly one of them
+    // would fail.
+    const ORDERS = [
+        ['prop declared before the array', SCALAR_FIRST],
+        ['prop declared after the array',  ARRAY_FIRST],
+    ];
+
+    ORDERS.forEach(([label, registry]) => {
+        describe(label, () => {
+            it('gives the name to more than one control, so the pair is genuinely ambiguous', async () => {
+                const { $ } = await bootEditor(FIXTURE, registry);
+                // Guards the fixture itself: if the markup ever stopped emitting a
+                // shared name, every assertion below would pass vacuously.
+                expect(controls($, 'title').length).toBe(3);
+                expect(scalarControl($, 'title').length).toBe(1);
+            });
+
+            it('writes an edit of the top-level prop to the top-level prop', async () => {
+                const { $, getBuffer } = await bootEditor(FIXTURE, registry);
+                const parsed = await editAndSync($, scalarControl($, 'title'), 'Heading edited', getBuffer);
+
+                expect(parsed[0].props.title).toBe('Heading edited');
+                expect(parsed[0].props.items[0].title).toBe('Row one');
+                expect(parsed[0].props.items[1].title).toBe('Row two');
+            });
+
+            it('writes an edit of a row sub-field to that row only', async () => {
+                const { $, getBuffer } = await bootEditor(FIXTURE, registry);
+                const parsed = await editAndSync($, rowControl($, 'title', 0), 'Row one edited', getBuffer);
+
+                expect(parsed[0].props.items[0].title).toBe('Row one edited');
+                expect(parsed[0].props.items[1].title).toBe('Row two');
+                expect(parsed[0].props.title).toBe('Section heading');
+            });
+
+            it('leaves the top-level prop alone when a row sub-field drives the sync', async () => {
+                const { $, getBuffer } = await bootEditor(FIXTURE, registry);
+                const parsed = await editAndSync($, rowControl($, 'body', 1), 'Second body edited', getBuffer);
+
+                expect(parsed[0].props.title).toBe('Section heading');
+                expect(parsed[0].props.items[1].body).toBe('Second body edited');
+            });
+        });
+    });
+
+    it('leaves the prop alone when only a row carries its name', async () => {
+        // `body` is a sub-key here and NOT a top-level prop, so the card has no
+        // scalar control for it. The sync must report it unresolved rather than
+        // adopt a row's value.
+        const { $, getBuffer } = await bootEditor(FIXTURE, SCALAR_FIRST);
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        // Take the scalar title control out of reach, then drive the sync from a
+        // row so the pass still runs over the now-unresolvable prop.
+        scalarControl($, 'title').removeAttr('data-field');
+
+        const parsed = await editAndSync($, rowControl($, 'body', 0), 'First body edited', getBuffer);
+
+        expect(parsed[0].props.title).toBe('Section heading');
+        expect(parsed[0].props.items[0].body).toBe('First body edited');
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('no control resolved'));
+    });
+});
+
+// ─── 2. Round-tripping numeric and boolean values ───────────────────────────
+
+describe('a stored value renders as itself and reads back as itself', () => {
+    function fixtureWithTitle(value) {
+        return JSON.stringify([{ component: 'card', props: { title: value, items: [] } }]);
+    }
+
+    // 0 and false are the cases a falsy-based default silently blanks; '' and a
+    // plain string are the controls that must not change.
+    const VALUES = [
+        ['the number zero',  0,       '0'],
+        ['a nonzero number', 42,      '42'],
+        ['boolean false',    false,   'false'],
+        ['boolean true',     true,    'true'],
+        ['the empty string', '',      ''],
+        ['a plain string',   'Hello', 'Hello'],
+    ];
+
+    VALUES.forEach(([label, stored, rendered]) => {
+        it('renders ' + label + ' into the field', async () => {
+            const { $ } = await bootEditor(fixtureWithTitle(stored), SCALAR_FIRST);
+            expect(scalarControl($, 'title').val()).toBe(rendered);
+        });
+    });
+
+    it('renders an absent value as an empty field', async () => {
+        const { $ } = await bootEditor(
+            JSON.stringify([{ component: 'card', props: { items: [] } }]), SCALAR_FIRST);
+        expect(scalarControl($, 'title').val()).toBe('');
+    });
+
+    it('renders a null value as an empty field', async () => {
+        const { $ } = await bootEditor(fixtureWithTitle(null), SCALAR_FIRST);
+        expect(scalarControl($, 'title').val()).toBe('');
+    });
+
+    it('keeps a zero when an unrelated field is edited', async () => {
+        // The sync rewrites every resolved field, so a value that rendered blank
+        // would be read back as '' and written over even though the user never
+        // touched it. Editing a DIFFERENT field is what exposes that.
+        const json = JSON.stringify([
+            { component: 'card', props: { title: 0, subheading: 'Sub', items: [] } },
+        ]);
+        const { $, getBuffer } = await bootEditor(json, SCALAR_FIRST);
+        const parsed = await editAndSync($, scalarControl($, 'subheading'), 'Sub edited', getBuffer);
+
+        expect(parsed[0].props.subheading).toBe('Sub edited');
+        expect(parsed[0].props.title).toBe('0');
+    });
+
+    it('keeps a false when an unrelated field is edited', async () => {
+        const json = JSON.stringify([
+            { component: 'card', props: { title: false, subheading: 'Sub', items: [] } },
+        ]);
+        const { $, getBuffer } = await bootEditor(json, SCALAR_FIRST);
+        const parsed = await editAndSync($, scalarControl($, 'subheading'), 'Sub edited', getBuffer);
+
+        expect(parsed[0].props.title).toBe('false');
+    });
+
+    it('renders a zero into a multiline field', async () => {
+        const json = JSON.stringify([{ component: 'card', props: { title: 'T', body: 0 } }]);
+        const { $ } = await bootEditor(json, MULTILINE_REGISTRY);
+
+        const $body = scalarControl($, 'body');
+        expect($body.prop('tagName')).toBe('TEXTAREA');
+        expect($body.val()).toBe('0');
+    });
+
+    it('renders a zero into a row sub-field', async () => {
+        const json = JSON.stringify([
+            { component: 'card', props: { title: 'T', items: [{ title: 0, body: false }] } },
+        ]);
+        const { $ } = await bootEditor(json, SCALAR_FIRST);
+
+        expect(rowControl($, 'title', 0).val()).toBe('0');
+        expect(rowControl($, 'body', 0).val()).toBe('false');
+    });
+
+    it('keeps a zero in a row when an unrelated field is edited', async () => {
+        // The render fix has to hold one level down too: row values are assembled
+        // before the renderer sees them, so a falsy default applied there would
+        // blank the value just as effectively, and the sync would read '' back.
+        const json = JSON.stringify([
+            { component: 'card', props: { title: 'Heading', items: [{ title: 0, body: 'B' }] } },
+        ]);
+        const { $, getBuffer } = await bootEditor(json, SCALAR_FIRST);
+        const parsed = await editAndSync($, scalarControl($, 'title'), 'Heading edited', getBuffer);
+
+        expect(parsed[0].props.title).toBe('Heading edited');
+        expect(parsed[0].props.items[0].title).toBe('0');
+        expect(parsed[0].props.items[0].body).toBe('B');
+    });
+});
+
+// ─── 2b. The array guard, on originals that are not objects ─────────────────
+
+describe('the array guard measures whether originals exist, not what type they are', () => {
+    it('fires for object originals', () => {
+        expect(wouldLoseArrayData([{}, {}], [{ title: 'a' }, { title: 'b' }])).toBe(true);
+    });
+
+    // Object.keys(1) and Object.keys(true) are both [], so an item-by-item
+    // content test reads these originals as empty and stands the guard down.
+    it('fires for numeric originals', () => {
+        expect(wouldLoseArrayData([{}, {}, {}], [1, 2, 3])).toBe(true);
+    });
+
+    it('fires for boolean originals', () => {
+        expect(wouldLoseArrayData([{}], [true])).toBe(true);
+    });
+
+    it('fires for zero and false, which are falsy as well as non-object', () => {
+        expect(wouldLoseArrayData([{}, {}], [0, false])).toBe(true);
+    });
+
+    it('fires for string originals', () => {
+        expect(wouldLoseArrayData([{}], ['a'])).toBe(true);
+    });
+
+    it('fires for null originals, which would otherwise become empty objects', () => {
+        expect(wouldLoseArrayData([{}, {}], [null, null])).toBe(true);
+    });
+
+    it('fires for originals that were already empty objects', () => {
+        // The guard no longer inspects the originals item by item, so this shape
+        // now answers true where it once answered false. It costs nothing: the
+        // skipped write and the performed write produce the same value.
+        expect(wouldLoseArrayData([{}], [{}])).toBe(true);
+        expect(wouldLoseArrayData([{}, {}], [{}, {}])).toBe(true);
+    });
+
+    it('stays down when the read produced content', () => {
+        expect(wouldLoseArrayData([{ title: 'edited' }], [{ title: 'a' }])).toBe(false);
+    });
+
+    it('stays down when a partial read produced some content', () => {
+        expect(wouldLoseArrayData([{ title: 'a' }, {}], [{ title: 'a' }, { title: 'b' }])).toBe(false);
+    });
+
+    it('stays down when there were no originals', () => {
+        expect(wouldLoseArrayData([{}, {}], [])).toBe(false);
+        expect(wouldLoseArrayData([{}, {}], undefined)).toBe(false);
+    });
+
+    it('stays down when every row was removed', () => {
+        expect(wouldLoseArrayData([], [{ title: 'a' }])).toBe(false);
+    });
+});
+
+describe('a pass-through array survives a sync of the component that holds it', () => {
+    // No schema entry for `tags`, so it has no sub-key spec and its rows render
+    // no controls — the DOM can only ever read them back as empty objects.
+    const PASSTHROUGH = JSON.stringify([
+        { component: 'card', props: { title: 'Heading', tags: [1, 2, 3] } },
+    ]);
+
+    it('keeps the stored items when another field is edited', async () => {
+        const { $, getBuffer } = await bootEditor(PASSTHROUGH, SCALAR_FIRST);
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const parsed = await editAndSync($, scalarControl($, 'title'), 'Heading edited', getBuffer);
+
+        expect(parsed[0].props.title).toBe('Heading edited');
+        expect(parsed[0].props.tags).toEqual([1, 2, 3]);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('data-loss guard fired'));
+    });
+
+    it('keeps the stored items across a structural row operation', async () => {
+        // The edit before the click is what makes this bite: it leaves a sync
+        // pending, so the move settles one, which drives the guard over a
+        // pass-through array on the way to rewriting the buffer. Without the
+        // pending edit the sync never runs and the guard is never consulted.
+        const json = JSON.stringify([
+            { component: 'card', props: { title: 'First', tags: [1, 2, 3] } },
+            { component: 'card', props: { title: 'Second', tags: [] } },
+        ]);
+        const { $, getBuffer } = await bootEditor(json, SCALAR_FIRST);
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const $card0 = $('#pp-accordion-view .pp-accordion-card').eq(0);
+        await editThen(scalarControl($, 'title', $card0), 'First edited',
+            () => $card0.find('.pp-move-down').trigger('click'));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed.map((c) => c.props.title)).toEqual(['Second', 'First edited']);
+        expect(parsed[1].props.tags).toEqual([1, 2, 3]);
+    });
+});
+
+// ─── 3. Pending edits across row operations ─────────────────────────────────
+
+describe('an edit made just before a row operation survives it', () => {
+    function twoCards() {
+        return JSON.stringify([
+            { component: 'card', props: { title: 'First', items: [] } },
+            { component: 'card', props: { title: 'Second', items: [] } },
+        ]);
+    }
+
+    function card(idx, $) {
+        return $('#pp-accordion-view .pp-accordion-card[data-comp-idx="' + idx + '"]');
+    }
+
+    it('survives moving its own component down', async () => {
+        const { $, getBuffer } = await bootEditor(twoCards(), SCALAR_FIRST);
+        const $title = scalarControl($, 'title', card(0, $));
+
+        await editThen($title, 'First edited', () => card(0, $).find('.pp-move-down').trigger('click'));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed.map((c) => c.props.title)).toEqual(['Second', 'First edited']);
+    });
+
+    it('survives moving its own component up', async () => {
+        const { $, getBuffer } = await bootEditor(twoCards(), SCALAR_FIRST);
+        const $title = scalarControl($, 'title', card(1, $));
+
+        await editThen($title, 'Second edited', () => card(1, $).find('.pp-move-up').trigger('click'));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed.map((c) => c.props.title)).toEqual(['Second edited', 'First']);
+    });
+
+    it('survives deleting a different component', async () => {
+        const { $, getBuffer } = await bootEditor(twoCards(), SCALAR_FIRST);
+        const $title = scalarControl($, 'title', card(0, $));
+
+        await editThen($title, 'First edited', () => card(1, $).find('.pp-delete-btn').trigger('click'));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed.map((c) => c.props.title)).toEqual(['First edited']);
+    });
+
+    it('survives adding a component', async () => {
+        const { $, getBuffer } = await bootEditor(twoCards(), SCALAR_FIRST);
+        const $title = scalarControl($, 'title', card(0, $));
+
+        await editThen($title, 'First edited', () => {
+            $('#pp-accordion-view .pp-accordion-insert').first().val('card').trigger('change');
+        });
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed.length).toBe(3);
+        expect(parsed[0].props.title).toBe('First edited');
+    });
+
+    it('survives adding a row to an array', async () => {
+        const json = JSON.stringify([
+            { component: 'card', props: { title: 'Heading', items: [{ title: 'Row one', body: 'B' }] } },
+        ]);
+        const { $, getBuffer } = await bootEditor(json, SCALAR_FIRST);
+
+        await editThen(scalarControl($, 'title'), 'Heading edited',
+            () => $('#pp-accordion-view .pp-array-add-btn').first().trigger('click'));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed[0].props.title).toBe('Heading edited');
+        expect(parsed[0].props.items.length).toBe(2);
+        expect(parsed[0].props.items[0].title).toBe('Row one');
+    });
+
+    it('survives removing a row from an array', async () => {
+        const json = JSON.stringify([
+            {
+                component: 'card',
+                props: {
+                    title: 'Heading',
+                    items: [{ title: 'Row one', body: 'B1' }, { title: 'Row two', body: 'B2' }],
+                },
+            },
+        ]);
+        const { $, getBuffer } = await bootEditor(json, SCALAR_FIRST);
+
+        await editThen(scalarControl($, 'title'), 'Heading edited',
+            () => $('#pp-accordion-view .pp-array-remove-btn').eq(1).trigger('click'));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed[0].props.title).toBe('Heading edited');
+        expect(parsed[0].props.items.length).toBe(1);
+        expect(parsed[0].props.items[0].title).toBe('Row one');
+    });
+
+    it('survives as a row sub-field edit across a move', async () => {
+        const json = JSON.stringify([
+            { component: 'card', props: { title: 'First', items: [{ title: 'Row one', body: 'B' }] } },
+            { component: 'card', props: { title: 'Second', items: [] } },
+        ]);
+        const { $, getBuffer } = await bootEditor(json, SCALAR_FIRST);
+
+        await editThen(rowControl($, 'title', 0), 'Row one edited',
+            () => card(0, $).find('.pp-move-down').trigger('click'));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed.map((c) => c.props.title)).toEqual(['Second', 'First']);
+        expect(parsed[1].props.items[0].title).toBe('Row one edited');
+    });
+
+    // `subheading` is declared by the schema but absent from every fixture, so it
+    // is untouched and stays out of the serialized output. A sync marks every
+    // control it resolves as touched, so if an operation settled a sync that was
+    // never scheduled, the prop appears on bands the user never opened. That
+    // makes it the probe for "this click rewrote more than it should have".
+    it('does not rewrite the composition when no edit is pending', async () => {
+        const { $, getBuffer } = await bootEditor(twoCards(), SCALAR_FIRST);
+
+        card(0, $).find('.pp-move-down').trigger('click');
+        await new Promise((resolve) => setTimeout(resolve, 600));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed.map((c) => c.props.title)).toEqual(['Second', 'First']);
+        expect('subheading' in parsed[0].props).toBe(false);
+        expect('subheading' in parsed[1].props).toBe(false);
+    });
+
+    it('does not rewrite existing components when one is added', async () => {
+        // The insert control is a <select> inside the accordion, so it matches the
+        // generic field-change handler as well as its own. If that handler treated
+        // it as a field, every insert would leave a sync pending and rewrite the
+        // whole composition on the way through.
+        const { $, getBuffer } = await bootEditor(twoCards(), SCALAR_FIRST);
+
+        $('#pp-accordion-view .pp-accordion-insert').first().val('card').trigger('change');
+        await new Promise((resolve) => setTimeout(resolve, 600));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed.length).toBe(3);
+        expect(parsed[0].props.title).toBe('First');
+        expect(parsed[1].props.title).toBe('Second');
+        // The new component is seeded from required props only, and every prop
+        // in this registry is optional, so it arrives with an empty props object.
+        expect(parsed[2].props).toEqual({});
+        // The two that already existed are returned byte-for-byte unchanged.
+        expect('subheading' in parsed[0].props).toBe(false);
+        expect('subheading' in parsed[1].props).toBe(false);
+        expect(parsed[0].props.items).toEqual([]);
+    });
+
+    it('does not rewrite untouched fields when a row is added', async () => {
+        const json = JSON.stringify([
+            { component: 'card', props: { title: 'Heading', items: [] } },
+        ]);
+        const { $, getBuffer } = await bootEditor(json, SCALAR_FIRST);
+
+        $('#pp-accordion-view .pp-array-add-btn').first().trigger('click');
+        await new Promise((resolve) => setTimeout(resolve, 600));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed[0].props.items.length).toBe(1);
+        expect('subheading' in parsed[0].props).toBe(false);
+    });
+
+    it('settles the edit once, not again on the trailing edge', async () => {
+        // A flush that ran the sync without disarming its timer would fire again
+        // 300ms later, against a DOM the re-render had already replaced. The
+        // second run usually writes the same text, so the buffer cannot reveal
+        // it — count the writes instead.
+        const { $, getBuffer, getWrites } = await bootEditor(twoCards(), SCALAR_FIRST);
+        const $title = scalarControl($, 'title', card(0, $));
+
+        const before = getWrites();
+        $title.val('First edited').trigger('input');
+        card(0, $).find('.pp-move-down').trigger('click');
+
+        // One write settles the pending edit, one applies the move.
+        expect(getWrites() - before).toBe(2);
+
+        // Let the window the trailing edge would have fired in elapse.
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        expect(getWrites() - before).toBe(2);
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed.map((c) => c.props.title)).toEqual(['Second', 'First edited']);
+    });
+
+    it('writes nothing extra when a row operation follows another', async () => {
+        const { $, getBuffer } = await bootEditor(twoCards(), SCALAR_FIRST);
+        const $title = scalarControl($, 'title', card(0, $));
+
+        await editThen($title, 'First edited', () => {
+            card(0, $).find('.pp-move-down').trigger('click');
+            card(1, $).find('.pp-move-up').trigger('click');
+        });
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed.map((c) => c.props.title)).toEqual(['First edited', 'Second']);
+    });
+});
+
+// ─── 4. The two fixes that only work together ───────────────────────────────
+
+describe('a pending edit to a name shared with a row lands on the right field', () => {
+    // Settling pending edits turns the name collision from a discarded edit into
+    // a committed one, so the two behaviors have to hold at the same time: the
+    // edit must survive the operation AND land on the prop the user typed into.
+    const FIXTURE = JSON.stringify([
+        {
+            component: 'card',
+            props: {
+                title: 'Section heading',
+                items: [{ title: 'Row one', body: 'First body' }],
+            },
+        },
+        { component: 'card', props: { title: 'Second', items: [] } },
+    ]);
+
+    [['prop declared before the array', SCALAR_FIRST],
+     ['prop declared after the array',  ARRAY_FIRST]].forEach(([label, registry]) => {
+        it('keeps a top-level edit off the row (' + label + ')', async () => {
+            const { $, getBuffer } = await bootEditor(FIXTURE, registry);
+            const $card0 = $('#pp-accordion-view .pp-accordion-card[data-comp-idx="0"]');
+
+            await editThen(scalarControl($, 'title', $card0), 'Heading edited',
+                () => $card0.find('.pp-move-down').trigger('click'));
+
+            const parsed = JSON.parse(getBuffer());
+            const moved = parsed[1];
+            expect(moved.props.title).toBe('Heading edited');
+            expect(moved.props.items[0].title).toBe('Row one');
+        });
+
+        it('keeps a row edit off the top-level prop (' + label + ')', async () => {
+            const { $, getBuffer } = await bootEditor(FIXTURE, registry);
+            const $card0 = $('#pp-accordion-view .pp-accordion-card[data-comp-idx="0"]');
+
+            await editThen(rowControl($, 'title', 0), 'Row one edited',
+                () => $card0.find('.pp-move-down').trigger('click'));
+
+            const parsed = JSON.parse(getBuffer());
+            const moved = parsed[1];
+            expect(moved.props.title).toBe('Section heading');
+            expect(moved.props.items[0].title).toBe('Row one edited');
+        });
+    });
+
+    it('keeps a zero on a shared name across a row operation', async () => {
+        const json = JSON.stringify([
+            { component: 'card', props: { title: 0, items: [{ title: 'Row one', body: 'B' }] } },
+            { component: 'card', props: { title: 'Second', items: [] } },
+        ]);
+        const { $, getBuffer } = await bootEditor(json, SCALAR_FIRST);
+        const $card0 = $('#pp-accordion-view .pp-accordion-card[data-comp-idx="0"]');
+
+        await editThen(rowControl($, 'body', 0), 'Body edited',
+            () => $card0.find('.pp-move-down').trigger('click'));
+
+        const parsed = JSON.parse(getBuffer());
+        expect(parsed[1].props.title).toBe('0');
+        expect(parsed[1].props.items[0].body).toBe('Body edited');
+    });
+});


### PR DESCRIPTION
Editor form-sync robustness: correct round-tripping of numeric and boolean values, deterministic field resolution for nested rows, and pending-edit consistency across row operations.

All three properties live on the accordion's read-back path, where `syncAccordionToJson` reads edited values out of the DOM and rewrites the JSON buffer.

## Scope

**Numeric and boolean round-trip.** `buildFieldHtml` rendered values as `esc(String(field.value || ''))`. That wrapper is falsy-based, so it cannot tell "no value" from "the value `0`" — both rendered empty, and the next sync read the empty string back as the value. Values now go to `esc()` directly, which treats only `null`/`undefined` as absent. `buildArrayFieldHtml` assembled row values with the same idiom one level up, so it is corrected too; fixing only the renderer would have left row values blanked before the renderer ever saw them. Strings render identically either way.

**Deterministic field resolution.** `data-comp` plus `data-field` is not a unique key: prop names and array sub-keys are separate namespaces that can collide, and `grid` ships exactly that pair (`title` and `items[].title`). Which control answered for the prop fell out of document order, which follows the order the schema file declares props in. `findScalarControl` delegates to `findByCompField` and drops candidates inside a `.pp-accordion-array`, making the winner a stated rule. On every shipped schema this selects the same element document order already selected, so no resolution moves. A prop whose own control is absent is now reported and left alone rather than adopting a row's value. The array-container and row-sub-key lookups are unchanged.

**Pending-edit consistency.** The sync is debounced, so an edit made inside that window was still in the DOM, unwritten, when a structural handler read the buffer and re-rendered from it — which replaced the control, losing the edit from the DOM as well. `debounce` gained a `flush` handle and the six handlers that rebuild the composition settle pending edits first. `flush` disarms the timer before running, so the trailing edge cannot fire a second time against the re-rendered DOM, and it is a no-op when nothing is pending. A throw while settling is contained, so a failed sync costs the pending edit rather than the operation.

**Array guard.** `wouldLoseArrayData` asked `Object.keys(orig).length > 0` of each stored item, a question only an object answers — `Object.keys(1)` is `[]` — so a stored `[1, 2, 3]` read as having no content and stood the guard down. It now asks whether the stored array had items at all.

**Insert dropdown.** It sits inside the accordion and matched the generic field-change handler, so choosing a component to add always left a sync pending. Every insert therefore rewrote the whole composition, marking every resolved control touched and writing schema defaults into bands the author never opened. It is chrome, not a field, and no longer schedules a sync.

## Validation

- `npm test` — 1206 passed (22 files), up from 1154. Zero unhandled errors.
- `./vendor/bin/phpunit --configuration phpunit.xml` — 3148 passed, 14222 assertions. Warning and deprecation counts (4 / 2) are identical to an unmodified tree.
- `bash scripts/package.sh` — "Version consistency: OK" across all five version files; build zip deleted (releases are CI-built from tags).
- **Non-vacuity:** every new test was run against pre-fix source. 28 of the original 47 failed; the 19 that passed are deliberate controls (string originals, non-zero numbers, the guard's stays-down cases, and the scalar-first declaration order that already resolved correctly).
- **Mutation-checked:** removing `clearTimeout` from `flush` fails exactly the trailing-edge test; restoring the insert dropdown to the field handler fails exactly the insert-invariant test.

JS-only. No PHP, schema, or CSS changes.

## Accepted limitations

- **Type is not preserved across a sync, only value.** A stored `0` now renders as `0` and reads back as the string `"0"` rather than being lost. Every DOM read returns a string, so a sync still converts a number or boolean to its string form. This fixes value loss, not type preservation; typed write-back would need a different mechanism.
- **The array guard sees only arrays that render no row controls.** An array whose schema declares sub-keys renders a control per sub-key, so a scalar item reads back as `{sub: ''}` — not empty — and the guard stays down. Detecting that needs a comparison against the original item's type, which is a different question from the one the guard asks. The limit is documented at the function.

## Review

`/plan-eng-review` (with a Codex outside voice) and `/review` (testing, maintainability, security, performance, and red-team passes, plus Claude and Codex adversarial) both ran on this content. Twenty findings: eleven applied, two refuted as false positives with file:line evidence, the rest recorded as pre-existing and out of scope. The security pass returned no findings on the escaping change.
