### PR TITLE
v1.13.10 fix: delete dead .pp-ai-preview-error-alternatives rule and pin the disclosure's real contract (#627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.13.10] — 2026-08-14 — tests: the preview-error card's alternatives test now fails when alternatives break (#627)
+
+**One of the two tests guarding the rejected-slot card could not fail.** It asked whether the rendered card contained an element with the class `pp-ai-preview-error-alternatives` and asserted that it did not. No code path has emitted that class since the alternatives moved into the technical-details disclosure, so the assertion was true by construction: alternatives rendering could break completely and the test would stay green. The stylesheet still carried a rule for that class, styling nothing.
+
+Both are gone. In their place the disclosure's actual contract is pinned, line by line: an empty `alternatives` list adds no "Available slots" line but the disclosure still opens for a raw error; with neither a list nor a raw error there is no disclosure at all; a list alone opens it and is its only line; and a cross-component hint contributes its own line between the two, in that order. Assertions are line-exact against the direct child the stylesheet contracts on, so a reordering or a dropped contribution fails rather than passes.
+
+Nothing an author sees changes. The deleted rule matched no element in any state the renderer can produce, which is why it could be deleted rather than repaired.
+
+### Fixed
+
+- `assets/css/pp-ai-chat.css` drops the `.pp-ai-preview-error-alternatives` rule (#627). The class was orphaned when the alternatives list became the body of the `.pp-ai-preview-error-detail` disclosure; the surviving rule already carries the typeface, size and colour it declared.
+
+### Tests
+
+- `tests/js/pp-ai-chat-proposal.test.js` replaces the vacuous absence assertion with three pins on what `ppChatRenderPreviewError()` actually emits, covering both sides of the disclosure's two-part guard and the slot line inside it.
+- The cross-component-hint test now also pins the hint's line inside the disclosure, so the order the renderer joins raw error, hint lines, and slot list in is a contract rather than an accident.
+
+---
+
 ## [v1.13.9] — 2026-08-14 — diagnostics: a mistyped slot name is a mistake to fix, not a capability the component lacks (#625)
 
 **The chat told authors a change wasn't possible while the setting they wanted sat in the same response.** A failed preview step is painted with one of three classes, and `pp-ai-step-impossible` is a claim about capability — "there is nothing to change here". It was painted on any `invalid_style_slot` whose `cross_component_hints` came back empty, and the status bar said "This change isn't possible with the current component settings." A near miss like `--hero-bgs` for `--hero-bg` normalizes to a suffix no other component declares, so it produced no hint and landed there — with `--hero-bg` listed in `alternatives` in the very same payload.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.13.9-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.13.10-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/assets/css/pp-ai-chat.css
+++ b/assets/css/pp-ai-chat.css
@@ -410,13 +410,6 @@ body.pp-ai-chat-page #wpfooter {
     margin-bottom: 4px;
 }
 
-.pp-ai-preview-error-alternatives {
-    font-size: 12px;
-    font-family: monospace;
-    color: #646970;
-    word-break: break-all;
-}
-
 .pp-ai-step-impossible {
     background: #f0f0f1;
 }

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.13.9');
+define('PP_VERSION', '1.13.10');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.13.9",
+  "version": "1.13.10",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.13.9
+Stable tag: 1.13.10
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.13.9
+Version:          1.13.10
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/js/pp-ai-chat-proposal.test.js
+++ b/tests/js/pp-ai-chat-proposal.test.js
@@ -255,7 +255,35 @@ describe('renderPreviewError', function () {
         expect(summary.textContent).toBe('Show technical details');
     });
 
-    test('structured error without alternatives omits alternatives element', function () {
+    // The three tests below pin what `alternatives` controls in THIS renderer (#627):
+    // whether the technical-details disclosure opens at all, and the one line it
+    // contributes inside. The same field also decides the step's fixable-vs-impossible
+    // class and the status sentence, through ppChatHasSlotAlternatives() ->
+    // ppChatGetErrorStepClass() / ppChatGetStatusMessage() (#625); those are pinned in
+    // their own describe blocks below. An empty list is not an element that fails to
+    // render — there is no per-alternatives element at any size of the list. It is a
+    // LINE that is not added to the disclosure's text, and when nothing else would fill
+    // the disclosure, the disclosure itself is skipped.
+    //
+    //   alternatives non-empty ──┐
+    //                            ├── OR ──► <details class="pp-ai-preview-error-detail">
+    //   raw_error truthy ────────┘                 raw_error line
+    //                                              hint lines
+    //                                              "Available slots: …" (alternatives only)
+    //   neither ─────────────────────────► no <details> at all
+    //
+    // Asserting on absent ELEMENTS here is what made the predecessor of these tests
+    // vacuous: it looked for a class the renderer never writes, so it would have kept
+    // passing through any breakage of alternatives rendering.
+    //
+    // One line per contribution is a cross-layer promise, not a JS-only one. The split
+    // below separates them because the sole producer of this payload,
+    // _pp_build_friendly_error() (lib/ai-chat.php), routes every caller-supplied string
+    // it reflects through _pp_clean_reflected_text(), which strips \p{Cc} — so no
+    // reflected text arrives carrying a newline of its own. The renderer does not
+    // enforce that itself; a future producer that skips the cleaner could forge a line.
+
+    test('empty alternatives add no slot line, and the disclosure still opens for raw_error', function () {
         var diffArea = document.createElement('div');
         renderPreviewError(diffArea, {
             error_code: 'no_style_slots',
@@ -264,9 +292,41 @@ describe('renderPreviewError', function () {
             raw_error: 'raw'
         });
 
-        var altEl = diffArea.querySelector('.pp-ai-preview-error-alternatives');
-        expect(altEl).toBeNull();
+        var detailEl = diffArea.querySelector('.pp-ai-preview-error-detail');
+        expect(detailEl).not.toBeNull();
+
+        // Line-exact, not a substring scan: the claim is that no slot line was added,
+        // and a line is what the renderer joins.
+        var lines = detailEl.querySelector(':scope > div').textContent.split('\n');
+        expect(lines).toEqual(['raw']);
+
         expect(diffArea.querySelector('.pp-ai-preview-error-message').textContent).toContain('doesn\'t support');
+    });
+
+    test('no disclosure at all when there is neither an alternatives list nor a raw error', function () {
+        var diffArea = document.createElement('div');
+        renderPreviewError(diffArea, {
+            error_code: 'no_style_slots',
+            user_message: 'This component doesn\'t support style customization.',
+            alternatives: []
+        });
+
+        expect(diffArea.querySelector('.pp-ai-preview-error-detail')).toBeNull();
+        expect(diffArea.querySelector('.pp-ai-preview-error-message').textContent).toContain('doesn\'t support');
+    });
+
+    test('alternatives alone open the disclosure and are its only line', function () {
+        var diffArea = document.createElement('div');
+        renderPreviewError(diffArea, {
+            error_code: 'invalid_style_slot',
+            user_message: 'Not available.',
+            alternatives: ['--hero-bg', '--hero-heading-color']
+        });
+
+        var detailEl = diffArea.querySelector('.pp-ai-preview-error-detail');
+        expect(detailEl).not.toBeNull();
+        var lines = detailEl.querySelector(':scope > div').textContent.split('\n');
+        expect(lines).toEqual(['Available slots: --hero-bg, --hero-heading-color']);
     });
 
     test('plain string error renders as text content', function () {
@@ -304,6 +364,16 @@ describe('renderPreviewError', function () {
         var hintEl = diffArea.querySelector('.pp-ai-preview-error-hint');
         expect(hintEl).not.toBeNull();
         expect(hintEl.textContent).toContain('grid');
+
+        // The hint also contributes a line INSIDE the disclosure, between the raw error
+        // and the slot list. Line-exact, so the order the renderer joins them in is
+        // pinned too, not just their presence.
+        var detailEl = diffArea.querySelector('.pp-ai-preview-error-detail');
+        expect(detailEl.querySelector(':scope > div').textContent.split('\n')).toEqual([
+            'raw',
+            'Available on grid: --grid-gap',
+            'Available slots: --section-bg'
+        ]);
     });
 
     test('cross-component hint element absent when no hints', function () {


### PR DESCRIPTION
Closes #627

## Scope

`.pp-ai-preview-error-alternatives` (`assets/css/pp-ai-chat.css`) styled a class no code path emits, and the only other reference to it was a test asserting the element was absent — an assertion true by construction, so alternatives rendering could break entirely and stay green.

- The rule is deleted.
- The vacuous test is REPLACED, not dropped, by pins on what `ppChatRenderPreviewError()` actually emits:
  - empty `alternatives` contributes no "Available slots" line, and the disclosure still opens for a `raw_error`;
  - neither a list nor a raw error means no disclosure element at all;
  - a list alone opens the disclosure and is its only line.
- The existing cross-component-hint test also pins the hint's line inside the disclosure, so the join order (raw error, hint lines, slot list) is a contract.

Assertions are line-exact and query `.pp-ai-preview-error-detail > div`, the direct child the stylesheet contracts on, rather than a descendant that could silently retarget.

## Why the CSS deletion is safe

The class has zero emitters. `git grep` finds it only in the deleted rule and the deleted assertion; every `className` assignment in `assets/js/pp-ai-chat.js` is a literal string, so no dynamic path can synthesize it; no PHP, template, doc, or `ai-instructions/` file names it. History explains it: `0bfa4b2` rendered alternatives into their own element with that class, and `b45dca9` replaced that element with the `<details>` disclosure, leaving the rule behind.

Rendered markup for three representative payloads (structured error with alternatives + raw error; cross-component hint; `no_style_slots` with an empty list) contains zero nodes matching the deleted selector. The renderer is untouched by this diff, so the markup is unchanged by construction.

The #625 promise that "the settings it does have are listed above" is carried by `user_message` in `.pp-ai-preview-error-message`, built from slot DESCRIPTIONS in `_pp_build_friendly_error()` — not by the disclosure and not by the deleted rule. Verified in `lib/ai-chat.php` before touching anything.

## Validation

- `npm test` — 22 files, 1265 passed (1263 before; one vacuous test replaced by three).
- `./vendor/bin/phpunit --configuration phpunit.xml` — 3315 tests, 14857 assertions. Warning/deprecation counts (4 / 2) are identical to the unmodified tree.
- Local Playwright `style-render.spec.ts --grep @smoke` before opening this PR (repo rule for any `assets/css/` change): 198 passed, 1 skipped.
- Non-vacuity proof, run on a COPY of the tree (never in the working tree): three mutations of `ppChatRenderPreviewError()` — dropping the empty-list guard on the slot line, making the disclosure unconditional, and blanking the slot line — each fail the new tests (1, 1 and 3 failures). Re-adding the OLD assertion alongside shows it passing green under all three, which is the vacuity it was filed for.

## Accepted limitations

The deleted rule carried `word-break: break-all`, which `b45dca9` did not carry over to the live selector. That is a real pre-existing overflow defect, filed as #666 rather than fixed here, since fixing it changes rendered output and touches the selector #662 owns.

## Review outcome

No 7A question arose: the issue records the fix shape, and no finding extended it. Four informational review findings; two applied here (comment accuracy, the hint-line pin), two filed out of scope: #666, #667, #668.