### PR TITLE
v1.13.6 fix: nested item locators name the stored key instead of fabricating item 0 (#634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.13.6] — 2026-08-13 — diagnostics: nested item locators name the stored key instead of fabricating item 0 (#634)
+
+**`pp_validate_composition_errors()` answered "which item?" two ways inside one function, and one of them lied.** Six nested rules rendered the `items[]` array key honestly; the link-URL and per-item-style paths hard-cast it, so a composition whose `items` decoded to a JSON object rather than a list reported `item 0` — `(int) "aa"` is 0, and there is no item 0. The message sent the operator to repair an element that does not exist, which is worse than carrying no locator at all.
+
+The population this hits is exactly the one the read-only diagnostics exist for. #622 routed the error engine into `wp pp check page` and `wp pp validate site`, whose whole job is to be pointed at compositions that never passed write validation — a raw `update_post_meta()` write, or a history-ring snapshot stored as an object. The write path produces it too: a JSON object where a list belongs survives `pp_execute_action`'s params intact, so `create_page` and `update_composition` fabricated the same locator on input an author actually sent.
+
+All eight locator sites now render the key through one helper, `_pp_item_index_label()`. That is the anti-drift half of the fix: #614 and #600 each added a nested rule and each left the idiom copied inline, and #621/#643/#644 will add more. One renderer means a new rule inherits the honest locator by calling it, and a source tripwire fails the suite if a ninth site casts on the way in — proven against that exact evasion rather than assumed.
+
+**Nothing about what is accepted or rejected changes.** A string-keyed `items` map is exactly as valid as it was; only the text of the message moves. No coercion, no alias, no validator weakened — the v1.13.0 posture is untouched. An ordinary list still reports its integer position, which is what every shipped example shows.
+
+### Fixed
+
+- Nested `items[]` locators name the stored array key rather than an integer cast of it (#634). `_pp_link_url_error_message()` and the per-item `_pp_validate_style_slot_map()` call in `pp_validate_composition_errors()` (`lib/admin.php`) dropped their `(int)` casts, so a `{"aa": {...}}` items map reports `Component "grid" prop "items" item aa field "link_url" ...` and `Component "grid" item aa has no style slot ...` instead of pointing at item 0.
+
+### Changed
+
+- `_pp_item_index_label()` (`lib/admin.php`) is the single renderer for the `item N` fragment; all eight nested locator sites call it, including the six that were already honest. `_pp_link_url_error_message()` and `_pp_validate_style_slot_map()` widened their `?int $item_index` parameter to `int|string|null` — a PHP array key is exactly that, and the `!== null` per-item scope gate (#323) is unaffected, so a string-keyed item still enforces card-scoped slots.
+
+### Docs
+
+- `docs/reference-apply-cli.md` says what the `item N` locator names — the stored key, identical to the counted position for a list, different for an object-shaped `items` value — and how to act on the object-shaped case.
+
+### Tests
+
+- `tests/DiagnosticReachTest.php` gains the locator family: both repaired sites at a string key, the list shape still reporting integer positions, one key rendered identically by three different nested rules, the #323 scope gate under a string key, the authoring path through `update_composition` and `create_page` (with the stored composition proven unchanged after rejection), the `wp pp check page` reach, and a drift-catcher that pins every `item %s` locator to one renderer call and rejects a cast passed into it.
+
+---
+
 ## [v1.13.5] — 2026-08-13 — validation: nested items[] enums are strict at write (#600)
 
 **A nested `items[]` enum field is held to its declared values at the write path now, so `text_role: "terminal"` is rejected by name instead of persisting behind an `ok:true` and rendering as ordinary body text.** This was the last accept-at-write / coerce-at-render surface in the composition grammar. `strict` shipped in #380 and #579 made every top-level enum declare it, but the gate that reads the flag walked `$schema['props']` only — so one level down, declaring `"strict": true` was a silent no-op and an out-of-set value sailed through every write surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The population this hits is exactly the one the read-only diagnostics exist for.
 
 All eight locator sites now render the key through one helper, `_pp_item_index_label()`. That is the anti-drift half of the fix: #614 and #600 each added a nested rule and each left the idiom copied inline, and #621/#643/#644 will add more. One renderer means a new rule inherits the honest locator by calling it, and a source tripwire fails the suite if a ninth site casts on the way in — proven against that exact evasion rather than assumed.
 
-**Nothing about what is accepted or rejected changes.** A string-keyed `items` map is exactly as valid as it was; only the text of the message moves. No coercion, no alias, no validator weakened — the v1.13.0 posture is untouched. An ordinary list still reports its integer position, which is what every shipped example shows.
+**What is accepted and what is rejected are unchanged.** An object-shaped `items` value is neither newly accepted nor newly refused; only the text of the message moves. No coercion, no alias, no validator weakened — the v1.13.0 posture is untouched. An ordinary list still reports its integer position, which is what every shipped example shows.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.13.5-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.13.6-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/docs/reference-apply-cli.md
+++ b/docs/reference-apply-cli.md
@@ -226,6 +226,12 @@ Two nested shapes are deliberately still uncovered, named here rather than left 
 
 Like every rule here, both checks run in the shared `pp_validate_composition()` and are reported (never blocked) by `restore_composition` (#233).
 
+**Reading the `item N` locator (#634).** Every message in this nested family names the offending entry by its **stored `items` key**, not by a counted position. For the ordinary case they are the same thing: an `items` array authored as a JSON list gives `item 0`, `item 1`, `item 2`, exactly as the examples above show. They differ when `items` was stored as a JSON *object* rather than a list — a shape a raw `update_post_meta()` write, a history-ring snapshot, or an author sending `{"aa": {...}}` can produce, and one these read-only diagnostics exist to be pointed at:
+
+> `Component "grid" prop "items" item aa field "link_url" is not a usable link URL: ... [invalid_prop_value]`
+
+Two of these locators used to cast the key to an integer, so a `"aa"`-keyed entry reported `item 0` and sent the operator to repair an element that does not exist. All eight now render the key through one shared helper, so every nested rule answers "which item?" the same way. Repair the entry under the named key; if the whole `items` value is an object where a list belongs, rewrite it as a list.
+
 **Output** — the preflight result:
 
 ```json

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.13.5');
+define('PP_VERSION', '1.13.6');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -660,9 +660,10 @@ function pp_normalize_composition(array $items): array {
  *
  * Typed `int|string` because a PHP array key is exactly that — the callers all read a
  * `foreach` key, so the `gettype()` arm the inline copies carried was unreachable. The
- * signature states the assumption instead of branching on it. The key is reflected
- * VERBATIM, the same way the six sibling rules always did; sanitizing values reflected
- * into messages is #647's business and stays uniform across the family until then.
+ * signature states the assumption instead of branching on it. The key is rendered WHOLE:
+ * no truncation, no control-character strip, exactly what the six sibling rules always
+ * did. Bounding what a message reflects is #647/#649's business and stays uniform across
+ * the family until then.
  *
  * @param  int|string $index  An `items[]` array key (list position or object key).
  * @return string             The locator fragment, never a fabricated position.

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -639,6 +639,39 @@ function pp_normalize_composition(array $items): array {
 }
 
 /**
+ * Renders an `items[]` array KEY as the item locator inside a validation message (#634).
+ *
+ * The single renderer for the "item N" fragment every nested rule in
+ * pp_validate_composition_errors() emits, and for the two message builders those rules
+ * delegate to (_pp_link_url_error_message, _pp_validate_style_slot_map). Before #634 the
+ * SAME function reported the position two ways: six rules rendered the key honestly while
+ * the link-URL and per-item-style paths hard-cast it, so a composition whose `items`
+ * decoded to a JSON OBJECT rather than a list — `{"aa": {...}}`, reachable from
+ * create_page/update_composition, a raw update_post_meta() write, or a history-ring
+ * snapshot — reported `item 0`. `(int) "aa"` is 0, and there is no item 0: the message
+ * sent the operator to repair an element that does not exist, which is worse than
+ * carrying no locator at all.
+ *
+ *   items array           key passed here      rendered locator
+ *   ["a", "b"]            int 1                "1"      (list position)
+ *   {"aa": {...}}         string "aa"          "aa"     (was "0" before #634)
+ *   {"5": {...}}          int 5 (PHP folds     "5"
+ *                         numeric-string keys)
+ *
+ * Typed `int|string` because a PHP array key is exactly that — the callers all read a
+ * `foreach` key, so the `gettype()` arm the inline copies carried was unreachable. The
+ * signature states the assumption instead of branching on it. The key is reflected
+ * VERBATIM, the same way the six sibling rules always did; sanitizing values reflected
+ * into messages is #647's business and stays uniform across the family until then.
+ *
+ * @param  int|string $index  An `items[]` array key (list position or object key).
+ * @return string             The locator fragment, never a fabricated position.
+ */
+function _pp_item_index_label(int|string $index): string {
+    return (string) $index;
+}
+
+/**
  * Validates a style-slot override map against a component's declared style slots.
  *
  * The single shared gate for BOTH grid-level component style (`item['style']`) and
@@ -660,17 +693,22 @@ function pp_normalize_composition(array $items): array {
  * keeps the pre-323 behavior (any declared slot accepted), so this shared engine
  * never over-rejects an un-annotated component.
  *
- * @param  array    $style           Slot => value overrides to validate.
- * @param  array    $available_slots  The component's declared style_slots.
- * @param  string   $component_name   Component name, for the error message.
- * @param  int|null $item_index       Card index when validating a per-item override,
- *                                     or null for grid-level component style.
- * @return WP_Error|null              A WP_Error on the first bad slot/value, else null.
+ * @param  array           $style            Slot => value overrides to validate.
+ * @param  array           $available_slots  The component's declared style_slots.
+ * @param  string          $component_name   Component name, for the error message.
+ * @param  int|string|null $item_index       The items[] KEY when validating a per-item
+ *                                            override (a list position or an object key,
+ *                                            #634), or null for grid-level component style.
+ * @return WP_Error|null                     A WP_Error on the first bad slot/value, else null.
  */
-function _pp_validate_style_slot_map(array $style, array $available_slots, string $component_name, ?int $item_index = null): ?WP_Error {
+function _pp_validate_style_slot_map(array $style, array $available_slots, string $component_name, int|string|null $item_index = null): ?WP_Error {
+    // The key is rendered, never cast (#634): a string-keyed entry names itself rather
+    // than collapsing to the non-existent item 0. Everything below still keys off
+    // `!== null`, so a string key is an item exactly like an integer one and the #323
+    // per-item scope gate applies to it unchanged.
     $where = $item_index === null
         ? sprintf('Component "%s"', $component_name)
-        : sprintf('Component "%s" item %d', $component_name, $item_index);
+        : sprintf('Component "%s" item %s', $component_name, _pp_item_index_label($item_index));
 
     // Card-scoped subset for per-item validation (issue 323). A slot opts into
     // per-item use via item_eligible in its style_slots definition. Enforce the
@@ -1003,16 +1041,18 @@ function _pp_link_url_is_valid($value): bool {
 /**
  * Builds the rejection message for an invalid `format: "link_url"` value (#507).
  *
- * @param string      $component  Component name.
- * @param string      $prop_name  Top-level prop (e.g. "button_url" or the array prop "items").
- * @param int|null    $item_index Item index when the prop is a nested items[] link, else null.
- * @param string|null $field      Item field name (e.g. "link_url") when nested, else null.
- * @param mixed       $value      The rejected value.
+ * @param string          $component  Component name.
+ * @param string          $prop_name  Top-level prop (e.g. "button_url" or the array prop "items").
+ * @param int|string|null $item_index The items[] KEY when the prop is a nested items[] link
+ *                                     (a list position or an object key, #634), else null.
+ * @param string|null     $field      Item field name (e.g. "link_url") when nested, else null.
+ * @param mixed           $value      The rejected value.
  */
-function _pp_link_url_error_message(string $component, string $prop_name, ?int $item_index, ?string $field, $value): string {
+function _pp_link_url_error_message(string $component, string $prop_name, int|string|null $item_index, ?string $field, $value): string {
+    // Rendered, never cast (#634) — see _pp_item_index_label().
     $where = ($item_index === null)
         ? sprintf('prop "%s"', $prop_name)
-        : sprintf('prop "%s" item %d field "%s"', $prop_name, $item_index, (string) $field);
+        : sprintf('prop "%s" item %s field "%s"', $prop_name, _pp_item_index_label($item_index), (string) $field);
     // The value is always a string here (_pp_link_url_is_valid returns false only
     // for strings), but cast defensively. Strip control characters and cap the
     // length so a pathological URL cannot bloat the error envelope or corrupt logs.
@@ -1682,7 +1722,7 @@ function pp_validate_composition_errors(array $items): array {
                                         'Component "%s" prop "%s" item %s must be an object; got %s.',
                                         $name,
                                         $prop_name,
-                                        is_scalar($entry_index) ? (string) $entry_index : gettype($entry_index),
+                                        _pp_item_index_label($entry_index),
                                         gettype($entry)
                                     )
                                 );
@@ -1708,7 +1748,7 @@ function pp_validate_composition_errors(array $items): array {
                                         'Component "%s" prop "%s" item %s must be an array; got %s.',
                                         $name,
                                         $prop_name,
-                                        is_scalar($entry_index) ? (string) $entry_index : gettype($entry_index),
+                                        _pp_item_index_label($entry_index),
                                         gettype($entry)
                                     )
                                 );
@@ -1807,7 +1847,7 @@ function pp_validate_composition_errors(array $items): array {
                                     'Component "%s" prop "%s" item %s is missing required field "%s".',
                                     $name,
                                     $prop_name,
-                                    is_scalar($entry_index) ? (string) $entry_index : gettype($entry_index),
+                                    _pp_item_index_label($entry_index),
                                     $field_name
                                 )
                             );
@@ -1849,7 +1889,7 @@ function pp_validate_composition_errors(array $items): array {
                                     'Component "%s" prop "%s" item %s field "%s" must be a %s; got %s.',
                                     $name,
                                     $prop_name,
-                                    is_scalar($entry_index) ? (string) $entry_index : gettype($entry_index),
+                                    _pp_item_index_label($entry_index),
                                     $field_name,
                                     $field_type,
                                     _pp_schema_value_for_message($entry[$field_name])
@@ -1906,7 +1946,7 @@ function pp_validate_composition_errors(array $items): array {
                                     'Component "%s" prop "%s" item %s field "%s" must be one of: %s; got %s.',
                                     $name,
                                     $prop_name,
-                                    is_scalar($entry_index) ? (string) $entry_index : gettype($entry_index),
+                                    _pp_item_index_label($entry_index),
                                     $field_name,
                                     implode(', ', $field_def['values']),
                                     _pp_schema_value_for_message($entry[$field_name])
@@ -1929,7 +1969,7 @@ function pp_validate_composition_errors(array $items): array {
                                             'Component "%s" prop "%s" item %s field "%s" items must be strings; got %s.',
                                             $name,
                                             $prop_name,
-                                            is_scalar($entry_index) ? (string) $entry_index : gettype($entry_index),
+                                            _pp_item_index_label($entry_index),
                                             $field_name,
                                             gettype($bullet)
                                         )
@@ -1993,7 +2033,7 @@ function pp_validate_composition_errors(array $items): array {
                                 if (array_key_exists($field, $entry) && !_pp_link_url_is_valid($entry[$field])) {
                                     $errors[] = _pp_composition_item_error($i,
                                         'invalid_prop_value',
-                                        _pp_link_url_error_message($name, $prop_name, (int) $entry_index, $field, $entry[$field])
+                                        _pp_link_url_error_message($name, $prop_name, $entry_index, $field, $entry[$field])
                                     );
                                     continue 3;
                                 }
@@ -2048,7 +2088,7 @@ function pp_validate_composition_errors(array $items): array {
                         $element['style'],
                         $available_slots,
                         $name,
-                        (int) $elem_index
+                        $elem_index
                     );
                     if (is_wp_error($style_error)) {
                         // Same restamp as the component-level style map above (#622):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.13.5
+Stable tag: 1.13.6
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.13.5
+Version:          1.13.6
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/DiagnosticReachTest.php
+++ b/tests/DiagnosticReachTest.php
@@ -637,4 +637,275 @@ class DiagnosticReachTest extends TestCase
             _pp_cli_page_diagnostics([])
         );
     }
+
+    // ── 7. Nested ITEM locators name a real position, never a cast (#634) ──────
+    //
+    // The band-level half of this theme is section 2 above: an error-derived finding
+    // carries the composition offset, and a cross-item rule reports none rather than a
+    // fabricated 0. #634 is the same rule one level down, inside the message TEXT.
+    //
+    //   items value          key seen by the rule    locator, before -> after
+    //   ["a", "b"]           int 1                   "1"    -> "1"    (unchanged)
+    //   {"aa": {...}}        string "aa"             "0"    -> "aa"
+    //   {"zz": {...}} style  string "zz"             "0"    -> "zz"
+    //
+    // Two of the eight nested-locator sites hard-cast the key ((int) "aa" === 0) while
+    // six rendered it honestly, so ONE function answered "which item?" two ways. There
+    // is no item 0 in a string-keyed map: the message sent the operator to repair an
+    // element that does not exist, which is worse than carrying no locator at all.
+
+    /** An `items` map that is a JSON object rather than a list, keyed 'aa'. */
+    private function stringKeyedGrid(array $itemFields): array
+    {
+        return [['component' => 'grid', 'props' => ['items' => ['aa' => $itemFields]]]];
+    }
+
+    public function testTheNestedLinkUrlLocatorNamesTheStoredKeyRatherThanFabricatingItemZero(): void
+    {
+        $errors = pp_validate_composition_errors(
+            $this->stringKeyedGrid(['title' => 'X', 'link_url' => 'javascript:alert(1)'])
+        );
+
+        $this->assertCount(1, $errors);
+        $message = $errors[0]->get_error_message();
+        $this->assertStringContainsString('item aa field "link_url"', $message);
+        $this->assertStringNotContainsString('item 0', $message, '(int) "aa" is 0, and there is no item 0');
+    }
+
+    public function testThePerItemStyleLocatorNamesTheStoredKeyRatherThanFabricatingItemZero(): void
+    {
+        $errors = pp_validate_composition_errors(
+            $this->stringKeyedGrid(['title' => 'X', 'style' => ['--nope' => '1']])
+        );
+
+        $this->assertCount(1, $errors);
+        $message = $errors[0]->get_error_message();
+        $this->assertStringContainsString('Component "grid" item aa has no style slot', $message);
+        $this->assertStringNotContainsString('item 0', $message);
+    }
+
+    /**
+     * The per-item style path reaches the shared slot engine through a widened parameter,
+     * and that engine decides per-item SCOPE (#323) on `$item_index !== null`. A string
+     * key must still be "an item" for that gate — otherwise widening the type would have
+     * quietly turned a container-scoped slot on one card into an unknown-slot error, or
+     * into acceptance.
+     */
+    public function testAStringKeyedItemStillEnforcesThePerItemSlotScope(): void
+    {
+        $errors = pp_validate_composition_errors(
+            $this->stringKeyedGrid(['title' => 'X', 'style' => ['--grid-gap' => '2rem']])
+        );
+
+        $this->assertCount(1, $errors);
+        $this->assertSame('invalid_style_slot', $errors[0]->get_error_code());
+        $this->assertStringContainsString(
+            'Component "grid" item aa style slot "--grid-gap" is container-scoped',
+            $errors[0]->get_error_message()
+        );
+    }
+
+    /**
+     * NON-VACUITY, and the case every shipped example is: an ordinary LIST still reports
+     * its integer position at both fixed sites. Written at index 1, not 0, so a rule that
+     * lost the index entirely (or reported the band) fails here. `docs/reference-apply-cli.md`
+     * shows this shape; #634 must not disturb it.
+     */
+    public function testAListShapedItemsArrayStillReportsItsIntegerPositionAtBothSites(): void
+    {
+        $link = pp_validate_composition_errors([
+            ['component' => 'grid', 'props' => ['items' => [
+                ['title' => 'Fine', 'link_url' => '/ok'],
+                ['title' => 'Dead', 'link_url' => 'javascript:alert(1)'],
+            ]]],
+        ]);
+        $this->assertStringContainsString('item 1 field "link_url"', $link[0]->get_error_message());
+
+        $style = pp_validate_composition_errors([
+            ['component' => 'grid', 'props' => ['items' => [
+                ['title' => 'Fine'],
+                ['title' => 'Bad', 'style' => ['--nope' => '1']],
+            ]]],
+        ]);
+        $this->assertStringContainsString('Component "grid" item 1 has no style slot', $style[0]->get_error_message());
+    }
+
+    /**
+     * ONE CONVENTION, proved on ONE key. The two repaired rules and one of the six that
+     * were always honest are asked about the same key in the same composition: before
+     * #634 the first two said `item 0` and the third said `item aa` — the divergence the
+     * issue reports, inside a single validation pass.
+     */
+    public function testEveryNestedRuleRendersTheSameKeyTheSameWay(): void
+    {
+        $errors = pp_validate_composition_errors([
+            ['component' => 'logos', 'props' => ['items' => ['aa' => ['image_alt' => 'X']]]],
+            ['component' => 'grid',  'props' => ['items' => ['aa' => ['title' => 'X', 'link_url' => 'javascript:alert(1)']]]],
+            ['component' => 'grid',  'props' => ['items' => ['aa' => ['title' => 'X', 'style' => ['--nope' => '1']]]]],
+        ]);
+
+        $this->assertCount(3, $errors, 'one error per band');
+        foreach ($errors as $i => $error) {
+            $this->assertStringContainsString('item aa', $error->get_error_message(), "band {$i} names the stored key");
+            $this->assertStringNotContainsString('item 0', $error->get_error_message());
+        }
+    }
+
+    /**
+     * Section 14.1 — the AUTHORING path, which is where this defect is most reachable and
+     * where the issue's own repro understates it. A JSON object where a list belongs
+     * survives `pp_execute_action`'s params intact, so `create_page` / `update_composition`
+     * produced the fabricated locator themselves; no raw `update_post_meta()` write or
+     * history-ring snapshot was required. The rejection must also leave the stored
+     * composition untouched — a validation failure never half-writes.
+     */
+    public function testTheAuthoringPathReportsTheHonestItemLocatorAndStoresNothing(): void
+    {
+        $before = [['component' => 'hero', 'props' => ['title' => 'Hi']]];
+        $this->seedPage(320, $before);
+
+        $result = pp_execute_action('update_composition', [
+            'post_id'     => 320,
+            'composition' => $this->stringKeyedGrid(['title' => 'X', 'link_url' => 'javascript:alert(1)']),
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('invalid_prop_value', $result['error_code']);
+        $this->assertStringContainsString('item aa field "link_url"', $result['error']);
+        $this->assertStringNotContainsString('item 0', $result['error']);
+        $this->assertSame(
+            wp_json_encode($before),
+            $GLOBALS['_pp_test_store']['post_meta'][320]['_pp_composition'],
+            'a rejected write stores nothing'
+        );
+    }
+
+    public function testTheCreatePagePathReportsTheHonestItemLocatorForAPerItemStyle(): void
+    {
+        $result = pp_execute_action('create_page', [
+            'title'       => 'New',
+            'composition' => $this->stringKeyedGrid(['title' => 'X', 'style' => ['--nope' => '1']]),
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('Component "grid" item aa has no style slot', $result['error']);
+        $this->assertStringNotContainsString('item 0', $result['error']);
+    }
+
+    /**
+     * The read-only reach #622 opened. `wp pp check page` is pointed at stored data that
+     * never passed write validation — exactly the population where a non-list `items` map
+     * lives — so the honest locator has to survive the CLI's own sanitizer, not just the
+     * validator.
+     */
+    public function testCheckPageReportsTheHonestItemLocator(): void
+    {
+        $this->seedPage(321, $this->stringKeyedGrid(['title' => 'X', 'link_url' => 'javascript:alert(1)']));
+
+        (new PP_Check_Command())->page([], ['post_id' => 321]);
+
+        $this->assertSame([], WP_CLI::$successes);
+        $joined = implode("\n", array_merge(WP_CLI::$warnings, WP_CLI::$lines));
+        $this->assertStringContainsString('item aa field "link_url"', $joined);
+        $this->assertStringNotContainsString('item 0', $joined);
+    }
+
+    /**
+     * The renderer itself, both arms of its union type. PHP folds a numeric-STRING array
+     * key ("5") to the integer 5 on the way in, so the string arm is only observable
+     * through a genuinely non-numeric key — which is why the behavioral tests above are
+     * keyed 'aa' and this one asserts the two arms directly.
+     *
+     * @dataProvider itemIndexLabelProvider
+     */
+    public function testTheItemIndexLabelRendersBothArrayKeyTypes($index, string $expected): void
+    {
+        $this->assertSame($expected, _pp_item_index_label($index));
+    }
+
+    public static function itemIndexLabelProvider(): array
+    {
+        return [
+            'first list position'  => [0, '0'],
+            'later list position'  => [7, '7'],
+            'object key'           => ['aa', 'aa'],
+            'numeric-string key'   => ['5', '5'],
+            // The degenerate key `{"": {...}}`. The locator renders EMPTY rather than
+            // inventing a position for it — "no locator at all" is one of the two answers
+            // the issue names as acceptable, and it is what the six sibling rules already
+            // produce for the same key. Pinned so the empty render is a recorded choice
+            // rather than something nobody looked at.
+            'empty object key'     => ['', ''],
+        ];
+    }
+
+    /**
+     * THE DRIFT-CATCHER. Eight sites render this fragment and #614/#600 each added one;
+     * #621/#643/#644 will add more. The behavioral pins above prove the eight that exist
+     * today, but only a source check stops a NINTH rule from re-introducing the cast that
+     * started this, or from open-coding the old inline copy beside the shared renderer.
+     *
+     * The load-bearing assertion is the PAIRING, not the name blocklist. A guard that only
+     * greps for `(int) $entry_index` / `(int) $elem_index` is evadable by a new rule whose
+     * key variable has a different name — `foreach ($rows as $row_index => $row)` with
+     * `_pp_item_index_label((int) $row_index)` defeats every name-based check while
+     * reintroducing exactly this defect. So: every `item %s` locator in the file must be
+     * matched by one call to the shared renderer, and no call may be handed a cast.
+     *
+     * SCOPE, stated so the guard is not read as covering more than it does: the lowercase
+     * `item %s` family is the nested items[] locator #634 owns. The capital-I `Item %d`
+     * messages ~500 lines above name the COMPOSITION offset (which band), a different
+     * locator with its own open defect and its own issue. This test deliberately does not
+     * assert on them.
+     */
+    public function testEveryItemIndexLocatorRoutesThroughTheSharedLabel(): void
+    {
+        // Asserted on booleans and counts, not on the 140 KB haystack: a string assertion
+        // that fails here dumps the whole file into the report and buries its own message.
+        $source = file_get_contents(dirname(__DIR__) . '/lib/admin.php');
+
+        $this->assertSame(
+            substr_count($source, 'item %s'),
+            substr_count($source, '_pp_item_index_label($'),
+            'every nested item locator must be fed by the shared renderer — one call per locator'
+        );
+        $this->assertSame(
+            0,
+            preg_match_all('/_pp_item_index_label\(\s*\((?:int|string|float|bool)\)/', $source),
+            'the renderer takes the raw array key; casting on the way in is the #634 defect wearing a hat'
+        );
+        $this->assertFalse(str_contains($source, '(int) $entry_index'), 'a cast fabricates item 0 for a string key');
+        $this->assertFalse(str_contains($source, '(int) $elem_index'), 'same cast on the per-item style path');
+        $this->assertFalse(
+            str_contains($source, 'is_scalar($entry_index) ?'),
+            'the inline copies are the shared renderer now — a new copy is how the two conventions came back'
+        );
+        $this->assertFalse(str_contains($source, 'item %d'), 'no nested locator formats the key as an integer');
+        $this->assertGreaterThanOrEqual(8, substr_count($source, 'item %s'), 'the eight known locators are still there');
+    }
+
+    /**
+     * THE DEFERRAL, recorded in the suite rather than only in a docblock. The key is
+     * reflected VERBATIM — unbounded and unstripped — which is what the six sibling rules
+     * have always done and what #634 was fenced to keep uniform rather than fix at two
+     * sites out of eight. Bounding it for the whole family is #649.
+     *
+     * Two surfaces, deliberately asserted apart: the CLI finding line IS sanitized
+     * (_pp_cli_printable), the action envelope is NOT. When #649 lands, this test should
+     * be rewritten to the new contract, not deleted — that is the signal that the gap was
+     * closed on purpose.
+     */
+    public function testAHostileItemKeyIsStillReflectedVerbatimIntoTheEnvelopeUntil649(): void
+    {
+        $key    = "aa\x1b[31m\nWARNING: fake";
+        $errors = pp_validate_composition_errors([
+            ['component' => 'grid', 'props' => ['items' => [$key => ['title' => 'X', 'link_url' => 'javascript:a']]]],
+        ]);
+
+        $this->assertStringContainsString("\x1b", $errors[0]->get_error_message(), 'documented gap, not a claim that this is right (#649)');
+
+        $line = _pp_cli_finding_line(['type' => 'invalid_prop_value', 'index' => 0, 'message' => $errors[0]->get_error_message()]);
+        $this->assertStringNotContainsString("\x1b", $line, 'the CLI surface strips it today');
+        $this->assertStringNotContainsString("\n", $line);
+    }
 }


### PR DESCRIPTION
Closes #634

## Scope

`pp_validate_composition_errors()` (`lib/admin.php`) answered "which item?" two ways inside one function. Six nested rules rendered the `items[]` array key honestly; the link-URL and per-item-style paths hard-cast it, so a composition whose `items` decoded to a JSON object rather than a list reported `item 0`. `(int) "aa"` is 0, and there is no item 0 — the locator sent the operator to repair an element that does not exist.

Against the issue acceptance criteria:

- **`_pp_link_url_error_message()` (`lib/admin.php`)** — `(int) $entry_index` cast dropped at the call site; `?int $item_index` widened to `int|string|null`; `item %d` -> `item %s`.
- **`_pp_validate_style_slot_map()` (`lib/admin.php`)** — same three changes on the per-item style path. Its `$item_index !== null` per-item scope gate (#323) is unaffected: a string key is an item exactly like an integer one, pinned by a test.
- **The rendering chosen** is the honest `is_scalar(...)` one the six sibling rules already used, which the issue names as correct ("The sibling rules correctly report `item 5` for a `"5"`-keyed entry"). Extracted to `_pp_item_index_label()` and routed through all eight sites, including the six that were already honest — #614 and #600 each left the idiom copied inline because #634 owns it, and #621/#643/#644 will add more nested rules.

Reach is broader than the issue assumed: a JSON object where a list belongs survives `pp_execute_action` params intact, so `create_page` / `update_composition` fabricated the locator themselves — no raw `update_post_meta()` write or history-ring snapshot required.

**No behavior change beyond the message text.** A string-keyed `items` map is exactly as valid as before. No coercion, no alias, no validator weakened (v1.13.0 posture). An ordinary list still reports its integer position.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml` — 3241 tests / 14506 assertions, green. Baseline on `main` was 3226 / 14461. Warnings 4 -> 4 and PHPUnit deprecations 2 -> 2, both pre-existing (confirmed against a stashed tree; the 2 deprecations live in this test file already).
- `npm test` — 1249 passed, unchanged.
- `bash scripts/package.sh` — "Version consistency: OK" at 1.13.6 across all five files; the zip it builds as a side effect was deleted.
- **Non-vacuity** (Section 14.7 compliant — done on a copied tree, the shared working tree was never mutated): 12 of the 13 new behavioral tests fail against the pre-fix `lib/admin.php`. The 13th is the list-shape regression guard, which must pass both ways. The drift-catcher was separately proven against the exact evasion a review specialist demonstrated — a ninth locator site casting under a fresh variable name — and fails with `Failed asserting that 8 is identical to 9`.
- **Authoring path (Section 14.1)**: `update_composition` and `create_page` both return the honest locator, and the stored composition is byte-unchanged after the rejection.

## Review

`/plan-eng-review` and `/review` both ran in this session against this content (4 specialists + red team + Codex adversarial). Findings inside the fence were applied: the drift-catcher now pins an exact `item %s` <-> renderer-call pairing plus a no-cast-into-the-helper regex, a deferral pin records the reflected-key gap, and the empty-key row is pinned. Codex objected that `int|string` unions might break the PHP floor; refuted — `style.css:13` declares PHP 8.0 (unions shipped in 8.0) and `lib/operate.php:2145` already ships `array|WP_Error`.

## Accepted limitations

- **Reflected key is not bounded or sanitized.** The key is echoed verbatim, which is what the six sibling rules have always done; keeping the family uniform was the fence, and bounding it for all eight sites is #649. A test pins the current behavior so the deferral is visible in the suite rather than only in a docblock, and the CLI surface is already covered by `_pp_cli_printable()`.
- **Numeric-string keys still cannot be told apart from list positions.** PHP folds them to integers at decode, so a reordered `{"1": ok, "0": bad}` map reports `item 0` for an entry at position 1. Pre-#634 behavior was identical (not a regression), and the issue explicitly blesses key rendering. Filed as #652, to be decided with the #621/#642 diagnostics-vocabulary family rather than alone.
- **An empty object key renders an empty locator** (`item  field`) rather than a fabricated position. Pinned in the data provider; "no locator at all" is one of the two answers the issue names as acceptable.

## 7A decision

Asked: the red-team pass argued the numeric-string collision above should be closed inside this issue by widening the renderer to take the container and rendering non-list keys distinguishably (`item key "0"`). Answered: **ship as recorded**. The issue body is the decision of record, and rendering the key is what it blesses; the alternative is a public message-contract redesign at eight sites plus four doc surfaces that the issue did not scope, and it would likely be churned again by #621/#642. Filed as #652 instead.

## Found while working on this, filed not fixed

- #649 — item keys reflected raw while prop keys (#633) and values (#647) are bounded.
- #650 — band-level `Item %d` fabricates band 0 for an object-shaped composition, while the same error carries `index: null`.
- #651 — `wp pp action preview` / `apply preview` print an empty line and exit 1 when `json_encode` returns false.
- #652 — the numeric-key collision above.