### PR TITLE
v1.13.15 fix: catch style-slot rename drift against a pinned baseline (#598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to PromptingPress are documented here.
 
 ---
 
+## [v1.13.15] — 2026-08-14 — A renamed style slot can no longer ship without a documented breaking change, and the prop register stops accepting notes that document nothing (#598)
+
+**Renaming a style slot was invisible to CI.** Every slot pin the theme had was rename-invariant: `testStyleSlotsExistForV1Components` and `css-lint.test.js` both COUNT slots, and a rename removes one name and adds another, so no total ever moves. Everything else that touches slots re-globs the live schemas, so it re-derives its expectations from the file the rename just edited. That mattered because `pp_render_style_vars()` drops an undeclared slot name with a bare `continue` — no finding, no warning, no log — so a renamed slot means every stored page that set the old name silently renders unstyled while every action still returns `ok:true`. Under the ratified no-alias posture (#570 Addendum #5, #603/#604) that breakage is ALLOWED, but only as a documented, deliberate one. Nothing made "documented" mandatory. Measured on the surface as it stood: 254 of 261 slot names appeared incidentally somewhere under `tests/`, so many renames would have tripped some unrelated test with a misleading message, and 7 (`--cta-inner-gap`, `--embed-padding-bottom`, `--faq-padding-bottom`, `--hero-content-gap`, `--logos-padding-bottom`, `--stats-padding-bottom`, `--table-padding-bottom`) appeared nowhere at all and would have renamed in total silence.
+
+**The slot surface now has the prop surface's drift-catcher, and both surfaces got stricter about what a migration note has to be.** `PINNED_SLOT_BASELINE` freezes 261 slots across the 10 slot-bearing components; a name that disappears from a schema fails the build unless the same change records it in `SLOT_RENAME_MIGRATION_NOTES`, and a newly added slot must be appended to the baseline in the same commit. Implementing it exposed three holes in the prop-side catcher this was copied from, all of which let an undocumented rename ship green, and all of which are closed here on BOTH surfaces so the two cannot enforce different contracts: the pinned baselines were not append-only, so deleting (or quietly editing) a baseline line was the cheapest path to a green build and the failure messages steered authors there; note content was never validated, so `''`, `null` and `0` cleared drift exactly as well as real prose; and a note naming a still-live name was accepted silently, which allowed a two-commit disarm where one commit pre-notes names that still exist and a later commit deletes them unremarked.
+
+**This is enforcement mechanics, not a contract change.** No schema key was added or removed, no slot or prop renamed, no accepted value, type, or grammar altered, and no runtime code touched. The ratified contract (#604, #570 Addendum #5, #606) is unchanged: renames are documented breaking changes, never aliased migrations. Nothing here makes a renamed slot keep working, and no alias machinery returns — `StoredCompositionAliasRenderTest` still guards that negative space. What changed is that the documentation trail is now mandatory rather than remembered.
+
+### Fixed
+
+- A style-slot rename, removal, or unpinned addition now fails CI. Previously all three passed: the rename and the addition silently, the removal loudly only where some unrelated test happened to name the slot.
+- A migration note must say something and cite the ruling issue (a non-empty string matching `#<number>`). An empty, whitespace, or non-string value no longer clears drift on either surface.
+- A migration note may only describe a name the schemas no longer declare. Pre-authorising a future removal in an earlier commit is rejected, which collapses the two-commit disarm back into one honest commit.
+- The pinned baselines are append-only, enforced by a count floor and a content fingerprint. The floor catches a net removal; the fingerprint catches the count-preserving swap the floor cannot see, which is the edit that actually shipped an undocumented rename.
+- Both add-path guards iterate the LIVE schema set and so could pass vacuously with nothing discovered. They now pin the component set in both directions first, making a broken glob or a moved schema a hard failure instead of a silently unguarded surface.
+- Schema discovery for both surfaces runs through one helper that fails loudly on unparseable JSON. `liveProps()` previously degraded to an empty prop list, which reads downstream as a mass removal and misdiagnoses the cause.
+
+### Docs
+
+- `ai-instructions/add-component.md` no longer tells agents that a renamed style slot "has no such tripwire today" and that the surfaces are asymmetric. Both statements were made false by this change. It now states the symmetric contract, the three things the register enforces, and that adding a prop or slot means updating the baseline, floor, and fingerprint in the same change.
+- `docs/AI_IMPLEMENTATION_RECIPES.md` Recipe A gains the baseline step. Following the recipe without it produced a red build with no explanation of why.
+
+### Tests
+
+- `tests/SchemaValidationTest.php` — `PINNED_SLOT_BASELINE` (261 slots: cta 40, embed 8, faq 21, grid 38, hero 49, logos 8, section 47, stats 17, table 6, testimonials 27), `SLOT_RENAME_MIGRATION_NOTES` (empty by design), plus `SLOT_BASELINE_FLOOR` / `SLOT_BASELINE_FINGERPRINT` and their prop-side twins. footer and nav are absent because they declare `chrome_custom_properties` rather than `style_slots`; the add-path guard fails if either ever gains real slots, so their absence is enforced rather than assumed.
+- Both surfaces run one shared algorithm — `detectSchemaRenameDrift()`, `detectUnpinnedAdditions()`, `detectMigrationNoteDefects()`, `detectBaselineShrink()`, `baselineFingerprint()` — so neither can drift into a weaker notion of what "documented" means. The `$kind` parameter is a message label with no default, so a third surface cannot inherit the wrong one silently.
+- Self-tests prove each guard fires rather than standing as a permanently-green tripwire: a count-preserving rename, a plain removal, a note naming some other slot, an unpinned addition, an unknown component, an empty or uncited note, a note for a still-live name, and a baseline below its floor. One test pins the premise directly — the same simulated rename that the count pins cannot see is caught by the baseline.
+- Failure messages instruct the remedy (write the note citing the ruling issue) and state that deleting the baseline entry is not a fix. Asserted, not just written, so the guidance cannot rot.
+
+---
+
 ## [v1.13.14] — 2026-08-14 — `styling.tokens` is documented as the curated subset it is, and nine schemas stop promising a write that fails (#616)
 
 **Nine band schemas told an authoring agent that one `update_design_token` write on `--pp-band-heading-size` retunes every band heading at once. That write returns `unknown_token`.** `pp_design_tokens()` parses the FIRST `:root` block of `base.css` and stops there; the shared band rhythm and heading scale are declared in a later block, deliberately, so they are not design tokens and no action in the write path reaches them. An agent following those descriptions got an error and no site-wide retune. The nine now state what is true: the shared scale is not a token, nothing can retune it site-wide, and setting the slot changes that one band.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-F7DF1E?style=flat-square&logo=javascript&logoColor=black)](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 [![Vitest](https://img.shields.io/badge/Vitest-Tests-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev)
 [![Tests](https://img.shields.io/badge/Tests-passing-22C55E?style=flat-square)](tests/)
-[![Version](https://img.shields.io/badge/version-1.13.14-6366F1?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.13.15-6366F1?style=flat-square)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-GPL--2.0-blue?style=flat-square)](LICENSE)
 
 </div>

--- a/ai-instructions/add-component.md
+++ b/ai-instructions/add-component.md
@@ -263,15 +263,37 @@ name ships, the old name is simply absent, documents that still store it lose th
 declaration with the consequences spelled out below, and the change says so out loud in
 the CHANGELOG.
 
-**Know what CI actually catches here, because it is not symmetric.** A renamed or removed
-**prop** trips the drift-catcher in `tests/SchemaValidationTest.php`, which fails the build
-unless the same change records the rename in `SCHEMA_RENAME_MIGRATION_NOTES` — the note is
-the discipline, forcing the author to state what happens to already-stored documents
-instead of making the problem disappear. A renamed **style slot** has **no such tripwire
-today**: there is no pinned slot baseline, so the rename ships green and every stored
-declaration of the old name silently stops painting. On the slot surface the CHANGELOG
-entry and the maintainer's ratification at review are the only gates, so say it out loud
-there.
+**Know what CI actually catches here — since #598 the two surfaces are symmetric.** A
+renamed or removed **prop** OR **style slot** trips the drift-catcher in
+`tests/SchemaValidationTest.php`, which fails the build unless the same change records the
+change in the matching migration-notes register (`SCHEMA_RENAME_MIGRATION_NOTES` for props,
+`SLOT_RENAME_MIGRATION_NOTES` for slots). The note is the discipline: it forces the author
+to state what happens to already-stored documents instead of making the problem disappear.
+Both surfaces run one shared algorithm, so neither can drift into a weaker notion of what
+"documented" means.
+
+The register is enforced, not merely offered:
+
+- **The note must say something and cite the ruling.** A non-empty string carrying an issue
+  reference (`#598`) — an empty, whitespace, or non-string value is rejected, and so is
+  prose with no issue number. "Documented" means a human wrote down what happened and which
+  issue authorised it.
+- **A note may only describe a name that is actually gone.** Writing a note for a name the
+  schemas still declare fails. Pre-authorising a future removal in an earlier commit is not
+  documentation, and it would let the removal itself ship unremarked later.
+- **The pinned baselines are append-only.** Retiring a name MOVES it into the notes
+  register; deleting (or quietly editing) its baseline line is not a fix, and both the count
+  floor and the baseline fingerprint fail if you try. That closes the count-preserving
+  rename — swapping one name for another in the schema and in the baseline — which leaves
+  every total identical and used to ship green.
+
+**Adding** a prop or slot touches the same pins: append it to `PINNED_PROP_BASELINE` /
+`PINNED_SLOT_BASELINE` and update the matching `*_BASELINE_FLOOR` and
+`*_BASELINE_FINGERPRINT` in the SAME change. The failure messages tell you which. This is
+what keeps a name added today from being renamed unremarked next month.
+
+The CHANGELOG entry and the maintainer's ratification at review still apply on both
+surfaces — CI now makes the trail mandatory rather than remembered.
 
 **Renaming a slot or a prop is a breaking change, and that is the accepted cost.** A composition
 stored under the old name loses that declaration at render, and the three actions that validate

--- a/docs/AI_IMPLEMENTATION_RECIPES.md
+++ b/docs/AI_IMPLEMENTATION_RECIPES.md
@@ -77,8 +77,18 @@ Used by: #99, #100, #108, #111, #61 (and the #99 scaffold issue defines the reus
    `getComputedStyle(...).borderColor`, and read it AGAIN with the site-wide knob
    (`--btn-border-color`) also set — that second read is what separates "declared" from "wins".
 
-8. **Test:** `tests/ComponentPropsTest.php` — assert the schema declares the slot with `type`+`default`; a render test asserts setting the slot emits the inline `--{name}-{slot}: <value>`; a negative test asserts an injection value (`}<script>`) is dropped.
-9. **Verify:** `composer test`.
+8. **Pin the new slot in the baseline, in the SAME change (#598).** Append it to
+   `PINNED_SLOT_BASELINE` in `tests/SchemaValidationTest.php`, then update
+   `SLOT_BASELINE_FLOOR` (the count) and `SLOT_BASELINE_FINGERPRINT` (run the suite; the
+   failure prints what it should be). Skipping this fails the build, by design: an
+   unpinned slot is one a later rename could retire with no documentation trail, because
+   it was never in the baseline to go missing from. The same applies to a new **prop** and
+   `PINNED_PROP_BASELINE` / `PROP_BASELINE_FLOOR` / `PROP_BASELINE_FINGERPRINT`.
+   Retiring or renaming a slot is a different path — see "How a rename happens now" in
+   `ai-instructions/add-component.md`: the name MOVES into `SLOT_RENAME_MIGRATION_NOTES`
+   with a note citing the ruling issue. Deleting its baseline line is never the fix.
+9. **Test:** `tests/ComponentPropsTest.php` — assert the schema declares the slot with `type`+`default`; a render test asserts setting the slot emits the inline `--{name}-{slot}: <value>`; a negative test asserts an injection value (`}<script>`) is dropped.
+10. **Verify:** `composer test`.
 
 ---
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  */
 
 // ── Theme version (single source of truth — keep in sync with style.css) ──
-define('PP_VERSION', '1.13.14');
+define('PP_VERSION', '1.13.15');
 
 // ── Load lib files ─────────────────────────────────────────────────────────
 require_once get_template_directory() . '/lib/wp.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptingpress",
-  "version": "1.13.14",
+  "version": "1.13.15",
   "private": true,
   "description": "PromptingPress WordPress theme — JS tests and E2E infrastructure",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fjcf76
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.13.14
+Stable tag: 1.13.15
 Requires PHP: 8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:       PromptingPress
 Theme URI:        https://github.com/FJCF76/PromptingPress
 Description:      An AI-first WordPress theme built for clarity — zero raw WP calls in templates, typed component props, machine-readable schemas, and a single AI_CONTEXT.md that maps the entire site.
-Version:          1.13.14
+Version:          1.13.15
 Author:           PromptingPress Contributors
 Author URI:       https://github.com/FJCF76/PromptingPress
 License:          GPL-2.0-or-later

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -3352,6 +3352,17 @@ class SchemaValidationTest extends TestCase
     private const SCHEMA_RENAME_MIGRATION_NOTES = [];
 
     /**
+     * The append-only floor for the prop surface (#598). 126 props across 12 components
+     * as of v1.13.15. NEVER DECREASE THIS. Adding props raises what the baseline holds,
+     * which is fine (the check is >=); retiring one moves it into the notes register, so
+     * the accounted total still never drops.
+     */
+    private const PROP_BASELINE_FLOOR = 126;
+
+    /** Content fingerprint of PINNED_PROP_BASELINE. See baselineFingerprint(). */
+    private const PROP_BASELINE_FINGERPRINT = '7033f12eb731ca20';
+
+    /**
      * Pure drift detector: any baseline prop that no longer exists in the live schema
      * must be covered by a migration note, else it is a violation. Kept as a static
      * helper so the real run and the simulated-rename test share one implementation.
@@ -3360,25 +3371,38 @@ class SchemaValidationTest extends TestCase
      * surface itself — dropping it, rather than passing [] forever, is what makes the
      * note the only reachable escape hatch.
      *
-     * @param array<string,string[]>              $baseline   component => prop names
-     * @param array<string,string[]>              $liveProps  component => prop names
-     * @param array<string,array<string,string>>  $notes      component => [prop => note]
+     * SURFACE-AGNOSTIC (#598). The algorithm only ever compared "declared names per
+     * component" against "pinned names per component", which is exactly the shape of
+     * the STYLE-SLOT surface too. `$kind` is a message label, not a behaviour switch:
+     * both surfaces run this one implementation, so neither can drift into its own
+     * subtly-different notion of what counts as a rename.
+     *
+     * @param array<string,string[]>              $baseline   component => declared names
+     * @param array<string,string[]>              $liveNames  component => declared names
+     * @param array<string,array<string,string>>  $notes      component => [name => note]
+     * @param string                              $kind       'prop' or 'style slot' (label only)
      * @return string[]  Human-readable violations (empty = no drift).
      */
-    private static function detectSchemaRenameDrift(array $baseline, array $liveProps, array $notes): array
+    private static function detectSchemaRenameDrift(array $baseline, array $liveNames, array $notes, string $kind): array
     {
         $violations = [];
-        foreach ($baseline as $component => $props) {
-            $live = $liveProps[$component] ?? [];
-            foreach ($props as $prop) {
-                if (in_array($prop, $live, true)) {
+        foreach ($baseline as $component => $names) {
+            $live = $liveNames[$component] ?? [];
+            foreach ($names as $name) {
+                if (in_array($name, $live, true)) {
                     continue; // still declared — no drift
                 }
-                if (!isset($notes[$component]) || !array_key_exists($prop, $notes[$component])) {
+                if (!isset($notes[$component]) || !array_key_exists($name, $notes[$component])) {
                     $violations[] = sprintf(
-                        'Component "%s" prop "%s" was removed/renamed without a migration note.',
+                        'Component "%s" %s "%s" was removed/renamed without a migration note. '
+                        . 'FIX: add \'%s\' => \'<what replaced it, or that it is gone, naming the ruling issue e.g. #598>\' '
+                        . 'to the %s migration-notes register. Deleting the pinned baseline entry is NOT a fix — '
+                        . 'the baseline is append-only.',
                         $component,
-                        $prop
+                        $kind,
+                        $name,
+                        $name,
+                        $kind
                     );
                 }
             }
@@ -3386,13 +3410,251 @@ class SchemaValidationTest extends TestCase
         return $violations;
     }
 
-    /** Live declared props per component, read from the shipped schemas. */
-    private function liveProps(): array
+    /**
+     * The ADD-PATH counterpart, extracted as a pure helper for the same reason the
+     * remove-path is one (#598): an inline loop over the live schemas can only ever be
+     * exercised by the live schemas, so nothing proves it fires. As a helper, a
+     * simulated unpinned addition can be fed to it directly.
+     *
+     * Two ways a baseline goes stale, both caught here:
+     *   1. a whole component the baseline has never heard of (a NEW slot-bearing
+     *      component, including footer/nav if they ever trade
+     *      `chrome_custom_properties` for real `style_slots`);
+     *   2. a new name on a component the baseline already covers.
+     *
+     * Either one would let a LATER removal of that name slip past the remove-path
+     * guard, because the removed name was never in the baseline to begin with.
+     *
+     * @param array<string,string[]>  $baseline   component => declared names
+     * @param array<string,string[]>  $liveNames  component => declared names
+     * @param string                  $kind       'prop' or 'style slot' (label only)
+     * @return string[]  Human-readable violations (empty = baseline is current).
+     */
+    private static function detectUnpinnedAdditions(array $baseline, array $liveNames, string $kind): array
+    {
+        $violations = [];
+        foreach ($liveNames as $component => $names) {
+            if (!array_key_exists($component, $baseline)) {
+                $violations[] = sprintf(
+                    'Component "%s" is not in the pinned %s baseline — add it.',
+                    $component,
+                    $kind
+                );
+                continue;
+            }
+            foreach ($names as $name) {
+                if (!in_array($name, $baseline[$component], true)) {
+                    $violations[] = sprintf(
+                        'Component "%s" %s "%s" is not pinned in the baseline — append it in this same change.',
+                        $component,
+                        $kind,
+                        $name
+                    );
+                }
+            }
+        }
+        return $violations;
+    }
+
+    /**
+     * H1 (part 2) — a stable fingerprint of a pinned baseline's CONTENTS.
+     *
+     * The count floor below catches a baseline that SHRANK. It cannot catch a
+     * count-preserving SWAP: renaming a name in the schema and editing the same line in
+     * the baseline leaves the total untouched, so a fully undocumented rename ships
+     * green. That is the identical count-blindness this whole issue exists to kill —
+     * `testSlotCountPinsCannotSeeARenameButTheBaselineCan()` names it — and a floor
+     * reproduces it one level up.
+     *
+     * The fingerprint closes it by making the baseline's CONTENT the pinned thing, so
+     * every edit to either literal has to be acknowledged by updating a second, labelled
+     * constant. Names are sorted before hashing, so pure reordering or reformatting does
+     * not trip it; only the actual set of names does.
+     *
+     * Honest about what this is: an author who edits the literal can also edit the
+     * fingerprint. No pinned-literal scheme can prevent that. What it guarantees is that
+     * the author is TOLD, at the moment of the edit, what documentation the change owes —
+     * and that the edit is a visible line in review rather than one name quietly
+     * changing inside a ninety-line block.
+     */
+    private static function baselineFingerprint(array $baseline): string
+    {
+        $canonical = [];
+        foreach ($baseline as $component => $names) {
+            sort($names);
+            $canonical[$component] = $names;
+        }
+        ksort($canonical);
+
+        return substr(hash('sha256', json_encode($canonical)), 0, 16);
+    }
+
+    /**
+     * The remedy text for a changed baseline. Written once so both surfaces say the same
+     * thing, and deliberately phrased so the instruction is what to DOCUMENT — never
+     * "delete the entry", which is the wrong fix the old messages implied by naming the
+     * constant and nothing else.
+     */
+    private static function baselineEditRemedy(string $kind, string $baselineConst, string $fingerprintConst, string $notesConst): string
+    {
+        return sprintf(
+            "%s baseline contents changed (%s).\n"
+            . "  ADDED a %s?    Append it to %s, then update %s.\n"
+            . "  RETIRED a %s?  Record it in %s with a note naming its replacement (or that it is gone) "
+            . "and the issue that ruled it, e.g. 'renamed to X (#598)'. Then update %s.\n"
+            . "  RENAMED one?   That is a retirement plus an addition: do BOTH of the above.\n"
+            . "Silently editing the name in %s is not a fix — a rename that nobody documented is exactly "
+            . "what this guard exists to stop.",
+            ucfirst($kind),
+            $baselineConst,
+            $kind,
+            $baselineConst,
+            $fingerprintConst,
+            $kind,
+            $notesConst,
+            $fingerprintConst,
+            $baselineConst
+        );
+    }
+
+    /**
+     * H2 + H3 — the migration-notes register polices itself (#598, 7A Option B).
+     *
+     * The register is the SOLE escape hatch from the remove-path guard, and an escape
+     * hatch nobody inspects is just a hole. Two ways a note fails to be a documented
+     * breaking change:
+     *
+     *   H2  CONTENT. detectSchemaRenameDrift() clears drift on key existence alone, so
+     *       '', null and 0 silence it exactly as well as real prose. The recorded
+     *       decision requires each entry to name the change AND the issue that ruled it,
+     *       so require a non-empty string carrying an issue reference (#123).
+     *
+     *   H3  STALENESS. A note for a name the schemas STILL declare is accepted silently
+     *       today, which means the guard can be disarmed in advance: one commit adds
+     *       notes for live names (zero failures, reads as documentation), a later commit
+     *       deletes those names and sails through. Pre-authorisation is not
+     *       documentation. A note may only describe a name that is actually gone.
+     *
+     * @param array<string,array<string,mixed>>  $notes      component => [name => note]
+     * @param array<string,string[]>             $liveNames  component => declared names
+     * @param string                             $kind       'prop' or 'style slot' (label only)
+     * @return string[]  Human-readable violations (empty = register is honest).
+     */
+    private static function detectMigrationNoteDefects(array $notes, array $liveNames, string $kind): array
+    {
+        $violations = [];
+        foreach ($notes as $component => $entries) {
+            foreach ($entries as $name => $note) {
+                if (!is_string($note) || trim($note) === '') {
+                    $violations[] = sprintf(
+                        'Migration note for %s "%s.%s" is empty. FIX: write what replaced it (or that it is '
+                        . 'gone) and cite the issue that ruled it, e.g. \'renamed to X (#598)\'.',
+                        $kind,
+                        $component,
+                        $name
+                    );
+                    continue;
+                }
+                if (!preg_match('/#\d+/', $note)) {
+                    $violations[] = sprintf(
+                        'Migration note for %s "%s.%s" does not cite a ruling issue. FIX: add the issue '
+                        . 'reference (e.g. #598) that ruled this breaking change.',
+                        $kind,
+                        $component,
+                        $name
+                    );
+                }
+                if (in_array($name, $liveNames[$component] ?? [], true)) {
+                    $violations[] = sprintf(
+                        '%s "%s.%s" still exists, so its migration note describes a breaking change that has '
+                        . 'not happened. FIX: remove the note. A note may only be written in the SAME change '
+                        . 'that retires the name — pre-authorising a future removal disarms the guard.',
+                        ucfirst($kind),
+                        $component,
+                        $name
+                    );
+                }
+            }
+        }
+        return $violations;
+    }
+
+    /**
+     * H1 — the pinned baseline is APPEND-ONLY (#598, 7A Option B).
+     *
+     * Without this, the guard is defeated by the cheapest possible edit. A rename that
+     * also deletes the old name from the baseline literal leaves nothing missing to
+     * detect, so every check passes and the migration note is never written. The old
+     * failure text even steered an author there by naming the constant.
+     *
+     * The floor is a second, independent record of how many names the baseline is
+     * accountable for. A retired name must MOVE into the notes register (or simply stay
+     * pinned alongside its note); either way the accounted total never drops. Deleting
+     * a line without writing a note drops it, and that fails here.
+     *
+     * The floor is itself a literal someone could edit down — but it is one labelled
+     * number whose entire job is to be a floor, which a reviewer sees, rather than one
+     * line vanishing from a ninety-line literal, which a reviewer does not.
+     *
+     * @param array<string,string[]>             $baseline  component => pinned names
+     * @param array<string,array<string,mixed>>  $notes     component => [name => note]
+     * @param int                                $floor     names this surface must account for
+     * @param string                             $kind      'prop' or 'style slot' (label only)
+     * @return string[]  Human-readable violations (empty = nothing went missing).
+     */
+    private static function detectBaselineShrink(array $baseline, array $notes, int $floor, string $kind): array
+    {
+        $pinned   = array_sum(array_map('count', $baseline));
+        $recorded = array_sum(array_map('count', $notes));
+        $accounted = $pinned + $recorded;
+
+        if ($accounted >= $floor) {
+            return [];
+        }
+
+        return [sprintf(
+            'The pinned %s baseline shrank: %d names are accounted for (%d pinned + %d in migration notes) '
+            . 'but this surface must account for at least %d. A retired name MOVES into the migration-notes '
+            . 'register with a note naming its replacement and ruling issue — deleting the baseline entry is '
+            . 'NOT a valid fix, and lowering the floor is not either.',
+            $kind,
+            $accounted,
+            $pinned,
+            $recorded,
+            $floor
+        )];
+    }
+
+    /**
+     * Every shipped schema, decoded, keyed by component name. The single discovery
+     * point for BOTH surfaces (#598): liveProps() and liveSlots() are projections over
+     * it, so they cannot drift into different ideas of which components exist or of
+     * what a malformed schema means.
+     *
+     * A schema that fails to parse fails LOUDLY here. It used to decode to null and
+     * flow onward as an empty prop list, which reads downstream as "this component
+     * declares nothing" — indistinguishable from a mass removal, and a misdiagnosis
+     * pointed at the wrong fix.
+     */
+    private function liveSchemas(): array
     {
         $out = [];
         foreach (glob($this->themeRoot . '/components/*/schema.json') as $schemaFile) {
             $schema = json_decode(file_get_contents($schemaFile), true);
-            $name   = $schema['component'] ?? basename(dirname($schemaFile));
+            $this->assertNotNull(
+                $schema,
+                basename(dirname($schemaFile)) . '/schema.json is not valid JSON — discovery would silently skip it.'
+            );
+            $out[$schema['component'] ?? basename(dirname($schemaFile))] = $schema;
+        }
+        return $out;
+    }
+
+    /** Live declared props per component, read from the shipped schemas. */
+    private function liveProps(): array
+    {
+        $out = [];
+        foreach ($this->liveSchemas() as $name => $schema) {
             $out[$name] = array_keys($schema['props'] ?? []);
         }
         return $out;
@@ -3410,9 +3672,43 @@ class SchemaValidationTest extends TestCase
         $drift = self::detectSchemaRenameDrift(
             self::PINNED_PROP_BASELINE,
             $this->liveProps(),
-            self::SCHEMA_RENAME_MIGRATION_NOTES
+            self::SCHEMA_RENAME_MIGRATION_NOTES,
+            'prop'
         );
         $this->assertSame([], $drift, implode("\n", $drift));
+    }
+
+    public function testPropMigrationNotesAreWellFormedAndCurrent(): void
+    {
+        // H2 + H3 on the prop surface. Empty today, so this is a contract waiting for
+        // the first real note — but it is the contract that makes the note mean
+        // something when one is finally written.
+        $defects = self::detectMigrationNoteDefects(
+            self::SCHEMA_RENAME_MIGRATION_NOTES,
+            $this->liveProps(),
+            'prop'
+        );
+        $this->assertSame([], $defects, implode("\n", $defects));
+    }
+
+    public function testPropBaselineIsAppendOnly(): void
+    {
+        // H1 on the prop surface: the baseline may grow, never shrink.
+        $shrink = self::detectBaselineShrink(
+            self::PINNED_PROP_BASELINE,
+            self::SCHEMA_RENAME_MIGRATION_NOTES,
+            self::PROP_BASELINE_FLOOR,
+            'prop'
+        );
+        $this->assertSame([], $shrink, implode("\n", $shrink));
+
+        // The floor alone cannot see a count-preserving SWAP, which is the edit that
+        // actually shipped an undocumented rename. The fingerprint can.
+        $this->assertSame(
+            self::PROP_BASELINE_FINGERPRINT,
+            self::baselineFingerprint(self::PINNED_PROP_BASELINE),
+            self::baselineEditRemedy('prop', 'PINNED_PROP_BASELINE', 'PROP_BASELINE_FINGERPRINT', 'SCHEMA_RENAME_MIGRATION_NOTES')
+        );
     }
 
     public function testEveryLiveSchemaPropIsPinnedInBaseline(): void
@@ -3424,20 +3720,30 @@ class SchemaValidationTest extends TestCase
         // change must touch the baseline in the same commit, and a rename then fails on
         // both the remove-path (which needs a migration note — the sole escape hatch
         // since #604, and still the sole one after #606) and here.
-        foreach ($this->liveProps() as $component => $props) {
-            $baseline = self::PINNED_PROP_BASELINE[$component] ?? null;
-            $this->assertNotNull(
-                $baseline,
-                sprintf('Component "%s" is not in PINNED_PROP_BASELINE — add it (SchemaValidationTest).', $component)
-            );
-            foreach ($props as $prop) {
-                $this->assertContains(
-                    $prop,
-                    $baseline,
-                    sprintf('Prop "%s.%s" is not pinned in PINNED_PROP_BASELINE — append it in this same change.', $component, $prop)
-                );
-            }
-        }
+        //
+        // The check itself moved into detectUnpinnedAdditions() in #598 with its
+        // semantics unchanged (unknown component, or unpinned name on a known
+        // component). It was an inline loop over the live schemas, which meant nothing
+        // could prove it fires; testUnpinnedAdditionIsCaught() now does.
+        //
+        // The add-path iterates the LIVE set, so — unlike the remove-path — an empty or
+        // partial discovery would pass it vacuously. Pin the component set first, in
+        // both directions, so a broken glob is a hard failure here rather than a green
+        // check that guards nothing.
+        $live = $this->liveProps();
+        $this->assertNotEmpty($live, 'prop discovery found no components — the add-path guard would pass vacuously.');
+        $this->assertSame(
+            array_keys(self::PINNED_PROP_BASELINE),
+            array_keys($live),
+            'the discovered component set must match PINNED_PROP_BASELINE exactly.'
+        );
+
+        $violations = self::detectUnpinnedAdditions(self::PINNED_PROP_BASELINE, $live, 'prop');
+        $this->assertSame(
+            [],
+            $violations,
+            "PINNED_PROP_BASELINE (SchemaValidationTest) is stale:\n" . implode("\n", $violations)
+        );
     }
 
     public function testSchemaRenameDriftIsCaught(): void
@@ -3450,15 +3756,498 @@ class SchemaValidationTest extends TestCase
         $baseline = ['cta' => ['id', 'headline', 'button_text']];
         $live     = ['cta' => ['id', 'button_text']]; // `headline` removed
 
-        $unnoted = self::detectSchemaRenameDrift($baseline, $live, []);
+        $unnoted = self::detectSchemaRenameDrift($baseline, $live, [], 'prop');
         $this->assertNotEmpty($unnoted, 'a schema rename with no migration note must be flagged');
         $this->assertStringContainsString('headline', $unnoted[0]);
 
         // An explicit migration note in the SAME change clears it. Since #604 this is
         // the ONLY thing that does — the alias-entry branch that used to sit here was
         // removed with the alias surface it depended on.
-        $withNote = self::detectSchemaRenameDrift($baseline, $live, ['cta' => ['headline' => 'migrated by #999']]);
+        $withNote = self::detectSchemaRenameDrift($baseline, $live, ['cta' => ['headline' => 'migrated by #999']], 'prop');
         $this->assertSame([], $withNote, 'a migration note for the renamed prop clears the drift');
+    }
+
+
+    // ── Style-slot rename drift-catcher (#598), on the shared prop/slot engine ──
+    //
+    // The SLOT surface had every kind of pin EXCEPT a rename-catcher. The count pins
+    // (testStyleSlotsExistForV1Components here, and the slot count in css-lint.test.js)
+    // are rename-INVARIANT by construction: a rename removes one name and adds another,
+    // so no total ever moves. Everything else that touches slots — StyleSlotContractTest,
+    // css-lint's per-slot consumption check — globs the LIVE schemas, so it re-derives
+    // its expectations from the very file the rename just edited and stays green.
+    //
+    // Why that mattered: pp_render_style_vars() (lib/wp.php) drops an undeclared slot
+    // name with a bare `continue` — no finding, no warning, no log. A renamed slot means
+    // every stored page that set the old name silently renders unstyled while every
+    // action still returns ok:true. Under the ratified no-alias posture (#570 Addendum
+    // #5, #603/#604) that breakage is ALLOWED — renames are documented breaking changes,
+    // not aliased migrations. This guard is what makes "documented" enforceable.
+    //
+    // Scope, stated plainly: this is a CI tripwire on future schema edits. It does not
+    // repair, resolve, or alias anything at runtime, and it does nothing for pages that
+    // already stored a name a deliberate rename retired. StoredCompositionAliasRenderTest
+    // guards the negative space (the removed alias machinery stays removed).
+
+    /**
+     * The pinned baseline of declared style slots per component AS OF #598 (v1.13.14,
+     * the v1.14.0 gate's final schema state — this issue lands last for exactly that
+     * reason). A FROZEN LITERAL for the same reason PINNED_PROP_BASELINE is one: if it
+     * were re-globbed at runtime, a removal would delete itself from the baseline and
+     * the drift would be invisible.
+     *
+     * 261 slots across the 10 slot-bearing components. footer and nav are absent because
+     * they declare no `style_slots` at all (they carry `chrome_custom_properties`
+     * instead) — and if either ever gains real slots, the add-path guard below fails
+     * until it is pinned here, so their absence is enforced rather than assumed.
+     *
+     * When you intentionally ADD a slot, append it here in the same change.
+     */
+    private const PINNED_SLOT_BASELINE = [
+        'cta'          => [
+            '--cta-padding-top', '--cta-padding-bottom', '--cta-bg', '--cta-heading-color',
+            '--cta-heading-accent-color', '--cta-eyebrow-color', '--cta-eyebrow-bg', '--cta-eyebrow-radius',
+            '--cta-eyebrow-border-width', '--cta-eyebrow-border-color', '--cta-eyebrow-text-transform',
+            '--cta-heading-size', '--cta-body-color', '--cta-body-size', '--cta-inner-gap', '--cta-accent',
+            '--cta-accent-hover', '--cta-button-bg', '--cta-button-border', '--cta-button-color',
+            '--cta-button-hover-bg', '--cta-button-hover-border', '--cta-button-hover-color',
+            '--cta-button-shadow', '--cta-button2-bg', '--cta-button2-border', '--cta-button2-color',
+            '--cta-button2-hover-bg', '--cta-button2-hover-border', '--cta-button2-hover-color',
+            '--cta-button2-shadow', '--cta-border-color', '--cta-border-width', '--cta-radius', '--cta-shadow',
+            '--cta-heading-measure', '--cta-heading-margin-bottom', '--cta-body-measure', '--cta-overlay-bg',
+            '--cta-bg-position',
+        ],
+        'embed'        => [
+            '--embed-padding-top', '--embed-padding-bottom', '--embed-heading-size', '--embed-heading-color',
+            '--embed-heading-measure', '--embed-heading-margin-bottom', '--embed-body-measure',
+            '--embed-body-color',
+        ],
+        'faq'          => [
+            '--faq-padding-top', '--faq-padding-bottom', '--faq-bg', '--faq-item-bg', '--faq-eyebrow-color',
+            '--faq-eyebrow-bg', '--faq-eyebrow-radius', '--faq-eyebrow-border-width', '--faq-eyebrow-border-color',
+            '--faq-eyebrow-text-transform', '--faq-heading-size', '--faq-heading-color', '--faq-heading-measure',
+            '--faq-body-measure', '--faq-heading-accent-color', '--faq-heading-margin-bottom',
+            '--faq-question-color', '--faq-answer-color', '--faq-item-border-color', '--faq-item-radius',
+            '--faq-question-open-color',
+        ],
+        'grid'         => [
+            '--grid-padding-top', '--grid-padding-bottom', '--grid-bg', '--grid-heading-color',
+            '--grid-heading-accent-color', '--grid-eyebrow-color', '--grid-eyebrow-bg', '--grid-eyebrow-radius',
+            '--grid-eyebrow-border-width', '--grid-eyebrow-border-color', '--grid-eyebrow-text-transform',
+            '--grid-subheading-color', '--grid-subheading-margin-bottom', '--grid-heading-margin-bottom',
+            '--grid-heading-size', '--grid-heading-measure', '--grid-gap', '--grid-item-bg',
+            '--grid-item-border-color', '--grid-item-border-width', '--grid-item-radius', '--grid-item-shadow',
+            '--grid-item-bar-color', '--grid-item-bar-height', '--grid-featured-texture-color',
+            '--grid-featured-shadow', '--grid-item-padding', '--grid-item-gap', '--grid-item-text-align',
+            '--grid-item-icon-size', '--grid-item-title-size', '--grid-item-title-color', '--grid-item-text-color',
+            '--grid-item-bullet-color', '--grid-item-link-color', '--grid-item-link-hover-color', '--grid-step-bg',
+            '--grid-step-text-color',
+        ],
+        'hero'         => [
+            '--hero-padding-top', '--hero-padding-bottom', '--hero-bg', '--hero-heading-color',
+            '--hero-heading-accent-color', '--hero-eyebrow-color', '--hero-eyebrow-bg', '--hero-eyebrow-radius',
+            '--hero-eyebrow-border-width', '--hero-eyebrow-border-color', '--hero-eyebrow-text-transform',
+            '--hero-accent', '--hero-accent-hover', '--hero-button-bg', '--hero-button-hover-bg',
+            '--hero-button-border', '--hero-button-hover-border', '--hero-button-color', '--hero-button-shadow',
+            '--hero-button2-bg', '--hero-button2-border', '--hero-button2-color', '--hero-button2-hover-bg',
+            '--hero-button2-hover-border', '--hero-button2-hover-color', '--hero-heading-size',
+            '--hero-heading-measure', '--hero-heading-margin-bottom', '--hero-heading-weight',
+            '--hero-subheading-size', '--hero-subheading-color', '--hero-proof-color', '--hero-content-gap',
+            '--hero-content-width', '--hero-overlay-bg', '--hero-image-radius', '--hero-image-position',
+            '--hero-image-aspect-ratio', '--hero-bg-position', '--hero-border-color', '--hero-border-width',
+            '--hero-radius', '--hero-shadow', '--hero-surface-bg', '--hero-surface-padding',
+            '--hero-surface-border-color', '--hero-surface-border-width', '--hero-surface-radius',
+            '--hero-surface-shadow',
+        ],
+        'logos'        => [
+            '--logos-padding-top', '--logos-padding-bottom', '--logos-heading-size', '--logos-heading-color',
+            '--logos-heading-measure', '--logos-heading-margin-bottom', '--logos-image-size', '--logos-gap',
+        ],
+        'section'      => [
+            '--section-padding-top', '--section-padding-bottom', '--section-bg', '--section-body-color',
+            '--section-body-link-color', '--section-body-link-hover-color', '--section-heading-size',
+            '--section-heading-measure', '--section-heading-color', '--section-heading-accent-color',
+            '--section-eyebrow-color', '--section-eyebrow-bg', '--section-eyebrow-radius',
+            '--section-eyebrow-border-width', '--section-eyebrow-border-color', '--section-eyebrow-text-transform',
+            '--section-subheading-color', '--section-subheading-margin-bottom', '--section-heading-margin-bottom',
+            '--section-body-measure', '--section-body-size', '--section-body-weight', '--section-border-color',
+            '--section-border-width', '--section-radius', '--section-image-radius', '--section-image-position',
+            '--section-image-aspect-ratio', '--section-bg-position', '--section-overlay-bg', '--section-shadow',
+            '--section-panel-bg', '--section-panel-border-color', '--section-panel-border-width',
+            '--section-panel-radius', '--section-panel-padding', '--section-panel-text', '--section-panel-font',
+            '--section-panel-marker-color', '--section-panel-cta-bg', '--section-panel-cta-border',
+            '--section-panel-cta-hover-border', '--section-panel-cta-color', '--section-panel-cta-shadow',
+            '--section-body-marker-color', '--section-separator-color', '--section-inline-items-align',
+        ],
+        'stats'        => [
+            '--stats-padding-top', '--stats-padding-bottom', '--stats-bg', '--stats-heading-size',
+            '--stats-heading-color', '--stats-heading-measure', '--stats-heading-margin-bottom',
+            '--stats-heading-accent-color', '--stats-number-color', '--stats-number-size', '--stats-number-font',
+            '--stats-number-weight', '--stats-label-color', '--stats-bg-position', '--stats-overlay-bg',
+            '--stats-radius', '--stats-max-width',
+        ],
+        'table'        => [
+            '--table-padding-top', '--table-padding-bottom', '--table-heading-size', '--table-heading-color',
+            '--table-heading-measure', '--table-heading-margin-bottom',
+        ],
+        'testimonials' => [
+            '--testimonials-padding-top', '--testimonials-padding-bottom', '--testimonials-bg',
+            '--testimonials-heading-size', '--testimonials-heading-color', '--testimonials-heading-measure',
+            '--testimonials-heading-accent-color', '--testimonials-eyebrow-color', '--testimonials-eyebrow-bg',
+            '--testimonials-eyebrow-radius', '--testimonials-eyebrow-border-width',
+            '--testimonials-eyebrow-border-color', '--testimonials-eyebrow-text-transform',
+            '--testimonials-subheading-color', '--testimonials-subheading-margin-bottom',
+            '--testimonials-heading-margin-bottom', '--testimonials-gap', '--testimonials-item-bg',
+            '--testimonials-item-border-color', '--testimonials-item-border-width', '--testimonials-item-radius',
+            '--testimonials-item-shadow', '--testimonials-item-padding', '--testimonials-quote-color',
+            '--testimonials-quote-mark-color', '--testimonials-author-color', '--testimonials-meta-color',
+        ],
+    ];
+
+    /**
+     * The SOLE escape hatch for a retired style slot — the slot-side twin of
+     * SCHEMA_RENAME_MIGRATION_NOTES. Empty today, by design. A future slot removal or
+     * rename must record `component => [slot => note]` here, in the SAME change, naming
+     * the replacement (or the removal) and the issue that ruled it, or the drift-catcher
+     * below fails CI. Deliberately a note and not an alias: a note is a human writing
+     * down what happens to documents that already store the old name; an alias would
+     * make the problem quietly go away, which #603/#604 removed the machinery for.
+     */
+    private const SLOT_RENAME_MIGRATION_NOTES = [];
+
+    /**
+     * The append-only floor for the style-slot surface (#598). 261 slots across the 10
+     * slot-bearing components as of v1.13.15. NEVER DECREASE THIS — same contract as
+     * PROP_BASELINE_FLOOR, deliberately identical in shape so neither surface can drift
+     * into a weaker notion of what "documented" means.
+     */
+    private const SLOT_BASELINE_FLOOR = 261;
+
+    /** Content fingerprint of PINNED_SLOT_BASELINE. See baselineFingerprint(). */
+    private const SLOT_BASELINE_FINGERPRINT = 'b7c047c306d4d33b';
+
+    /**
+     * Live declared style slots per component, read from the shipped schemas.
+     *
+     * Discovery is a glob over ALL component schemas, not a walk of the pinned set: a
+     * brand-new slot-bearing component has to reach the add-path guard, not slip past it
+     * because the baseline never named it. Components with no `style_slots` are omitted
+     * so the guards speak only about the slot surface.
+     */
+    private function liveSlots(): array
+    {
+        $out = [];
+        foreach ($this->liveSchemas() as $name => $schema) {
+            $slots = array_keys($schema['styling']['style_slots'] ?? []);
+            if ($slots !== []) {
+                $out[$name] = $slots;
+            }
+        }
+        return $out;
+    }
+
+    public function testLiveSchemasHaveNoUnnotedSlotRenameDriftFromBaseline(): void
+    {
+        // The real guard (remove-path): today baseline == live, so there is no drift.
+        // A future slot removal or rename WITHOUT a migration note fails HERE.
+        //
+        // Fail-closed by construction: if the glob ever breaks, liveSlots() returns []
+        // and every baseline slot reads as missing, so a broken discovery is a loud
+        // failure rather than a vacuous pass.
+        $drift = self::detectSchemaRenameDrift(
+            self::PINNED_SLOT_BASELINE,
+            $this->liveSlots(),
+            self::SLOT_RENAME_MIGRATION_NOTES,
+            'style slot'
+        );
+        $this->assertSame([], $drift, implode("\n", $drift));
+    }
+
+    public function testSlotMigrationNotesAreWellFormedAndCurrent(): void
+    {
+        // H2 + H3 on the slot surface — the identical contract, run through the
+        // identical helper. The mirror the issue asked for, held at the stronger level.
+        $defects = self::detectMigrationNoteDefects(
+            self::SLOT_RENAME_MIGRATION_NOTES,
+            $this->liveSlots(),
+            'style slot'
+        );
+        $this->assertSame([], $defects, implode("\n", $defects));
+    }
+
+    public function testSlotBaselineIsAppendOnly(): void
+    {
+        // H1 on the slot surface. This is the guard that makes the migration note the
+        // real escape hatch: without it the cheapest way to a green build is deleting
+        // the baseline line, which documents nothing.
+        $shrink = self::detectBaselineShrink(
+            self::PINNED_SLOT_BASELINE,
+            self::SLOT_RENAME_MIGRATION_NOTES,
+            self::SLOT_BASELINE_FLOOR,
+            'style slot'
+        );
+        $this->assertSame([], $shrink, implode("\n", $shrink));
+
+        // The swap-catcher. Renaming a slot in the schema and editing the matching line
+        // here keeps every count identical; without this the rename ships undocumented.
+        $this->assertSame(
+            self::SLOT_BASELINE_FINGERPRINT,
+            self::baselineFingerprint(self::PINNED_SLOT_BASELINE),
+            self::baselineEditRemedy('style slot', 'PINNED_SLOT_BASELINE', 'SLOT_BASELINE_FINGERPRINT', 'SLOT_RENAME_MIGRATION_NOTES')
+        );
+    }
+
+    public function testEveryLiveSchemaSlotIsPinnedInBaseline(): void
+    {
+        // The add-path: a newly added slot must be appended to PINNED_SLOT_BASELINE in
+        // the same commit. Without this, a slot added today and renamed next month would
+        // never have been in the baseline, so the remove-path guard above would have
+        // nothing to miss and the rename would ship undocumented after all.
+        //
+        // This path iterates the LIVE set, so it has the one weakness the remove-path
+        // does not: with nothing discovered there is nothing to check, and it would pass
+        // green. Pin the component set in both directions first — that turns a broken
+        // glob, a moved schema, or a component that stopped declaring slots into a hard
+        // failure instead of a silently unguarded surface.
+        $live = $this->liveSlots();
+        $this->assertNotEmpty($live, 'slot discovery found no components — the add-path guard would pass vacuously.');
+        $this->assertSame(
+            array_keys(self::PINNED_SLOT_BASELINE),
+            array_keys($live),
+            'the discovered slot-bearing component set must match PINNED_SLOT_BASELINE exactly.'
+        );
+
+        $violations = self::detectUnpinnedAdditions(self::PINNED_SLOT_BASELINE, $live, 'style slot');
+        $this->assertSame(
+            [],
+            $violations,
+            "PINNED_SLOT_BASELINE (SchemaValidationTest) is stale:\n" . implode("\n", $violations)
+        );
+    }
+
+    public function testSlotRenameDriftIsCaught(): void
+    {
+        // The self-test for the headline scenario, and the one the count pins cannot
+        // see: a RENAME, where the slot total does not move at all.
+        $baseline = ['hero' => ['--hero-bg', '--hero-heading-color']];
+        $live     = ['hero' => ['--hero-bg', '--hero-title-color']]; // renamed, count unchanged
+
+        $this->assertCount(
+            count($baseline['hero']),
+            $live['hero'],
+            'the simulated rename must preserve the slot count, or it is not testing the blind spot.'
+        );
+
+        $unnoted = self::detectSchemaRenameDrift($baseline, $live, [], 'style slot');
+        $this->assertNotEmpty($unnoted, 'a slot rename with no migration note must be flagged');
+        $this->assertStringContainsString('--hero-heading-color', $unnoted[0]);
+        // The label is load-bearing, not cosmetic: the message has to tell the author
+        // which surface drifted, or a shared algorithm reports prop drift for slots.
+        $this->assertStringContainsString('style slot', $unnoted[0]);
+        $this->assertStringContainsString('hero', $unnoted[0]);
+
+        // A migration note in the SAME change is the only thing that clears it.
+        $withNote = self::detectSchemaRenameDrift(
+            $baseline,
+            $live,
+            ['hero' => ['--hero-heading-color' => 'renamed to --hero-title-color by #999']],
+            'style slot'
+        );
+        $this->assertSame([], $withNote, 'a migration note for the renamed slot clears the drift');
+    }
+
+    public function testSlotRemovalDriftIsCaught(): void
+    {
+        // A plain removal (no replacement) is the same violation, and the note must be
+        // slot-scoped: a note about a DIFFERENT slot on the same component does not
+        // launder it.
+        $baseline = ['stats' => ['--stats-bg', '--stats-radius']];
+        $live     = ['stats' => ['--stats-bg']];
+
+        $unnoted = self::detectSchemaRenameDrift($baseline, $live, [], 'style slot');
+        $this->assertCount(1, $unnoted);
+        $this->assertStringContainsString('--stats-radius', $unnoted[0]);
+
+        $wrongNote = self::detectSchemaRenameDrift(
+            $baseline,
+            $live,
+            ['stats' => ['--stats-bg' => 'this slot still exists — irrelevant to the removal']],
+            'style slot'
+        );
+        $this->assertCount(1, $wrongNote, 'a note naming some other slot must not clear the removal');
+
+        // Removing a component's slots wholesale is drift for every one of them.
+        $gone = self::detectSchemaRenameDrift($baseline, [], [], 'style slot');
+        $this->assertCount(2, $gone);
+    }
+
+    public function testUnpinnedAdditionIsCaught(): void
+    {
+        // The add-path self-test, covering both surfaces because both now run this one
+        // helper. Without it the add-path guards could only ever be exercised by the
+        // live schemas, which is to say: never proven to fire.
+        $clean = self::detectUnpinnedAdditions(['hero' => ['--hero-bg']], ['hero' => ['--hero-bg']], 'style slot');
+        $this->assertSame([], $clean, 'a live set already pinned in the baseline is not drift');
+
+        // 1. A new name on a component the baseline already covers.
+        $added = self::detectUnpinnedAdditions(
+            ['hero' => ['--hero-bg']],
+            ['hero' => ['--hero-bg', '--hero-glow']],
+            'style slot'
+        );
+        $this->assertCount(1, $added, 'an unpinned slot addition must be flagged');
+        $this->assertStringContainsString('--hero-glow', $added[0]);
+        $this->assertStringContainsString('style slot', $added[0]);
+
+        // 2. A whole component the baseline has never heard of — the footer/nav case,
+        //    if either ever trades chrome_custom_properties for real style slots.
+        $newComponent = self::detectUnpinnedAdditions(
+            ['hero' => ['--hero-bg']],
+            ['hero' => ['--hero-bg'], 'footer' => ['--footer-glow']],
+            'style slot'
+        );
+        $this->assertCount(1, $newComponent, 'a slot-bearing component missing from the baseline must be flagged');
+        $this->assertStringContainsString('footer', $newComponent[0]);
+
+        // 3. Same helper, prop surface — the label is the only difference.
+        $propAdded = self::detectUnpinnedAdditions(['cta' => ['id']], ['cta' => ['id', 'kicker']], 'prop');
+        $this->assertCount(1, $propAdded);
+        $this->assertStringContainsString('prop "kicker"', $propAdded[0]);
+    }
+
+    public function testEmptyOrUncitedMigrationNotesAreRejected(): void
+    {
+        // H2 self-test, both surfaces. Before this guard, every one of these values
+        // cleared drift exactly as well as a real note: the remove-path only ever asked
+        // whether the KEY existed.
+        foreach (['' => 'empty string', '   ' => 'whitespace'] as $blank => $label) {
+            $defects = self::detectMigrationNoteDefects(
+                ['hero' => ['--hero-bg' => $blank]],
+                ['hero' => []],
+                'style slot'
+            );
+            $this->assertNotEmpty($defects, "a {$label} note must be rejected");
+            $this->assertStringContainsString('is empty', $defects[0]);
+        }
+
+        foreach ([null, 0, false, []] as $nonString) {
+            $this->assertNotEmpty(
+                self::detectMigrationNoteDefects(['hero' => ['--hero-bg' => $nonString]], ['hero' => []], 'style slot'),
+                'a non-string note must be rejected'
+            );
+        }
+
+        // Prose with no issue reference is not a ruling — the recorded decision requires
+        // the note to name the issue that authorised the break.
+        $uncited = self::detectMigrationNoteDefects(
+            ['cta' => ['eyebrow' => 'we renamed this ages ago']],
+            ['cta' => []],
+            'prop'
+        );
+        $this->assertNotEmpty($uncited, 'a note with no issue reference must be rejected');
+        $this->assertStringContainsString('does not cite a ruling issue', $uncited[0]);
+
+        // A well-formed note on a genuinely retired name is clean, on both surfaces.
+        $this->assertSame(
+            [],
+            self::detectMigrationNoteDefects(
+                ['cta' => ['eyebrow' => 'renamed to kicker (#598)']],
+                ['cta' => ['id', 'kicker']],
+                'prop'
+            )
+        );
+        $this->assertSame(
+            [],
+            self::detectMigrationNoteDefects(
+                ['hero' => ['--hero-bg' => 'removed, superseded by --hero-surface-bg (#598)']],
+                ['hero' => ['--hero-surface-bg']],
+                'style slot'
+            )
+        );
+    }
+
+    public function testMigrationNoteForAStillLiveNameIsRejected(): void
+    {
+        // H3 self-test, both surfaces: the two-commit disarm. Commit 1 pre-notes names
+        // that still exist (previously silent, and it reads as documentation in review);
+        // commit 2 deletes them and the remove-path finds a note waiting. Rejecting the
+        // pre-authorisation is what collapses that sequence back into one honest commit.
+        $slotDefects = self::detectMigrationNoteDefects(
+            ['hero' => ['--hero-bg' => 'planning to drop this (#598)']],
+            ['hero' => ['--hero-bg', '--hero-radius']], // still declared
+            'style slot'
+        );
+        $this->assertNotEmpty($slotDefects, 'a note for a still-declared slot must be rejected');
+        $this->assertStringContainsString('still exists', $slotDefects[0]);
+        $this->assertStringContainsString('pre-authorising', $slotDefects[0]);
+
+        $propDefects = self::detectMigrationNoteDefects(
+            ['cta' => ['eyebrow' => 'planning to drop this (#598)']],
+            ['cta' => ['id', 'eyebrow']],
+            'prop'
+        );
+        $this->assertNotEmpty($propDefects, 'a note for a still-declared prop must be rejected');
+        $this->assertStringContainsString('still exists', $propDefects[0]);
+    }
+
+    public function testBaselineShrinkWithoutANoteIsRejected(): void
+    {
+        // H1 self-test, both surfaces. This is the hole that let a fully undocumented
+        // rename ship green: delete the old name from the schema AND from the baseline,
+        // and nothing is missing to detect.
+        $shrunk = self::detectBaselineShrink(['hero' => ['--hero-bg']], [], 2, 'style slot');
+        $this->assertNotEmpty($shrunk, 'a baseline below its floor must be rejected');
+        $this->assertStringContainsString('shrank', $shrunk[0]);
+        // The message must point at the note, never at the baseline line.
+        $this->assertStringContainsString('MOVES into the migration-notes register', $shrunk[0]);
+        $this->assertStringContainsString('NOT a valid fix', $shrunk[0]);
+
+        // Moving the retired name into the notes register keeps the total accounted for.
+        $this->assertSame(
+            [],
+            self::detectBaselineShrink(
+                ['hero' => ['--hero-bg']],
+                ['hero' => ['--hero-glow' => 'removed (#598)']],
+                2,
+                'style slot'
+            ),
+            'a name that moved from the baseline into the notes register still counts'
+        );
+
+        // Keeping it pinned AND noting it is equally valid, and growth is always fine.
+        $this->assertSame([], self::detectBaselineShrink(['cta' => ['id', 'title', 'body']], [], 2, 'prop'));
+
+        // The floors the real guards run against are the live totals, so a silently
+        // dropped duplicate key in either literal falls below its floor.
+        $this->assertSame(
+            self::PROP_BASELINE_FLOOR,
+            array_sum(array_map('count', self::PINNED_PROP_BASELINE)),
+            'PROP_BASELINE_FLOOR must equal what PINNED_PROP_BASELINE actually holds today.'
+        );
+        $this->assertSame(
+            self::SLOT_BASELINE_FLOOR,
+            array_sum(array_map('count', self::PINNED_SLOT_BASELINE)),
+            'SLOT_BASELINE_FLOOR must equal what PINNED_SLOT_BASELINE actually holds today.'
+        );
+    }
+
+    public function testSlotCountPinsCannotSeeARenameButTheBaselineCan(): void
+    {
+        // Pins the PREMISE this issue rests on, so a future reader does not "simplify"
+        // the baseline away on the theory that the count pins already cover it. Both
+        // checks run against the same simulated rename; only one of them notices.
+        $baseline = ['grid' => ['--grid-bg', '--grid-gap']];
+        $renamed  = ['grid' => ['--grid-bg', '--grid-item-gap']];
+
+        $this->assertSame(
+            count($baseline['grid']),
+            count($renamed['grid']),
+            'count-based pins see nothing here — that is the blind spot.'
+        );
+        $this->assertNotEmpty(
+            self::detectSchemaRenameDrift($baseline, $renamed, [], 'style slot'),
+            'the baseline guard must catch what the count pins structurally cannot.'
+        );
     }
 
     // ── Generic schema-typed prop enforcement (issue 507) ───────────────────


### PR DESCRIPTION
Closes #598

## Scope

The prop surface had a rename drift-catcher; the slot surface had none. This adds it, mirroring the prop shape, then closes three holes that mirroring exposed — on both surfaces, so they cannot enforce different contracts.

**Premise verified before implementing.** No slot-side name baseline existed. The existing slot pins are rename-invariant by construction: `testStyleSlotsExistForV1Components` and `css-lint.test.js` both count slots, and a rename removes one name and adds another, so no total moves. Refinement worth recording: 254 of 261 slot names appear incidentally somewhere under `tests/`, so many renames would have tripped *some* unrelated test with a misleading message; 7 (`--cta-inner-gap`, `--embed-padding-bottom`, `--faq-padding-bottom`, `--hero-content-gap`, `--logos-padding-bottom`, `--stats-padding-bottom`, `--table-padding-bottom`) appear nowhere at all and rename in total silence.

### Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | Pin `PINNED_SLOT_BASELINE` from the live v1.13.14 schemas | Done — 261 slots / 10 components |
| 2 | Fail when a baseline slot vanishes without a migration note | Done, proven by mutation |
| 3 | Symmetric add-path guard (new slot must be pinned in the same commit) | Done, proven by mutation |
| 4 | Reuse `detectSchemaRenameDrift()`'s shape so both surfaces share one algorithm | Done — one algorithm, five shared helpers |
| — | No alias machinery | Held — nothing resolves an old name; `StoredCompositionAliasRenderTest` untouched |

Pinned baseline, per component: cta 40, embed 8, faq 21, grid 38, hero 49, logos 8, section 47, stats 17, table 6, testimonials 27 = **261**. `footer` and `nav` are absent because they declare `chrome_custom_properties`, not `style_slots`; the add-path guard fails if either ever gains real slots, so their absence is enforced rather than assumed.

## 7A question — asked and answered

**Asked:** implementation found three holes that let an undocumented rename ship green. Fixing them meant either breaking the prop/slot mirror or changing the behavior of a prop guard ratified across #495/#604/#606. Options: strict mirror / harden both / harden slot only.

**Answered: harden both surfaces, keeping them identical.** #598's rescoped body is the decision of record and requires both the prop SHAPE and that "each entry names the replacement or removal and the ruling issue", with the stated purpose that this catcher "is what makes 'documented' enforceable". The holes violate what that decision explicitly requires, so closing them is the decision-faithful implementation, not an extension of it.

**On the prop surface:** the ratified decisions (#604, #570 Addendum #5, #606) are the CONTRACT — renames are documented breaking changes, no aliases. The prop guard's test mechanics are implementation, not ratified contract. Closing the holes there changes enforcement mechanics in service of the identical ratified contract; it does not change what is accepted or rejected in any schema, and no runtime code is touched.

The three holes, all reproduced empirically before being fixed:

- **H1 — baselines were not append-only.** The cheapest path to a green build was deleting or editing a baseline line, and the failure messages named the constant, steering authors there. Closed with a count floor plus a content fingerprint. The floor alone was not enough: a count-preserving *swap* (rename in the schema, edit the matching baseline line) leaves every total identical, which is the same count-blindness this issue exists to kill. The fingerprint catches it.
- **H2 — note content was unvalidated.** `''`, `null` and `0` cleared drift as well as real prose. Now a non-empty string citing `#<number>`.
- **H3 — notes could pre-authorise.** A note for a still-live name was accepted silently, enabling a two-commit disarm. Now rejected.

## Validation

Both suites green, run fresh after the final code change:

- `./vendor/bin/phpunit --configuration phpunit.xml` — **3351 tests, 15081 assertions** (3338 before; +13). Warnings 4 and deprecations 2, identical to an unmodified tree.
- `npm test` — **1265 tests, 22 files**, unchanged.
- `bash scripts/package.sh` — version consistency OK across all five files at 1.13.15; build zip deleted (releases are CI-built from tags).

Assertion count moved 15089 → 15081 net because the prop add-path went from ~192 loop assertions to a collected-violation compare. Coverage is unchanged and is now provable — see the mutation matrix.

### Mutation proofs

Per Section 14.7 every mutation ran in a **copy** of the tree (`rsync` to a scratch dir); the shared working tree was never mutated, verified by `git status` throughout. Each case ran against live schemas, not simulated inputs.

| Case | Surface | Expected | Result |
|---|---|---|---|
| Unnoted rename | slot | fail | fail |
| Unnoted removal | slot | fail | fail |
| Unpinned addition | slot | fail | fail |
| Rename + baseline line edited (swap), no note | slot | fail | fail |
| Rename + baseline line edited (swap), no note | prop | fail | fail |
| Delete from schema + baseline, no note (shrink) | slot | fail | fail |
| Empty note on a retired name | slot / prop | fail | fail / fail |
| Note citing no issue | slot | fail | fail |
| Note for a still-live name | slot / prop | fail | fail / fail |
| Discovery returns nothing (broken glob) | both | fail | fail |
| One component's slots vanish (partial discovery) | slot | fail | fail |
| Documented retirement (baseline kept + well-formed note) | slot | **pass** | pass |
| Unmutated control | both | **pass** | pass |

The swap and both discovery cases passed green before this change; they are the holes it closes.

## Reviews

`/plan-eng-review` and `/review` both ran this session against this content — not re-dispatched for the commit (reviews ran pre-commit on the working tree; content is unchanged since). Codex outside voice, a testing specialist, a maintainability specialist and an adversarial pass all ran. Findings applied within the recorded decision: add-path vacuity on both surfaces, a shared `liveSchemas()` decode helper (fixes the malformed-JSON asymmetry where `liveProps()` degraded to an empty prop list), `$kind` made required so no surface inherits the wrong label, unknown-component message accuracy, and remedy-steering failure text.

## Accepted limitations

- No pinned-literal scheme can stop an author who edits both the literal and the fingerprint. What this guarantees is that the author is *told*, at the moment of the edit, what documentation the change owes, and that the edit is a visible line in review rather than one name changing quietly inside a ninety-line block. Stated plainly in the code comments rather than left implied.
- This is a CI tripwire on future schema edits. It does not repair, resolve, or alias anything at runtime, and it does nothing for pages that already stored a name a deliberate rename retired. That is the ratified posture, not a gap.
- `chrome_custom_properties` (footer/nav) are a separate surface and are out of scope here.

## Found while working on this (filed, not fixed)

- **#680** — schema discovery keys on `schema.component` in `SchemaValidationTest` but on the directory name in `StyleSlotContractTest`; a name collision would silently unguard a component. Latent today (all 12 agree).
- **#681** — `css-lint` sanctions a slot re-point (`--other-slot: var(--this-slot)`) that works as a one-way alias when the old name is *set*, re-opening the no-alias posture at the cascade level. Reproduced end-to-end.